### PR TITLE
toIterable() consistent wrapping of errors

### DIFF
--- a/rxjava-core/src/main/java/rx/ObservedException.java
+++ b/rxjava-core/src/main/java/rx/ObservedException.java
@@ -1,0 +1,9 @@
+package rx;
+
+public class ObservedException extends RuntimeException
+{
+    public ObservedException(Exception exception)
+    {
+        super(exception);
+    }
+}

--- a/rxjava-core/src/main/java/rx/operators/OperationMostRecent.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationMostRecent.java
@@ -66,7 +66,7 @@ public final class OperationMostRecent {
         @Override
         public T next() {
             if (observer.getException() != null) {
-                throw Exceptions.propagate(observer.getException());
+                throw Exceptions.propagateObserved(observer.getException());
             }
             return observer.getRecentValue();
         }

--- a/rxjava-core/src/main/java/rx/operators/OperationNext.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationNext.java
@@ -140,7 +140,7 @@ public final class OperationNext {
 
             if (lastItem.isOnError()) {
                 if (rethrowExceptionIfExists) {
-                    throw Exceptions.propagate(lastItem.getException());
+                    throw Exceptions.propagateObserved(lastItem.getException());
                 } else {
                     return true;
                 }

--- a/rxjava-core/src/main/java/rx/util/Exceptions.java
+++ b/rxjava-core/src/main/java/rx/util/Exceptions.java
@@ -15,6 +15,8 @@
  */
 package rx.util;
 
+import rx.ObservedException;
+
 public class Exceptions {
     private Exceptions() {
 
@@ -25,6 +27,14 @@ public class Exceptions {
             throw (RuntimeException) t;
         } else {
             throw new RuntimeException(t);
+        }
+    }
+
+    public static RuntimeException propagateObserved(Exception t) {
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        } else {
+            throw new ObservedException(t);
         }
     }
 


### PR DESCRIPTION
toIterable() now wraps errors reported through the Observable in a (newly created) ObservedException. This allows a catch block to handle only the exceptions that came through the Observable, not catching exceptions thrown by RxJava itself.
