### PR TITLE
update dematerialize so can chain correctly

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -2598,8 +2598,8 @@ public class Observable<T> {
      *             if attempted on Observable not of type {@code Observable<Notification<T>>}.
      */
     @SuppressWarnings("unchecked")
-    public Observable<T> dematerialize() {
-        return dematerialize((Observable<Notification<T>>) this);
+    public <T2> Observable<T2> dematerialize() {
+        return dematerialize((Observable<Notification<T2>>)this);
     }
 
     /**
@@ -3459,6 +3459,19 @@ public class Observable<T> {
             Observable<String> obs = Observable.toObservable();
 
             assertNull(obs.last());
+        }
+
+        @Test
+        public void testMaterializeDematerializeChaining() {
+            Observable<Integer> obs = Observable.just(1);
+            Observable<Integer> chained = obs.materialize().dematerialize();
+
+            Observer<Integer> observer = mock(Observer.class);
+            chained.subscribe(observer);
+
+            verify(observer, times(1)).onNext(1);
+            verify(observer, times(1)).onCompleted();
+            verify(observer, times(0)).onError(any(Exception.class));
         }
 
         private static class TestException extends RuntimeException {


### PR DESCRIPTION
Just noticed this when I actually had to chain it.

``` java
Observable<File> saveResult = ....;
```

current:

``` java
Observable<Notification<File>> a = saveResult.materialize().dematerialize();
```

expected:

``` java
Observable<File> a = saveResult.materialize().dematerialize();
```

here is what is happening

``` java
Observable<File> x = saveResult;
Observable<Notification<File>> y = x.materialize();
Observable<Notification<File>> currentResult = y.dematerialize();
Observable<File> expectedResult = Observable.dematerialize(y);
```

workaround is to use static method to get the expected result.

With this change you can chain correctly. Added unit test.

``` java
Observable<Integer> obs = Observable.just(1);
Observable<Integer> chained = obs.materialize().dematerialize();
```

This will be a breaking change. But I think this is the expected way.
