### PR TITLE
Add pointer regarding unit tests as inner classes

### DIFF
--- a/rxjava-core/src/test/java/README.md
+++ b/rxjava-core/src/test/java/README.md
@@ -1,0 +1,8 @@
+This test folder only contains performance and functional/integration style tests.
+
+The unit tests themselves are embedded as inner classes of the Java code (such as here: [rxjava-core/src/main/java/rx/operators](https://github.com/Netflix/RxJava/tree/master/rxjava-core/src/main/java/rx/operators)).
+
+* For an explanation of this design choice see 
+Ben J. Christensen's [JUnit Tests as Inner Classes](http://benjchristensen.com/2011/10/23/junit-tests-as-inner-classes/).
+
+Also, each of the language adaptors has a /src/test/ folder which further testing (see Groovy for an example: [language-adaptors/rxjava-groovy/src/test](https://github.com/Netflix/RxJava/tree/master/language-adaptors/rxjava-groovy/src/test)).

--- a/rxjava-core/src/test/java/README.txt
+++ b/rxjava-core/src/test/java/README.txt
@@ -1,7 +1,0 @@
-This test folder only contains performance and functional/integration style tests.
-
-The unit tests themselves are embedded as inner classes of the Java code (such as here https://github.com/Netflix/RxJava/tree/master/rxjava-core/src/main/java/rx/operators).
-
-  * For an explanation of this design choice see http://benjchristensen.com/2011/10/23/junit-tests-as-inner-classes/.
-
-Also, each of the language adaptors has a /src/test/ folder which further testing. See Groovy for an example: https://github.com/Netflix/RxJava/tree/master/language-adaptors/rxjava-groovy/src/test


### PR DESCRIPTION
@benjchristensen - If I hadn't stumbled over your respective [pointer](https://github.com/Netflix/RxJava/issues/154#issuecomment-14544894) by chance, I would have asked the same question as Matt Bishop when encountering this README.

Your reasoning for embedding unit tests as inner classes is inspiring (thanks much) and a helpful explanation for those who disagree regardless, so I suggest to promote it accordingly.
