### PR TITLE
Remove use of JSR 305 and dependency on com.google.code.findbugs

### DIFF
--- a/rxjava-core/build.gradle
+++ b/rxjava-core/build.gradle
@@ -8,7 +8,6 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.0'
-    compile 'com.google.code.findbugs:jsr305:2.0.0'
     provided 'junit:junit:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationZip.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationZip.java
@@ -23,9 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -68,7 +65,9 @@ public final class OperationZip {
         return a;
     }
 
-    @ThreadSafe
+    /*
+     * ThreadSafe
+     */
     private static class ZipObserver<R, T> implements Observer<T> {
         final Observable<T> w;
         final Aggregator<R> a;
@@ -110,9 +109,10 @@ public final class OperationZip {
     /**
      * Receive notifications from each of the Observables we are reducing and execute the zipFunction whenever we have received events from all Observables.
      * 
+     * This class is thread-safe.
+     * 
      * @param <T>
      */
-    @ThreadSafe
     private static class Aggregator<T> implements Func1<Observer<T>, Subscription> {
 
         private volatile SynchronizedObserver<T> observer;
@@ -132,10 +132,11 @@ public final class OperationZip {
 
         /**
          * Receive notification of a Observer starting (meaning we should require it for aggregation)
+         *
+         * Thread Safety => Invoke ONLY from the static factory methods at top of this class which are always an atomic execution by a single thread.
          * 
          * @param w
          */
-        @GuardedBy("Invoked ONLY from the static factory methods at top of this class which are always an atomic execution by a single thread.")
         private void addObserver(ZipObserver<T, ?> w) {
             // initialize this ZipObserver
             observers.add(w);

--- a/rxjava-core/src/main/java/rx/util/AtomicObservableSubscription.java
+++ b/rxjava-core/src/main/java/rx/util/AtomicObservableSubscription.java
@@ -18,8 +18,6 @@ package rx.util;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import rx.Subscription;
 
 /**
@@ -32,7 +30,6 @@ import rx.Subscription;
  * <li>handle both synchronous and asynchronous subscribe() execution flows</li>
  * </ul>
  */
-@ThreadSafe
 public final class AtomicObservableSubscription implements Subscription {
 
     private AtomicReference<Subscription> actualSubscription = new AtomicReference<Subscription>();

--- a/rxjava-core/src/main/java/rx/util/SynchronizedObserver.java
+++ b/rxjava-core/src/main/java/rx/util/SynchronizedObserver.java
@@ -26,8 +26,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -50,7 +48,6 @@ import rx.util.functions.Func1;
  * 
  * @param <T>
  */
-@ThreadSafe
 public final class SynchronizedObserver<T> implements Observer<T> {
 
     /**


### PR DESCRIPTION
fixes https://github.com/Netflix/RxJava/issues/192

The library and annotations were being used for trivial reasons so removing the usage so we don't have the dependency.
