### PR TITLE
Implement ConnectableObservable and Observable.publish

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -74,6 +74,7 @@ import rx.plugins.RxJavaObservableExecutionHook;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.BooleanSubscription;
 import rx.subscriptions.Subscriptions;
+import rx.subjects.ConnectableObservable;
 import rx.util.AtomicObservableSubscription;
 import rx.util.AtomicObserver;
 import rx.util.Range;
@@ -1562,6 +1563,13 @@ public class Observable<T> {
     }
 
     /**
+     * Returns a {@link ConnectableObservable} that publishes the source Observable to any number of Observers.
+     */
+    public static <T> ConnectableObservable<T> publish(Observable<T> observable) {
+        return new ConnectableObservable<T>(observable);
+    }
+
+    /**
      * Returns an Observable that applies a function of your choosing to the first item emitted by a
      * source Observable, then feeds the result of that function along with the second item emitted
      * by an Observable into the same function, and so on until all items have been emitted by the
@@ -3003,6 +3011,13 @@ public class Observable<T> {
                 return (T) _f.call(e);
             }
         });
+    }
+
+    /**
+     * Returns a {@link ConnectableObservable} that publishes the source Observable to any number of Observers.
+     */
+    public ConnectableObservable<T> publish() {
+        return publish(this);
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/subjects/ConnectableObservable.java
+++ b/rxjava-core/src/main/java/rx/subjects/ConnectableObservable.java
@@ -1,0 +1,76 @@
+package rx.subjects;
+
+import rx.Observable;
+import rx.Observer;
+import rx.Subscription;
+import rx.subjects.Subject;
+import rx.util.AtomicObservableSubscription;
+
+/**
+ * An {@link Observable} that behaves like a {@link Subject} and can be <code>connect</code>ed (subscribed) to a source {@link Observable}.
+ *
+ * @param <T>
+ */
+
+public class ConnectableObservable<T> extends Observable<T> {
+
+    private Subject<T> subject;
+    private Observable<T> source;
+    private Subscription subscription;
+    private Object lock = new Object();
+
+    /**
+     * Constructs a {@link ConnectableObservable} that subscribes <code>subject</code> to <code>source</code> when {@link #connect()} is called.
+     *
+     * @param source
+     *            {@link Observable} to connect the <code>subject</code> to.
+     * @param subject
+     *            The {@link Subject} that will provide the {@link Observable} behaviour.
+     */
+    public ConnectableObservable(Observable<T> source, Subject<T> subject) {
+        this.subject = subject;
+        this.source = source;
+    }
+
+    /**
+     * Constructs a {@link ConnectableObservable} that subscribes to <code>source</code> when {@link #connect()} is called.
+     * @param source
+     *            {@link Observable} to connect the <code>subject</code> to.
+     */
+    public ConnectableObservable(Observable<T> source) {
+        this.subject = Subject.create();
+        this.source = source;
+    }
+
+    /**
+     * Subscribes <code>observer</code> to the {@link Subject}.
+     */
+    public Subscription subscribe(Observer<T> observer) {
+        return subject.subscribe(observer);
+    }
+
+    /**
+     * Subscribes the {@link Subject} to the source {@link Observable}, if it was not subscribed already.
+     * <p>
+     * If it was subscribed still, it returns the existing {@link Subscription}.
+     * @return a {@link Subscription} that can be used to unsubscribe from the source again.
+     */
+    public Subscription connect() {
+        synchronized(lock) {
+            if (subscription == null) {
+                final Subscription actualSubscription = source.subscribe(subject);
+                this.subscription = new AtomicObservableSubscription(
+                    new Subscription() {
+                        public void unsubscribe() {
+                            synchronized(lock) {
+                                actualSubscription.unsubscribe();
+                                subscription = null;
+                            }
+                        }
+                    }
+                );
+            }
+            return subscription;
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I hope you appreciate this implementation. Most of it is a quite straightforward mimic of the .NET version. Could you perhaps verify if I used the lock and the subscription wrapper correctly?

Following the behaviour of the .NET Rx implementation, a ConnectableObservable
consists of a Subject that can be connected to its source Observable by calling
the connect() method. The Observable.publish() method can be used to create a
new ConnectableObservable for the given Observable.

Greetings,
Gerben
