### PR TITLE
Fix multiple subscription bug on operation filter

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationFilter.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationFilter.java
@@ -37,7 +37,6 @@ public final class OperationFilter<T> {
 
         private final Observable<T> that;
         private final Func1<T, Boolean> predicate;
-        private final AtomicObservableSubscription subscription = new AtomicObservableSubscription();
 
         public Filter(Observable<T> that, Func1<T, Boolean> predicate) {
             this.that = that;
@@ -45,6 +44,7 @@ public final class OperationFilter<T> {
         }
 
         public Subscription call(final Observer<T> observer) {
+            final AtomicObservableSubscription subscription = new AtomicObservableSubscription();
             return subscription.wrap(that.subscribe(new Observer<T>() {
                 public void onNext(T value) {
                     try {


### PR DESCRIPTION
A new subscription must be created on every subscribe call, otherwise any
subscribe call after the first directly fails.
