### PR TITLE
Created the initial implementation of BehaviorSubject

### DIFF
--- a/rxjava-core/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/rxjava-core/src/main/java/rx/subjects/BehaviorSubject.java
@@ -15,10 +15,8 @@
  */
 package rx.subjects;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,7 +33,7 @@ import rx.util.functions.Func0;
 import rx.util.functions.Func1;
 
 /**
- * Subject that publishes the previous and all subsequent events to each {@link Observer} that subscribes. 
+ * Subject that publishes the last and all subsequent events to each {@link Observer} that subscribes. 
  * <p>
  * Example usage:
  * <p>
@@ -61,6 +59,15 @@ import rx.util.functions.Func1;
  */
 public class BehaviorSubject<T> extends Subject<T, T> {
 
+    /**
+     * Creates a {@link BehaviorSubject} which publishes the last and all subsequent events to each 
+     * {@link Observer} that subscribes to it.
+     *  
+     * @param defaultValue
+     *            The value which will be published to any {@link Observer} as long as the 
+     *            {@link BehaviorSubject} has not yet received any events.
+     * @return the constructed {@link BehaviorSubject}.
+     */
     public static <T> BehaviorSubject<T> createWithDefaultValue(T defaultValue) {
         final ConcurrentHashMap<Subscription, Observer<T>> observers = new ConcurrentHashMap<Subscription, Observer<T>>();
 


### PR DESCRIPTION
I've been trying to implement the BehaviorSubject. Functionally it works as it should, but I'm not entirely happy with the static `createWithDefaultValue(T)` method. I can't create a static method `create(T)` because Subject extends Observable, which has a static `create(Object)` method. So to resolve that I had to give the static method in BehaviorSubject a different name.

Additionally I'm using an `AtomicReference<T>` in this static method to keep track of the last published value. I tried coming up with different solutions to push the last published value to the Observer when it's subscribing, but this seems to be the most clean solution.

If there's any feedback on either issue, please let me know.
