### PR TITLE
Publish, Replay and Cache Operators

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -4356,10 +4356,10 @@ public class Observable<T> {
 
                         @Override
                         public void run() {
+                            counter.incrementAndGet();
                             System.out.println("published observable being executed");
                             observer.onNext("one");
                             observer.onCompleted();
-                            counter.incrementAndGet();
                         }
                     }).start();
                     return subscription;
@@ -4416,10 +4416,10 @@ public class Observable<T> {
 
                         @Override
                         public void run() {
+                            counter.incrementAndGet();
                             System.out.println("published observable being executed");
                             observer.onNext("one");
                             observer.onCompleted();
-                            counter.incrementAndGet();
                         }
                     }).start();
                     return subscription;

--- a/rxjava-core/src/main/java/rx/operators/OperationCache.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationCache.java
@@ -83,10 +83,10 @@ public class OperationCache {
 
                         @Override
                         public void run() {
+                            counter.incrementAndGet();
                             System.out.println("published observable being executed");
                             observer.onNext("one");
                             observer.onCompleted();
-                            counter.incrementAndGet();
                         }
                     }).start();
                     return subscription;


### PR DESCRIPTION
Added basic Publish (https://github.com/Netflix/RxJava/issues/15) and Replay (https://github.com/Netflix/RxJava/issues/71) operators to Observable. I have not done any of the overloads (particularly `Replay` which has 10+ in .Net.

I also added a new `Cache` operator as discussed by @johngmyers and I at https://github.com/Netflix/RxJava/pull/209.

Playing with `Replay` and `ConnectableObservable` it does not cater well to the typical use case of needing to just de-dupe calls (cache the responses) so this `Cache` operator can be thought of as an automatic version of `Replay`. It comes with the same risk as `toList` if used with infinite or very large sequences as you can not unsubscribe from it.
