### PR TITLE
change from junit to junit-dep

### DIFF
--- a/language-adaptors/rxjava-clojure/build.gradle
+++ b/language-adaptors/rxjava-clojure/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'osgi'
 dependencies {
     compile project(':rxjava-core')
     provided 'org.clojure:clojure:1.4.+'
-    provided 'junit:junit:4.10'
+    provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
     
     // clojure

--- a/language-adaptors/rxjava-groovy/build.gradle
+++ b/language-adaptors/rxjava-groovy/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'osgi'
 dependencies {
     compile project(':rxjava-core')
     groovy 'org.codehaus.groovy:groovy-all:2.+'
-    provided 'junit:junit:4.10'
+    provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }
 

--- a/language-adaptors/rxjava-jruby/build.gradle
+++ b/language-adaptors/rxjava-jruby/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'osgi'
 dependencies {
     compile project(':rxjava-core')
     provided 'org.jruby:jruby:1.6+'
-    provided 'junit:junit:4.10'
+    provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }
 

--- a/language-adaptors/rxjava-scala/build.gradle
+++ b/language-adaptors/rxjava-scala/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     provided 'org.scalatest:scalatest_2.10:1.9.1'
 
     compile project(':rxjava-core')
-    provided 'junit:junit:4.10'
+    provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 
     testCompile 'org.scalatest:scalatest_2.10:1.9.1'

--- a/rxjava-contrib/rxjava-swing/build.gradle
+++ b/rxjava-contrib/rxjava-swing/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
     compile project(':rxjava-core')
-    provided 'junit:junit:4.10'
+    provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }
 

--- a/rxjava-core/build.gradle
+++ b/rxjava-core/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.0'
-    provided 'junit:junit:4.10'
+    provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }
 


### PR DESCRIPTION
- removes Hamcrest dependencies (http://saltnlight5.blogspot.com/2012/10/whats-up-with-junit-and-hamcrest.html)
- solves conflicts on our CI server (blocking release to Maven Central)
