### PR TITLE
Make ScheduledSubscription public, expose scheduler field

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSubscribeOn.java
@@ -21,6 +21,7 @@ import rx.Observer;
 import rx.Scheduler;
 import rx.Subscription;
 import rx.concurrency.Schedulers;
+import rx.subscriptions.ScheduledSubscription;
 import rx.util.functions.Action0;
 import rx.util.functions.Func0;
 import rx.util.functions.Func1;
@@ -54,26 +55,6 @@ public class OperationSubscribeOn {
                 @Override
                 public Subscription call() {
                     return new ScheduledSubscription(source.subscribe(observer), scheduler);
-                }
-            });
-        }
-    }
-
-    private static class ScheduledSubscription implements Subscription {
-        private final Subscription underlying;
-        private final Scheduler scheduler;
-
-        private ScheduledSubscription(Subscription underlying, Scheduler scheduler) {
-            this.underlying = underlying;
-            this.scheduler = scheduler;
-        }
-
-        @Override
-        public void unsubscribe() {
-            scheduler.schedule(new Action0() {
-                @Override
-                public void call() {
-                    underlying.unsubscribe();
                 }
             });
         }

--- a/rxjava-core/src/main/java/rx/subscriptions/ScheduledSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/ScheduledSubscription.java
@@ -1,0 +1,30 @@
+package rx.subscriptions;
+
+import rx.Scheduler;
+import rx.Subscription;
+import rx.util.functions.Action0;
+
+public class ScheduledSubscription implements Subscription {
+    private final Subscription underlying;
+    private final Scheduler scheduler;
+
+    public ScheduledSubscription(Subscription underlying, Scheduler scheduler) {
+        this.underlying = underlying;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void unsubscribe() {
+        scheduler.schedule(new Action0() {
+            @Override
+            public void call() {
+                underlying.unsubscribe();
+            }
+        });
+    }
+
+    public Scheduler getScheduler() {
+        return this.scheduler;
+    }
+
+}


### PR DESCRIPTION
As proposed in issue #293

This will make it easier to verify proper scheduling behavior of services implemented using rx.
