### PR TITLE
Update Observable.isInternalImplementation, get rid of NullPointerExcept...

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -3745,7 +3745,8 @@ public class Observable<T> {
         if (o instanceof AtomicObserver)
             return true;
         // we treat the following package as "internal" and don't wrap it
-        return o.getClass().getPackage().getName().startsWith("rx.operators");
+        Package p = o.getClass().getPackage(); // it can be null
+        return p != null && p.getName().startsWith("rx.operators");
     }
 
     public static class UnitTest {


### PR DESCRIPTION
...ion

NullPointerException has been encountered during my tests. It is because java.lang.Class.getPackage() may return null "... if no package information is available from the archive or codebase" (documented feature).
