### PR TITLE
Getting rid of one of the Gradle 1.6 deprecation warnings

### DIFF
--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -24,8 +24,8 @@ subprojects { project ->
         extension 'jar'
     }
 
-    configurations.add('sources')
-    configurations.add('javadoc')
+    configurations.create('sources')
+    configurations.create('javadoc')
     configurations.archives {
         extendsFrom configurations.sources
         extendsFrom configurations.javadoc


### PR DESCRIPTION
This PR addresses one of Gradle's new deprecation warnings.

(The other warning is caused by the LicensePlugin, as far as I can see.)
