### PR TITLE
Ensure now() is always updated in TestScheduler.advanceTo/By

### DIFF
--- a/rxjava-core/src/main/java/rx/concurrency/TestScheduler.java
+++ b/rxjava-core/src/main/java/rx/concurrency/TestScheduler.java
@@ -80,7 +80,6 @@ public class TestScheduler extends Scheduler {
         while (!queue.isEmpty()) {
             TimedAction<?> current = queue.peek();
             if (current.time > targetTimeInNanos) {
-                time = targetTimeInNanos;
                 break;
             }
             time = current.time;
@@ -88,6 +87,7 @@ public class TestScheduler extends Scheduler {
             // because the queue can have wildcards we have to ignore the type T for the state
             ((Func2<Scheduler, Object, Subscription>) current.action).call(current.scheduler, current.state);
         }
+        time = targetTimeInNanos;
     }
 
     @Override


### PR DESCRIPTION
The TestScheduler advanceTimeTo() and advanceTimeBy() methods only update now() correctly if there is a scheduled event in the work queue after the target time. If the queue is empty, now() is not updated at all. If it has no items after the target time, then now() is updated to the time of the last event on the queue.

The pull request ensures now() is always updated to the target time. There is no check to make sure time always moves forwards, but then that check is not in the current implementation either.
