### PR TITLE
Fix for OperatorOnErrorResumeNextViaObservable and async Resume

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationOnErrorResumeNextViaObservable.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationOnErrorResumeNextViaObservable.java
@@ -84,8 +84,8 @@ public final class OperationOnErrorResumeNextViaObservable<T> {
                 public void onError(Exception ex) {
                     /* remember what the current subscription is so we can determine if someone unsubscribes concurrently */
                     AtomicObservableSubscription currentSubscription = subscriptionRef.get();
-                    // check that we have not been unsubscribed before we can process the error
-                    if (currentSubscription != null) {
+                    // check that we have not been unsubscribed and not already resumed before we can process the error
+                    if (currentSubscription == subscription) {
                         /* error occurred, so switch subscription to the 'resumeSequence' */
                         AtomicObservableSubscription innerSubscription = new AtomicObservableSubscription(resumeSequence.subscribe(observer));
                         /* we changed the sequence, so also change the subscription to the one of the 'resumeSequence' instead */
@@ -148,8 +148,8 @@ public final class OperationOnErrorResumeNextViaObservable<T> {
         @Test
         public void testMapResumeAsyncNext() {
             Subscription sr = mock(Subscription.class);
-            // Trigger failure on the second event
-            Observable<String> w = Observable.from("one", "fail", "two", "three");
+            // Trigger multiple failures
+            Observable<String> w = Observable.from("one", "fail", "two", "three", "fail");
             // Resume Observable is async
             TestObservable resume = new TestObservable(sr, "twoResume", "threeResume");
 


### PR DESCRIPTION
This patch is to ensure that OnErrorResumeNextViaObservable handles source Observables that emit invalid sequences of onNext/onError/onCompleted.

Please see #306 for a more detailed description of how this can occur (and what other fixes might be needed)

To re-create the issue the provided resume Observable itself must be async. Because it does not complete immediately there is a window where the source Observable can produce additional events which are then propogated into the output. 

The fix ensures the operator only propogates onNext/onCompleted as long as the original subscription is valid. It also prevents the resume subscription happening more than once even if multiple onError events being received.
