### PR TITLE
Preserve metadata on fn and action macros

### DIFF
--- a/language-adaptors/rxjava-clojure/build.gradle
+++ b/language-adaptors/rxjava-clojure/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
 tasks.compileExamplesClojure.classpath = files(tasks.compileClojure.destinationDir) + tasks.compileClojure.classpath
 
+clojureTest.dependsOn compileTestJava
 /*
  * Clojure
  */

--- a/language-adaptors/rxjava-clojure/src/main/clojure/rx/lang/clojure/interop.clj
+++ b/language-adaptors/rxjava-clojure/src/main/clojure/rx/lang/clojure/interop.clj
@@ -66,11 +66,13 @@
 
   "
   [& fn-form]
+  ; preserve metadata so type hints work
   ; have to qualify fn*. Otherwise bad things happen with the fn* special form in clojure
-  `(rx.lang.clojure.interop/fn* (clojure.core/fn ~@fn-form)))
+  (with-meta `(rx.lang.clojure.interop/fn* (clojure.core/fn ~@fn-form))
+             (meta &form)))
 
 (defn action*
-  "Given function f, returns an object that implements rx.util.functions.Action0-9
+  "Given function f, returns an object that implements rx.util.functions.Action0-3
   by delegating to the given function.
 
   Example:
@@ -93,6 +95,8 @@
 
   "
   [& fn-form]
-  `(action* (clojure.core/fn ~@fn-form)))
+  ; preserve metadata so type hints work
+  (with-meta `(action* (clojure.core/fn ~@fn-form))
+             (meta &form)))
 
 ;################################################################################

--- a/language-adaptors/rxjava-clojure/src/test/java/rx/lang/clojure/interop/DummyObservable.java
+++ b/language-adaptors/rxjava-clojure/src/test/java/rx/lang/clojure/interop/DummyObservable.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.lang.clojure.interop;
+
+// Dummy class with some overloads to make sure that type hinting works
+// correctly with the fn and action macros. Used only for testing.
+public class DummyObservable {
+
+    public String call(Object f) {
+        return "Object";
+    }
+
+    public String call(rx.util.functions.Func1 f) {
+        return "rx.util.functions.Func1";
+    }
+
+    public String call(rx.util.functions.Func2 f) {
+        return "rx.util.functions.Func2";
+    }
+
+    public String call(rx.util.functions.Action1 f) {
+        return "rx.util.functions.Action1";
+    }
+
+    public String call(rx.util.functions.Action2 f) {
+        return "rx.util.functions.Action2";
+    }
+
+}


### PR DESCRIPTION
Because they're macros, rx/fn and rx/action would lose metadata attached
to them, in particular type hints which are slightly important to
disambiguate overloaded Observable methods. Fixed.
