### PR TITLE
Change Interval and Sample default Scheduler

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationInterval.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationInterval.java
@@ -46,7 +46,7 @@ public final class OperationInterval {
      * Creates an event each time interval.
      */
     public static OnSubscribeFunc<Long> interval(long interval, TimeUnit unit) {
-        return interval(interval, unit, Schedulers.executor(Executors.newSingleThreadScheduledExecutor()));
+        return interval(interval, unit, Schedulers.threadPoolForComputation());
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/operators/OperationSample.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSample.java
@@ -49,7 +49,7 @@ public final class OperationSample {
      * Samples the observable sequence at each interval.
      */
     public static <T> OnSubscribeFunc<T> sample(final Observable<? extends T> source, long period, TimeUnit unit) {
-        return new Sample<T>(source, period, unit, Schedulers.executor(Executors.newSingleThreadScheduledExecutor()));
+        return new Sample<T>(source, period, unit, Schedulers.threadPoolForComputation());
     }
 
     /**


### PR DESCRIPTION
Change to use built-in thread-pools rather than creating a new Executor on each invocation.
The built-in ones are shared across all operators, have threads ready, are marked as daemon threads so don't prevent system shutdown, and are named for clarity when looking at thread dumps and debuggers.

This fixes https://github.com/Netflix/RxJava/issues/388
