### PR TITLE
Removing 'comparator` overloads of `distinct`

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -3047,39 +3047,6 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that forwards all items emitted from the source Observable that are sequentially
-     * distinct according to a comparator.
-     * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinctUntilChanged.png">
-     * 
-     * @param equalityComparator
-     *            a comparator for deciding whether two emitted items are equal or not
-     * @return an Observable of sequentially distinct items
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229776%28v=vs.103%29.aspx">MSDN: Observable.distinctUntilChanged</a>
-     */
-    public <U> Observable<T> distinctUntilChanged(Comparator<T> equalityComparator) {
-        return create(OperationDistinctUntilChanged.distinctUntilChanged(this, equalityComparator));
-    }
-
-    /**
-     * Returns an Observable that forwards all items emitted from the source Observable that are sequentially
-     * distinct according to a key selector function and a comparator.
-     * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinctUntilChanged.key.png">
-     * 
-     * @param keySelector
-     *            a function that projects an emitted item to a key value which is used for deciding whether an item is sequentially
-     *            distinct from another one or not
-     * @param equalityComparator
-     *            a comparator for deciding whether two emitted item keys are equal or not
-     * @return an Observable of sequentially distinct items
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229533%28v=vs.103%29.aspx">MSDN: Observable.distinctUntilChanged</a>
-     */
-    public <U> Observable<T> distinctUntilChanged(Func1<? super T, ? extends U> keySelector, Comparator<U> equalityComparator) {
-        return create(OperationDistinctUntilChanged.distinctUntilChanged(this, keySelector, equalityComparator));
-    }
-
-    /**
      * Returns an Observable that forwards all distinct items emitted from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.png">
@@ -3089,21 +3056,6 @@ public class Observable<T> {
      */
     public Observable<T> distinct() {
         return create(OperationDistinct.distinct(this));
-    }
-    
-    /**
-     * Returns an Observable that forwards all items emitted from the source Observable that are distinct according
-     * to a comparator.
-     * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.png">
-     * 
-     * @param equalityComparator
-     *            a comparator for deciding whether two emitted items are equal or not
-     * @return an Observable of distinct items
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh211630(v=vs.103).aspx">MSDN: Observable.distinct</a>
-     */
-    public <U> Observable<T> distinct(Comparator<T> equalityComparator) {
-        return create(OperationDistinct.distinct(this, equalityComparator));
     }
     
     /**
@@ -3120,24 +3072,6 @@ public class Observable<T> {
      */
     public <U> Observable<T> distinct(Func1<? super T, ? extends U> keySelector) {
         return create(OperationDistinct.distinct(this, keySelector));
-    }
-    
-    /**
-     * Returns an Observable that forwards all items emitted from the source Observable that are distinct according
-     * to a key selector function and a comparator.
-     * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.key.png">
-     * 
-     * @param keySelector
-     *            a function that projects an emitted item to a key value which is used for deciding whether an item is
-     *            distinct from another one or not
-     * @param equalityComparator
-     *            a comparator for deciding whether two emitted item keys are equal or not
-     * @return an Observable of distinct items
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229050(v=vs.103).aspx">MSDN: Observable.distinct</a>
-     */
-    public <U> Observable<T> distinct(Func1<? super T, ? extends U> keySelector, Comparator<U> equalityComparator) {
-        return create(OperationDistinct.distinct(this, keySelector, equalityComparator));
     }
     
     /**


### PR DESCRIPTION
Removing these fairly recently added overloads as they turn out to not be the best approach.

Discussion ongoing as to how to implement them at https://github.com/Netflix/RxJava/issues/395
