### PR TITLE
Do not run RxScalaDemo on each build

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -23,7 +23,7 @@ import org.junit.{Before, Test, Ignore}
 import org.junit.Assert._
 import rx.lang.scala.concurrency.NewThreadScheduler
 
-//@Ignore // Since this doesn't do automatic testing, don't increase build time unnecessarily
+@Ignore // Since this doesn't do automatic testing, don't increase build time unnecessarily
 class RxScalaDemo extends JUnitSuite {
 
   @Test def intervalExample() {


### PR DESCRIPTION
On my last pull request, I forgot to uncomment the line which ignores `RxScalaDemo`, so currently it is executed on each build, even though it does no automatic testing. And since `RxScalaDemo` takes about 48 seconds, this significantly increases build time. Sorry for this...

After this change, the complete build took 3 mins 33.932 secs on my 3 years old laptop, so if cloudbees can't build it in 10 min, there might be something else not properly working...
