### PR TITLE
update counter before triggering latch

### DIFF
--- a/rxjava-core/src/test/java/rx/concurrency/TestSchedulers.java
+++ b/rxjava-core/src/test/java/rx/concurrency/TestSchedulers.java
@@ -361,8 +361,8 @@ public class TestSchedulers {
             @Override
             public Subscription call(Scheduler scheduler, String state) {
                 System.out.println("doing work");
-                latch.countDown();
                 counter.incrementAndGet();
+                latch.countDown();
                 if (latch.getCount() == 0) {
                     return Subscriptions.empty();
                 } else {


### PR DESCRIPTION
as mentioned in #383

rx.concurrency.TestSchedulers.testSchedulingWithDueTime

is flaky because there is a race-condition where the test can assert the counter value before it is updated. fix is just to update the counter before releasing the latch.
