### PR TITLE
Fixed the issues of takeLast(items, 0) and null values

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationTakeLast.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationTakeLast.java
@@ -15,18 +15,22 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.util.Iterator;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
 import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
-import rx.subscriptions.Subscriptions;
 import rx.Observer;
 import rx.Subscription;
 
@@ -60,33 +64,21 @@ public final class OperationTakeLast {
         }
 
         public Subscription onSubscribe(Observer<? super T> observer) {
-            if(count == 0) {
-                items.subscribe(new Observer<T>() {
-
-                    @Override
-                    public void onCompleted() {
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(T args) {
-                    }
-
-                }).unsubscribe();
-                observer.onCompleted();
-                return Subscriptions.empty();
+            if (count < 0) {
+                throw new IndexOutOfBoundsException(
+                        "count could not be negative");
             }
-
             return subscription.wrap(items.subscribe(new ItemObserver(observer)));
         }
 
         private class ItemObserver implements Observer<T> {
 
-            private LinkedBlockingDeque<T> deque = new LinkedBlockingDeque<T>(count);
+            /**
+             * Store the last count elements until now.
+             */
+            private Deque<T> deque = new LinkedList<T>();
             private final Observer<? super T> observer;
+            private final ReentrantLock lock = new ReentrantLock();
 
             public ItemObserver(Observer<? super T> observer) {
                 this.observer = observer;
@@ -94,11 +86,14 @@ public final class OperationTakeLast {
 
             @Override
             public void onCompleted() {
-                Iterator<T> reverse = deque.descendingIterator();
-                while (reverse.hasNext()) {
-                    observer.onNext(reverse.next());
+                try {
+                    for (T value : deque) {
+                        observer.onNext(value);
+                    }
+                    observer.onCompleted();
+                } catch (Throwable e) {
+                    observer.onError(e);
                 }
-                observer.onCompleted();
             }
 
             @Override
@@ -107,9 +102,27 @@ public final class OperationTakeLast {
             }
 
             @Override
-            public void onNext(T args) {
-                while (!deque.offerFirst(args)) {
-                    deque.removeLast();
+            public void onNext(T value) {
+                if (count == 0) {
+                    // If count == 0, we do not need to put value into deque and
+                    // remove it at once. We can ignore the value directly.
+                    return;
+                }
+                lock.lock();
+                try {
+                    deque.offerLast(value);
+                    if (deque.size() > count) {
+                        // Now deque has count + 1 elements, so the first
+                        // element in the deque definitely does not belong
+                        // to the last count elements of the source
+                        // sequence. We can drop it now.
+                        deque.removeFirst();
+                    }
+                } catch (Throwable e) {
+                    observer.onError(e);
+                    subscription.unsubscribe();
+                } finally {
+                    lock.unlock();
                 }
             }
 
@@ -172,6 +185,35 @@ public final class OperationTakeLast {
             verify(aObserver, never()).onNext("one");
             verify(aObserver, never()).onError(any(Throwable.class));
             verify(aObserver, times(1)).onCompleted();
+        }
+
+        @Test
+        public void testTakeLastWithNull() {
+            Observable<String> w = Observable.from("one", null, "three");
+            Observable<String> take = Observable.create(takeLast(w, 2));
+
+            @SuppressWarnings("unchecked")
+            Observer<String> aObserver = mock(Observer.class);
+            take.subscribe(aObserver);
+            verify(aObserver, never()).onNext("one");
+            verify(aObserver, times(1)).onNext(null);
+            verify(aObserver, times(1)).onNext("three");
+            verify(aObserver, never()).onError(any(Throwable.class));
+            verify(aObserver, times(1)).onCompleted();
+        }
+
+        @Test
+        public void testTakeLastWithNegativeCount() {
+            Observable<String> w = Observable.from("one");
+            Observable<String> take = Observable.create(takeLast(w, -1));
+
+            @SuppressWarnings("unchecked")
+            Observer<String> aObserver = mock(Observer.class);
+            take.subscribe(aObserver);
+            verify(aObserver, never()).onNext("one");
+            verify(aObserver, times(1)).onError(
+                    any(IndexOutOfBoundsException.class));
+            verify(aObserver, never()).onCompleted();
         }
 
     }


### PR DESCRIPTION
Hi,

There are two issues about `takeLast` #85 #140. The essential cause is `LinkedBlockingDeque`.
1. count == 0
   `takeLast` in RxJava will throw an exception when count == 0, as `LinkedBlockingDeque` rejects count <= 0. However, in c#, TakeLast with 0 count is valid. The following codes is OK in C# (no exception and do nothing):

``` c#
            var source = Observable.Return(1).TakeLast(0);
            source.Subscribe(
                x => 
                    Console.WriteLine("subscriber got " + x)
            );
            Console.ReadLine();
```
1. null values
   LinkedBlockingDeque requires the elements can not be null but an observable can emit a null value.

I used `ReentrantLock` and `LinkedList` to replace `LinkedBlockingDeque`. Please take a look. Thanks.
