### PR TITLE
Adding collect method to Scala Observable

### DIFF
--- a/language-adaptors/rxjava-scala/README.md
+++ b/language-adaptors/rxjava-scala/README.md
@@ -40,6 +40,9 @@ def sample(duration: Duration): Observable[T]
 // called skip in Java, but drop in Scala
 def drop(n: Int): Observable[T] 
 
+// the Scala collect method
+def collect[R](pf: PartialFunction[T, R]): Observable[R]
+
 // there's only mapWithIndex in Java, because Java doesn't have tuples:
 def zipWithIndex: Observable[(T, Int)] 
 

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
@@ -655,6 +655,19 @@ class Observable[+T](val asJava: rx.Observable[_ <: T])
   }
 
   /**
+   * The classic collect operation from the Scala collection library. Takes a partial function
+   * and filters only those elements for which the function is defined and then applies the
+   * function on those elements
+   *
+   * @param pf A partial function that will be applied to the elements emitted by this Observable
+   * @return A new observable that emits elements from the source observable if those elements are in the
+   *         partial function's domain, transformed by the partial function
+   */
+  def collect[R](pf: PartialFunction[T, R]): Observable[R] = {
+    filter(pf.isDefinedAt).map(pf)
+  }
+
+  /**
    * Registers an {@link Action0} to be called when this Observable invokes {@link Observer#onCompleted onCompleted} or {@link Observer#onError onError}.
    * <p>
    * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/finallyDo.png">


### PR DESCRIPTION
I think it's a good idea to add a `collect` method analogous with the one in the Scala collection library. It was simplest to implement it using a combination of `filter` & `map`.

If you find any major disadvantages with this please chime in.
