### PR TITLE
[RFC] Initial implementation of OperationObserveInForeground (Android)

### DIFF
--- a/rxjava-contrib/rxjava-android/build.gradle
+++ b/rxjava-contrib/rxjava-android/build.gradle
@@ -2,10 +2,13 @@ apply plugin: 'osgi'
 
 dependencies {
     compile project(':rxjava-core')
+    provided 'com.google.android:android:4.0.1.2'
+    provided 'com.google.android:support-v4:r7'
+
+    // testing
     provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
     provided 'org.robolectric:robolectric:2.1.1'
-    provided 'com.google.android:android:4.0.1.2'
 }
 
 javadoc {

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/FragmentAware.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/FragmentAware.java
@@ -1,0 +1,9 @@
+package rx.operators;
+
+import android.app.Fragment;
+
+public interface FragmentAware {
+
+    Fragment getFragment();
+
+}

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/FragmentObserver.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/FragmentObserver.java
@@ -1,0 +1,17 @@
+package rx.operators;
+
+import rx.Observer;
+
+public class FragmentObserver<T> implements Observer<T> {
+    @Override
+    public void onCompleted() {
+    }
+
+    @Override
+    public void onError(Throwable e) {
+    }
+
+    @Override
+    public void onNext(T args) {
+    }
+}

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperationObserveInForeground.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperationObserveInForeground.java
@@ -1,0 +1,75 @@
+package rx.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import rx.Observable;
+import rx.Observer;
+import rx.Subscription;
+import rx.android.concurrency.AndroidSchedulers;
+
+public class OperationObserveInForeground {
+
+    public static <T> Observable<T> observeInForeground(Observable<T> source) {
+        return Observable.create(new ObserveInForeground<T>(source));
+    }
+
+    private static final class ObserveInForeground<T> implements Observable.OnSubscribeFunc<T> {
+
+        private final Observable<T> source;
+
+        private ObserveInForeground(Observable<T> source) {
+            this.source = source;
+        }
+
+        @Override
+        public Subscription onSubscribe(final Observer<? super T> observer) {
+            if (!isValidObserver(observer)) {
+                throw new IllegalArgumentException("Observer must be one of: " +
+                 FragmentObserver.class.getCanonicalName() + "\n" +
+                 SupportFragmentObserver.class.getCanonicalName());
+            }
+            return source.observeOn(AndroidSchedulers.mainThread()).subscribe(observer);
+        }
+
+        private boolean isValidObserver(final Observer<? super T> observer) {
+            return observer instanceof FragmentObserver || observer instanceof SupportFragmentObserver;
+        }
+    }
+
+    @RunWith(RobolectricTestRunner.class)
+    @Config(manifest = Config.NONE)
+    public static final class UnitTest {
+
+        @Mock
+        private FragmentObserver mockObserver;
+
+        @Mock
+        private Observable<Integer> mockObservable;
+
+        @Before
+        public void setupMocks() {
+            MockitoAnnotations.initMocks(this);
+        }
+
+        @Test
+        public void itObservesTheSourceSequenceOnTheMainUIThread() {
+            OperationObserveInForeground.observeInForeground(mockObservable).subscribe(mockObserver);
+            verify(mockObservable).observeOn(AndroidSchedulers.mainThread());
+        }
+
+        public void itFailsTheSequenceIfAWrongObserverTypeIsUsed() {
+            Observer<Integer> wrongObserver = mock(Observer.class); // plain observers not allowed
+            OperationObserveInForeground.observeInForeground(mockObservable).subscribe(wrongObserver);
+            verify(mockObserver).onError(any(IllegalArgumentException.class));
+        }
+    }
+}

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/SupportFragmentAware.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/SupportFragmentAware.java
@@ -1,0 +1,9 @@
+package rx.operators;
+
+import android.support.v4.app.Fragment;
+
+public interface SupportFragmentAware {
+
+    Fragment getFragment();
+
+}

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/SupportFragmentObserver.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/SupportFragmentObserver.java
@@ -1,0 +1,223 @@
+package rx.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import rx.Observable;
+import rx.Observer;
+import rx.subjects.PublishSubject;
+
+import android.support.v4.app.Fragment;
+
+import java.lang.ref.WeakReference;
+
+
+public class SupportFragmentObserver<T> implements Observer<T> {
+
+    private final WeakReference<Observer<T>> wrappedRef;
+    private final WeakReference<Fragment> fragmentRef;
+
+    public <ObserverT extends Fragment & Observer<T>> SupportFragmentObserver(ObserverT wrapped) {
+        this(new WeakReference<Observer<T>>(wrapped), new WeakReference<Fragment>(wrapped));
+    }
+
+    public <ObserverT extends SupportFragmentAware & Observer<T>> SupportFragmentObserver(ObserverT wrapped) {
+        this(new WeakReference<Observer<T>>(wrapped), new WeakReference<Fragment>(wrapped.getFragment()));
+    }
+
+    SupportFragmentObserver(final WeakReference<Observer<T>> observerRef,
+                            final WeakReference<Fragment> fragmentRef) {
+        this.wrappedRef = observerRef;
+        this.fragmentRef = fragmentRef;
+    }
+
+    @Override
+    public void onCompleted() {
+        final Observer<T> target = wrappedRef.get();
+        final Fragment fragment = fragmentRef.get();
+        if (forwardMessage(target, fragment)) {
+            target.onCompleted();
+        }
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        final Observer<T> target = wrappedRef.get();
+        final Fragment fragment = fragmentRef.get();
+        if (forwardMessage(target, fragment)) {
+            target.onError(e);
+        }
+    }
+
+    @Override
+    public void onNext(T args) {
+        final Observer<T> target = wrappedRef.get();
+        final Fragment fragment = fragmentRef.get();
+        if (forwardMessage(target, fragment)) {
+            target.onNext(args);
+        }
+    }
+
+    private boolean forwardMessage(final Observer<T> target, final Fragment fragment) {
+        return (target != null && fragment != null && fragment.isAdded());
+    }
+
+    @RunWith(RobolectricTestRunner.class)
+    @Config(manifest = Config.NONE)
+    public static final class UnitTest {
+
+        private interface WrappedObserverType extends Observer<Integer>, SupportFragmentAware {}
+
+        @Mock
+        private WrappedObserverType mockObserver;
+
+        @Mock
+        private Fragment mockFragment;
+
+        @Mock
+        private Observable<Integer> mockObservable;
+
+        @Before
+        public void setupMocks() {
+            MockitoAnnotations.initMocks(this);
+            when(mockFragment.isAdded()).thenReturn(true);
+            when(mockObserver.getFragment()).thenReturn(mockFragment);
+        }
+
+        @Test
+        public void itForwardsOnNextOnCompletedSequenceToTargetObserver() {
+            Observable<Integer> source = Observable.from(1, 2, 3);
+            source.subscribe(new SupportFragmentObserver<Integer>(mockObserver));
+            verify(mockObserver, times(3)).onNext(anyInt());
+            verify(mockObserver).onCompleted();
+            verify(mockObserver, never()).onError(any(Exception.class));
+        }
+
+        @Test
+        public void itForwardsOnErrorToTargetObserver() {
+            final Exception exception = new Exception();
+            Observable<Integer> source = Observable.error(exception);
+            source.subscribe(new SupportFragmentObserver<Integer>(mockObserver));
+            verify(mockObserver).onError(exception);
+            verify(mockObserver, never()).onNext(anyInt());
+            verify(mockObserver, never()).onCompleted();
+        }
+
+        @Test
+        public void itDropsOnNextOnCompletedSequenceIfFragmentIsGone() {
+            PublishSubject<Integer> source = PublishSubject.create();
+            WeakReference<Fragment> fragmentRef = new WeakReference<Fragment>(mockFragment);
+
+            source.subscribe(new SupportFragmentObserver<Integer>(
+                    new WeakReference<Observer<Integer>>(mockObserver), fragmentRef));
+
+            source.onNext(1);
+            fragmentRef.clear();
+
+            source.onNext(2);
+            source.onNext(3);
+            source.onCompleted();
+
+            verify(mockObserver).onNext(1);
+            verifyNoMoreInteractions(mockObserver);
+        }
+
+        @Test
+        public void itDropsOnNextOnCompletedSequenceIfObserverIsGone() {
+            PublishSubject<Integer> source = PublishSubject.create();
+            WeakReference<Observer<Integer>> observerRef = new WeakReference<Observer<Integer>>(mockObserver);
+
+            source.subscribe(new SupportFragmentObserver<Integer>(
+                    observerRef, new WeakReference<Fragment>(mockFragment)));
+
+            source.onNext(1);
+            observerRef.clear();
+
+            source.onNext(2);
+            source.onNext(3);
+            source.onCompleted();
+
+            verify(mockObserver).onNext(1);
+            verifyNoMoreInteractions(mockObserver);
+        }
+
+        @Test
+        public void itDropsOnErrorIfFragmentIsGone() {
+            PublishSubject<Integer> source = PublishSubject.create();
+            WeakReference<Fragment> fragmentRef = new WeakReference<Fragment>(mockFragment);
+
+            source.subscribe( new SupportFragmentObserver<Integer>(
+                    new WeakReference<Observer<Integer>>(mockObserver), fragmentRef));
+
+            source.onNext(1);
+            fragmentRef.clear();
+
+            source.onError(new Exception());
+
+            verify(mockObserver).onNext(1);
+            verifyNoMoreInteractions(mockObserver);
+        }
+
+        @Test
+        public void itDropsOnErrorIfSourceObserverIsGone() {
+            PublishSubject<Integer> source = PublishSubject.create();
+            WeakReference<Observer<Integer>> observerRef = new WeakReference<Observer<Integer>>(mockObserver);
+
+            source.subscribe(new SupportFragmentObserver<Integer>(
+                    observerRef, new WeakReference<Fragment>(mockFragment)));
+
+            source.onNext(1);
+            observerRef.clear();
+
+            source.onError(new Exception());
+
+            verify(mockObserver).onNext(1);
+            verifyNoMoreInteractions(mockObserver);
+        }
+
+        @Test
+        public void itDoesNotForwardOnNextOnCompletedSequenceIfFragmentIsDetached() {
+            PublishSubject<Integer> source = PublishSubject.create();
+            source.subscribe(new SupportFragmentObserver<Integer>(mockObserver));
+
+            source.onNext(1);
+
+            when(mockFragment.isAdded()).thenReturn(false);
+            source.onNext(2);
+            source.onNext(3);
+            source.onCompleted();
+
+            verify(mockObserver).onNext(1);
+            verify(mockObserver, never()).onCompleted();
+        }
+
+        @Test
+        public void itDoesNotForwardOnErrorIfFragmentIsDetached() {
+            PublishSubject<Integer> source = PublishSubject.create();
+            source.subscribe(new SupportFragmentObserver<Integer>(mockObserver));
+
+            source.onNext(1);
+
+            when(mockFragment.isAdded()).thenReturn(false);
+            source.onError(new Exception());
+
+            verify(mockObserver).onNext(1);
+            verify(mockObserver, never()).onError(any(Exception.class));
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
In reference to the discussion in [0] and our work with RxJava on Android, here is an initial attempt at providing an Rx operator which wraps the boilerplate required to observe sequences on Android UI components like Fragments and Activities (although I should mention that I haven't added support for the latter yet but focused on Fragments from the support-v4 library.)

Here's what I did:
- provide an operator which accepts a specialized observer type that is able to expose a Fragment reference. This is essential for us to decide whether it's safe to forward messages to that fragment, and we can only ask the fragment itself to make that decision
- schedule observer callbacks on the Android UI thread by default

There is some discussions to be had around this. I would really appreciate if everyone with and without Android experience could weigh in. Specific questions I think need discussing:
- I am terminating the sequence early if the caller does not subscribe using one of the specialized Observer types I provide (`FragmentObserver` or `SupportFragmentObserver` for native and back-compat fragments respectively). As mentioned above, I must force the caller to give me a reference to the fragment, since otherwise callbacks cannot be executed in a safe manner (safe w.r.t. not calling back in case Android decided to remove the fragment from the window; this is a life-cycle event in Android which cannot be intercepted other than asking the fragment whether it's still attached or not). I realize this has a smell to it, but I don't see another option.
- the specialized observer class keeps weak references to the source observer and the fragment (both can be the same object, but then again, could also not if e.g. you use inner classes as observers). In case the references got cleared, messages will be dropped
- Naming: observeInForeground is the best I could come up with, which doesn't mean much :-) Feel free to submit better naming suggestions

TODO:
- Implement native `FragmentObserver` in the same manner as `SupportFragmentObserver` (the latter is what we need so I built that one first)
- Add `ActivityObserver` in the same manner
- Think about auto-unsubscribing from the source sequence in case the references got cleared

[0] https://groups.google.com/forum/?fromgroups=#!topic/rxjava/7o_NJw36Enw
