### PR TITLE
Fixed issue #428

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
+++ b/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
@@ -187,8 +187,11 @@ public class ChunkedOperation {
                 return;
             }
 
-            subscription.unsubscribe();
+            // Fixed issue 428.
+            // As unsubscribe will cancel the Future, and the currrent thread's interrupt status
+            // will be set. So we need to emit the chunk before unsubscribe.
             super.emitChunk(chunk);
+            subscription.unsubscribe();
             createChunk();
         }
 


### PR DESCRIPTION
I fixed the issue #428. This issus is because the wrong order of `unsubscribe` and `emitChunk`.

`unsubscribe` will cancel the Future, and the currrent thread's interrupt status will be set. If `unsubscribe` is called before `emitChunk`, the currrent thread's interrupt status has already set before `emitChunk`. It may confuse users when they have some codes depending on the interrupt status.

I put `emitChunk` before `unsubscribe` and added a unit test for it.
