### PR TITLE
Reimplemented the 'reduce' operator

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -3522,29 +3522,13 @@ public class Observable<T> {
      *            Observable, whose result will be used in the next accumulator call
      * @return an Observable that emits a single item that is the result of accumulating the
      *         output from the source Observable
-     * @throws UnsupportedOperationException
-     *            the Observable is empty
+     * @throws IllegalArgumentException
+     *            When the Observable is empty, Observers will receive an onError notification with an IllegalArgumentException.
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229154(v%3Dvs.103).aspx">MSDN: Observable.Aggregate</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
      */
     public Observable<T> reduce(Func2<T, T, T> accumulator) {
-        return create(OperationScan.scan(this, accumulator)).takeLast(1).assertNonEmpty();
-    }
-
-    private Observable<T> assertNonEmpty() {
-        return materialize().map(new Func1<Notification<T>, Notification<T>>() {
-            private boolean isEmpty = true;
-            @Override
-            public Notification<T> call(Notification<T> t1) {
-                if (t1.isOnNext()) {
-                    isEmpty = false;
-                }
-                else if (t1.isOnCompleted() && isEmpty) {
-                    return new Notification<T>(new UnsupportedOperationException("Can not apply on an empty sequence"));
-                }
-                return t1;
-            }
-        }).dematerialize();
+        return create(OperationScan.scan(this, accumulator)).last();
     }
 
     /**
@@ -3797,7 +3781,7 @@ public class Observable<T> {
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
      */
     public <R> Observable<R> reduce(R initialValue, Func2<R, ? super T, R> accumulator) {
-        return create(OperationScan.scan(this, initialValue, accumulator)).takeLast(1);
+        return create(OperationScan.scan(this, initialValue, accumulator)).last();
     }
 
     /**

--- a/rxjava-core/src/test/java/rx/ReduceTests.java
+++ b/rxjava-core/src/test/java/rx/ReduceTests.java
@@ -15,8 +15,8 @@
  */
 package rx;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -213,8 +213,7 @@ public class ReduceTests {
         m.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                any(UnsupportedOperationException.class));
+        inOrder.verify(observer, times(1)).onError(isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
 }


### PR DESCRIPTION
Hi,

I reimplemented the 'reduce' operator. The improvements are as follow:
- As I mentioned in #423, 'reduce' should throw an exception when applying on an empty sequence without an initial value.
- Now 'reduce' does not need a 'takeLast' operator, and should be more efficient.
