### PR TITLE
OperationSwitch notify onComplete() too early.

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationSwitch.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSwitch.java
@@ -173,7 +173,6 @@ public final class OperationSwitch {
         @Override
         public void onCompleted() {
             synchronized (gate) {
-                this.child.unsubscribe();
                 this.stopped = true;
                 if (!this.hasLatest) {
                     this.observer.onCompleted();


### PR DESCRIPTION
OperationSwitch has to wait that both parent and child complete before complete itself.
