### PR TITLE
Don't emit null onComplete when no onNext received in AsyncSubject

### DIFF
--- a/rxjava-core/src/test/java/rx/subjects/AsyncSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/AsyncSubjectTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2013 Netflix, Inc.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import rx.Observer;
@@ -42,10 +43,6 @@ public class AsyncSubjectTest {
         subject.onNext("two");
         subject.onNext("three");
 
-        assertNeverCompletedObserver(aObserver);
-    }
-
-    private void assertNeverCompletedObserver(Observer<String> aObserver) {
         verify(aObserver, Mockito.never()).onNext(anyString());
         verify(aObserver, Mockito.never()).onError(testException);
         verify(aObserver, Mockito.never()).onCompleted();
@@ -64,10 +61,6 @@ public class AsyncSubjectTest {
         subject.onNext("three");
         subject.onCompleted();
 
-        assertCompletedObserver(aObserver);
-    }
-
-    private void assertCompletedObserver(Observer<String> aObserver) {
         verify(aObserver, times(1)).onNext("three");
         verify(aObserver, Mockito.never()).onError(any(Throwable.class));
         verify(aObserver, times(1)).onCompleted();
@@ -89,10 +82,6 @@ public class AsyncSubjectTest {
         subject.onError(new Throwable());
         subject.onCompleted();
 
-        assertErrorObserver(aObserver);
-    }
-
-    private void assertErrorObserver(Observer<String> aObserver) {
         verify(aObserver, Mockito.never()).onNext(anyString());
         verify(aObserver, times(1)).onError(testException);
         verify(aObserver, Mockito.never()).onCompleted();
@@ -110,15 +99,14 @@ public class AsyncSubjectTest {
         subject.onNext("two");
 
         subscription.unsubscribe();
-        assertNoOnNextEventsReceived(aObserver);
+
+        verify(aObserver, Mockito.never()).onNext(anyString());
+        verify(aObserver, Mockito.never()).onError(any(Throwable.class));
+        verify(aObserver, Mockito.never()).onCompleted();
 
         subject.onNext("three");
         subject.onCompleted();
 
-        assertNoOnNextEventsReceived(aObserver);
-    }
-
-    private void assertNoOnNextEventsReceived(Observer<String> aObserver) {
         verify(aObserver, Mockito.never()).onNext(anyString());
         verify(aObserver, Mockito.never()).onError(any(Throwable.class));
         verify(aObserver, Mockito.never()).onCompleted();
@@ -145,5 +133,22 @@ public class AsyncSubjectTest {
                 },
                 null
                 );
+    }
+
+    @Test
+    public void testEmptySubjectCompleted() {
+        AsyncSubject<String> subject = AsyncSubject.create();
+
+        @SuppressWarnings("unchecked")
+        Observer<String> aObserver = mock(Observer.class);
+        subject.subscribe(aObserver);
+
+        subject.onCompleted();
+
+        InOrder inOrder = inOrder(aObserver);
+        inOrder.verify(aObserver, never()).onNext(null);
+        inOrder.verify(aObserver, never()).onNext(any(String.class));
+        inOrder.verify(aObserver, times(1)).onCompleted();
+        inOrder.verifyNoMoreInteractions();
     }
 }


### PR DESCRIPTION
Reported via email by @axel22 and @headinthebox 
