### PR TITLE
BugFix: Emit an IllegalArgumentException instead of ArithmeticException if the observable is empty

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -3593,7 +3593,7 @@ public class Observable<T> {
 
     /**
      * Returns an Observable that computes the average of all elements in the source Observable.
-     * For an empty source, it causes an ArithmeticException.
+     * For an empty source, it causes an IllegalArgumentException.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
@@ -3601,6 +3601,8 @@ public class Observable<T> {
      *            Source observable to compute the average of.
      * @return an Observable emitting the averageof all the elements of the source Observable
      *         as its single item.
+     * @throws IllegalArgumentException
+     *             if Observable sequence is empty.
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average%28v=vs.103%29.aspx">MSDN: Observable.Average</a>
      */
     public static Observable<Integer> average(Observable<Integer> source) {

--- a/rxjava-core/src/main/java/rx/operators/OperationAverage.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationAverage.java
@@ -44,7 +44,10 @@ public final class OperationAverage {
         }).map(new Func1<Tuple2<Integer>, Integer>() {
             @Override
             public Integer call(Tuple2<Integer> result) {
-                return result.current / result.count; // may throw DivisionByZero, this should be correct...
+                if (result.count == 0) {
+                    throw new IllegalArgumentException("Sequence contains no elements");
+                }
+                return result.current / result.count;
             }
         });
     }
@@ -58,7 +61,10 @@ public final class OperationAverage {
         }).map(new Func1<Tuple2<Long>, Long>() {
             @Override
             public Long call(Tuple2<Long> result) {
-                return result.current / result.count; // may throw DivisionByZero, this should be correct...
+                if (result.count == 0) {
+                    throw new IllegalArgumentException("Sequence contains no elements");
+                }
+                return result.current / result.count;
             }
         });
     }
@@ -73,7 +79,7 @@ public final class OperationAverage {
             @Override
             public Float call(Tuple2<Float> result) {
                 if (result.count == 0) {
-                    throw new ArithmeticException("divide by zero");
+                    throw new IllegalArgumentException("Sequence contains no elements");
                 }
                 return result.current / result.count;
             }
@@ -90,7 +96,7 @@ public final class OperationAverage {
             @Override
             public Double call(Tuple2<Double> result) {
                 if (result.count == 0) {
-                    throw new ArithmeticException("divide by zero");
+                    throw new IllegalArgumentException("Sequence contains no elements");
                 }
                 return result.current / result.count;
             }

--- a/rxjava-core/src/test/java/rx/operators/OperationAverageTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationAverageTest.java
@@ -52,7 +52,7 @@ public class OperationAverageTest {
         average(src).subscribe(w);
 
         verify(w, never()).onNext(anyInt());
-        verify(w, times(1)).onError(any(ArithmeticException.class));
+        verify(w, times(1)).onError(isA(IllegalArgumentException.class));
         verify(w, never()).onCompleted();
     }
 
@@ -73,7 +73,7 @@ public class OperationAverageTest {
         averageLongs(src).subscribe(wl);
 
         verify(wl, never()).onNext(anyLong());
-        verify(wl, times(1)).onError(any(ArithmeticException.class));
+        verify(wl, times(1)).onError(isA(IllegalArgumentException.class));
         verify(wl, never()).onCompleted();
     }
 
@@ -94,7 +94,7 @@ public class OperationAverageTest {
         averageFloats(src).subscribe(wf);
 
         verify(wf, never()).onNext(anyFloat());
-        verify(wf, times(1)).onError(any(ArithmeticException.class));
+        verify(wf, times(1)).onError(isA(IllegalArgumentException.class));
         verify(wf, never()).onCompleted();
     }
 
@@ -115,7 +115,7 @@ public class OperationAverageTest {
         averageDoubles(src).subscribe(wd);
 
         verify(wd, never()).onNext(anyDouble());
-        verify(wd, times(1)).onError(any(ArithmeticException.class));
+        verify(wd, times(1)).onError(isA(IllegalArgumentException.class));
         verify(wd, never()).onCompleted();
     }
 }


### PR DESCRIPTION
This PR fixed the `average` issue in #423. If an observable is empty, `average` will emit an `IllegalArgumentException` instead of `ArithmeticException`. Thanks!
