### PR TITLE
Added  aliases and objects for concrete subject types in Scala.

### DIFF
--- a/language-adaptors/rxjava-scala/TODO.md
+++ b/language-adaptors/rxjava-scala/TODO.md
@@ -18,7 +18,6 @@ TODOs which came up at the meeting with Erik Meijer on 2013-10-11:
 *    There are no examples yet using `async`, but `async` will be used in the course. Write examples and check if everything works as expected when combined with `async`.
 *    Futures: For the moment, just add a Future->Observable converter method to `object Observable`. Later, think if `Future[T] extends Observable[T]`.
 *    Operator `delay`: Once Erik has commented on [this](https://github.com/Netflix/RxJava/pull/384), make sure this operator is added accordingly to RxJava and then to RxScala
-*    add wrappers or aliases for `AsyncSubject<T>`, `BehaviorSubject<T>`, `PublishSubject<T>`, and `ReplaySubject<T>`
 *    go through Erik's code that he showed at the meeting and check if everything can now be done nicely
 *    get Erik's slides from the course and check if they are compatible with the library
 

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/subjects/package.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/subjects/package.scala
@@ -22,7 +22,7 @@ package object subjects {
 
   /**
    * A Subject is an Observable and an Observer at the same time. 
-   * 
+   *
    * The Java Subject looks like this: 
    * {{{
    * public abstract class Subject<T,R> extends Observable<R> implements Observer<T>
@@ -30,17 +30,77 @@ package object subjects {
    */
   type Subject[-T, +R] = rx.subjects.Subject[_ >: T, _ <: R]
 
+  /**
+   * Subject that publishes only the last event to each [[Observer]] that has subscribed when the
+   * sequence completes.
+   *
+   * The Java AsyncSubject looks like this:
+   * {{{
+   * public class AsyncSubject<T> extends Subject<T, T>
+   * }}}
+   */
+  type AsyncSubject[T] = rx.subjects.AsyncSubject[T]
+  object AsyncSubject {
+    /**
+     * Creates an [[AsyncSubject]]
+     */
+    def apply[T]() = rx.subjects.AsyncSubject.create[T]()
+  }
+
+  /**
+   * Subject that publishes the most recent and all subsequent events to each subscribed [[Observer]].
+   *
+   * The Java BehaviorSubject looks like this:
+   * {{{
+   * public class BehaviorSubject<T> extends Subject<T, T>
+   * }}}
+   */
+  type BehaviorSubject[T] = rx.subjects.BehaviorSubject[T]
+  object BehaviorSubject {
+    /**
+     * Creates a [[BehaviorSubject]]
+     */
+    def apply[T](defaultValue:T) =
+      rx.subjects.BehaviorSubject.createWithDefaultValue[T](defaultValue)
+  }
+
+  /**
+   * Subject that retains all events and will replay them to an [[Observer]] that subscribes.
+   *
+   * The Java PublishSubject looks like this:
+   * {{{
+   * public final class ReplaySubject<T> extends Subject<T, T>
+   * }}}
+   */
+  type ReplaySubject[T] = rx.subjects.ReplaySubject[T]
+  object ReplaySubject {
+    /**
+     * Creates a [[ReplaySubject]]
+     */
+    def apply[T]() = rx.subjects.ReplaySubject.create[T]()
+  }
+
+  /**
+   * Subject that, once and [[Observer]] has subscribed, publishes all subsequent
+   * events to the subscriber.
+   *
+   * The Java PublishSubject looks like this:
+   * {{{
+   * public class PublishSubject<T> extends Subject<T, T>
+   * }}}
+   */
+  type PlubishSubject[T] = rx.subjects.PublishSubject[T]
+  object PublishSubject {
+    /**
+     * Creates a [[PublishSubject]]
+     */
+    def apply[T]() = rx.subjects.PublishSubject.create[T]()
+  }
+
   // For nicer scaladoc, we would like to present something like this:
   /*
   trait Observable[+R] {}
   trait Observer[-T] {}
   trait Subject[-T, +R] extends Observable[R] with Observer[T] { }
   */
-  
-  // We don't make aliases to these types, because they are considered internal/not needed by users:
-  // rx.subjects.AsyncSubject
-  // rx.subjects.BehaviorSubject
-  // rx.subjects.PublishSubject
-  // rx.subjects.ReplaySubject
-
 }

--- a/rxjava-core/src/main/java/rx/subjects/AsyncSubject.java
+++ b/rxjava-core/src/main/java/rx/subjects/AsyncSubject.java
@@ -33,7 +33,7 @@ import rx.operators.SafeObservableSubscription;
  * <p>
  * <pre> {@code
 
- * / observer will receive no onNext events because the subject.onCompleted() isn't called.
+ * // observer will receive no onNext events because the subject.onCompleted() isn't called.
   AsyncSubject<Object> subject = AsyncSubject.create();
   subject.subscribe(observer);
   subject.onNext("one");

--- a/rxjava-core/src/main/java/rx/subjects/PublishSubject.java
+++ b/rxjava-core/src/main/java/rx/subjects/PublishSubject.java
@@ -32,7 +32,7 @@ import rx.operators.SafeObservableSubscription;
  * <p>
  * <pre> {@code
 
- * ublishSubject<Object> subject = PublishSubject.create();
+ * PublishSubject<Object> subject = PublishSubject.create();
   // observer1 will receive all onNext and onCompleted events
   subject.subscribe(observer1);
   subject.onNext("one");


### PR DESCRIPTION
-AsyncSubject[T]
-BehaviorSubject[T]
-PublishSubject[T]
-ReplaySubject[T]
