### PR TITLE
Operation GroupByUntil

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -50,6 +50,7 @@ import rx.operators.OperationFilter;
 import rx.operators.OperationFinally;
 import rx.operators.OperationFirstOrDefault;
 import rx.operators.OperationGroupBy;
+import rx.operators.OperationGroupByUntil;
 import rx.operators.OperationInterval;
 import rx.operators.OperationLast;
 import rx.operators.OperationMap;
@@ -120,6 +121,7 @@ import rx.util.functions.Func8;
 import rx.util.functions.Func9;
 import rx.util.functions.FuncN;
 import rx.util.functions.Function;
+import rx.util.functions.Functions;
 
 /**
  * The Observable interface that implements the Reactive Pattern.
@@ -5688,6 +5690,30 @@ public class Observable<T> {
             internalClassMap.put(clazz, isInternal);
             return isInternal;
         }
+    }
+
+    /**
+     * Groups the elements of an observable sequence according to a specified key selector function until the duration observable expires for the key.
+     * @param keySelector A function to extract the key for each element.
+     * @param durationSelector A function to signal the expiration of a group.
+     * @return A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+     * 
+     * @see <a href='http://msdn.microsoft.com/en-us/library/hh211932.aspx'>MSDN: Observable.GroupByUntil</a>
+     */
+    public <TKey, TDuration> Observable<GroupedObservable<TKey, T>> groupByUntil(Func1<T, TKey> keySelector, Func1<GroupedObservable<TKey, T>, Observable<TDuration>> durationSelector) {
+        return groupByUntil(keySelector, Functions.<T>identity(), durationSelector);
+    }
+    /**
+     * Groups the elements of an observable sequence according to a specified key and value selector function  until the duration observable expires for the key.
+     * @param keySelector A function to extract the key for each element.
+     * @param valueSelector A function to map each source element to an element in an observable group.
+     * @param durationSelector A function to signal the expiration of a group.
+     * @return A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
+     * 
+     * @see <a href='http://msdn.microsoft.com/en-us/library/hh229433.aspx'>MSDN: Observable.GroupByUntil</a>
+     */
+    public <TKey, TValue, TDuration> Observable<GroupedObservable<TKey, TValue>> groupByUntil(Func1<T, TKey> keySelector, Func1<T, TValue> valueSelector, Func1<GroupedObservable<TKey, TValue>, Observable<TDuration>> durationSelector) {
+        return create(new OperationGroupByUntil<T, TKey, TValue, TDuration>(this, keySelector, valueSelector, durationSelector));
     }
 
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationGroupByUntil.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationGroupByUntil.java
@@ -1,0 +1,259 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.operators;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
+import rx.Observer;
+import rx.Subscription;
+import rx.observables.GroupedObservable;
+import rx.subjects.PublishSubject;
+import rx.subjects.Subject;
+import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.SerialSubscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Func1;
+
+/**
+ * Groups the elements of an observable sequence according to a specified key selector, value selector and duration selector function.
+ * 
+ * @see <a href='http://msdn.microsoft.com/en-us/library/hh211932.aspx'>MSDN: Observable.GroupByUntil</a>
+ * @see <a href='http://msdn.microsoft.com/en-us/library/hh229433.aspx'>MSDN: Observable.GroupByUntil</a>
+ */
+public class OperationGroupByUntil<TSource, TKey, TResult, TDuration> implements OnSubscribeFunc<GroupedObservable<TKey, TResult>> {
+    final Observable<TSource> source;
+    final Func1<TSource, TKey> keySelector;
+    final Func1<TSource, TResult> valueSelector;
+    final Func1<GroupedObservable<TKey, TResult>, Observable<TDuration>> durationSelector;
+    public OperationGroupByUntil(Observable<TSource> source,
+            Func1<TSource, TKey> keySelector,
+            Func1<TSource, TResult> valueSelector,
+            Func1<GroupedObservable<TKey, TResult>, Observable<TDuration>> durationSelector) {
+        this.source = source;
+        this.keySelector = keySelector;
+        this.valueSelector = valueSelector;
+        this.durationSelector = durationSelector;
+    }
+
+    @Override
+    public Subscription onSubscribe(Observer<? super GroupedObservable<TKey, TResult>> t1) {
+        SerialSubscription cancel = new SerialSubscription();
+        ResultSink sink = new ResultSink(t1, cancel);
+        cancel.setSubscription(sink.run());
+        return cancel;
+    }
+    /** The source value sink and group manager. */
+    class ResultSink implements Observer<TSource> {
+        /** Guarded by gate. */
+        protected final Observer<? super GroupedObservable<TKey, TResult>> observer;
+        protected final Subscription cancel;
+        protected final CompositeSubscription group = new CompositeSubscription();
+        protected final Object gate = new Object();
+        /** Guarded by gate. */
+        protected final Map<TKey, GroupSubject<TKey, TResult>> map = new HashMap<TKey, GroupSubject<TKey, TResult>>();
+        public ResultSink(Observer<? super GroupedObservable<TKey, TResult>> observer, Subscription cancel) {
+            this.observer = observer;
+            this.cancel = cancel;
+        }
+        /** Prepare the subscription tree. */
+        public Subscription run() {
+            SerialSubscription toSource = new SerialSubscription();
+            group.add(toSource);
+            
+            toSource.setSubscription(source.subscribe(this));
+            
+            return group;
+        }
+
+        @Override
+        public void onNext(TSource args) {
+            TKey key;
+            TResult value;
+            try {
+                key = keySelector.call(args);
+                value = valueSelector.call(args);
+            } catch (Throwable t) {
+                onError(t);
+                return;
+            }
+            
+            GroupSubject<TKey, TResult> g;
+            boolean newGroup = false;
+            synchronized (key) {
+                g = map.get(key);
+                if (g == null) {
+                    g = create(key);
+                    map.put(key, g);
+                    newGroup = true;
+                }
+            }
+            
+            if (newGroup) {
+                Observable<TDuration> duration;
+                try {
+                    duration = durationSelector.call(g);
+                } catch (Throwable t) {
+                    onError(t);
+                    return;
+                }
+
+                synchronized (gate) {
+                    observer.onNext(g);
+                }
+
+                SerialSubscription durationHandle = new SerialSubscription();
+                group.add(durationHandle);
+                
+                DurationObserver durationObserver = new DurationObserver(key, durationHandle);
+                durationHandle.setSubscription(duration.subscribe(durationObserver));
+                
+            }
+
+            synchronized (gate) {
+                g.onNext(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            synchronized (gate) {
+                List<GroupSubject<TKey, TResult>> gs = new ArrayList<GroupSubject<TKey, TResult>>(map.values());
+                map.clear();
+                for (GroupSubject<TKey, TResult> g : gs) {
+                    g.onError(e);
+                }
+                observer.onError(e);
+            }
+            cancel.unsubscribe();
+        }
+
+        @Override
+        public void onCompleted() {
+            synchronized (gate) {
+                List<GroupSubject<TKey, TResult>> gs = new ArrayList<GroupSubject<TKey, TResult>>(map.values());
+                map.clear();
+                for (GroupSubject<TKey, TResult> g : gs) {
+                    g.onCompleted();
+                }
+                observer.onCompleted();
+            }
+            cancel.unsubscribe();
+        }
+        /** Create a new group. */
+        public GroupSubject<TKey, TResult> create(TKey key) {
+            PublishSubject<TResult> publish = PublishSubject.create();
+            return new GroupSubject<TKey, TResult>(key, publish);
+        }
+        /** Terminate a group. */
+        public void expire(TKey key, Subscription handle) {
+            synchronized (gate) {
+                GroupSubject<TKey, TResult> g = map.remove(key);
+                if (g != null) {
+                    g.onCompleted();
+                }
+            }
+            handle.unsubscribe();
+        }
+        /** Observe the completion of a group. */
+        class DurationObserver implements Observer<TDuration> {
+            final TKey key;
+            final Subscription handle;
+            public DurationObserver(TKey key, Subscription handle) {
+                this.key = key;
+                this.handle = handle;
+            }
+            @Override
+            public void onNext(TDuration args) {
+                expire(key, handle);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                ResultSink.this.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                expire(key, handle);
+            }
+            
+        }
+    }
+    protected static <T> OnSubscribeFunc<T> neverSubscribe() {
+        return new OnSubscribeFunc<T>() {
+            @Override
+            public Subscription onSubscribe(Observer<? super T> t1) {
+                return Subscriptions.empty();
+            }
+        };
+    }
+    /** A grouped observable with subject-like behavior. */
+    public static class GroupSubject<K, V> extends GroupedObservable<K, V> implements Observer<V> {
+        protected final Subject<V, V> publish;
+        protected Throwable error;
+        protected boolean done;
+        protected final Object sgate = new Object();
+        public GroupSubject(K key, Subject<V, V> publish) {
+            super(key, OperationGroupByUntil.<V>neverSubscribe());
+            this.publish = publish;
+        }
+
+        @Override
+        public Subscription subscribe(Observer<? super V> observer) {
+            // handle escaped group subjects
+            synchronized (sgate) {
+                if (done) {
+                    if (error != null) {
+                        observer.onError(error);
+                    } else {
+                        observer.onCompleted();
+                    }
+                    return Subscriptions.empty();
+                }
+                return publish.subscribe(observer);
+            }
+        }
+        
+        @Override
+        public void onNext(V args) {
+            publish.onNext(args);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            synchronized (sgate) {
+                if (!done) {
+                    done = true;
+                    error = e;
+                }
+            }
+            publish.onError(e);
+        }
+
+        @Override
+        public void onCompleted() {
+            synchronized (sgate) {
+                done = true;
+            }
+            publish.onCompleted();
+        }
+        
+    }
+}

--- a/rxjava-core/src/test/java/rx/operators/OperationGroupByUntilTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationGroupByUntilTest.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.operators;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+import rx.Observable;
+import rx.Observer;
+import rx.observables.GroupedObservable;
+import rx.util.functions.Action1;
+import rx.util.functions.Func1;
+import rx.util.functions.Functions;
+
+/**
+ *
+ */
+public class OperationGroupByUntilTest {
+    @Mock
+    Observer<Object> observer;
+    <T, R> Func1<T, R> just(final R value) {
+        return new Func1<T, R>() {
+            @Override
+            public R call(T t1) {
+                return value;
+            }
+        };
+    }
+    <T> Func1<Integer, T> fail(T dummy) {
+        return new Func1<Integer, T>() {
+            @Override
+            public T call(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+    }
+    <T, R> Func1<T, R> fail2(R dummy2) {
+        return new Func1<T, R>() {
+            @Override
+            public R call(T t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+    }
+    Func1<Integer, Integer> dbl = new Func1<Integer, Integer>() {
+        @Override
+        public Integer call(Integer t1) {
+            return t1 * 2;
+        }
+    };
+    Func1<Integer, Integer> identity = Functions.identity();
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+    @Test
+    public void normalBehavior() {
+        Observable<String> source = Observable.from(Arrays.asList(
+                "  foo",
+                " FoO ",
+                "baR  ",
+                "foO ",
+                " Baz   ",
+                "  qux ",
+                "   bar",
+                " BAR  ",
+                "FOO ",
+                "baz  ",
+                " bAZ ",
+                "    fOo    "
+        ));
+        
+        Func1<GroupedObservable<String, String>, Observable<String>> duration = new Func1<GroupedObservable<String, String>, Observable<String>>() {
+            @Override
+            public Observable<String> call(GroupedObservable<String, String> t1) {
+                return t1.skip(2);
+            }
+        };
+        Func1<GroupedObservable<String, String>, String> getkey = new Func1<GroupedObservable<String, String>, String>() {
+
+            @Override
+            public String call(GroupedObservable<String, String> t1) {
+                return t1.getKey();
+            }
+            
+        };
+        Func1<String, String> keysel = new Func1<String, String>() {
+            @Override
+            public String call(String t1) {
+                return t1.trim().toLowerCase();
+            }
+        };
+        Func1<String, String> valuesel = new Func1<String, String>() {
+            @Override
+            public String call(String t1) {
+                return t1 + t1;
+            }
+        };
+
+        Observable<String> m = source.groupByUntil(
+                keysel, valuesel, 
+                duration).map(getkey);
+
+        m.subscribe(observer);
+        
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("foo");
+        inOrder.verify(observer, times(1)).onNext("bar");
+        inOrder.verify(observer, times(1)).onNext("baz");
+        inOrder.verify(observer, times(1)).onNext("qux");
+        inOrder.verify(observer, times(1)).onNext("foo");
+        inOrder.verify(observer, times(1)).onCompleted();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+    @Test
+    public void behaveAsGroupBy() {
+        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
+        
+        Observable<GroupedObservable<Integer, Integer>> m = source.groupByUntil(
+                identity, dbl, 
+                duration);
+        
+        final Map<Integer, Integer> actual = new HashMap<Integer, Integer>();
+        
+        m.subscribe(new Action1<GroupedObservable<Integer, Integer>>() {
+            @Override
+            public void call(final GroupedObservable<Integer, Integer> t1) {
+                t1.subscribe(new Action1<Integer>() {
+                    @Override
+                    public void call(Integer t2) {
+                        actual.put(t1.getKey(), t2);
+                    }
+                });
+            }
+        });
+        
+        Map<Integer, Integer> expected = new HashMap<Integer, Integer>();
+        for (int i = 0; i < 7; i++) {
+            expected.put(i, i * 2);
+        }
+        
+        Assert.assertEquals(expected, actual);
+    }
+    @Test
+    public void keySelectorThrows() {
+        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
+        
+        Observable<GroupedObservable<Integer, Integer>> m = source.groupByUntil(
+                fail(0), dbl, 
+                duration);
+        
+        m.subscribe(observer);
+        
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onCompleted();
+        
+    }
+    @Test
+    public void valueSelectorThrows() {
+        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
+        
+        Observable<GroupedObservable<Integer, Integer>> m = source.groupByUntil(
+                identity, fail(0), 
+                duration);
+        
+        m.subscribe(observer);
+        
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onCompleted();
+        
+    }
+    @Test
+    public void durationSelectorThrows() {
+        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = fail2((Observable<Object>)null);
+        
+        Observable<GroupedObservable<Integer, Integer>> m = source.groupByUntil(
+                identity, dbl, 
+                duration);
+        
+        m.subscribe(observer);
+        
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onCompleted();
+        
+    }
+    @Test
+    public void durationThrows() {
+        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+
+        Func1<GroupedObservable<Integer, Integer>, Integer> getkey = new Func1<GroupedObservable<Integer, Integer>, Integer>() {
+
+            @Override
+            public Integer call(GroupedObservable<Integer, Integer> t1) {
+                return t1.getKey();
+            }
+            
+        };
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.error(new RuntimeException("Forced failure")));
+        
+        Observable<Integer> m = source.groupByUntil(
+                identity, dbl, 
+                duration).map(getkey);
+        
+        m.subscribe(observer);
+        
+        verify(observer, times(1)).onNext(0);
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onNext(1);
+        verify(observer, never()).onNext(2);
+        verify(observer, never()).onNext(3);
+        verify(observer, never()).onNext(4);
+        verify(observer, never()).onNext(5);
+        verify(observer, never()).onNext(6);
+        verify(observer, never()).onCompleted();
+        
+    }
+    @Test
+    public void innerEscapeCompleted() {
+        Observable<Integer> source = Observable.from(0);
+        
+        final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();
+
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
+        
+        Observable<GroupedObservable<Integer, Integer>> m = source.groupByUntil(identity, dbl, duration);
+        
+        m.subscribe(new Action1<GroupedObservable<Integer, Integer>>() {
+            @Override
+            public void call(GroupedObservable<Integer, Integer> t1) {
+                inner.set(t1);
+            }
+        });
+        
+        inner.get().subscribe(observer);
+
+        verify(observer, times(1)).onCompleted();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+    }
+    
+    @Test
+    public void innerEscapeError() {
+        Observable<Integer> source = Observable.concat(Observable.from(0), Observable.<Integer>error(new RuntimeException("Forced failure")));
+        
+        final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();
+
+        Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
+        
+        Observable<GroupedObservable<Integer, Integer>> m = source.groupByUntil(identity, dbl, duration);
+        
+        m.subscribe(new Observer<GroupedObservable<Integer, Integer>>() {
+            @Override
+            public void onNext(GroupedObservable<Integer, Integer> t1) {
+                inner.set(t1);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+            
+            @Override
+            public void onCompleted() {
+            }
+            
+        });
+        
+        inner.get().subscribe(observer);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onCompleted();
+        verify(observer, never()).onNext(any());
+    }
+}


### PR DESCRIPTION
Issue #52

Note that Rx.NET's Subject<T> once onCompleted() or onError()'d, any subsequent subscriptions from observers will immediately receive onCompleted() or onError(). RxJava's PublishSubject however doesn't seem to do that, leaving future observers never do anything. Since the Rx.NET.GroupByUntil relied on the described behavior to handle escaped groups, the proposed implementation inside the GroupSubject will do this manually.
