### PR TITLE
BugFix: Handling of Terminal State for Behavior/Publish Subjects

### DIFF
--- a/rxjava-core/src/main/java/rx/subjects/AbstractSubject.java
+++ b/rxjava-core/src/main/java/rx/subjects/AbstractSubject.java
@@ -1,0 +1,152 @@
+package rx.subjects;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import rx.Notification;
+import rx.Observer;
+import rx.Subscription;
+import rx.operators.SafeObservableSubscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action2;
+
+public abstract class AbstractSubject<T> extends Subject<T, T> {
+
+    protected AbstractSubject(rx.Observable.OnSubscribeFunc<T> onSubscribe) {
+        super(onSubscribe);
+    }
+
+    protected static class SubjectState<T> {
+        protected final ConcurrentHashMap<Subscription, Observer<? super T>> observers = new ConcurrentHashMap<Subscription, Observer<? super T>>();
+        protected final AtomicReference<Notification<T>> currentValue = new AtomicReference<Notification<T>>();
+        protected final AtomicBoolean completed = new AtomicBoolean();
+        protected final ReentrantLock SUBSCRIPTION_LOCK = new ReentrantLock();
+    }
+
+    protected static <T> OnSubscribeFunc<T> getOnSubscribeFunc(final SubjectState<T> state, final Action2<SubjectState<T>, Observer<? super T>> onEach) {
+        return new OnSubscribeFunc<T>() {
+            @Override
+            public Subscription onSubscribe(Observer<? super T> observer) {
+                /*
+                 * Subscription needs to be synchronized with terminal states to ensure
+                 * race conditions are handled. When subscribing we must make sure
+                 * onComplete/onError is correctly emitted to all observers, even if it
+                 * comes in while the onComplete/onError is being propagated.
+                 */
+                state.SUBSCRIPTION_LOCK.lock();
+                try {
+                    if (state.completed.get()) {
+                        emitNotification(state.currentValue.get(), observer);
+                        if (onEach != null) {
+                            onEach.call(state, observer);
+                        }
+                        return Subscriptions.empty();
+                    } else {
+                        // the subject is not completed so we subscribe
+                        final SafeObservableSubscription subscription = new SafeObservableSubscription();
+
+                        subscription.wrap(new Subscription() {
+                            @Override
+                            public void unsubscribe() {
+                                // on unsubscribe remove it from the map of outbound observers to notify
+                                state.observers.remove(subscription);
+                            }
+                        });
+
+                        // on subscribe add it to the map of outbound observers to notify
+                        state.observers.put(subscription, observer);
+
+                        // invoke onSubscribe logic
+                        if (onEach != null) {
+                            onEach.call(state, observer);
+                        }
+
+                        return subscription;
+                    }
+                } finally {
+                    state.SUBSCRIPTION_LOCK.unlock();
+                }
+
+            }
+
+        };
+    }
+
+    protected static <T> void emitNotification(Notification<T> value, Observer<? super T> observer) {
+        // if null that means onNext was never invoked (no Notification set)
+        if (value != null) {
+            if (value.isOnNext()) {
+                observer.onNext(value.getValue());
+            } else if (value.isOnError()) {
+                observer.onError(value.getThrowable());
+            } else if (value.isOnCompleted()) {
+                observer.onCompleted();
+            }
+        }
+    }
+
+    /**
+     * Emit the current value.
+     * 
+     * @param state
+     */
+    protected static <T> void emitNotification(final SubjectState<T> state, final Action2<SubjectState<T>, Observer<? super T>> onEach) {
+        for (Subscription s : snapshotOfObservers(state)) {
+            Observer<? super T> o = state.observers.get(s);
+            // emit notifications to this observer
+            emitNotification(state.currentValue.get(), o);
+            // onEach action if applicable
+            if (onEach != null) {
+                onEach.call(state, o);
+            }
+        }
+    }
+
+    /**
+     * Emit the current value to all observers and remove their subscription.
+     * 
+     * @param state
+     */
+    protected void emitNotificationAndTerminate(final SubjectState<T> state, final Action2<SubjectState<T>, Observer<? super T>> onEach) {
+        /*
+         * We can not allow new subscribers to be added while we execute the terminal state.
+         */
+        state.SUBSCRIPTION_LOCK.lock();
+        try {
+            if (state.completed.compareAndSet(false, true)) {
+                for (Subscription s : snapshotOfObservers(state)) {
+                    Observer<? super T> o = state.observers.get(s);
+                    // emit notifications to this observer
+                    emitNotification(state.currentValue.get(), o);
+                    // onEach action if applicable
+                    if (onEach != null) {
+                        onEach.call(state, o);
+                    }
+
+                    // remove the subscription as it is completed
+                    state.observers.remove(s);
+                }
+            }
+        } finally {
+            state.SUBSCRIPTION_LOCK.unlock();
+        }
+    }
+
+    /**
+     * Current snapshot of 'state.observers.keySet()' so that concurrent modifications aren't included.
+     * 
+     * This makes it behave deterministically in a single-threaded execution when nesting subscribes.
+     * 
+     * In multi-threaded execution it will cause new subscriptions to wait until the following onNext instead
+     * of possibly being included in the current onNext iteration.
+     * 
+     * @return List<Observer<T>>
+     */
+    private static <T> Collection<Subscription> snapshotOfObservers(final SubjectState<T> state) {
+        return new ArrayList<Subscription>(state.observers.keySet());
+    }
+}

--- a/rxjava-core/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2013 Netflix, Inc.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,10 +43,6 @@ public class BehaviorSubjectTest {
         subject.onNext("two");
         subject.onNext("three");
 
-        assertReceivedAllEvents(aObserver);
-    }
-
-    private void assertReceivedAllEvents(Observer<String> aObserver) {
         verify(aObserver, times(1)).onNext("default");
         verify(aObserver, times(1)).onNext("one");
         verify(aObserver, times(1)).onNext("two");
@@ -57,7 +53,7 @@ public class BehaviorSubjectTest {
 
     @Test
     public void testThatObserverDoesNotReceiveDefaultValueIfSomethingWasPublished() {
-        BehaviorSubject<String> subject = BehaviorSubject.createWithDefaultValue("default");
+        BehaviorSubject<String> subject = BehaviorSubject.create("default");
 
         subject.onNext("one");
 
@@ -68,10 +64,6 @@ public class BehaviorSubjectTest {
         subject.onNext("two");
         subject.onNext("three");
 
-        assertDidNotReceiveTheDefaultValue(aObserver);
-    }
-
-    private void assertDidNotReceiveTheDefaultValue(Observer<String> aObserver) {
         verify(aObserver, Mockito.never()).onNext("default");
         verify(aObserver, times(1)).onNext("one");
         verify(aObserver, times(1)).onNext("two");
@@ -82,7 +74,7 @@ public class BehaviorSubjectTest {
 
     @Test
     public void testCompleted() {
-        BehaviorSubject<String> subject = BehaviorSubject.createWithDefaultValue("default");
+        BehaviorSubject<String> subject = BehaviorSubject.create("default");
 
         @SuppressWarnings("unchecked")
         Observer<String> aObserver = mock(Observer.class);
@@ -91,54 +83,6 @@ public class BehaviorSubjectTest {
         subject.onNext("one");
         subject.onCompleted();
 
-        assertCompletedObserver(aObserver);
-    }
-    
-    @Test
-    public void testCompletedStopsEmittingData() {
-        BehaviorSubject<Integer> channel = BehaviorSubject.createWithDefaultValue(2013);
-        @SuppressWarnings("unchecked")
-        Observer<Object> observerA = mock(Observer.class);
-        @SuppressWarnings("unchecked")
-        Observer<Object> observerB = mock(Observer.class);
-        @SuppressWarnings("unchecked")
-        Observer<Object> observerC = mock(Observer.class);
-
-        InOrder inOrder = inOrder(observerA, observerB, observerC);
-
-        Subscription a = channel.subscribe(observerA);
-        Subscription b = channel.subscribe(observerB);
-
-        inOrder.verify(observerA).onNext(2013);
-        inOrder.verify(observerB).onNext(2013);
-        
-        channel.onNext(42);
-
-        inOrder.verify(observerA).onNext(42);
-        inOrder.verify(observerB).onNext(42);
-
-        a.unsubscribe();
-
-        channel.onNext(4711);
-
-        inOrder.verify(observerA, never()).onNext(any());
-        inOrder.verify(observerB).onNext(4711);
-
-        channel.onCompleted();
-
-        inOrder.verify(observerA, never()).onCompleted();
-        inOrder.verify(observerB).onCompleted();
-
-        Subscription c = channel.subscribe(observerC);
-
-        inOrder.verify(observerC).onCompleted();
-
-        channel.onNext(13);
-
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    private void assertCompletedObserver(Observer<String> aObserver) {
         verify(aObserver, times(1)).onNext("default");
         verify(aObserver, times(1)).onNext("one");
         verify(aObserver, Mockito.never()).onError(any(Throwable.class));
@@ -146,8 +90,54 @@ public class BehaviorSubjectTest {
     }
 
     @Test
+    public void testCompletedStopsEmittingData() {
+        BehaviorSubject<Integer> channel = BehaviorSubject.create(2013);
+        @SuppressWarnings("unchecked")
+        Observer<Object> observerA = mock(Observer.class);
+        @SuppressWarnings("unchecked")
+        Observer<Object> observerB = mock(Observer.class);
+        @SuppressWarnings("unchecked")
+        Observer<Object> observerC = mock(Observer.class);
+
+        Subscription a = channel.subscribe(observerA);
+        Subscription b = channel.subscribe(observerB);
+
+        InOrder inOrderA = inOrder(observerA);
+        InOrder inOrderB = inOrder(observerB);
+        InOrder inOrderC = inOrder(observerC);
+
+        inOrderA.verify(observerA).onNext(2013);
+        inOrderB.verify(observerB).onNext(2013);
+
+        channel.onNext(42);
+
+        inOrderA.verify(observerA).onNext(42);
+        inOrderB.verify(observerB).onNext(42);
+
+        a.unsubscribe();
+        inOrderA.verifyNoMoreInteractions();
+
+        channel.onNext(4711);
+
+        inOrderB.verify(observerB).onNext(4711);
+
+        channel.onCompleted();
+
+        inOrderB.verify(observerB).onCompleted();
+
+        Subscription c = channel.subscribe(observerC);
+
+        inOrderC.verify(observerC).onCompleted();
+
+        channel.onNext(13);
+
+        inOrderB.verifyNoMoreInteractions();
+        inOrderC.verifyNoMoreInteractions();
+    }
+
+    @Test
     public void testCompletedAfterError() {
-        BehaviorSubject<String> subject = BehaviorSubject.createWithDefaultValue("default");
+        BehaviorSubject<String> subject = BehaviorSubject.create("default");
 
         @SuppressWarnings("unchecked")
         Observer<String> aObserver = mock(Observer.class);
@@ -158,10 +148,6 @@ public class BehaviorSubjectTest {
         subject.onNext("two");
         subject.onCompleted();
 
-        assertErrorObserver(aObserver);
-    }
-
-    private void assertErrorObserver(Observer<String> aObserver) {
         verify(aObserver, times(1)).onNext("default");
         verify(aObserver, times(1)).onNext("one");
         verify(aObserver, times(1)).onError(testException);
@@ -173,7 +159,7 @@ public class BehaviorSubjectTest {
                 new Func0<BehaviorSubject<String>>() {
                     @Override
                     public BehaviorSubject<String> call() {
-                        return BehaviorSubject.createWithDefaultValue("default");
+                        return BehaviorSubject.create("default");
                     }
                 }, new Action1<BehaviorSubject<String>>() {
                     @Override

--- a/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
@@ -20,18 +20,12 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-
-import junit.framework.Assert;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-import rx.Notification;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
@@ -40,57 +34,6 @@ import rx.util.functions.Func0;
 import rx.util.functions.Func1;
 
 public class PublishSubjectTest {
-
-    @Test
-    public void test() {
-        PublishSubject<Integer> subject = PublishSubject.create();
-        final AtomicReference<List<Notification<Integer>>> actualRef = new AtomicReference<List<Notification<Integer>>>();
-
-        Observable<List<Notification<Integer>>> wNotificationsList = subject.materialize().toList();
-        wNotificationsList.subscribe(new Action1<List<Notification<Integer>>>() {
-            @Override
-            public void call(List<Notification<Integer>> actual) {
-                actualRef.set(actual);
-            }
-        });
-
-        Subscription sub = Observable.create(new Observable.OnSubscribeFunc<Integer>() {
-            @Override
-            public Subscription onSubscribe(final Observer<? super Integer> observer) {
-                final AtomicBoolean stop = new AtomicBoolean(false);
-                new Thread() {
-                    @Override
-                    public void run() {
-                        int i = 1;
-                        while (!stop.get()) {
-                            observer.onNext(i++);
-                        }
-                        observer.onCompleted();
-                    }
-                }.start();
-                return new Subscription() {
-                    @Override
-                    public void unsubscribe() {
-                        stop.set(true);
-                    }
-                };
-            }
-        }).subscribe(subject);
-        // the subject has received an onComplete from the first subscribe because
-        // it is synchronous and the next subscribe won't do anything.
-        Observable.from(-1, -2, -3).subscribe(subject);
-
-        List<Notification<Integer>> expected = new ArrayList<Notification<Integer>>();
-        expected.add(new Notification<Integer>(-1));
-        expected.add(new Notification<Integer>(-2));
-        expected.add(new Notification<Integer>(-3));
-        expected.add(new Notification<Integer>());
-        Assert.assertTrue(actualRef.get().containsAll(expected));
-
-        sub.unsubscribe();
-    }
-
-    private final Throwable testException = new Throwable();
 
     @Test
     public void testCompleted() {
@@ -127,35 +70,37 @@ public class PublishSubjectTest {
         @SuppressWarnings("unchecked")
         Observer<Object> observerC = mock(Observer.class);
 
-        InOrder inOrder = inOrder(observerA, observerB, observerC);
-
         Subscription a = channel.subscribe(observerA);
         Subscription b = channel.subscribe(observerB);
 
+        InOrder inOrderA = inOrder(observerA);
+        InOrder inOrderB = inOrder(observerB);
+        InOrder inOrderC = inOrder(observerC);
+
         channel.onNext(42);
 
-        inOrder.verify(observerA).onNext(42);
-        inOrder.verify(observerB).onNext(42);
+        inOrderA.verify(observerA).onNext(42);
+        inOrderB.verify(observerB).onNext(42);
 
         a.unsubscribe();
+        inOrderA.verifyNoMoreInteractions();
 
         channel.onNext(4711);
 
-        inOrder.verify(observerA, never()).onNext(any());
-        inOrder.verify(observerB).onNext(4711);
+        inOrderB.verify(observerB).onNext(4711);
 
         channel.onCompleted();
 
-        inOrder.verify(observerA, never()).onCompleted();
-        inOrder.verify(observerB).onCompleted();
+        inOrderB.verify(observerB).onCompleted();
 
         Subscription c = channel.subscribe(observerC);
 
-        inOrder.verify(observerC).onCompleted();
+        inOrderC.verify(observerC).onCompleted();
 
         channel.onNext(13);
 
-        inOrder.verifyNoMoreInteractions();
+        inOrderB.verifyNoMoreInteractions();
+        inOrderC.verifyNoMoreInteractions();
     }
 
     private void assertCompletedObserver(Observer<String> aObserver) {
@@ -380,43 +325,7 @@ public class PublishSubjectTest {
         s2.unsubscribe();
     }
 
-    /**
-     * Even if subject received an onError/onCompleted, new subscriptions should be able to restart it.
-     */
-    @Test
-    public void testReSubscribeAfterTerminalState() {
-        final PublishSubject<Integer> ps = PublishSubject.create();
 
-        Observer<Integer> o1 = mock(Observer.class);
-        Subscription s1 = ps.subscribe(o1);
+    private final Throwable testException = new Throwable();
 
-        // emit
-        ps.onNext(1);
-
-        // validate we got it
-        InOrder inOrder1 = inOrder(o1);
-        inOrder1.verify(o1, times(1)).onNext(1);
-        inOrder1.verifyNoMoreInteractions();
-
-        // unsubscribe
-        s1.unsubscribe();
-
-        ps.onCompleted();
-
-        // emit again but nothing will be there to receive it
-        ps.onNext(2);
-
-        Observer<Integer> o2 = mock(Observer.class);
-        Subscription s2 = ps.subscribe(o2);
-
-        // emit
-        ps.onNext(3);
-
-        // validate we got it
-        InOrder inOrder2 = inOrder(o2);
-        inOrder2.verify(o2, times(1)).onNext(3);
-        inOrder2.verifyNoMoreInteractions();
-
-        s2.unsubscribe();
-    }
 }


### PR DESCRIPTION
- They were not correctly emitting onCompleted when new Observers subscribed after the Subject was terminated.
- Added same logic that already existed on AsyncSubject
