### PR TITLE
Add scala adapters for doOnEach operator.

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
@@ -1826,7 +1826,7 @@ trait Observable[+T]
    *
    * @return an Observable with the side-effecting behavior applied.
    */
-  def doOnEach[U >: T](observer: Observer[U]): Observable[T] = {
+  def doOnEach(observer: Observer[T]): Observable[T] = {
     Observable[T](asJavaObservable.doOnEach(observer.asJavaObserver))
   }
 


### PR DESCRIPTION
This re-integrates support for doOnEach that was lost in the Scala refactor.
