### PR TITLE
Don't call plugin's handler if handler is given

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -418,7 +418,6 @@ public class Observable<T> {
 
             @Override
             public void onError(Throwable e) {
-                handleError(e);
                 onError.call(e);
             }
 
@@ -477,7 +476,6 @@ public class Observable<T> {
 
             @Override
             public void onError(Throwable e) {
-                handleError(e);
                 onError.call(e);
             }
 


### PR DESCRIPTION
When an error handler is explicitly supplied, don't delegate to the
plugin's error handler.

This looks like a mistake, but I'm not certain.  I wasn't able to find documentation on the error handler plugin that describes when it's called.  My assumption here is that it's a default error handler, called when no onError() implementation is supplied.
