### PR TITLE
A bug in apply(u:=>Unit) method of Subscription companion object fixed w...

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Subscription.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Subscription.scala
@@ -67,7 +67,7 @@ object Subscription {
       def isUnsubscribed = unsubscribed.get()
 
       val asJavaSubscription = new rx.Subscription {
-        def unsubscribe() { if(!unsubscribed.get()) { u ; unsubscribed.set(true) }}
+        def unsubscribe() { if(unsubscribed.compareAndSet(false, true)) u }
       }
     }
   }


### PR DESCRIPTION
...hich may cause multiple invocations of u, in a multithreaded, multi-unsubscribe situation.

Threads may be pre-empted after evaluation of condition (!unsubscribed.get()) which may result in two or more threads executing the consequent block more than once. A code that relies on single evaluation of u will fail if that case happens.
