### PR TITLE
Fixes OnCompleted.unapply result type

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Notification.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Notification.scala
@@ -95,9 +95,9 @@ object Notification {
       Notification(new rx.Notification())
     }
 
-    def unapply[U](n: Notification[U]): Option[Unit] = n match {
-      case n2: OnCompleted[U] => Some()
-      case _ => None
+    def unapply[U](n: Notification[U]): Boolean = n match {
+      case n2: OnCompleted[U] => true
+      case _ => false
     }
   }
 

--- a/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/NotificationTest.scala
+++ b/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/NotificationTest.scala
@@ -1,0 +1,18 @@
+package rx.lang.scala
+
+import org.scalatest.junit.JUnitSuite
+import org.junit.Test
+import rx.lang.scala.Notification.OnCompleted
+
+class NotificationTest extends JUnitSuite {
+  @Test
+  def testOnCompletePatternMatch(): Unit = {
+    val o = Observable()
+
+    val o2 = o.materialize map {
+      case OnCompleted() => true
+      case _ => false
+    }
+    assert(o2.toBlockingObservable.toIterable.toList === List(true))
+  }
+}


### PR DESCRIPTION
The Scala spec says that an extractor matches a pattern with zero
argument pattern if the result type of unapply is Boolean. The result
type of Option[T] means that the extractor has exactly one argument
pattern of type T.

The "Option[Unit]" result type does work, but it's probably a compiler
bug. Based on the result type, the pattern match "case OnCompleted() =>"
should not compile and "case OnCompleted(()) =>" should be used instead.
Using the latter one crashes the compiler... Changing the result type of
unapply to Boolean does _not_ change any of this, so using the pattern
"case OnCompleted(()) =>" still crashes the compiler, but at least the
pattern is not suggested by the unapply result type and the pattern
match results in one less object allocation.

The included test does _not_ check for this problem, it simply makes
sure that it still works correctly when using the correct pattern.
