### PR TITLE
Lock-free subscriptions

### DIFF
--- a/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -1,18 +1,18 @@
-/**
- * Copyright 2013 Netflix, Inc.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ /**
+  * Copyright 2013 Netflix, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package rx.subscriptions;
 
 import static java.util.Arrays.asList;
@@ -20,6 +20,7 @@ import static java.util.Collections.unmodifiableSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,50 +31,60 @@ import rx.util.CompositeException;
 /**
  * Subscription that represents a group of Subscriptions that are unsubscribed
  * together.
- * 
+ *
  * @see <a
  *      href="http://msdn.microsoft.com/en-us/library/system.reactive.disposables.compositedisposable(v=vs.103).aspx">Rx.Net
  *      equivalent CompositeDisposable</a>
  */
 public class CompositeSubscription implements Subscription {
-    private static final Set<Subscription> MUTATE_STATE = unmodifiableSet(new HashSet<Subscription>());
-    private static final Set<Subscription> UNSUBSCRIBED_STATE = unmodifiableSet(new HashSet<Subscription>());
-
+    /** Sentinel to indicate a thread is modifying the subscription set. */
+    private static final Set<Subscription> MUTATE_SENTINEL = unmodifiableSet(Collections.<Subscription>emptySet());
+    /** Sentinel to indicate the entire CompositeSubscription has been unsubscribed.*/
+    private static final Set<Subscription> UNSUBSCRIBED_SENTINEL = unmodifiableSet(Collections.<Subscription>emptySet());
+    /** The reference to the set of subscriptions. */
     private final AtomicReference<Set<Subscription>> reference = new AtomicReference<Set<Subscription>>();
-
+    
     public CompositeSubscription(final Subscription... subscriptions) {
         reference.set(new HashSet<Subscription>(asList(subscriptions)));
     }
-
+    
     public boolean isUnsubscribed() {
-        return reference.get() == UNSUBSCRIBED_STATE;
+        return reference.get() == UNSUBSCRIBED_SENTINEL;
     }
-
+    
     public void add(final Subscription s) {
         do {
             final Set<Subscription> existing = reference.get();
-            if (existing == UNSUBSCRIBED_STATE) {
+            if (existing == UNSUBSCRIBED_SENTINEL) {
                 s.unsubscribe();
                 break;
             }
-
-            if (reference.compareAndSet(existing, MUTATE_STATE)) {
+            
+            if (existing == MUTATE_SENTINEL) {
+                continue;
+            }
+            
+            if (reference.compareAndSet(existing, MUTATE_SENTINEL)) {
                 existing.add(s);
                 reference.set(existing);
                 break;
             }
         } while (true);
     }
-
+    
     public void remove(final Subscription s) {
         do {
             final Set<Subscription> subscriptions = reference.get();
-            if (subscriptions == UNSUBSCRIBED_STATE) {
+            if (subscriptions == UNSUBSCRIBED_SENTINEL) {
                 s.unsubscribe();
                 break;
             }
-
-            if (reference.compareAndSet(subscriptions, MUTATE_STATE)) {
+            
+            if (subscriptions == MUTATE_SENTINEL) {
+                continue;
+            }
+            
+            if (reference.compareAndSet(subscriptions, MUTATE_SENTINEL)) {
                 // also unsubscribe from it:
                 // http://msdn.microsoft.com/en-us/library/system.reactive.disposables.compositedisposable.remove(v=vs.103).aspx
                 subscriptions.remove(s);
@@ -83,54 +94,66 @@ public class CompositeSubscription implements Subscription {
             }
         } while (true);
     }
-
+    
     public void clear() {
         do {
             final Set<Subscription> subscriptions = reference.get();
-            if (subscriptions == UNSUBSCRIBED_STATE) {
+            if (subscriptions == UNSUBSCRIBED_SENTINEL) {
                 break;
             }
-
-            if (reference.compareAndSet(subscriptions, MUTATE_STATE)) {
+            
+            if (subscriptions == MUTATE_SENTINEL) {
+                continue;
+            }
+            
+            if (reference.compareAndSet(subscriptions, MUTATE_SENTINEL)) {
                 final Set<Subscription> copy = new HashSet<Subscription>(
                         subscriptions);
                 subscriptions.clear();
                 reference.set(subscriptions);
-
-                for (final Subscription subscription : copy) {
-                    subscription.unsubscribe();
-                }
+                
+                unsubscribeAll(copy);
                 break;
             }
         } while (true);
     }
-
+    /**
+     * Unsubscribe from the collection of subscriptions.
+     * <p>
+     * Exceptions thrown by any of the {@code unsubscribe()} methods are
+     * collected into a {@link CompositeException} and thrown once
+     * all unsubscriptions have been attempted.
+     * @param subs the collection of subscriptions
+     */
+    private void unsubscribeAll(Collection<Subscription> subs) {
+        final Collection<Throwable> es = new ArrayList<Throwable>();
+        for (final Subscription s : subs) {
+            try {
+                s.unsubscribe();
+            } catch (final Throwable e) {
+                es.add(e);
+            }
+        }
+        if (!es.isEmpty()) {
+            throw new CompositeException(
+                    "Failed to unsubscribe to 1 or more subscriptions.", es);
+        }
+    }
     @Override
     public void unsubscribe() {
         do {
             final Set<Subscription> subscriptions = reference.get();
-            if (subscriptions == UNSUBSCRIBED_STATE) {
+            if (subscriptions == UNSUBSCRIBED_SENTINEL) {
                 break;
             }
-
-            if (subscriptions == MUTATE_STATE) {
+            
+            if (subscriptions == MUTATE_SENTINEL) {
                 continue;
             }
-
-            if (reference.compareAndSet(subscriptions, UNSUBSCRIBED_STATE)) {
-                final Collection<Throwable> es = new ArrayList<Throwable>();
-                for (final Subscription s : subscriptions) {
-                    try {
-                        s.unsubscribe();
-                    } catch (final Throwable e) {
-                        es.add(e);
-                    }
-                }
-                if (es.isEmpty()) {
-                    break;
-                }
-                throw new CompositeException(
-                        "Failed to unsubscribe to 1 or more subscriptions.", es);
+            
+            if (reference.compareAndSet(subscriptions, UNSUBSCRIBED_SENTINEL)) {
+                unsubscribeAll(subscriptions);
+                break;
             }
         } while (true);
     }

--- a/rxjava-core/src/main/java/rx/subscriptions/SingleAssignmentSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/SingleAssignmentSubscription.java
@@ -32,7 +32,7 @@ public final class SingleAssignmentSubscription implements Subscription {
     /** Holds the current resource. */
     private final AtomicReference<Subscription> current = new AtomicReference<Subscription>();
     /** Sentinel for the unsubscribed state. */
-    private static final Subscription SENTINEL = new Subscription() {
+    private static final Subscription UNSUBSCRIBED_SENTINEL = new Subscription() {
         @Override
         public void unsubscribe() {
         }
@@ -42,7 +42,7 @@ public final class SingleAssignmentSubscription implements Subscription {
      */
     public Subscription get() {
         Subscription s = current.get();
-        if (s == SENTINEL) {
+        if (s == UNSUBSCRIBED_SENTINEL) {
             return Subscriptions.empty();
         }
         return s;
@@ -57,7 +57,7 @@ public final class SingleAssignmentSubscription implements Subscription {
         if (current.compareAndSet(null, s)) {
             return;
         }
-        if (current.get() != SENTINEL) {
+        if (current.get() != UNSUBSCRIBED_SENTINEL) {
             throw new IllegalStateException("Subscription already set");
         }
         if (s != null) {
@@ -66,7 +66,7 @@ public final class SingleAssignmentSubscription implements Subscription {
     }
     @Override
     public void unsubscribe() {
-        Subscription old = current.getAndSet(SENTINEL);
+        Subscription old = current.getAndSet(UNSUBSCRIBED_SENTINEL);
         if (old != null) {
             old.unsubscribe();
         }
@@ -75,7 +75,7 @@ public final class SingleAssignmentSubscription implements Subscription {
      * Test if this subscription is already unsubscribed.
      */
     public boolean isUnsubscribed() {
-        return current.get() == SENTINEL;
+        return current.get() == UNSUBSCRIBED_SENTINEL;
     }
     
 }

--- a/rxjava-core/src/test/java/rx/subscriptions/MultipleAssignmentSubscriptionTest.java
+++ b/rxjava-core/src/test/java/rx/subscriptions/MultipleAssignmentSubscriptionTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.subscriptions;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import rx.Subscription;
+import static rx.subscriptions.Subscriptions.create;
+import rx.util.functions.Action0;
+
+public class MultipleAssignmentSubscriptionTest {
+    Action0 unsubscribe;
+    Subscription s;
+    @Before
+    public void before() {
+         unsubscribe = mock(Action0.class);
+         s = create(unsubscribe);
+    }
+    @Test
+    public void testNoUnsubscribeWhenReplaced() {
+        MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
+        
+        mas.setSubscription(s);
+        mas.setSubscription(null);
+        mas.unsubscribe();        
+        
+        verify(unsubscribe, never()).call();
+        
+    }
+    @Test
+    public void testUnsubscribeWhenParentUnsubscribes() {
+        MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
+        mas.setSubscription(s);
+        mas.unsubscribe();
+        mas.unsubscribe();
+        
+        verify(unsubscribe, times(1)).call();
+        
+        Assert.assertEquals(true, mas.isUnsubscribed());
+    }
+    @Test
+    public void testUnsubscribedDoesntLeakSentinel() {
+        MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
+
+        mas.setSubscription(s);
+        mas.unsubscribe();
+        
+        Assert.assertEquals(true, mas.getSubscription() == Subscriptions.empty());
+    }
+}

--- a/rxjava-core/src/test/java/rx/subscriptions/RefCountSubscriptionTest.java
+++ b/rxjava-core/src/test/java/rx/subscriptions/RefCountSubscriptionTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.subscriptions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import static org.mockito.Mockito.*;
+import rx.Subscription;
+import static rx.subscriptions.Subscriptions.create;
+import rx.util.functions.Action0;
+
+public class RefCountSubscriptionTest {
+    Action0 main;
+    RefCountSubscription rcs;
+    @Before
+    public void before() {
+        main = mock(Action0.class);
+        rcs = new RefCountSubscription(create(main));
+    }
+    @Test
+    public void testImmediateUnsubscribe() {
+        InOrder inOrder = inOrder(main);
+
+        rcs.unsubscribe();
+        
+        inOrder.verify(main, times(1)).call();
+        
+        rcs.unsubscribe();
+
+        inOrder.verifyNoMoreInteractions();
+    }
+    @Test
+    public void testRCSUnsubscribeBeforeClient() {
+        InOrder inOrder = inOrder(main);
+        
+        Subscription s = rcs.getSubscription();
+        
+        rcs.unsubscribe();
+        
+        inOrder.verify(main, never()).call();
+        
+        s.unsubscribe();
+        
+        inOrder.verify(main, times(1)).call();
+        
+        rcs.unsubscribe();
+        s.unsubscribe();
+        
+        inOrder.verifyNoMoreInteractions();
+        
+    }
+    @Test
+    public void testMultipleClientsUnsubscribeFirst() {
+        InOrder inOrder = inOrder(main);
+
+        Subscription s1 = rcs.getSubscription();
+        Subscription s2 = rcs.getSubscription();
+
+        s1.unsubscribe();
+        inOrder.verify(main, never()).call();
+        s2.unsubscribe();
+        inOrder.verify(main, never()).call();
+        
+        rcs.unsubscribe();
+        inOrder.verify(main, times(1)).call();
+
+        s1.unsubscribe();
+        s2.unsubscribe();
+        rcs.unsubscribe();
+        
+        inOrder.verifyNoMoreInteractions();
+    }
+    @Test
+    public void testMultipleClientsMainUnsubscribeFirst() {
+        InOrder inOrder = inOrder(main);
+
+        Subscription s1 = rcs.getSubscription();
+        Subscription s2 = rcs.getSubscription();
+
+        rcs.unsubscribe();
+        inOrder.verify(main, never()).call();
+        s1.unsubscribe();
+        inOrder.verify(main, never()).call();
+        s2.unsubscribe();
+        
+        inOrder.verify(main, times(1)).call();
+
+        s1.unsubscribe();
+        s2.unsubscribe();
+        rcs.unsubscribe();
+        
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/rxjava-core/src/test/java/rx/subscriptions/SerialSubscriptionTests.java
+++ b/rxjava-core/src/test/java/rx/subscriptions/SerialSubscriptionTests.java
@@ -49,11 +49,11 @@ public class SerialSubscriptionTests {
     }
 
     @Test
-    public void getSubscriptionShouldReturnSubscriptionAfterUnsubscribe() {
+    public void getSubscriptionShouldReturnEmptySubscriptionAfterUnsubscribe() {
         final Subscription underlying = mock(Subscription.class);
         serialSubscription.setSubscription(underlying);
         serialSubscription.unsubscribe();
-        assertEquals(null, serialSubscription.getSubscription());
+        assertEquals(Subscriptions.empty(), serialSubscription.getSubscription());
     }
 
     @Test


### PR DESCRIPTION
- Uniform naming of inner components: Issue #592
- Lock-free approach to avoid deadlocks: Issue #577
- SerialSubscription.isUnsubscribe added: Issue #590

Remarks:
- IMO, an unsubscribed Single/Serial/Multiple subscription return Subscriptions.empty() instead of null. So unless the user put a null in there he/she shouldn't worry about null.
- There was a concurrency bug in @jloisel 's reimplementation of CompositeSubscription. It allowed multiple threads to enter the mutation part if the current state was already MUTATE. I've added the necessary checks to allow only NORMAL -> MUTATE transitions.
