### PR TITLE
Subjects reimplemented.

### DIFF
--- a/rxjava-core/src/main/java/rx/Notification.java
+++ b/rxjava-core/src/main/java/rx/Notification.java
@@ -125,6 +125,33 @@ public class Notification<T> {
             observer.onError(getThrowable());
         }
     }
+    /**
+     * Emits the notification value to the observer
+     * and captures the exception thrown by the onNext method.
+     * @param observer the observer to send the notification to
+     * @return false if a terminal condition was reached, i.e.,
+     * this is an isOnCompleted, isOnError or the observer.onNext threw
+     */
+    public boolean acceptSafe(Observer<? super T> observer) {
+        if (isOnNext()) {
+            try {
+                observer.onNext(getValue());
+                return true;
+            } catch (Throwable t) {
+                observer.onError(t);
+                return false;
+            }
+        } else 
+        if (isOnCompleted()) {
+            observer.onCompleted();
+            return false;
+        } else 
+        if (isOnError()) {
+            observer.onError(getThrowable());
+            return false;
+        }
+        return false;
+    }
 
     public static enum Kind {
         OnNext, OnError, OnCompleted

--- a/rxjava-core/src/test/java/rx/subjects/AsyncSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/AsyncSubjectTest.java
@@ -16,7 +16,6 @@
 package rx.subjects;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
@@ -300,5 +299,31 @@ public class AsyncSubjectTest {
             }
         }
     }
+    @Test
+    public void testFirstErrorOnly() {
+        AsyncSubject<Object> subject = AsyncSubject.create();
+        Observer<Object> observer = mock(Observer.class);
+        
+        subject.subscribe(observer);
+        
+        RuntimeException ex = new RuntimeException("Forced failure");
+        
+        subject.onError(ex);
 
+        verify(observer, times(1)).onError(ex);
+        verify(observer, never()).onCompleted();
+        verify(observer, never()).onNext(any());
+        
+        RuntimeException ex2 = new RuntimeException("Forced failure 2");
+        
+        subject.onError(ex2);
+
+        Observer<Object> observer2 = mock(Observer.class);
+        
+        subject.subscribe(observer2);
+        verify(observer2, times(1)).onError(ex);
+        verify(observer2, never()).onError(ex2);
+        verify(observer2, never()).onCompleted();
+        verify(observer2, never()).onNext(any());
+    }
 }

--- a/rxjava-core/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -15,7 +15,6 @@
  */
 package rx.subjects;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
@@ -178,5 +177,32 @@ public class BehaviorSubjectTest {
                     }
                 }
                 );
+    }
+    @Test
+    public void testFirstErrorOnly() {
+        BehaviorSubject<Integer> subject = BehaviorSubject.create(0);
+        Observer<Object> observer = mock(Observer.class);
+        
+        subject.subscribe(observer);
+        
+        RuntimeException ex = new RuntimeException("Forced failure");
+        
+        subject.onError(ex);
+
+        verify(observer, times(1)).onNext(0);
+        verify(observer, times(1)).onError(ex);
+        verify(observer, never()).onCompleted();
+        
+        RuntimeException ex2 = new RuntimeException("Forced failure 2");
+        
+        subject.onError(ex2);
+
+        Observer<Object> observer2 = mock(Observer.class);
+        
+        subject.subscribe(observer2);
+        verify(observer2, never()).onNext(any());
+        verify(observer2, times(1)).onError(ex);
+        verify(observer2, never()).onError(ex2);
+        verify(observer2, never()).onCompleted();
     }
 }

--- a/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
@@ -328,4 +328,32 @@ public class PublishSubjectTest {
 
     private final Throwable testException = new Throwable();
 
+    
+    @Test
+    public void testFirstErrorOnly() {
+        PublishSubject<Object> subject = PublishSubject.create();
+        Observer<Object> observer = mock(Observer.class);
+        
+        subject.subscribe(observer);
+        
+        RuntimeException ex = new RuntimeException("Forced failure");
+        
+        subject.onError(ex);
+
+        verify(observer, times(1)).onError(ex);
+        verify(observer, never()).onCompleted();
+        verify(observer, never()).onNext(any());
+        
+        RuntimeException ex2 = new RuntimeException("Forced failure 2");
+        
+        subject.onError(ex2);
+
+        Observer<Object> observer2 = mock(Observer.class);
+        
+        subject.subscribe(observer2);
+        verify(observer2, times(1)).onError(ex);
+        verify(observer2, never()).onError(ex2);
+        verify(observer2, never()).onCompleted();
+        verify(observer2, never()).onNext(any());
+    }
 }

--- a/rxjava-core/src/test/java/rx/subjects/ReplaySubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/ReplaySubjectTest.java
@@ -269,4 +269,35 @@ public class ReplaySubjectTest {
                 }
                 );
     }
+    @Test
+    public void testFirstErrorOnly() {
+        ReplaySubject<Integer> subject = ReplaySubject.create();
+        Observer<Object> observer = mock(Observer.class);
+        
+        subject.subscribe(observer);
+        
+        RuntimeException ex = new RuntimeException("Forced failure");
+        
+        subject.onNext(0);
+        subject.onError(ex);
+
+        verify(observer, times(1)).onNext(0);
+        verify(observer, times(1)).onError(ex);
+        verify(observer, never()).onCompleted();
+        
+        RuntimeException ex2 = new RuntimeException("Forced failure 2");
+        
+        subject.onNext(1);
+        subject.onError(ex2);
+
+        Observer<Object> observer2 = mock(Observer.class);
+        
+        subject.subscribe(observer2);
+        verify(observer2, times(1)).onNext(0);
+        verify(observer2, times(1)).onError(ex);
+
+        verify(observer2, never()).onNext(1);
+        verify(observer2, never()).onError(ex2);
+        verify(observer2, never()).onCompleted();
+    }
 }


### PR DESCRIPTION
Reimplemented all 4 kinds of subjects with the following properties:
- The `onNext`, `onError` and `onCompleted` are fully thread safe against subscription and unsubscription.
- A terminated subject won't accept any new events; `AsyncSubject`, `PublishSubject` and `BehaviorSubject` will re-emit just the very first exception when an observer subscribes to them.
- Emitting events to subscribed observers is done while holding the state lock. 
  - In Rx.NET when an event is received, the list of observers is retrieved while holding the lock, then outside the lock, the list is traversed and the events are propagated to the observers. Note however, if an observer unsubscribes right after the unlock and before the event propagation, it will still appear in the list and will receive the event. IMO, this is an undesired behavior.
  - The drawback of my solution is that it might be possible to deadlock the subjects, i.e., when an observer deliberately passes the source subject to another thread (which sends an event to the subject) and waits for its completion.
- Added the `Notification.acceptSafe` which will capture the exception of the `onNext` and propagate it through the `onError`. Its return value indicates if the observer can still be used after (i.e., no terminal event was delivered).
- Added the reusable state classes to `AbstractSubject`, although none of the subjects use this class any more.
- There is an `UnsubscribeTester` class, which seems to be out-of-place. Can this be moved into the test directory?
