### PR TITLE
Javadoc improvements:

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -413,7 +413,8 @@ public class Observable<T> {
         /**
          * Wrapping since raw functions provided by the user are being invoked.
          * 
-         * See https://github.com/Netflix/RxJava/issues/216 for discussion on "Guideline 6.4: Protect calls to user code from within an operator"
+         * See https://github.com/Netflix/RxJava/issues/216 for discussion on
+         * "Guideline 6.4: Protect calls to user code from within an operator"
          */
         return protectivelyWrapAndSubscribe(new Observer<T>() {
 
@@ -617,7 +618,7 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits no data to the {@link Observer} and
+     * Returns an Observable that emits no items to the {@link Observer} and
      * immediately invokes its {@link Observer#onCompleted onCompleted} method.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/empty.png">
@@ -634,7 +635,7 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits no data to the {@link Observer} and
+     * Returns an Observable that emits no items to the {@link Observer} and
      * immediately invokes its {@link Observer#onCompleted onCompleted} method
      * with the specified scheduler.
      * <p>
@@ -715,7 +716,8 @@ public class Observable<T> {
     }
 
     /**
-     * Converts an {@link Iterable} sequence into an Observable with the specified scheduler.
+     * Converts an {@link Iterable} sequence into an Observable with the
+     * specified scheduler.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.s.png">
      * 
@@ -733,7 +735,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts an Array into an Observable.
+     * Converts an Array into an Observable that emits the items in the Array.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -775,7 +777,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -798,7 +800,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -822,7 +824,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -847,7 +849,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -873,7 +875,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -900,7 +902,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -928,7 +930,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -957,7 +959,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -987,7 +989,7 @@ public class Observable<T> {
     }
 
     /**
-     * Converts a series of items into an Observable.
+     * Converts a series of items into an Observable that emits those items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
@@ -1018,7 +1020,7 @@ public class Observable<T> {
     }
 
     /**
-     * Generates an Observable that emits a sequence of integers within a
+     * Generates an Observable that emits a sequence of Integers within a
      * specified range.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/range.png">
@@ -1028,9 +1030,9 @@ public class Observable<T> {
      * {@link Subscription} is returned, it is not possible to unsubscribe from
      * the sequence before it completes.
      * 
-     * @param start the value of the first integer in the sequence
-     * @param count the number of sequential integers to generate
-     * @return an Observable that emits a range of sequential integers
+     * @param start the value of the first Integer in the sequence
+     * @param count the number of sequential Integers to generate
+     * @return an Observable that emits a range of sequential Integers
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#range">RxJava Wiki: range()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229460.aspx">Observable.Range Method (Int32, Int32)</a>
      */
@@ -1039,14 +1041,15 @@ public class Observable<T> {
     }
 
     /**
-     * Generates an Observable that emits a sequence of integers within a
+     * Generates an Observable that emits a sequence of Integers within a
      * specified range with the specified scheduler.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/range.s.png">
-     * @param start the value of the first integer in the sequence
-     * @param count the number of sequential integers to generate
+     *
+     * @param start the value of the first Integer in the sequence
+     * @param count the number of sequential Integers to generate
      * @param scheduler the scheduler to run the generator loop on
-     * @return an Observable that emits a range of sequential integers
+     * @return an Observable that emits a range of sequential Integers
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#range">RxJava Wiki: range()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211896.aspx">Observable.Range Method (Int32, Int32, IScheduler)</a>
      */
@@ -1057,7 +1060,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that calls an Observable factory to create its
      * Observable for each new Observer that subscribes. That is, for each
-     * subscriber, the actuall Observable is determined by the factory function.
+     * subscriber, the actual Observable is determined by the factory function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/defer.png">
      * <p>
@@ -1092,8 +1095,7 @@ public class Observable<T> {
      * while the <code>just()</code> method converts an Iterable into an
      * Observable that emits the entire Iterable as a single item.
      * 
-     * @param value the item to pass to the {@link Observer}'s
-     *              {@link Observer#onNext onNext} method
+     * @param value the item to emit
      * @param <T> the type of that item
      * @return an Observable that emits a single item and then completes
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#just">RxJava Wiki: just()</a>
@@ -1106,18 +1108,17 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits a single item and then completes on a
+     * Returns an Observable that emits a single item and then completes, on a
      * specified scheduler.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/just.s.png">
      * <p>
      * This is a scheduler version of {@link Observable#just(Object)}.
      * 
-     * @param value the item to pass to the {@link Observer}'s
-     *              {@link Observer#onNext onNext} method
+     * @param value the item to emit
      * @param <T> the type of that item
-     * @param scheduler the scheduler to send the single element on
-     * @return an Observable that emits a single item and then completes on a
+     * @param scheduler the scheduler to emit the single item on
+     * @return an Observable that emits a single item and then completes, on a
      *         specified scheduler
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#just">RxJava Wiki: just()</a>
      */
@@ -1860,8 +1861,8 @@ public class Observable<T> {
      * This Observable is useful primarily for testing purposes.
      * 
      * @param <T> the type of items (not) emitted by the Observable
-     * @return an Observable that never sends any items or notifications to an
-     *         {@link Observer}
+     * @return an Observable that never emits any items or sends any
+     *         notifications to an {@link Observer}
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#empty-error-and-never">RxJava Wiki: never()</a>
      */
     public static <T> Observable<T> never() {
@@ -1869,15 +1870,15 @@ public class Observable<T> {
     }
 
     /**
-     * Given an Observable that emits Observables, creates a single Observable
-     * that emits the items emitted by the most recently published of those
+     * Given an Observable that emits Observables, returns an Observable that
+     * emits the items emitted by the most recently emitted of those
      * Observables.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/switchDo.png">
      * 
      * @param sequenceOfSequences the source Observable that emits Observables
-     * @return an Observable that emits only the items emitted by the most
-     *         recently published Observable
+     * @return an Observable that emits only the items emitted by the Observable
+     *         most recently emitted by the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#switchonnext">RxJava Wiki: switchOnNext()</a>
      * @deprecated use {@link #switchOnNext}
      */
@@ -1887,15 +1888,15 @@ public class Observable<T> {
     }
 
     /**
-     * Given an Observable that emits Observables, creates a single Observable
-     * that emits the items emitted by the most recently published of those
+     * Given an Observable that emits Observables, returns an Observable that
+     * emits the items emitted by the most recently emitted of those
      * Observables.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/switchDo.png">
      * 
      * @param sequenceOfSequences the source Observable that emits Observables
-     * @return an Observable that emits only the items emitted by the most
-     *         recently published Observable
+     * @return an Observable that emits only the items emitted by the Observable
+     *         most recently emitted by the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#switchonnext">RxJava Wiki: switchOnNext()</a>
      */
     public static <T> Observable<T> switchOnNext(Observable<? extends Observable<? extends T>> sequenceOfSequences) {
@@ -1929,8 +1930,8 @@ public class Observable<T> {
     /**
      * Accepts an Observable and wraps it in another Observable that ensures
      * that the resulting Observable is chronologically well-behaved. This is
-     * accomplished by acquiring a mutual-exclusion lock for the object
-     * provided as the lock parameter.
+     * accomplished by acquiring a mutual-exclusion lock for the object provided
+     * as the lock parameter.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/synchronize.png">
      * <p>
@@ -1962,7 +1963,8 @@ public class Observable<T> {
     }
 
     /**
-     * Emits an item each time interval (containing a sequential number).
+     * Returns an Observable that emits an item each time interval, containing
+     * a sequential number.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/interval.png">
      * 
@@ -1977,7 +1979,8 @@ public class Observable<T> {
     }
 
     /**
-     * Emits an item each time interval (containing a sequential number).
+     * Returns an Observable that emits an item each time interval, containing
+     * a sequential number.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/interval.s.png">
      * 
@@ -1993,56 +1996,64 @@ public class Observable<T> {
     }
 
     /**
-     * Emits one item after a given delay, and then completes.
+     * Returns an Observable that emits one item after a given delay, and then
+     * completes.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.png">
      * 
-     * @param interval
-     *            interval size in time units
-     * @param unit
-     *            time units to use for the interval size
+     * @param interval interval size in time units
+     * @param unit time units to use for the interval size
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#timer">RxJava wiki: timer()</a>
      */
     public static Observable<Void> timer(long interval, TimeUnit unit) {
         return create(OperationTimer.timer(interval, unit));
     }
 
     /**
-     * Emits one item after a given delay, and then completes.
+     * Returns an Observable that emits one item after a given delay, and then
+     * completes.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.s.png">
      * 
-     * @param interval
-     *            interval size in time units
-     * @param unit
-     *            time units to use for the interval size
-     * @param scheduler
-     *            the scheduler to use for scheduling the item
+     * @param interval interval size in time units
+     * @param unit time units to use for the interval size
+     * @param scheduler the scheduler to use for scheduling the item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#timer">RxJava wiki: timer()</a>
      */
     public static Observable<Void> timer(long interval, TimeUnit unit, Scheduler scheduler) {
         return create(OperationTimer.timer(interval, unit, scheduler));
     }
 
     /**
-     * Returns an Observable that emits the results of shifting the items emitted by the source
-     * Observable by a specified delay. Errors emitted by the source Observable are not delayed.
-     * @param delay
-     *            the delay to shift the source by
-     * @param unit
-     *            the {@link TimeUnit} in which <code>period</code> is defined
+     * Returns an Observable that emits the items emitted by the source
+     * Observable shifted forward in time by a specified delay. Error
+     * notifications from the source Observable are not delayed.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.png">
+     *
+     * @param delay the delay to shift the source by
+     * @param unit the {@link TimeUnit} in which <code>period</code> is defined
      * @return the source Observable, but shifted by the specified delay
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229810%28v=vs.103%29.aspx">MSDN: Observable.Delay</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#delay">RxJava Wiki: delay()</a>
+     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229810.aspx">MSDN: Observable.Delay</a>
      */
     public Observable<T> delay(long delay, TimeUnit unit) {
         return OperationDelay.delay(this, delay, unit, Schedulers.threadPoolForComputation());
     }
 
     /**
-     * Returns an Observable that emits the results of shifting the items emitted by the source
-     * Observable by a specified delay. Errors emitted by the source Observable are not delayed.
-     * @param delay
-     *            the delay to shift the source by
-     * @param unit
-     *            the {@link TimeUnit} in which <code>period</code> is defined
-     * @param scheduler
-     *            the {@link Scheduler} to use for delaying
+     * Returns an Observable that emits the items emitted by the source
+     * Observable shifted forward in time by a specified delay. Error
+     * notifications from the source Observable are not delayed.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.s.png">
+     *
+     * @param delay the delay to shift the source by
+     * @param unit the {@link TimeUnit} in which <code>period</code> is defined
+     * @param scheduler the {@link Scheduler} to use for delaying
      * @return the source Observable, but shifted by the specified delay
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229280(v=vs.103).aspx">MSDN: Observable.Delay</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#delay">RxJava Wiki: delay()</a>
+     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229280.aspx">MSDN: Observable.Delay</a>
      */
     public Observable<T> delay(long delay, TimeUnit unit, Scheduler scheduler) {
         return OperationDelay.delay(this, delay, unit, scheduler);
@@ -2052,8 +2063,8 @@ public class Observable<T> {
      * Drops items emitted by an Observable that are followed by newer items
      * before a timeout value expires. The timer resets on each emission.
      * <p>
-     * Note: If events keep firing faster than the timeout then no data will be
-     * emitted.
+     * Note: If events keep firing faster than the timeout then no items will be
+     * emitted by the resulting Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/debounce.png">
      * <p>
@@ -2065,11 +2076,12 @@ public class Observable<T> {
      * <li><a href="http://www.illyriad.co.uk/blog/index.php/2011/09/javascript-dont-spam-your-server-debounce-and-throttle/">Javascript - don't spam your server: debounce and throttle</a></li>
      * </ul>
      * 
-     * @param timeout the time each value has to be "the most recent" of the
-     *                {@link Observable} to ensure that it's not dropped
+     * @param timeout the time each item has to be "the most recent" of those
+     *                emitted by the source {@link Observable} to ensure that
+     *                it's not dropped
      * @param unit the {@link TimeUnit} for the timeout 
-     * @return an {@link Observable} that filters out items that are too
-     *         quickly followed by newer items
+     * @return an {@link Observable} that filters out items that are too quickly
+     *         followed by newer items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#throttlewithtimeout-or-debounce">RxJava Wiki: debounce()</a>
      * @see #throttleWithTimeout(long, TimeUnit)
      */
@@ -2081,8 +2093,8 @@ public class Observable<T> {
      * Drops items emitted by an Observable that are followed by newer items
      * before a timeout value expires. The timer resets on each emission.
      * <p>
-     * Note: If events keep firing faster than the timeout then no data will be
-     * emitted.
+     * Note: If events keep firing faster than the timeout then no items will be
+     * emitted by the resulting Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/debounce.s.png">
      * <p>
@@ -2094,13 +2106,14 @@ public class Observable<T> {
      * <li><a href="http://www.illyriad.co.uk/blog/index.php/2011/09/javascript-dont-spam-your-server-debounce-and-throttle/">Javascript - don't spam your server: debounce and throttle</a></li>
      * </ul>
      * 
-     * @param timeout the time each value has to be "the most recent" of the
-     *                {@link Observable} to ensure that it's not dropped
+     * @param timeout the time each item has to be "the most recent" of those
+     *                emitted by the source {@link Observable} to ensure that
+     *                it's not dropped
      * @param unit the unit of time for the specified timeout
      * @param scheduler the {@link Scheduler} to use internally to manage the
      *                  timers that handle the timeout for each event
-     * @return an {@link Observable} that filters out items that are too
-     *         quickly followed by newer items
+     * @return an {@link Observable} that filters out items that are too quickly
+     *         followed by newer items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#throttlewithtimeout-or-debounce">RxJava Wiki: debounce()</a>
      * @see #throttleWithTimeout(long, TimeUnit, Scheduler)
      */
@@ -2112,8 +2125,8 @@ public class Observable<T> {
      * Drops items emitted by an Observable that are followed by newer items
      * before a timeout value expires. The timer resets on each emission.
      * <p>
-     * Note: If events keep firing faster than the timeout then no data will be
-     * emitted.
+     * Note: If events keep firing faster than the timeout then no items will be
+     * emitted by the resulting Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleWithTimeout.png">
      * <p>
@@ -2125,11 +2138,12 @@ public class Observable<T> {
      * <li><a href="http://www.illyriad.co.uk/blog/index.php/2011/09/javascript-dont-spam-your-server-debounce-and-throttle/">Javascript - don't spam your server: debounce and throttle</a></li>
      * </ul>
      * 
-     * @param timeout the time each value has to be "the most recent" of the
-     *                {@link Observable} to ensure that it's not dropped
+     * @param timeout the time each item has to be "the most recent" of those
+     *                emitted by the source {@link Observable} to ensure that
+     *                it's not dropped
      * @param unit the {@link TimeUnit} for the timeout
-     * @return an {@link Observable} that filters out items that are too
-     *         quickly followed by newer items
+     * @return an {@link Observable} that filters out items that are too quickly
+     *         followed by newer items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#throttlewithtimeout-or-debounce">RxJava Wiki: throttleWithTimeout()</a>
      * @see #debounce(long, TimeUnit)
      */
@@ -2141,8 +2155,8 @@ public class Observable<T> {
      * Drops items emitted by an Observable that are followed by newer items
      * before a timeout value expires. The timer resets on each emission.
      * <p>
-     * Note: If events keep firing faster than the timeout then no data will be
-     * emitted.
+     * Note: If events keep firing faster than the timeout then no items will be
+     * emitted by the resulting Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleWithTimeout.s.png">
      * <p>
@@ -2154,13 +2168,13 @@ public class Observable<T> {
      * <li><a href="http://www.illyriad.co.uk/blog/index.php/2011/09/javascript-dont-spam-your-server-debounce-and-throttle/">Javascript - don't spam your server: debounce and throttle</a></li>
      * </ul>
      * 
-     * @param timeout the time each value has to be "the most recent" of the
-     *                {@link Observable} to ensure that it's not dropped
+     * @param timeout the time each item has to be "the most recent" emitted by
+     *                the {@link Observable} to ensure that it's not dropped
      * @param unit the {@link TimeUnit} for the timeout
      * @param scheduler the {@link Scheduler} to use internally to manage the
-     *                  timers that handle the timeout for each event
-     * @return an {@link Observable} that filters out items that are too
-     *         quickly followed by newer items
+     *                  timers that handle the timeout for each item
+     * @return an {@link Observable} that filters out items that are too quickly
+     *         followed by newer items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#throttlewithtimeout-or-debounce">RxJava Wiki: throttleWithTimeout()</a>
      * @see #debounce(long, TimeUnit, Scheduler)
      */
@@ -2169,15 +2183,16 @@ public class Observable<T> {
     }
 
     /**
-     * Throttles by skipping items until "skipDuration" passes and then emits
-     * the next received item.
+     * Throttles by skipping items emitted by the source Observable until
+     * <code>windowDuration</code> passes and then emitting the next item
+     * emitted by the source Observable.
      * <p>
      * This differs from {@link #throttleLast} in that this only tracks passage
      * of time whereas {@link #throttleLast} ticks at scheduled intervals.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleFirst.png">
      * 
-     * @param windowDuration time to wait before sending another item after
+     * @param windowDuration time to wait before emitting another item after
      *                       emitting the last item
      * @param unit the unit of time for the specified timeout
      * @return an Observable that performs the throttle operation
@@ -2188,15 +2203,16 @@ public class Observable<T> {
     }
 
     /**
-     * Throttles by skipping items until "skipDuration" passes and then emits
-     * the next received item.
+     * Throttles by skipping items emitted by the source Observable until
+     * <code>skipDuration</code> passes and then emitting the next item emitted
+     * by the source Observable.
      * <p>
      * This differs from {@link #throttleLast} in that this only tracks passage
      * of time whereas {@link #throttleLast} ticks at scheduled intervals.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleFirst.s.png">
      * 
-     * @param skipDuration time to wait before sending another item after
+     * @param skipDuration time to wait before emitting another item after
      *                     emitting the last item
      * @param unit the unit of time for the specified timeout
      * @param scheduler the {@link Scheduler} to use internally to manage the
@@ -2209,8 +2225,8 @@ public class Observable<T> {
     }
 
     /**
-     * Throttles by emitting the last item in each interval defined by
-     * <code>intervalDuration</code>.
+     * Throttles by emitting the last item from the source Observable that falls
+     * in each interval defined by <code>intervalDuration</code>.
      * <p>
      * This differs from {@link #throttleFirst} in that this ticks along at a
      * scheduled interval whereas {@link #throttleFirst} does not tick, it just
@@ -2219,7 +2235,7 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleLast.png">
      * 
      * @param intervalDuration duration of windows within which the last item
-     *                         will be emitted
+     *                         emitted by the source Observable will be emitted
      * @param unit the unit of time for the specified interval
      * @return an Observable that performs the throttle operation
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#takelast">RxJava Wiki: throttleLast()</a>
@@ -2240,7 +2256,7 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleLast.s.png">
      * 
      * @param intervalDuration duration of windows within which the last item
-     *                         will be emitted
+     *                         emitted by the source Observable will be emitted
      * @param unit the unit of time for the specified interval
      * @param scheduler the {@link Scheduler} to use internally to manage the
      *                  timers that handle timeout for each event
@@ -2356,16 +2372,17 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits a Boolean value that indicates
-     * whether two sequences are equal by comparing the elements pairwise.
+     * Returns an Observable that emits a Boolean value that indicates whether
+     * two sequences are equal by comparing the elements emitted by each
+     * Observable pairwise.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sequenceEqual.png">
      * 
      * @param first the first Observable to compare
      * @param second the second Observable to compare
      * @param <T> the type of items emitted by each Observable
-     * @return an Observable that emits a Boolean value that indicates
-     *         whether two sequences are equal by comparing the elements pairwise
+     * @return an Observable that emits a Boolean value that indicates whether
+     *         two sequences are equal by comparing the elements pairwise
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#sequenceequal">RxJava Wiki: sequenceEqual()</a>
      */
     public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> first, Observable<? extends T> second) {
@@ -2381,9 +2398,10 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits a Boolean value that indicates
-     * whether two sequences are equal by comparing the elements pairwise
-     * based on the results of a specified equality function.
+     * Returns an Observable that emits a Boolean value that indicates whether
+     * two sequences are equal by comparing the elements emitted by each
+     * Observable pairwise based on the results of a specified equality
+     * function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sequenceEqual.png">
      * 
@@ -2392,8 +2410,8 @@ public class Observable<T> {
      * @param equality a function used to compare items emitted by both
      *                 Observables
      * @param <T> the type of items emitted by each Observable
-     * @return an Observable that emits a Boolean value that indicates
-     *         whether two sequences are equal by comparing the elements pairwise
+     * @return an Observable that emits a Boolean value that indicates whether
+     *         two sequences are equal by comparing the elements pairwise
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#sequenceequal">RxJava Wiki: sequenceEqual()</a>
      */
     public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> first, Observable<? extends T> second, Func2<? super T, ? super T, Boolean> equality) {
@@ -2680,19 +2698,20 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1 the first source Observable
      * @param o2 the second source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Func2<? super T1, ? super T2, ? extends R> combineFunction) {
@@ -2700,10 +2719,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2711,9 +2730,10 @@ public class Observable<T> {
      * @param o2 the second source Observable
      * @param o3 the third source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Func3<? super T1, ? super T2, ? super T3, ? extends R> combineFunction) {
@@ -2721,10 +2741,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2733,9 +2753,10 @@ public class Observable<T> {
      * @param o3 the third source Observable
      * @param o4 the fourth source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, T4, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4,
@@ -2744,10 +2765,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2757,9 +2778,10 @@ public class Observable<T> {
      * @param o4 the fourth source Observable
      * @param o5 the fifth source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, T4, T5, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5,
@@ -2768,10 +2790,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2782,9 +2804,10 @@ public class Observable<T> {
      * @param o5 the fifth source Observable
      * @param o6 the sixth source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6,
@@ -2793,10 +2816,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2808,9 +2831,10 @@ public class Observable<T> {
      * @param o6 the sixth source Observable
      * @param o7 the seventh source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7,
@@ -2819,10 +2843,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2835,9 +2859,10 @@ public class Observable<T> {
      * @param o7 the seventh source Observable
      * @param o8 the eighth source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7, Observable<? extends T8> o8,
@@ -2846,10 +2871,10 @@ public class Observable<T> {
     }
 
     /**
-     * Combines the given Observables, emitting an event containing an
-     * aggregation of the latest values of each of the source observables each
-     * time an event is received from one of the source observables, where the
-     * aggregation is defined by the given function.
+     * Combines the given Observables, emitting an item that aggregates the
+     * latest values of each of the source Observables each time an item is
+     * received from any of the source Observables, where this aggregation is
+     * defined by a given function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
@@ -2863,9 +2888,10 @@ public class Observable<T> {
      * @param o8 the eighth source Observable
      * @param o9 the ninth source Observable
      * @param combineFunction the aggregation function used to combine the
-     *                        source observable values
-     * @return an Observable that combines the source Observables with the
-     *         given combine function
+     *                        items emitted by the source Observables
+     * @return an Observable whose emissions are the result of combining the
+     *         emissions of the source Observables with the given aggregation
+     *         function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#combinelatest">RxJava Wiki: combineLatest()</a>
      */
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7, Observable<? extends T8> o8, Observable<? extends T9> o9,
@@ -2873,28 +2899,26 @@ public class Observable<T> {
         return create(OperationCombineLatest.combineLatest(o1, o2, o3, o4, o5, o6, o7, o8, o9, combineFunction));
     }
 
-/**
-     * Creates an Observable that produces buffers of collected items.
+    /**
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping buffers. It emits the current buffer and replaces it with
+     * a new buffer when the Observable produced by the specified
+     * <code>bufferClosingSelector</code> emits an item. It then uses the
+     * <code>bufferClosingSelector</code> to create a new Observable to observe
+     * for the end of the next buffer.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer1.png">
-     * <p>
-     * This Observable produces connected, non-overlapping buffers. The current
-     * buffer is emitted and replaced with a new buffer when the Observable
-     * produced by the specified <code>bufferClosingSelector</code> produces an
-     * object. The <code>bufferClosingSelector</code>
-     * will then be used to create a new Observable to listen for the end of
-     * the next buffer.
      * 
      * @param bufferClosingSelector the {@link Func0} which is used to produce
      *                              an {@link Observable} for every buffer
-     *                              created. When this {@link Observable}
-     *                              produces an object,
-     *                              the associated buffer is emitted and
-     *                              replaced with a new one.
-     * @return an {@link Observable} which produces connected, non-overlapping
-     *         buffers, which are emitted when the current {@link Observable}
-     *         created with the {@link Func0} argument produces an
-     *         object
+     *                              created. When this {@link Observable} emits
+     *                              an item, <code>buffer()</code> emits the
+     *                              associated buffer and replaces it with a new
+     *                              one.
+     * @return an {@link Observable} that emits connected, non-overlapping
+     *         buffers when the current {@link Observable} created with the
+     *         {@code bufferClosingSelector} argument emits an item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public <TClosing> Observable<List<T>> buffer(Func0<? extends Observable<? extends TClosing>> bufferClosingSelector) {
@@ -2902,28 +2926,22 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable which produces buffers of collected values.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits buffers that it creates
+     * when the specified <code>bufferOpenings</code> Observable emits an item,
+     * and closes when the Observable returned from
+     * <code>bufferClosingSelector</code> emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer2.png">
-     * <p>
-     * This Observable produces buffers. Buffers are created when the specified
-     * <code>bufferOpenings</code> Observable produces an
-     * object. Additionally the <code>bufferClosingSelector</code> argument is
-     * used to create an Observable which produces
-     * objects. When this Observable produces such an object, the associated
-     * buffer is emitted.
      * 
-     * @param bufferOpenings the {@link Observable} that, when it produces an
-     *                       object, will cause another
-     *                       buffer to be created
+     * @param bufferOpenings the {@link Observable} that, when it emits an item,
+     *                       causes a new buffer to be created
      * @param bufferClosingSelector the {@link Func1} that is used to produce
      *                              an {@link Observable} for every buffer
-     *                              created. When this {@link Observable}
-     *                              produces an object,
-     *                              the associated buffer is emitted.
-     * @return an {@link Observable} that produces buffers that are created and
-     *         emitted when the specified {@link Observable}s publish certain
-     *         objects
+     *                              created. When this {@link Observable} emits
+     *                              an item, the associated buffer is emitted.
+     * @return an {@link Observable} that emits buffers that are created and
+     *         closed when the specified {@link Observable}s emit items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public <TOpening, TClosing> Observable<List<T>> buffer(Observable<? extends TOpening> bufferOpenings, Func1<? super TOpening, ? extends Observable<? extends TClosing>> bufferClosingSelector) {
@@ -2931,18 +2949,20 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected items.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping buffers, each containing <code>count</code> items. When
+     * the source Observable completes or encounters an error, it emits the
+     * current buffer is emitted, and propagates the notification from the
+     * source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer3.png">
-     * <p>
-     * This Observable produces connected, non-overlapping buffers, each
-     * containing <code>count</code> items. When the source Observable completes
-     * or encounters an error, the current buffer is emitted, and the event is
-     * propagated.
      * 
-     * @param count the maximum size of each buffer before it should be emitted
-     * @return an {@link Observable} that produces connected, non-overlapping
-     *         buffers containing at most "count" items
+     * @param count the maximum number of items in each buffer before it should
+     *              be emitted
+     * @return an {@link Observable} that emits connected, non-overlapping
+     *         buffers, each containing at most "count" items from the source
+     *         Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public Observable<List<T>> buffer(int count) {
@@ -2950,23 +2970,22 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable which produces buffers of collected items.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits buffers every
+     * <code>skip</code> items, each containing <code>count</code> items. When
+     * the source Observable completes or encounters an error, the resulting
+     * Observable emits the current buffer and propagates the notification from
+     * the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer4.png">
-     * <p>
-     * This Observable produces buffers every <code>skip</code> items, each
-     * containing <code>count</code> items. When the source Observable
-     * completes or encounters an error, the current buffer is emitted, and the
-     * event is propagated.
      * 
      * @param count the maximum size of each buffer before it should be emitted
      * @param skip how many produced items need to be skipped before starting a
      *             new buffer. Note that when <code>skip</code> and
      *             <code>count</code> are equal, this is the same operation as
      *             {@link Observable#buffer(int)}.
-     * @return an {@link Observable} that produces buffers every
-     *         <code>skip</code> item containing at most <code>count</code>
-     *         items
+     * @return an {@link Observable} that emits buffers every <code>skip</code>
+     *         item and containing at most <code>count</code> items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public Observable<List<T>> buffer(int count, int skip) {
@@ -2974,20 +2993,20 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected values.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping buffers, each of a fixed duration specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * encounters an error, the resulting Observable emits the current buffer
+     * and propagates the notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer5.png">
-     * <p>
-     * This Observable produces connected, non-overlapping buffers, each of a
-     * fixed duration specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current buffer is
-     * emitted and the event is propagated.
      * 
-     * @param timespan the period of time each buffer collects values before it
+     * @param timespan the period of time each buffer collects items before it
      *                 should be emitted and replaced with a new buffer
      * @param unit the unit of time which applies to the <code>timespan</code>
      *             argument
-     * @return an {@link Observable} that produces connected, non-overlapping
+     * @return an {@link Observable} that emits connected, non-overlapping
      *         buffers with a fixed duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
@@ -2996,22 +3015,22 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected values.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping buffers, each of a fixed duration specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * encounters an error, the resulting Observable emits the current buffer
+     * and propagates the notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer5.s.png">
-     * <p>
-     * This Observable produces connected, non-overlapping buffers, each of a
-     * fixed duration specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current buffer is
-     * emitted and the event is propagated.
      * 
-     * @param timespan the period of time each buffer collects values before it
+     * @param timespan the period of time each buffer collects items before it
      *                 should be emitted and replaced with a new buffer
      * @param unit the unit of time which applies to the <code>timespan</code>
      *             argument
      * @param scheduler the {@link Scheduler} to use when determining the end
      *                  and start of a buffer
-     * @return an {@link Observable} that produces connected, non-overlapping
+     * @return an {@link Observable} that emits connected, non-overlapping
      *         buffers with a fixed duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
@@ -3020,23 +3039,26 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected items. This
-     * Observable produces connected, non-overlapping buffers, each of a fixed
-     * duration specified by the <code>timespan</code> argument or a maximum
-     * size specified by the <code>count</code> argument (whichever is reached
-     * first). When the source Observable completes or encounters an error, the
-     * current buffer is emitted and the event is propagated.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping buffers, each of a fixed duration specified by the
+     * <code>timespan</code> argument or a maximum size specified by the
+     * <code>count</code> argument (whichever is reached first). When the source
+     * Observable completes or encounters an error, the resulting Observable
+     * emits the current buffer and propagates the notification from the source
+     * Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer6.png">
      * 
-     * @param timespan the period of time each buffer collects values before it
+     * @param timespan the period of time each buffer collects items before it
      *                 should be emitted and replaced with a new buffer
      * @param unit the unit of time which applies to the <code>timespan</code>
      *             argument
      * @param count the maximum size of each buffer before it should be emitted
-     * @return an {@link Observable} that produces connected, non-overlapping
-     *         buffers that are emitted after a fixed duration or when the
-     *         buffer reaches maximum capacity (whichever occurs first)
+     * @return an {@link Observable} that emits connected, non-overlapping
+     *         buffers of items emitted from the source Observable, after a
+     *         fixed duration or when the buffer reaches maximum capacity
+     *         (whichever occurs first)
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public Observable<List<T>> buffer(long timespan, TimeUnit unit, int count) {
@@ -3044,25 +3066,28 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected items. This
-     * Observable produces connected, non-overlapping buffers, each of a fixed
-     * duration specified by the <code>timespan</code> argument or a maximum
-     * size specified by the <code>count</code> argument (whichever is reached
-     * first). When the source Observable completes or encounters an error, the
-     * current buffer is emitted and the event is propagated.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping buffers, each of a fixed duration specified by the
+     * <code>timespan</code> argument or a maximum size specified by the
+     * <code>count</code> argument (whichever is reached first). When the source
+     * Observable completes or encounters an error, the resulting Observable
+     * emits the current buffer and propagates the notification from the source
+     * Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer6.s.png">
      * 
-     * @param timespan the period of time each buffer collects values before it
+     * @param timespan the period of time each buffer collects items before it
      *                 should be emitted and replaced with a new buffer
      * @param unit the unit of time which applies to the <code>timespan</code>
      *             argument
      * @param count the maximum size of each buffer before it should be emitted
      * @param scheduler the {@link Scheduler} to use when determining the end
                         and start of a buffer
-     * @return an {@link Observable} that produces connected, non-overlapping
-     *         buffers that are emitted after a fixed duration or when the
-     *         buffer has reached maximum capacity (whichever occurs first)
+     * @return an {@link Observable} that emits connected, non-overlapping
+     *         buffers of items emitted by the source Observable after a fixed
+     *         duration or when the buffer reaches maximum capacity (whichever
+     *         occurs first)
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public Observable<List<T>> buffer(long timespan, TimeUnit unit, int count, Scheduler scheduler) {
@@ -3070,23 +3095,25 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected items. This
-     * Observable starts a new buffer periodically, as determined by the
-     * <code>timeshift</code> argument. Each buffer is emitted after a fixed
-     * timespan, specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current buffer is
-     * emitted and the event is propagated.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable starts a new buffer
+     * periodically, as determined by the <code>timeshift</code> argument. It
+     * emits buffer after a fixed timespan, specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * encounters an error, it emits the current buffer and propagates the
+     * notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer7.png">
      * 
-     * @param timespan the period of time each buffer collects values before it
+     * @param timespan the period of time each buffer collects items before it
      *                 should be emitted
      * @param timeshift the period of time after which a new buffer will be
      *                  created
      * @param unit the unit of time that applies to the <code>timespan</code>
      *             and <code>timeshift</code> arguments
-     * @return an {@link Observable} that produces new buffers periodically and
-     *         emits these after a fixed timespan has elapsed.
+     * @return an {@link Observable} that emits new buffers of items emitted by
+     *         the source Observable periodically after a fixed timespan has
+     *         elapsed
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public Observable<List<T>> buffer(long timespan, long timeshift, TimeUnit unit) {
@@ -3094,16 +3121,17 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces buffers of collected items. This
-     * Observable starts a new buffer periodically, as determined by the
-     * <code>timeshift</code> argument. Each buffer is emitted after a fixed
-     * timespan, specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current buffer is
-     * emitted and the event is propagated.
+     * Creates an Observable that emits buffers of items it collects from the
+     * source Observable. The resulting Observable starts a new buffer
+     * periodically, as determined by the <code>timeshift</code> argument. It
+     * emits each buffer after a fixed timespan, specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * encounters an error, the resulting Observable emits the current buffer
+     * propagates the notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer7.s.png">
      * 
-     * @param timespan the period of time each buffer collects values before it
+     * @param timespan the period of time each buffer collects items before it
      *                 should be emitted
      * @param timeshift the period of time after which a new buffer will be
      *                  created
@@ -3111,8 +3139,9 @@ public class Observable<T> {
      *             and <code>timeshift</code> arguments
      * @param scheduler the {@link Scheduler} to use when determining the end
      *                  and start of a buffer
-     * @return an {@link Observable} that produces new buffers periodically and
-     *         emits these after a fixed timespan has elapsed
+     * @return an {@link Observable} that emits new buffers of items emitted by
+     *         the source Observable periodically after a fixed timespan has
+     *         elapsed
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#buffer">RxJava Wiki: buffer()</a>
      */
     public Observable<List<T>> buffer(long timespan, long timeshift, TimeUnit unit, Scheduler scheduler) {
@@ -3120,24 +3149,23 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces connected, non-overlapping windows. The current
-     * window is emitted and replaced with a new window when the Observable
-     * produced by the specified <code>closingSelector</code> produces an
-     * object. The <code>closingSelector</code> will
-     * then be used to create a new Observable to listen for the end of the next
-     * window.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping windows. It emits the current window and opens a new one
+     * when the Observable produced by the specified
+     * <code>closingSelector</code> emits an item. The
+     * <code>closingSelector</code> then creates a new Observable to observe
+     * for the end of the next window.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window1.png">
      * 
      * @param closingSelector the {@link Func0} used to produce an
      *            {@link Observable} for every window created. When this
-     *            {@link Observable} emits an object, the
-     *            associated window is emitted and replaced with a new one.
-     * @return an {@link Observable} that produces connected, non-overlapping
-     *         windows, which are emitted when the current {@link Observable}
-     *         created with the <code>closingSelector</code> argument emits an
-     *         object.
+     *            {@link Observable} emits an item, <code>window()</code> emits
+     *            the associated window and begins a new one.
+     * @return an {@link Observable} that emits connected, non-overlapping
+     *         windows when the current {@link Observable} created with the
+     *         <code>closingSelector</code> argument emits an item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
     public <TClosing> Observable<Observable<T>> window(Func0<? extends Observable<? extends TClosing>> closingSelector) {
@@ -3145,26 +3173,23 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces windows. Chunks are created when the
-     * <code>windowOpenings</code> Observable produces an
-     * object. Additionally the <code>closingSelector</code> argument creates an
-     * Observable that produces objects. When this
-     * Observable produces such an object, the associated window is emitted.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits windows. These windows
+     * contain those items emitted by the source Observable between the time
+     * when the <code>windowOpenings</code> Observable emits an item and when
+     * the Observable returned by <code>closingSelector</code> emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window2.png">
      * 
-     * @param windowOpenings the {@link Observable} that, when it produces an
-     *                       object, causes another
-     *                       window to be created
-     * @param closingSelector the {@link Func1} that produces an
+     * @param windowOpenings the {@link Observable} that, when it emits an item,
+     *                       causes another window to be created
+     * @param closingSelector a {@link Func1} that produces an 
      *                        {@link Observable} for every window created. When
-     *                        this {@link Observable} produces an
-     *                        object, the associated
-     *                        window is emitted.
-     * @return an {@link Observable} that produces windows that are created and
-     *         emitted when the specified {@link Observable}s publish certain
-     *         objects
+     *                        this {@link Observable} emits an item, the
+     *                        associated window is closed and emitted
+     * @return an {@link Observable} that emits windows of items emitted by the
+     *         source Observable that are governed by the specified
+     *         {@link Observable}s emitting items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
     public <TOpening, TClosing> Observable<Observable<T>> window(Observable<? extends TOpening> windowOpenings, Func1<? super TOpening, ? extends Observable<? extends TClosing>> closingSelector) {
@@ -3172,16 +3197,17 @@ public class Observable<T> {
     }
     
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces connected, non-overlapping windows, each containing
-     * <code>count</code> elements. When the source Observable completes or
-     * encounters an error, the current window is emitted, and the event is
-     * propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping windows, each containing <code>count</code> items. When
+     * the source Observable completes or encounters an error, the resulting
+     * Observable emits the current window and propagates the notification from
+     * the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window3.png">
      * 
      * @param count the maximum size of each window before it should be emitted
-     * @return an {@link Observable} that produces connected, non-overlapping
+     * @return an {@link Observable} that emits connected, non-overlapping
      *         windows containing at most <code>count</code> items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
@@ -3190,11 +3216,12 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces windows every <code>skip</code> items, each
-     * containing <code>count</code> elements. When the source Observable
-     * completes or encounters an error, the current window is emitted and the
-     * event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits windows every
+     * <code>skip</code> items, each containing <code>count</code> items.
+     * When the source Observable completes or encounters an error, the
+     * resulting Observable emits the current window and propagates the
+     * notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window4.png">
      * 
@@ -3202,7 +3229,7 @@ public class Observable<T> {
      * @param skip how many items need to be skipped before starting a new
      *             window. Note that if <code>skip</code> and <code>count</code>
      *             are equal this is the same operation as {@link #window(int)}.
-     * @return an {@link Observable} that produces windows every "skipped"
+     * @return an {@link Observable} that emits windows every "skipped"
      *         items containing at most <code>count</code> items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
@@ -3211,11 +3238,12 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces connected, non-overlapping windows, each of a fixed
-     * duration specified by the <code>timespan</code> argument. When the source
-     * Observable completes or encounters an error, the current window is
-     * emitted and the event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping windows, each of a fixed duration specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * encounters an error, the resulting Observable emits the current window
+     * and propagates the notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window5.png">
      * 
@@ -3223,7 +3251,7 @@ public class Observable<T> {
      *                 should be emitted and replaced with a new window
      * @param unit the unit of time that applies to the <code>timespan</code>
      *             argument
-     * @return an {@link Observable} that produces connected, non-overlapping
+     * @return an {@link Observable} that emits connected, non-overlapping
      *         windows with a fixed duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
@@ -3232,11 +3260,12 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces connected, non-overlapping windows, each of a fixed
-     * duration as specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current window is
-     * emitted and the event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping windows, each of a fixed duration as specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * encounters an error, the resulting Observable emits the current window
+     * and propagates the notification from the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window5.s.png">
      * 
@@ -3246,7 +3275,7 @@ public class Observable<T> {
      *             argument
      * @param scheduler the {@link Scheduler} to use when determining the end
      *                  and start of a window
-     * @return an {@link Observable} that produces connected, non-overlapping
+     * @return an {@link Observable} that emits connected, non-overlapping
      *         windows with a fixed duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
@@ -3255,23 +3284,25 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces connected non-overlapping windows, each of a fixed
-     * duration as specified by the <code>timespan</code> argument or a maximum
-     * size as specified by the <code>count</code> argument (whichever is
-     * reached first). When the source Observable completes or encounters an
-     * error, the current window is emitted and the event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping windows, each of a fixed duration as specified by the
+     * <code>timespan</code> argument or a maximum size as specified by the
+     * <code>count</code> argument (whichever is reached first). When the source
+     * Observable completes or encounters an error, the resulting Observable
+     * emits the current window and propagates the notification from the source
+     * Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window6.png">
      * 
-     * @param timespan the period of time each window collects values before it
+     * @param timespan the period of time each window collects items before it
      *                 should be emitted and replaced with a new window
      * @param unit the unit of time that applies to the <code>timespan</code>
      *             argument
      * @param count the maximum size of each window before it should be emitted
-     * @return an {@link Observable} that produces connected, non-overlapping
-     *         windows that are emitted after a fixed duration or when the
-     *         window has reached maximum capacity (whichever occurs first)
+     * @return an {@link Observable} that emits connected, non-overlapping
+     *         windows after a fixed duration or when the window has reached
+     *         maximum capacity (whichever occurs first)
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
     public Observable<Observable<T>> window(long timespan, TimeUnit unit, int count) {
@@ -3279,25 +3310,27 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable produces connected, non-overlapping windows, each of a fixed
-     * duration specified by the <code>timespan</code> argument or a maximum
-     * size specified by the <code>count</code> argument (whichever is reached
-     * first). When the source Observable completes or encounters an error, the
-     * current window is emitted and the event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable emits connected,
+     * non-overlapping windows, each of a fixed duration specified by the
+     * <code>timespan</code> argument or a maximum size specified by the
+     * <code>count</code> argument (whichever is reached first). When the source
+     * Observable completes or encounters an error, the resulting Observable
+     * emits the current window and propagates the notification from the source
+     * Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window6.s.png">
      * 
-     * @param timespan the period of time each window collects values before it
+     * @param timespan the period of time each window collects items before it
      *                 should be emitted and replaced with a new window
      * @param unit the unit of time which applies to the <code>timespan</code>
      *             argument
      * @param count the maximum size of each window before it should be emitted
      * @param scheduler the {@link Scheduler} to use when determining the end
      *                  and start of a window.
-     * @return an {@link Observable} that produces connected non-overlapping
-     *         windows that are emitted after a fixed duration or when the
-     *         window has reached maximum capacity (whichever occurs first).
+     * @return an {@link Observable} that emits connected non-overlapping
+     *         windows after a fixed duration or when the window has reached
+     *         maximum capacity (whichever occurs first).
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
     public Observable<Observable<T>> window(long timespan, TimeUnit unit, int count, Scheduler scheduler) {
@@ -3305,23 +3338,25 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable starts a new window periodically, as determined by the
-     * <code>timeshift</code> argument. Each window is emitted after a fixed
-     * timespan, specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current window is
-     * emitted and the event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable starts a new window
+     * periodically, as determined by the <code>timeshift</code> argument. It
+     * emits each window after a fixed timespan, specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * Observable completes or encounters an error, the resulting Observable
+     * emits the current window and propagates the notification from the source
+     * Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window7.png">
      * 
-     * @param timespan the period of time each window collects values before it
+     * @param timespan the period of time each window collects items before it
      *                 should be emitted
      * @param timeshift the period of time after which a new window will be
      *                  created
      * @param unit the unit of time that applies to the <code>timespan</code>
      *             and <code>timeshift</code> arguments
-     * @return an {@link Observable} that produces new windows periodically and
-     *         emits these after a fixed timespan has elapsed
+     * @return an {@link Observable} that emits new windows periodically as a
+     *         fixed timespan has elapsed
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
     public Observable<Observable<T>> window(long timespan, long timeshift, TimeUnit unit) {
@@ -3329,16 +3364,18 @@ public class Observable<T> {
     }
 
     /**
-     * Creates an Observable that produces windows of collected items. This
-     * Observable starts a new window periodically, as determined by the
-     * <code>timeshift</code> argument. Each window is emitted after a fixed
-     * timespan, specified by the <code>timespan</code> argument. When the
-     * source Observable completes or encounters an error, the current window is
-     * emitted and the event is propagated.
+     * Creates an Observable that emits windows of items it collects from the
+     * source Observable. The resulting Observable starts a new window
+     * periodically, as determined by the <code>timeshift</code> argument. It
+     * emits each window after a fixed timespan, specified by the
+     * <code>timespan</code> argument. When the source Observable completes or
+     * Observable completes or encounters an error, the resulting Observable
+     * emits the current window and propagates the notification from the source
+     * Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window7.s.png">
      * 
-     * @param timespan the period of time each window collects values before it
+     * @param timespan the period of time each window collects items before it
      *                 should be emitted
      * @param timeshift the period of time after which a new window will be
      *                  created
@@ -3346,8 +3383,8 @@ public class Observable<T> {
      *             and <code>timeshift</code> arguments
      * @param scheduler the {@link Scheduler} to use when determining the end
      *                  and start of a window
-     * @return an {@link Observable} that produces new windows periodically and
-     *         emits these after a fixed timespan has elapsed
+     * @return an {@link Observable} that emits new windows periodically as a
+     *         fixed timespan has elapsed
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava Wiki: window()</a>
      */
     public Observable<Observable<T>> window(long timespan, long timeshift, TimeUnit unit, Scheduler scheduler) {
@@ -3425,7 +3462,7 @@ public class Observable<T> {
      * @param predicate a function that evaluates the items emitted by the
      *                  source Observable, returning {@code true} if they pass
      *                  the filter
-     * @return an Observable that emits only those items in the original
+     * @return an Observable that emits only those items emitted by the source
      *         Observable that the filter evaluates as {@code true}
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#filter-or-where">RxJava Wiki: filter()</a>
      */
@@ -3434,12 +3471,13 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that forwards all sequentially distinct items
-     * emitted from the source Observable.
+     * Returns an Observable that emits all sequentially distinct items
+     * emitted by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinctUntilChanged.png">
      * 
-     * @return an Observable of sequentially distinct items
+     * @return an Observable that emits those items from the source Observable
+     *         that are sequentially distinct
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#distinctuntilchanged">RxJava Wiki: distinctUntilChanged()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229494.aspx">MSDN: Observable.distinctUntilChanged</a>
      */
@@ -3448,16 +3486,17 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that forwards all items emitted from the source
+     * Returns an Observable that emits all items emitted by the source
      * Observable that are sequentially distinct according to a key selector
      * function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinctUntilChanged.key.png">
      * 
      * @param keySelector a function that projects an emitted item to a key
-     *                    value that is used for deciding whether an item is
+     *                    value that is used to decide whether an item is
      *                    sequentially distinct from another one or not
-     * @return an Observable of sequentially distinct items
+     * @return an Observable that emits those items from the source Observable
+     *         whose keys are sequentially distinct
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#distinctuntilchanged">RxJava Wiki: distinctUntilChanged()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229508.aspx">MSDN: Observable.distinctUntilChanged</a>
      */
@@ -3466,12 +3505,13 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits all distinct items emitted from the
-     * source Observable.
+     * Returns an Observable that emits all items emitted by the source
+     * Observable that are distinct.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.png">
      * 
-     * @return an Observable of distinct items
+     * @return an Observable that emits only those items emitted by the source
+     *         Observable that are distinct from each other
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#distinct">RxJava Wiki: distinct()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229764.aspx">MSDN: Observable.distinct</a>
      */
@@ -3480,7 +3520,7 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that emits all items emitted from the source
+     * Returns an Observable that emits all items emitted by the source
      * Observable that are distinct according to a key selector function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.key.png">
@@ -3488,7 +3528,8 @@ public class Observable<T> {
      * @param keySelector a function that projects an emitted item to a key
      *                    value that is used to decide whether an item is
      *                    distinct from another one or not
-     * @return an Observable that emits distinct items
+     * @return an Observable that emits those items emitted by the source
+     *         Observable that have distinct keys
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#distinct">RxJava Wiki: distinct()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh244310.aspx">MSDN: Observable.distinct</a>
      */
@@ -3497,16 +3538,17 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the item at a specified index in a sequence.
+     * Returns an Observable that emits the item at a specified index in a
+     * sequence of emissions from a source Observbable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/elementAt.png">
      * 
      * @param index the zero-based index of the item to retrieve
      * @return an Observable that emits the item at the specified position in
-     *         the source sequence
+     *         the sequence of those emitted by the source Observable
      * @throws IndexOutOfBoundsException if <code>index</code> is greater than
-     *                                   or equal to the number of elements in
-     *                                   the source sequence
+     *                                   or equal to the number of items emitted
+     *                                   by the source Observable
      * @throws IndexOutOfBoundsException if <code>index</code> is less than 0
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#elementat">RxJava Wiki: elementAt()</a>
      */
@@ -3533,33 +3575,37 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an {@link Observable} that emits <code>true</code> if any element
-     * of the source {@link Observable} satisfies the given condition, otherwise
-     * <code>false</code>. Note: always emits <code>false</code> if the source
-     * {@link Observable} is empty.
+     * Returns an {@link Observable} that emits <code>true</code> if any item
+     * emitted by the source {@link Observable} satisfies a specified condition,
+     * otherwise <code>false</code>. Note: this always emits <code>false</code>
+     * if the source {@link Observable} is empty.
      * <p>
-     * In Rx.Net this is the <code>any</code> operator but renamed in RxJava to
-     * better match Java naming idioms.
+     * In Rx.Net this is the <code>any</code> operator but we renamed it in
+     * RxJava to better match Java naming idioms.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/exists.png">
      * 
-     * @param predicate the condition to test every element
+     * @param predicate the condition to test every item emitted by the source
+     *                  Observable
      * @return a subscription function for creating the target Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#exists-and-isempty">RxJava Wiki: exists()</a>
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh211993.aspx" >MSDN: Observable.Any</a> Note: the description in this page is wrong.
+     * @see <a href="http://msdn.microsoft.com/en-us/library/hh211993.aspx" >MSDN: Observable.Any</a> Note: the description in this page was wrong at the time of this writing.
      */
     public Observable<Boolean> exists(Func1<? super T, Boolean> predicate) {
         return create(OperationAny.exists(this, predicate));
     }
 
     /**
-     * Determines whether an Observable sequence contains a specified item.
+     * Returns an Observable that emits a Boolean that indicates whether the
+     * source Observable emitted a specified item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/contains.png">
      * 
-     * @param element the item to search in the sequence
-     * @return an Observable that emits <code>true</code> if the item is in the
-     *         source sequence
+     * @param element the item to search for in the emissions from the source
+     *                Observable
+     * @return an Observable that emits <code>true</code> if the specified item
+     *         is emitted by the source Observable, or <code>false</code> if the
+     *         source Observable completes without emitting that item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#contains">RxJava Wiki: contains()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228965.aspx">MSDN: Observable.Contains</a>
      */
@@ -3620,7 +3666,7 @@ public class Observable<T> {
      * @param predicate a function that evaluates an item emitted by the source
      *                  Observable, returning {@code true} if it passes the
      *                  filter
-     * @return an Observable that emits only those items emitted by the original
+     * @return an Observable that emits only those items emitted by the source
      *         Observable that the filter evaluates as {@code true}
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#filter-or-where">RxJava Wiki: where()</a>
      * @see #filter(Func1)
@@ -3631,7 +3677,8 @@ public class Observable<T> {
 
     /**
      * Returns an Observable that applies the given function to each item
-     * emitted by an Observable and emits the result.
+     * emitted by an Observable and emits the results of these function
+     * applications.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/map.png">
      * 
@@ -3647,13 +3694,14 @@ public class Observable<T> {
 
     /**
      * Returns an Observable that applies the given function to each item
-     * emitted by an Observable and emits the result.
+     * emitted by an Observable and emits the results of these function
+     * applications.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/map.png">
      * 
-     * @param func a function to apply to each item emitted by the Observable.
-     *             The function takes the index of the emitted item as
-     *             additional parameter.
+     * @param func a function to apply to each item emitted by the Observable
+     *             that takes the index of the emitted item as additional
+     *             parameter
      * @return an Observable that emits the items from the source Observable,
      *         transformed by the given function
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#mapwithindex">RxJava Wiki: mapWithIndex()</a>
@@ -3687,16 +3735,16 @@ public class Observable<T> {
     }
 
     /**
-     * Turns all of the notifications from a source Observable into
-     * {@link Observer#onNext onNext} emissions, and marks them with their
-     * original notification types within {@link Notification} objects.
+     * Turns all of the emissions and notifications from a source Observable
+     * into emissions marked with their original types within
+     * {@link Notification} objects.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/materialize.png">
      * 
      * @return an Observable whose items are the result of materializing the
      *         items and notifications of the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#materialize">RxJava Wiki: materialize()</a>
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229453(v=VS.103).aspx">MSDN: Observable.materialize</a>
+     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229453.aspx">MSDN: Observable.materialize</a>
      */
     public Observable<Notification<T>> materialize() {
         return create(OperationMaterialize.materialize(this));
@@ -3872,8 +3920,7 @@ public class Observable<T> {
      * function (<code>resumeFunction</code>) to an Observable's
      * <code>onErrorReturn</code> method, if the original Observable encounters
      * an error, instead of invoking its Observer's <code>onError</code> method,
-     * it will instead pass the return value of <code>resumeFunction</code> to
-     * the Observer's {@link Observer#onNext onNext} method.
+     * it will instead emit the return value of <code>resumeFunction</code>.
      * <p>
      * You can use this to prevent errors from propagating or to supply fallback
      * data should errors be encountered.
@@ -3908,7 +3955,7 @@ public class Observable<T> {
      *                    be used in the next accumulator call
      * @return an Observable that emits a single item that is the result of
      *         accumulating the output from the source Observable
-     * @throws IllegalArgumentException if the Observable sequence is empty
+     * @throws IllegalArgumentException if the source Observable emits no items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#reduce-or-aggregate">RxJava Wiki: reduce()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229154.aspx">MSDN: Observable.Aggregate</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
@@ -3923,12 +3970,12 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that counts the total number of items in the
-     * source Observable.
+     * Returns an Observable emits the count of the total number of items
+     * emitted by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/count.png">
      * 
-     * @return an Observable that emits the number of counted elements of the
+     * @return an Observable that emits the number of elements emitted by the
      *         source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#count-and-longcount">RxJava Wiki: count()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229470.aspx">MSDN: Observable.Count</a>
@@ -3944,14 +3991,14 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that sums up the integers emitted by the source
-     * Observable.
+     * Returns an Observable that emits the sum of all the Integers emitted by
+     * the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source source Observable to compute the sum of
-     * @return an Observable that emits the sum of all the items of the
-     *         source Observable as its single item
+     * @return an Observable that emits the sum of all the Integers emitted by
+     *         the source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#sum">RxJava Wiki: sum()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
@@ -3960,13 +4007,13 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that sums up the longs emitted by the source
-     * Observable.
+     * Returns an Observable that emits the sum of all the Longs emitted by the
+     * source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source source Observable to compute the sum of
-     * @return an Observable that emits the sum of all the items of the
+     * @return an Observable that emits the sum of all the Longs emitted by the
      *         source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#sum">RxJava Wiki: sumLongs()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
@@ -3976,13 +4023,13 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that sums up the floats emitted by the source
-     * Observable.
+     * Returns an Observable that emits the sum of all the Floats emitted by the
+     * source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source source Observable to compute the sum of
-     * @return an Observable that emits the sum of all the items of the
+     * @return an Observable that emits the sum of all the Floats emitted by the
      *         source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#sum">RxJava Wiki: sumFloats()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
@@ -3992,14 +4039,14 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that sums up the doubles emitted by the source
-     * Observable.
+     * Returns an Observable that emits the sum of all the Doubles emitted by
+     * the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source source Observable to compute the sum of
-     * @return an Observable that emits the sum of all the items of the
-     *         source Observable as its single item
+     * @return an Observable that emits the sum of all the Doubles emitted by
+     *         the source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#sum">RxJava Wiki: sumDoubles()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
@@ -4008,15 +4055,15 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that computes the average of the integers emitted
+     * Returns an Observable that computes the average of the Integers emitted
      * by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
      * @param source source observable to compute the average of
-     * @return an Observable that emits the average of all the items emitted by
-     *         the source Observable as its single item
-     * @throws IllegalArgumentException if the Observable sequence is empty
+     * @return an Observable that emits the average of all the Integers emitted
+     *         by the source Observable as its single item
+     * @throws IllegalArgumentException if the source Observable emits no items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#average">RxJava Wiki: average()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
@@ -4025,13 +4072,13 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that computes the average of the longs emitted by
+     * Returns an Observable that computes the average of the Longs emitted by
      * the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
-     * @param source source observable to compute the average of
-     * @return an Observable that emits the average of all the items emitted by
+     * @param source source Observable to compute the average of
+     * @return an Observable that emits the average of all the Longs emitted by
      *         the source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#average">RxJava Wiki: averageLongs()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
@@ -4041,13 +4088,13 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that computes the average of the floats emitted by
+     * Returns an Observable that computes the average of the Floats emitted by
      * the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
-     * @param source source observable to compute the average of
-     * @return an Observable that emits the average of all the items emitted by
+     * @param source source Observable to compute the average of
+     * @return an Observable that emits the average of all the Floats emitted by
      *         the source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#average">RxJava Wiki: averageFloats()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
@@ -4057,14 +4104,14 @@ public class Observable<T> {
     }
 
     /**
-     * Returns an Observable that computes the average of the doubles emitted
+     * Returns an Observable that emits the average of the Doubles emitted
      * by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
-     * @param source source observable to compute the average of
-     * @return an Observable that emits the average of all the items emitted by
-     *         the source Observable as its single item
+     * @param source source Observable to compute the average of
+     * @return an Observable that emits the average of all the Doubles emitted
+     *         by the source Observable as its single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#average">RxJava Wiki: averageDoubles()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
@@ -4073,13 +4120,15 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the minimum item emitted by an Observable. If there are more than
-     * one minimum items, its returns the last one.
+     * Returns an Observable that emits the minimum item emitted by the source
+     * Observable. If there is more than one such item, it returns the
+     * last-emitted one.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/min.png">
      *
-     * @param source an Observable sequence to determine the minimum item of
-     * @return an Observable that emits the minimum item
+     * @param source an Observable to determine the minimum item of
+     * @return an Observable that emits the minimum item emitted by the source
+     *         Observable
      * @throws IllegalArgumentException if the source is empty
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229715.aspx">MSDN: Observable.Min</a>
      */
@@ -4088,14 +4137,14 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the minimum item emitted by an Observable according to a
-     * specified comparator. If there are more than one minimum items, it
-     * returns the last one.
+     * Returns an Observable that emits the minimum item emitted by the source
+     * Observable, according to a specified comparator. If there is more than
+     * one such item, it returns the last-emitted one.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/min.png">
      *
      * @param comparator the comparer used to compare elements
-     * @return an Observable that emits the minimum value according to the
+     * @return an Observable that emits the minimum item according to the
      *         specified comparator
      * @throws IllegalArgumentException if the source is empty
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#min">RxJava Wiki: min()</a>
@@ -4106,15 +4155,15 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the items emitted by an Observable sequence with the minimum key
-     * value. For an empty source, returns an Observable that emits an empty
-     * List.
+     * Returns an Observable that emits a List of items emitted by the source
+     * Observable that have the minimum key value. For a source Observable that
+     * emits no items, the resulting Observable emits an empty List.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/minBy.png">
      *
      * @param selector the key selector function
-     * @return an Observable that emits a List of the items with the minimum key
-     *         value
+     * @return an Observable that emits a List of the items from the source
+     *         Observable that had the minimum key value
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#minby">RxJava Wiki: minBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228970.aspx">MSDN: Observable.MinBy</a>
      */
@@ -4123,16 +4172,18 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the elements emitted by an Observable with the minimum key value 
-     * according to the specified comparator. For an empty source, it returns an
-     * Observable that emits an empty List.
+     * Returns an Observable that emits a List of items emitted by the source
+     * Observable that have the minimum key value according to a given
+     * comparator function. For a source Observable that emits no items, the
+     * resulting Observable emits an empty List.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/minBy.png">
      *
      * @param selector the key selector function
      * @param comparator the comparator used to compare key values
-     * @return an Observable that emits a List of the elements with the minimum
-     *         key value according to the specified comparator
+     * @return an Observable that emits a List of the items emitted by the
+     *         source Observable that had the minimum key value according to the
+     *         specified comparator
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#minby">RxJava Wiki: minBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228970.aspx">MSDN: Observable.MinBy</a>
      */
@@ -4141,13 +4192,14 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the maximum item emitted by an Observable. If there is more
-     * than one maximum item, it returns the last one.
+     * Returns an Observable that emits the maximum item emitted by the source
+     * Observable. If there is more than one item with the same maximum value,
+     * it emits the last-emitted of these.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/max.png">
      *
-     * @param source an Observable to determine the maximum item of
-     * @return an Observable that emits the maximum element
+     * @param source an Observable to scan for the maximum emitted item
+     * @return an Observable that emits this maximum item from the source
      * @throws IllegalArgumentException if the source is empty
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#max">RxJava Wiki: max()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211837.aspx">MSDN: Observable.Max</a>
@@ -4157,15 +4209,15 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the maximum item emitted by an Observable according to the
-     * specified comparator. If there is more than one maximum item, it returns
-     * the last one.
+     * Returns an Observable that emits the maximum item emitted by the source
+     * Observable, according to the specified comparator. If there is more than
+     * one item with the same maximum value, it emits the last-emitted of these.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/max.png">
      *
      * @param comparator the comparer used to compare items
-     * @return an Observable that emits the maximum item according to the
-     *         specified comparator
+     * @return an Observable that emits the maximum item emitted by the source
+     *         Observable, according to the specified comparator
      * @throws IllegalArgumentException if the source is empty
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#max">RxJava Wiki: max()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211635.aspx">MSDN: Observable.Max</a>
@@ -4175,14 +4227,15 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the items emitted by an Observable with the maximum key value.
-     * For an empty source, it returns an Observable that emits an empty List.
+     * Returns an Observable that emits a List of items emitted by the source
+     * Observable that have the maximum key value. For a source Observable that
+     * emits no items, the resulting Observable emits an empty List.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/maxBy.png">
      *
      * @param selector the key selector function
-     * @return an Observable that emits a List of the items with the maximum key
-     *         value
+     * @return an Observable that emits a List of those items emitted by the
+     *         source Observable that had the maximum key value
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#maxby">RxJava Wiki: maxBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229058.aspx">MSDN: Observable.MaxBy</a>
      */
@@ -4191,16 +4244,18 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the items emitted by an Observable with the maximum key value
-     * according to the specified comparator. For an empty source, it returns an
-     * Observable that emits an empty List.
+     * Returns an Observable that emits a List of items emitted by the source
+     * Observable that have the maximum key value according to a specified
+     * comparator. For a source Observable that emits no items, the resulting
+     * Observable emits an empty List.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/maxBy.png">
      *
      * @param selector the key selector function
      * @param comparator the comparator used to compare key values
-     * @return an Observable that emits a List of the elements with the maximum
-     *         key value according to the specified comparator
+     * @return an Observable that emits a List of those items emitted by the
+     *         source Observable that had the maximum key value according to the
+     *         specified comparator
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#maxby">RxJava Wiki: maxBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh244330.aspx">MSDN: Observable.MaxBy</a>
      */
@@ -4224,22 +4279,24 @@ public class Observable<T> {
     }
 
     /**
-     * Retry subscription to origin Observable upto given retry count.
+     * Retry subscription to the source Observable when it calls
+     * <code>onError</code> up to a certain number of retries.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/retry.png">
      * <p>
-     * If {@link Observer#onError} is invoked the source Observable will be
-     * re-subscribed to as many times as defined by retryCount.
+     * If the source Observable calls {@link Observer#onError}, this method will
+     * resubscribe to the source Observable for a maximum of
+     * <code>retryCount</code> resubscriptions.
      * <p>
-     * Any {@link Observer#onNext} calls received on each attempt will be
-     * emitted and concatenated together.
-     * <p>
-     * For example, if an Observable fails on first time but emits [1, 2] then
+     * Any and all items emitted by the source Observable will be emitted by
+     * the resulting Observable, even those emitted during failed subscriptions.
+     * For example, if an Observable fails at first but emits [1, 2] then
      * succeeds the second time and emits [1, 2, 3, 4, 5] then the complete
-     * output would be [1, 2, 1, 2, 3, 4, 5, onCompleted].
+     * sequence of emissions and notifications would be
+     * [1, 2, 1, 2, 3, 4, 5, <i>onCompleted</i>].
      * 
      * @param retryCount number of retry attempts before failing
-     * @return an Observable with retry logic
+     * @return the source Observable modified with retry logic
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#retry">RxJava Wiki: retry()</a>
      */
     public Observable<T> retry(int retryCount) {
@@ -4247,22 +4304,22 @@ public class Observable<T> {
     }
 
     /**
-     * Retry subscription to origin Observable whenever <code>onError</code> is
-     * called (infinite retry count).
+     * Retry subscription to the source Observable whenever it calls
+     * <code>onError</code> (infinite retry count).
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/retry.png">
      * <p>
-     * If {@link Observer#onError} is invoked the source Observable will be
-     * re-subscribed to.
+     * If the source Observable calls {@link Observer#onError}, this method will
+     * resubscribe to the source Observable.
      * <p>
-     * Any {@link Observer#onNext} calls received on each attempt will be
-     * emitted and concatenated together.
-     * <p>
-     * For example, if an Observable fails on first time but emits [1, 2] then
+     * Any and all items emitted by the source Observable will be emitted by
+     * the resulting Observable, even those emitted during failed subscriptions.
+     * For example, if an Observable fails at first but emits [1, 2] then
      * succeeds the second time and emits [1, 2, 3, 4, 5] then the complete
-     * output would be [1, 2, 1, 2, 3, 4, 5, onCompleted].
+     * sequence of emissions and notifications would be
+     * [1, 2, 1, 2, 3, 4, 5, <i>onCompleted</i>].
      * 
-     * @return an Observable with retry logic
+     * @return the source Observable modified with retry logic
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#retry">RxJava Wiki: retry()</a>
      */
     public Observable<T> retry() {
@@ -4290,7 +4347,7 @@ public class Observable<T> {
      * items that will use up memory.
      * 
      * @return an Observable that, when first subscribed to, caches all of its
-     *         notifications for the benefit of subsequent subscribers.
+     *         items and notifications for the benefit of subsequent observers
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#cache">RxJava Wiki: cache()</a>
      */
     public Observable<T> cache() {
@@ -4333,7 +4390,6 @@ public class Observable<T> {
         return OperationParallel.parallel(this, f, s);
     }
 
-    
     /**
      * Merges an <code>Observable&lt;Observable&lt;T&gt;&gt;</code> to
      * <code>Observable&lt;Observable&lt;T&gt;&gt;</code> with the number of
@@ -4351,7 +4407,7 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/parallelMerge.png">
      * 
      * @param parallelObservables the number of Observables to merge into
-     * @return an Observable of Observables constrained to number defined by
+     * @return an Observable of Observables constrained in number by
      *         <code>parallelObservables</code>
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#parallelmerge">RxJava Wiki: parallelMerge()</a>
      */
@@ -4377,9 +4433,9 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/parallelMerge.png">
      * 
      * @param parallelObservables the number of Observables to merge into
-     * @param scheduler
-     * @return an Observable of Observables constrained to number defined by
-     *         <code>parallelObservables</code>.
+     * @param scheduler the Scheduler to run each Observable on
+     * @return an Observable of Observables constrained in number by
+     *         <code>parallelObservables</code>
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#parallelmerge">RxJava Wiki: parallelMerge()</a>
      */
     public static <T> Observable<Observable<T>> parallelMerge(Observable<Observable<T>> source, int parallelObservables, Scheduler scheduler) {
@@ -4403,8 +4459,8 @@ public class Observable<T> {
     }
 
     /**
-     * Returns a {@link ConnectableObservable} that shares a single subscription
-     * that contains the last notification only.
+     * Returns a {@link ConnectableObservable} that emits only the last item
+     * emitted by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishLast.png">
      * 
@@ -4479,9 +4535,6 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/scan.png">
      * <p>
      * This sort of function is sometimes called an accumulator.
-     * <p>
-     * Note that when you pass a seed to <code>scan()</code> the resulting
-     * Observable will emit that seed as its first emitted item.
      * 
      * @param accumulator an accumulator function to be invoked on each item
      *                    emitted by the source Observable, whose result will be
@@ -4531,16 +4584,16 @@ public class Observable<T> {
     }
     
     /**
-     * Return an Observable that emits the results of sampling the items
-     * emitted by this Observable when the <code>sampler</code>
-     * Observable produces an item or completes.
+     * Return an Observable that emits the results of sampling the items emitted
+     * by this Observable when the <code>sampler</code> Observable emits an item
+     * or completes.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sample.o.png">
      * 
-     * @param sampler the Observable to use for sampling this
+     * @param sampler the Observable to use for sampling the source Observable
      * @return an Observable that emits the results of sampling the items
-     *         emitted by this Observable when the <code>sampler</code>
-     *         Observable produces an item or completes.
+     *         emitted by this Observable whenever the <code>sampler</code>
+     *         Observable emits an item or completes
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#sample-or-throttlelast">RxJava Wiki: sample()</a>
      */
     public <U> Observable<T> sample(Observable<U> sampler) {
@@ -4561,7 +4614,7 @@ public class Observable<T> {
      * Note that when you pass a seed to <code>scan()</code> the resulting
      * Observable will emit that seed as its first emitted item.
      * 
-     * @param initialValue the initial (seed) accumulator value
+     * @param initialValue the initial (seed) accumulator item
      * @param accumulator an accumulator function to be invoked on each item
      *                    emitted by the source Observable, whose result will be
      *                    emitted to {@link Observer}s via
@@ -4597,15 +4650,11 @@ public class Observable<T> {
      * by the source Observable and emits the remainder.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skip.png">
-     * <p>
-     * You can ignore the first <code>num</code> items emitted by an Observable
-     * and attend only to those items that come after, by modifying the
-     * Observable with the <code>skip</code> method.
      * 
      * @param num the number of items to skip
      * @return an Observable that is identical to the source Observable except
      *         that it does not emit the first <code>num</code> items that the
-     *         source emits
+     *         source Observable emits
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#skip">RxJava Wiki: skip()</a>
      */
     public Observable<T> skip(int num) {
@@ -4618,9 +4667,9 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/first.png">
      * 
-     * @return an Observable that emits only the very first item from the
-     *         source, or none if the source Observable completes without
-     *         emitting a single item
+     * @return an Observable that emits only the very first item emitted by the
+     *         source Observable, or nothing if the source Observable completes
+     *         without emitting a single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#first">RxJava Wiki: first()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229177.aspx">MSDN: Observable.First</a>
      */
@@ -4636,8 +4685,8 @@ public class Observable<T> {
      * 
      * @param predicate the condition any source emitted item has to satisfy
      * @return an Observable that emits only the very first item satisfying the
-     *         given condition from the source, or none if the source Observable
-     *         completes without emitting a single matching item
+     *         given condition from the source, or nothing if the source
+     *         Observable completes without emitting a single matching item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#first">RxJava Wiki: first()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229177.aspx">MSDN: Observable.First</a>
      */
@@ -4647,14 +4696,14 @@ public class Observable<T> {
 
     /**
      * Returns an Observable that emits only the very first item emitted by the
-     * source Observable, or a default value.
+     * source Observable, or a default item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/firstOrDefault.png">
      * 
-     * @param defaultValue the default value to emit if the source Observable
+     * @param defaultValue the default item to emit if the source Observable
      *                     doesn't emit anything
      * @return an Observable that emits only the very first item from the
-     *         source, or a default value if the source Observable completes
+     *         source, or a default item if the source Observable completes
      *         without emitting a single item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#firstordefault">RxJava Wiki: firstOrDefault()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229320.aspx">MSDN: Observable.FirstOrDefault</a>
@@ -4665,16 +4714,16 @@ public class Observable<T> {
 
     /**
      * Returns an Observable that emits only the very first item emitted by the
-     * source Observable that satisfies a given condition, or a default value
+     * source Observable that satisfies a given condition, or a default item
      * otherwise.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/firstOrDefaultN.png">
      * 
      * @param predicate the condition any source emitted item has to satisfy
-     * @param defaultValue the default value to emit if the source Observable
+     * @param defaultValue the default item to emit if the source Observable
      *        doesn't emit anything that satisfies the given condition
      * @return an Observable that emits only the very first item from the source
-     *         that satisfies the given condition, or a default value otherwise
+     *         that satisfies the given condition, or a default item otherwise
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#firstordefault">RxJava Wiki: firstOrDefault()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229759.aspx">MSDN: Observable.FirstOrDefault</a>
      */
@@ -4683,14 +4732,16 @@ public class Observable<T> {
     }
 
     /**
-     * Returns the elements of the specified sequence or the specified default
-     * value in a singleton sequence if the sequence is empty.
+     * Returns an Observable that emits the items emitted by the source
+     * Observable or a specified default item if the source Observable is empty.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/defaultIfEmpty.png">
      * 
-     * @param defaultValue the value to return if the sequence is empty
-     * @return an Observable that emits the specified default value if the
-     *         source is empty; otherwise, the items emitted by the source
+     * @param defaultValue the item to emit if the source Observable emits no
+     *                     items
+     * @return an Observable that emits either the specified default item if the
+     *         source Observable emits no items, or the items emitted by the
+     *         source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#defaultifempty">RxJava Wiki: defaultIfEmpty()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229624.aspx">MSDN: Observable.DefaultIfEmpty</a>
      */
@@ -4711,9 +4762,9 @@ public class Observable<T> {
      * 
      * @param num the number of items to emit
      * @return an Observable that emits only the first <code>num</code> items
-     *         from the source Observable, or all of the items from the source
-     *         Observable if that Observable emits fewer than <code>num</code>
-     *         items
+     *         emitted by the source Observable, or all of the items from the
+     *         source Observable if that Observable emits fewer than
+     *         <code>num</code> items
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#take">RxJava Wiki: take()</a>
      */
     public Observable<T> take(final int num) {
@@ -4740,7 +4791,8 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the items emitted by a source Observable
      * so long as a given predicate remains true, where the predicate can
-     * operate on both the item and its index relative to the complete sequence.
+     * operate on both the item and its index relative to the complete sequence
+     * of items.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeWhileWithIndex.png">
      * 
@@ -4847,7 +4899,7 @@ public class Observable<T> {
 
     /**
      * Returns an Observable that bypasses all items from the source Observable
-     * as long as the specified condition holds true, but emits all further
+     * as long as a specified condition holds true, but emits all further
      * source items as soon as the condition becomes false.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipWhile.png">
@@ -4867,17 +4919,16 @@ public class Observable<T> {
      * Bypasses a specified number of items at the end of an Observable
      * sequence.
      * <p>
-     * This operator accumulates a queue with a length enough to store the first
+     * This operator accumulates a queue long enough to store the first
      * <code>count</code> items. As more items are received, items are taken
-     * from the front of the queue and produced on the result sequence. This
-     * causes elements to be delayed.
+     * from the front of the queue and emitted by the returned Observable. This
+     * causes such items to be delayed.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipLast.png">
      * 
-     * @param count number of elements to bypass at the end of the source
-     *            sequence
-     * @return an Observable sequence emitting the source sequence items
-     *         except for the bypassed ones at the end
+     * @param count number of items to bypass at the end of the source sequence
+     * @return an Observable that emits the items emitted by the source
+     *         Observable except for the bypassed ones at the end
      * @throws IndexOutOfBoundsException if <code>count</code> is less than zero
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#skiplast">RxJava Wiki: skipLast()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211750.aspx">MSDN: Observable.SkipLast</a>
@@ -5201,20 +5252,24 @@ public class Observable<T> {
     }
 
     /**
-     * Return an Observable which correlates two sequences when they overlap and groups the results.
+     * Return an Observable that correlates two sequences when they overlap and
+     * groups the results.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupJoin.png">
      * 
-     * @param right the other Observable to correlate values of this observable to
-     * @param leftDuration function that returns an Observable which indicates the duration of
-     *                     the values of this Observable
-     * @param rightDuration function that returns an Observable which indicates the duration of
-     *                      the values of the right Observable
-     * @param resultSelector function that takes a left value, the right observable and returns the
-     *                       value to be emitted
-     * @return an Observable that emits grouped values based on overlapping durations from this and
-     *         another Observable
-     * 
+     * @param right the other Observable to correlate items from this Observable
+     *              with
+     * @param leftDuration function that returns an Observable whose emissions
+     *                     indicate the duration of the values of this
+     *                     Observable
+     * @param rightDuration function that returns an Observable whose emissions
+     *                      indicate the duration of the values of the
+     *                      <code>right</code> Observable
+     * @param resultSelector function that takes an item emitted by each source
+     *                       Observable and returns the value to be emitted by
+     *                       the resulting Observable
+     * @return an Observable that emits grouped items based on overlapping
+     *         durations from this and another Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#join-and-groupjoin">RxJava Wiiki: groupJoin</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh244235.aspx">MSDN: Observable.GroupJoin</a>
      */
@@ -5225,11 +5280,11 @@ public class Observable<T> {
     }
     
     /**
-     * Returns an {@link Observable} that emits <code>true</code> if the source
-     * {@link Observable} is empty, otherwise <code>false</code>.
+     * Returns an Observable that emits <code>true</code> if the source
+     * Observable is empty, otherwise <code>false</code>.
      * <p>
-     * In Rx.Net this is negated as the <code>any</code> operator but renamed in
-     * RxJava to better match Java naming idioms.
+     * In Rx.Net this is negated as the <code>any</code> operator but we renamed
+     * this in RxJava to better match Java naming idioms.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/isEmpty.png">
      * 
@@ -5242,27 +5297,28 @@ public class Observable<T> {
     }
     
     /**
-     * Returns an {@link Observable} that emits the last item emitted by the
-     * source or an <code>IllegalArgumentException</code> if the source
-     * {@link Observable} is empty.
+     * Returns an Observable that emits the last item emitted by the source or
+     * notifies observers of an <code>IllegalArgumentException</code> if the
+     * source Observable is empty.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/last.png">
      * 
-     * @return 
+     * @return an Observable that emits the last item from the source Observable
+     *         or notifies observers of an error
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observable-Operators#last">RxJava Wiki: last()</a>
      */
     public Observable<T> last() {
         return create(OperationLast.last(this));
     }
 
-/**
-     * Returns an Observable that counts the total number of items in the
-     * source Observable as a 64 bit long.
+    /**
+     * Returns an Observable that counts the total number of items emitted by
+     * the source Observable and emits this count as a 64-bit long.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/longCount.png">
      * 
-     * @return an Observable that emits the number of counted elements of the
-     *         source Observable as its single, 64 bit long item 
+     * @return an Observable that emits the number of items emitted by the
+     *         source Observable as its single, 64-bit long item 
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-Operators#count-and-longcount">RxJava Wiki: count()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229120.aspx">MSDN: Observable.LongCount</a>
      * @see #count()
@@ -5280,7 +5336,7 @@ public class Observable<T> {
      * Converts an Observable into a {@link BlockingObservable} (an Observable
      * with blocking operators).
      * 
-     * @return
+     * @return a <code>BlockingObservable</code> version of this Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Blocking-Observable-Operators">RxJava Wiki: Blocking Observable Operators</a>
      */
     public BlockingObservable<T> toBlockingObservable() {
@@ -5338,18 +5394,18 @@ public class Observable<T> {
     }
 
     /**
-     * Applies a timeout policy for each element in the observable sequence,
-     * using the specified scheduler to run timeout timers. If the next element
-     * isn't received within the specified timeout duration starting from its
-     * predecessor, a TimeoutException is propagated to the observer.
+     * Applies a timeout policy for each item emitted by the Observable, using
+     * the specified scheduler to run timeout timers. If the next item isn't
+     * observed within the specified timeout duration starting from its
+     * predecessor, observers are notified of a <code>TimeoutException</code>.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1.png">
      *
-     * @param timeout maximum duration between values before a timeout occurs
+     * @param timeout maximum duration between items before a timeout occurs
      * @param timeUnit the unit of time which applies to the
      *                 <code>timeout</code> argument.
-     * @return the source Observable with a <code>TimeoutException</code> in
-     *         case of a timeout
+     * @return the source Observable modified to notify observers of a
+     *         <code>TimeoutException</code> in case of a timeout
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#timeout">RxJava Wiki: timeout()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh244283.aspx">MSDN: Observable.Timeout</a>
      */
@@ -5358,20 +5414,20 @@ public class Observable<T> {
     }
 
     /**
-     * Applies a timeout policy for each element in the observable sequence,
-     * using the specified scheduler to run timeout timers. If the next element
-     * isn't received within the specified timeout duration starting from its
-     * predecessor, the other observable sequence is used to produce future
-     * messages from that point on.
+     * Applies a timeout policy for each item emitted by the Observable, using
+     * the specified scheduler to run timeout timers. If the next item isn't
+     * observed within the specified timeout duration starting from its
+     * predecessor, a specified fallback Observable produces future items and
+     * notifications from that point on.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.2.png">
      *
-     * @param timeout maximum duration between values before a timeout occurs
+     * @param timeout maximum duration between items before a timeout occurs
      * @param timeUnit the unit of time which applies to the
      *                 <code>timeout</code> argument
-     * @param other sequence to return in case of a timeout
-     * @return the source sequence switching to the other sequence in case of a
-     *         timeout
+     * @param other fallback Observable to use in case of a timeout
+     * @return the source Observable modified to switch to the fallback
+     *         Observable in case of a timeout
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#timeout">RxJava Wiki: timeout()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229512.aspx">MSDN: Observable.Timeout</a>
      */
@@ -5380,19 +5436,19 @@ public class Observable<T> {
     }
 
     /**
-     * Applies a timeout policy for each element in the observable sequence,
-     * using the specified scheduler to run timeout timers. If the next element
-     * isn't received within the specified timeout duration starting from its
-     * predecessor, a TimeoutException is propagated to the observer.
+     * Applies a timeout policy for each item emitted by the Observable, using
+     * the specified scheduler to run timeout timers. If the next item isn't
+     * observed within the specified timeout duration starting from its
+     * predecessor, the observer is notified of a <code>TimeoutException</code>.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1s.png">
      *
-     * @param timeout maximum duration between values before a timeout occurs
+     * @param timeout maximum duration between items before a timeout occurs
      * @param timeUnit the unit of time which applies to the
      *                 <code>timeout</code> argument
      * @param scheduler Scheduler to run the timeout timers on
-     * @return the source sequence with a <code>TimeoutException</code> in case
-     *         of a timeout
+     * @return the source Observable modified to notify observers of a
+     *         <code>TimeoutException</code> in case of a timeout
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#timeout">RxJava Wiki: timeout()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228946.aspx">MSDN: Observable.Timeout</a>
      */
@@ -5401,21 +5457,21 @@ public class Observable<T> {
     }
 
     /**
-     * Applies a timeout policy for each element in the observable sequence,
-     * using the specified scheduler to run timeout timers. If the next element
-     * isn't received within the specified timeout duration starting from its
-     * predecessor, the other observable sequence is used to produce future
-     * messages from that point on.
+     * Applies a timeout policy for each item emitted by the Observable, using
+     * the specified scheduler to run timeout timers. If the next item isn't
+     * observed within the specified timeout duration starting from its
+     * predecessor, a specified fallback Observable sequence produces future
+     * items and notifications from that point on.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.2s.png">
      *
-     * @param timeout maximum duration between values before a timeout occurs
+     * @param timeout maximum duration between items before a timeout occurs
      * @param timeUnit the unit of time which applies to the
      *                 <code>timeout</code> argument
-     * @param other sequence to return in case of a timeout
+     * @param other Observable to use as the fallback in case of a timeout
      * @param scheduler Scheduler to run the timeout timers on
-     * @return the source sequence switching to the other sequence in case of a
-     *         timeout
+     * @return the source Observable modified so that it will switch to the
+     *         fallback Observable in case of a timeout
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#timeout">RxJava Wiki: timeout()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211676.aspx">MSDN: Observable.Timeout</a>
      */
@@ -5453,7 +5509,7 @@ public class Observable<T> {
     }
 
     /**
-     * Constructs an Observable that depends on a resource object.
+     * Constructs an Observable that creates a dependent resource object.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/using.png">
      *
@@ -5470,7 +5526,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the Observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5486,7 +5542,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the Observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5503,7 +5559,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5521,7 +5577,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the Observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5540,7 +5596,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5560,7 +5616,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5581,7 +5637,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5603,7 +5659,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5626,7 +5682,7 @@ public class Observable<T> {
     }
 
     /**
-     * Propagates the observable sequence that reacts first.
+     * Given multiple Observables, return the one that first emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      *
@@ -5645,9 +5701,9 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnEach.png">
      *
-     * @param observer the action to invoke for each item emitted in the source
-     *        sequence
-     * @return the source sequence with the side-effecting behavior applied
+     * @param observer the action to invoke for each item emitted by the source
+     *                 Observable
+     * @return the source Observable with the side-effecting behavior applied
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnEach()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229307.aspx">MSDN: Observable.Do</a>
      */
@@ -5660,9 +5716,9 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnEach.png">
      *
-     * @param onNext the action to invoke for each item in the source
-     *               sequence
-     * @return the source sequence with the side-effecting behavior applied
+     * @param onNext the action to invoke for each item emitted by the source
+     *               Observable
+     * @return the source Observable with the side-effecting behavior applied
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnEach()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
      */
@@ -5686,12 +5742,13 @@ public class Observable<T> {
     }
     
     /**
-     * Invokes an action if <code>onError</code> is called from the Observable.
+     * Invokes an action if the source Observable calls <code>onError</code>.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnError.png">
      *
-     * @param onError the action to invoke if <code>onError</code> is invoked
-     * @return the source sequence with the side-effecting behavior applied
+     * @param onError the action to invoke if the source Observable calls
+     *                <code>onError</code>
+     * @return the source Observable with the side-effecting behavior applied
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#doonerror">RxJava Wiki: doOnError()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
      */
@@ -5715,14 +5772,14 @@ public class Observable<T> {
     }
     
     /**
-     * Invokes an action when <code>onCompleted</code> is called by the
-     * Observable.
+     * Invokes an action when the source Observable calls
+     * <code>onCompleted</code>.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnCompleted.png">
      *
-     * @param onCompleted the action to invoke when <code>onCompleted</code> is
-     *                    called
-     * @return the source sequence with the side-effecting behavior applied
+     * @param onCompleted the action to invoke when the source Observable calls
+     *                    <code>onCompleted</code>
+     * @return the source Observable with the side-effecting behavior applied
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooncompleted">RxJava Wiki: doOnCompleted()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
      */
@@ -5750,10 +5807,11 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnEach.e.png">
      *
-     * @param onNext the action to invoke for each item in the source sequence
+     * @param onNext the action to invoke for each item emitted by the
+     *               Observable
      * @param onError the action to invoke when the source Observable calls
      *                <code>onError</code>
-     * @return the source sequence with the side-effecting behavior applied
+     * @return the source Observable with the side-effecting behavior applied
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnEach()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229539.aspx">MSDN: Observable.Do</a>
      */
@@ -5783,12 +5841,13 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnEach.ce.png">
      *
-     * @param onNext the action to invoke for each item in the source sequence
+     * @param onNext the action to invoke for each item emitted by the
+     *               Observable
      * @param onError the action to invoke when the source Observable calls
      *                <code>onError</code>
      * @param onCompleted the action to invoke when the source Observable calls
      *                    <code>onCompleted</code>
-     * @return the source sequence with the side-effecting behavior applied
+     * @return the source Observable with the side-effecting behavior applied
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnEach()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229830.aspx">MSDN: Observable.Do</a>
      */
@@ -5853,14 +5912,12 @@ public class Observable<T> {
     }
 
     /**
-     * Creates a pattern that matches when both Observable sequences have an
-     * available item.
+     * Creates a pattern that matches when both Observables emit an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      *
-     * @param right Observable sequence to match with the left sequence
-     * @return Pattern object that matches when both Observable sequences have
-     *         an available item
+     * @param second Observable to match with the source Observable
+     * @return Pattern object that matches when both Observables emit an item
      * @throws NullPointerException if <code>right</code> is null
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: and()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229153.aspx">MSDN: Observable.And</a>
@@ -5870,15 +5927,15 @@ public class Observable<T> {
     }
 
     /**
-     * Matches when the Observable sequence has an available item and
-     * projects the item by invoking the selector function.
+     * Matches when the Observable has an available item and projects the item
+     * by invoking the selector function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      *
-     * @param selector Selector that will be invoked for elements in the source
-     *        sequence
-     * @return Plan that produces the projected results, to be fed (with other
-     *         plans) to the When operator
+     * @param selector selector that will be invoked for items emitted by the
+     *                 source Observable
+     * @return a Plan that produces the projected results, to be fed (with other
+     *         Plans) to the {@link #when} operator
      * @throws NullPointerException if <code>selector</code> is null
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: then()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211662.aspx">MSDN: Observable.Then</a>
@@ -5892,9 +5949,9 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      *
-     * @param plans a series of plans created by use of the Then operator on
-     *              patterns
-     * @return an Observable sequence with the results from matching several
+     * @param plans a series of plans created by use of the {@link #then}
+     *              operator on patterns
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @throws NullPointerException if <code>plans</code> is null
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
@@ -5909,9 +5966,9 @@ public class Observable<T> {
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      *
-     * @param plans a series of plans created by use of the Then operator on
-     *        patterns
-     * @return an Observable sequence with the results from matching several
+     * @param plans a series of plans created by use of the {@link #then}
+     *              operator on patterns
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @throws NullPointerException if <code>plans</code> is null
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
@@ -5930,7 +5987,7 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      *
      * @param p1 the plan to join
-     * @return an Observable sequence with the results from matching a pattern
+     * @return an Observable that emits the results from matching a pattern
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
      */
@@ -5946,7 +6003,7 @@ public class Observable<T> {
      *
      * @param p1 a plan
      * @param p2 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -5964,7 +6021,7 @@ public class Observable<T> {
      * @param p1 a plan
      * @param p2 a plan
      * @param p3 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -5983,7 +6040,7 @@ public class Observable<T> {
      * @param p2 a plan
      * @param p3 a plan
      * @param p4 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -6003,7 +6060,7 @@ public class Observable<T> {
      * @param p3 a plan
      * @param p4 a plan
      * @param p5 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -6024,7 +6081,7 @@ public class Observable<T> {
      * @param p4 a plan
      * @param p5 a plan
      * @param p6 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -6046,7 +6103,7 @@ public class Observable<T> {
      * @param p5 a plan
      * @param p6 a plan
      * @param p7 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -6069,7 +6126,7 @@ public class Observable<T> {
      * @param p6 a plan
      * @param p7 a plan
      * @param p8 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -6093,7 +6150,7 @@ public class Observable<T> {
      * @param p7 a plan
      * @param p8 a plan
      * @param p9 a plan
-     * @return an Observable sequence with the results from matching several
+     * @return an Observable that emits the results from matching several
      *         patterns
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#and-then-and-when">RxJava Wiki: when()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229889.aspx">MSDN: Observable.When</a>
@@ -6104,22 +6161,22 @@ public class Observable<T> {
     }
 
     /**
-     * Correlates the elements of two sequences based on overlapping durations.
+     * Correlates the items emitted by two Observables based on overlapping
+     * durations.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/join_.png">
      *
-     * @param right the right observable sequence to join elements for
+     * @param right the second Observable to join items from
      * @param leftDurationSelector a function to select the duration of each 
-     *                             element of this observable sequence, used to
+     *                             item emitted by this Observable, used to
      *                             determine overlap
      * @param rightDurationSelector a function to select the duration of each
-     *                              element of the right observable sequence, 
-     *                              used to determine overlap
-     * @param resultSelector a function invoked to compute a result element 
-     *                       for any two overlapping elements of the left and
-     *                       right observable sequences
-     * @return an observable sequence that contains result elements computed
-     *         from source elements that have an overlapping duration
+     *                              item emitted by the <code>right</code>
+     *                              Observable, used to determine overlap
+     * @param resultSelector a function that computes a result item for any two
+     *                       overlapping items emitted by the two Observables
+     * @return an Observable that emits result items computed from source items
+     *         that have an overlapping duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Combining-Observables#join">RxJava Wiki: join()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229750.aspx">MSDN: Observable.Join</a>
      */
@@ -6135,14 +6192,14 @@ public class Observable<T> {
      * {@code keySelector} function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
-     * 
+     * <p>
      * If a source item maps to the same key, the HashMap will contain the
      * latest of those items.
      * 
      * @param keySelector the function that extracts the key from the source
      *                    items to be used as keys in the HashMap
      * @return an Observable that emits a single HashMap containing the mapped
-     *         values of the source Observable
+     *         items from the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229137.aspx">MSDN: Observable.ToDictionary</a>
      */
@@ -6152,7 +6209,7 @@ public class Observable<T> {
     
     /**
      * Return an Observable that emits a single HashMap containing elements with
-     * key and value extracted from the values emitted by the source Observable.
+     * key and value extracted from the items emitted by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
      * <p>
@@ -6164,7 +6221,7 @@ public class Observable<T> {
      * @param valueSelector the function that extracts the value from the source
      *                      items to be used as value in the HashMap
      * @return an Observable that emits a single HashMap containing the mapped
-     *         values of the source Observable
+     *         items from the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212075.aspx">MSDN: Observable.ToDictionary</a>
      */
@@ -6175,7 +6232,7 @@ public class Observable<T> {
     /**
      * Return an Observable that emits a single Map, returned by the
      * <code>mapFactory</code> function, containing key and value extracted from
-     * the values emitted by the source Observable.
+     * the items emitted by the source Observable.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
      * 
@@ -6185,7 +6242,7 @@ public class Observable<T> {
      *                      items to be used as value in the Map
      * @param mapFactory the function that returns an Map instance to be used
      * @return an Observable that emits a single Map containing the mapped
-     *         values of the source Observable
+     *         items emitted by the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      */
     public <K, V> Observable<Map<K, V>> toMap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func0<? extends Map<K, V>> mapFactory) {
@@ -6194,7 +6251,7 @@ public class Observable<T> {
     
     /**
      * Return an Observable that emits a single HashMap containing an ArrayList
-     * of elements, emitted by the source Observable and keyed by the
+     * of items, emitted by the source Observable and keyed by the
      * <code>keySelector</code> function.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMultiMap.png">
@@ -6202,7 +6259,7 @@ public class Observable<T> {
      * @param keySelector the function that extracts the key from the source
      *                    items to be used as key in the HashMap
      * @return an Observable that emits a single HashMap containing an ArrayList
-     *         of elements mapped from the source Observable
+     *         of items mapped from the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMultiMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212098.aspx">MSDN: Observable.ToLookup</a>
      */
@@ -6223,7 +6280,7 @@ public class Observable<T> {
      * @param valueSelector the function that extracts the value from the source
      *                      items to be used as value in the Map
      * @return an Observable that emits a single HashMap containing an ArrayList
-     *         of elements mapped from the source Observable
+     *         of items mapped from the source Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMultiMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229101.aspx">MSDN: Observable.ToLookup</a>
      */
@@ -6245,7 +6302,7 @@ public class Observable<T> {
      *                      items to be used as value in the Map
      * @param mapFactory the function that returns an Map instance to be used
      * @return an Observable that emits a single Map containing the list of
-     *         mapped values of the source observable.
+     *         mapped items from the source Observable.
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMultiMap()</a>
      */
     public <K, V> Observable<Map<K, Collection<V>>> toMultimap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func0<? extends Map<K, Collection<V>>> mapFactory) {
@@ -6254,7 +6311,7 @@ public class Observable<T> {
 
     /**
      * Return an Observable that emits a single Map, returned by the
-     * <code>mapFactory</code> function, containing a custom collection of
+     * <code>mapFactory</code> function, that contains a custom collection of
      * values, extracted by the <code>valueSelector</code> function, emitted by
      * the source Observable and keyed by the <code>keySelector</code> function.
      * <p>
@@ -6268,7 +6325,7 @@ public class Observable<T> {
      * @param collectionFactory the function that returns a Collection instance
      *                          for a particular key to be used in the Map
      * @return an Observable that emits a single Map containing the collection
-     *         of mapped values of the source Observable.
+     *         of mapped items from the source Observable.
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#tomap-and-tomultimap">RxJava Wiki: toMultiMap()</a>
      */
     public <K, V> Observable<Map<K, Collection<V>>> toMultimap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func0<? extends Map<K, Collection<V>>> mapFactory, Func1<? super K, ? extends Collection<V>> collectionFactory) {
@@ -6276,15 +6333,15 @@ public class Observable<T> {
     } 
     
     /**
-     * Return an Observable that skips elements from the source Observable until
-     * the secondary Observable emits an element.
+     * Return an Observable that skips items from the source Observable until
+     * the secondary Observable emits an item.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipUntil.png">
      * 
-     * @param other the other Observable that has to emit an element before this
+     * @param other the other Observable that has to emit an item before this
      *              Observable's elements are relayed
-     * @return an Observable that skips elements from the source Observable
-     *         until the secondary Observable emits an element.
+     * @return an Observable that skips items from the source Observable
+     *         until the secondary Observable emits an item.
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observables#skipuntil">RxJava Wiki: skipUntil()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229358.aspx">MSDN: Observable.SkipUntil</a>
      */
@@ -6300,9 +6357,9 @@ public class Observable<T> {
      *
      * @param keySelector a function to extract the key for each item
      * @param durationSelector a function to signal the expiration of a group
-     * @return a sequence of Observable groups, each of which corresponds to a
-     *         unique key value, containing all items that share that same
-     *         key value
+     * @return an Observable that emits grouped Observables, each of which
+     *         corresponds to a key value and emits all items that share that
+     *         same key value that were emitted during the key's duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#groupby-and-groupbyuntil">RxJava Wiki: groupByUntil()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211932.aspx">MSDN: Observable.GroupByUntil</a>
      */
@@ -6318,12 +6375,12 @@ public class Observable<T> {
      * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupByUntil.png">
      *
      * @param keySelector a function to extract the key for each item
-     * @param valueSelector a function to map each source element to an item
+     * @param valueSelector a function to map each source item to an item
      *                      emitted by an Observable group
      * @param durationSelector a function to signal the expiration of a group
-     * @return a sequence of Observable groups, each of which corresponds to a
-     *         unique key value, containing all items that share that same key
-     *         value
+     * @return an Observable that emits grouped Observables, each of which
+     *         corresponds to a key value and emits all items that share that
+     *         same key value that were emitted during the key's duration
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#groupby-and-groupbyuntil">RxJava Wiki: groupByUntil()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229433.aspx">MSDN: Observable.GroupByUntil</a>
      */
@@ -6332,35 +6389,41 @@ public class Observable<T> {
     }
 
     /**
-     * Invokes the specified function asynchronously, surfacing the result through an observable sequence.
+     * Invokes the specified function asynchronously and returns an Observable
+     * that emits the result.
      * <p>
-     * Note: The function is called immediately, not during the subscription of the resulting
-     * sequence. Multiple subscriptions to the resulting sequence can observe the
-     * function's result.
+     * Note: The function is called immediately and once, not whenever an
+     * observer subscribes to the resulting Observable. Multiple subscriptions
+     * to this Observable observe the same return value.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/start.png">
      * 
-     * @param func
-     *            Function to run asynchronously.
-     * @return An observable sequence exposing the function's result value, or an exception.
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229036(v=vs.103).aspx">MSDN: Observable.Start</a>
+     * @param func function to run asynchronously
+     * @return an Observable that emits the function's result value, or notifies
+     *         observers of an exception
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#start">RxJava Wiki: start()</a>
+     * @see <a href="http://msdn.microsoft.com/en-us/library/hh229036.aspx">MSDN: Observable.Start</a>
      */
     public static <T> Observable<T> start(Func0<T> func) {
         return Async.toAsync(func).call();
     }
 
     /**
-     * Invokes the specified function asynchronously on the specified scheduler, surfacing
-     * the result through an observable sequence.
+     * Invokes the specified function asynchronously on the specified scheduler
+     * and returns an Observable that emits the result.
      * <p>
-     * Note: The function is called immediately, not during the subscription of the resulting
-     * sequence. Multiple subscriptions to the resulting sequence can observe the
-     * function's result.
+     * Note: The function is called immediately and once, not whenever an
+     * observer subscribes to the resulting Observable. Multiple subscriptions
+     * to this Observable observe the same return value.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/start.s.png">
      * 
-     * @param func
-     *            Function to run asynchronously.
-     * @param scheduler
-     *            Scheduler to run the function on.
-     * @return An observable sequence exposing the function's result value, or an exception.
-     * @see <a href="http://msdn.microsoft.com/en-us/library/hh211721(v=vs.103).aspx">MSDN: Observable.Start</a>
+     * @param func function to run asynchronously
+     * @param scheduler scheduler to run the function on
+     * @return an Observable that emits the function's result value, or notifies
+     *         observers of an exception
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#start">RxJava Wiki: start()</a>
+     * @see <a href="http://msdn.microsoft.com/en-us/library/hh211721.aspx">MSDN: Observable.Start</a>
      */
     public static <T> Observable<T> start(Func0<T> func, Scheduler scheduler) {
         return Async.toAsync(func, scheduler).call();


### PR DESCRIPTION
- consistent nomenclature
- consistent/standard javadoc formatting
- more-precise descriptions
- timer() marble digram & wiki link
- delay() marble diagram & wiki link
