### PR TITLE
Replay additional overloads

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationMulticast.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationMulticast.java
@@ -16,10 +16,15 @@
 package rx.operators;
 
 import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
 import rx.observables.ConnectableObservable;
 import rx.subjects.Subject;
+import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Func0;
+import rx.util.functions.Func1;
 
 public class OperationMulticast {
     public static <T, R> ConnectableObservable<R> multicast(Observable<? extends T> source, final Subject<? super T, ? extends R> subject) {
@@ -80,5 +85,58 @@ public class OperationMulticast {
             };
         }
 
+    }
+    /**
+     * Returns an observable sequence that contains the elements of a sequence 
+     * produced by multicasting the source sequence within a selector function.
+     * 
+     * @param source
+     * @param subjectFactory
+     * @param selector
+     * @return 
+     * 
+     * @see <a href='http://msdn.microsoft.com/en-us/library/hh229708(v=vs.103).aspx'>MSDN: Observable.Multicast</a>
+     */
+    public static <TInput, TIntermediate, TResult> Observable<TResult> multicast(
+            final Observable<? extends TInput> source,
+            final Func0<? extends Subject<? super TInput, ? extends TIntermediate>> subjectFactory, 
+            final Func1<? super Observable<TIntermediate>, ? extends Observable<TResult>> selector) {
+        return Observable.create(new MulticastSubscribeFunc<TInput, TIntermediate, TResult>(source, subjectFactory, selector));
+    }
+    /** The multicast subscription function. */
+    private static final class MulticastSubscribeFunc<TInput, TIntermediate, TResult> implements OnSubscribeFunc<TResult> {
+        final Observable<? extends TInput> source;
+        final Func0<? extends Subject<? super TInput, ? extends TIntermediate>> subjectFactory;
+        final Func1<? super Observable<TIntermediate>, ? extends Observable<TResult>> resultSelector;
+        public MulticastSubscribeFunc(Observable<? extends TInput> source,
+                Func0<? extends Subject<? super TInput, ? extends TIntermediate>> subjectFactory, 
+                Func1<? super Observable<TIntermediate>, ? extends Observable<TResult>> resultSelector) {
+            this.source = source;
+            this.subjectFactory = subjectFactory;
+            this.resultSelector = resultSelector;
+        }
+        @Override
+        public Subscription onSubscribe(Observer<? super TResult> t1) {
+            Observable<TResult> observable;
+            ConnectableObservable<TIntermediate> connectable;
+            try {
+                Subject<? super TInput, ? extends TIntermediate> subject = subjectFactory.call();
+                
+                connectable = new MulticastConnectableObservable<TInput, TIntermediate>(source, subject);
+                
+                observable = resultSelector.call(connectable);
+            } catch (Throwable t) {
+                t1.onError(t);
+                return Subscriptions.empty();
+            }
+            
+            CompositeSubscription csub = new CompositeSubscription();
+            
+            csub.add(observable.subscribe(new SafeObserver<TResult>(
+                    new SafeObservableSubscription(csub), t1)));
+            csub.add(connectable.connect());
+            
+            return csub;
+        }
     }
 }


### PR DESCRIPTION
Issue #71
- Added several overloads of the `replay` operator: 
  - limited buffer, limited time window, buffer+time, 
  - scheduler overloads; 
  - versions which perform a projection before the replay
- Added missing `multicast` overload
