### PR TITLE
Operators: Observables from functionals (Action0, Func0, Runnable, Calla...

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,7 @@ import rx.operators.OperationGroupBy;
 import rx.operators.OperationGroupByUntil;
 import rx.operators.OperationGroupJoin;
 import rx.operators.OperationInterval;
+import rx.operators.OperationFromFunctionals;
 import rx.operators.OperationJoin;
 import rx.operators.OperationJoinPatterns;
 import rx.operators.OperationLast;
@@ -5822,7 +5824,132 @@ public class Observable<T> {
     public Observable<T> ignoreElements() {
         return filter(alwaysFalse());
     }
-
+    
+    /**
+     * Return an Observable which calls the given action and emits the given
+     * result when an Observer subscribes.
+     * <p>
+     * The action is run on the default thread pool for computation.
+     * @param <R> the return type
+     * @param action the action to invoke on each subscription
+     * @param result the result to emit to observers
+     * @return an Observable which calls the given action and emits the given
+     * result when an Observer subscribes
+     */
+    public static <R> Observable<R> fromAction(Action0 action, R result) {
+        return fromAction(action, result, Schedulers.threadPoolForComputation());
+    }
+    
+    /**
+     * Return an Observable which calls the given function and emits its
+     * result when an Observer subscribes.
+     * <p>
+     * The function is called on the default thread pool for computation.
+     * 
+     * @param <R> the return type
+     * @param function the function to call on each subscription
+     * @return an Observable which calls the given function and emits its
+     * result when an Observer subscribes
+     * @see #start(rx.util.functions.Func0) 
+     * @see #fromCallable(java.util.concurrent.Callable) 
+     */
+    public static <R> Observable<R> fromFunc0(Func0<? extends R> function) {
+        return fromFunc0(function, Schedulers.threadPoolForComputation());
+    }
+    /**
+     * Return an Observable which calls the given Callable and emits its
+     * result or Exception when an Observer subscribes.
+     * <p>
+     * The Callable is called on the default thread pool for computation.
+     * 
+     * @param <R> the return type
+     * @param callable the callable to call on each subscription
+     * @return an Observable which calls the given Callable and emits its
+     * result or Exception when an Observer subscribes
+     * @see #start(rx.util.functions.Func0) 
+     * @see #fromFunc0(rx.util.functions.Func0) 
+     */
+    public static <R> Observable<R> fromCallable(Callable<? extends R> callable) {
+        return fromCallable(callable, Schedulers.threadPoolForComputation());
+    }
+    
+    /**
+     * Return an Observable which calls the given Runnable and emits the given
+     * result when an Observer subscribes.
+     * <p>
+     * The Runnable is called on the default thread pool for computation.
+     * 
+     * @param <R> the return type
+     * @param run the runnable to invoke on each subscription
+     * @param result the result to emit to observers
+     * @return an Observable which calls the given Runnable and emits the given
+     * result when an Observer subscribes
+     */
+    public static <R> Observable<R> fromRunnable(final Runnable run, final R result) {
+        return fromRunnable(run, result, Schedulers.threadPoolForComputation());
+    }
+    
+    /**
+     * Return an Observable which calls the given action and emits the given
+     * result when an Observer subscribes.
+     * 
+     * @param <R> the return type
+     * @param action the action to invoke on each subscription
+     * @param scheduler the scheduler where the function is called and the result is emitted
+     * @param result the result to emit to observers
+     * @return an Observable which calls the given action and emits the given
+     * result when an Observer subscribes
+     */
+    public static <R> Observable<R> fromAction(Action0 action, R result, Scheduler scheduler) {
+        return create(OperationFromFunctionals.fromAction(action, result)).subscribeOn(scheduler);
+    }
+    
+    /**
+     * Return an Observable which calls the given function and emits its
+     * result when an Observer subscribes.
+     * 
+     * @param <R> the return type
+     * @param function the function to call on each subscription
+     * @param scheduler the scheduler where the function is called and the result is emitted
+     * @return an Observable which calls the given function and emits its
+     * result when an Observer subscribes
+     * @see #start(rx.util.functions.Func0) 
+     * @see #fromCallable(java.util.concurrent.Callable) 
+     */
+    public static <R> Observable<R> fromFunc0(Func0<? extends R> function, Scheduler scheduler) {
+        return create(OperationFromFunctionals.fromFunc0(function)).subscribeOn(scheduler);
+    }
+    /**
+     * Return an Observable which calls the given Callable and emits its
+     * result or Exception when an Observer subscribes.
+     * 
+     * @param <R> the return type
+     * @param callable the callable to call on each subscription
+     * @param scheduler the scheduler where the function is called and the result is emitted
+     * @return an Observable which calls the given Callable and emits its
+     * result or Exception when an Observer subscribes
+     * @see #start(rx.util.functions.Func0) 
+     * @see #fromFunc0(rx.util.functions.Func0) 
+     */
+    public static <R> Observable<R> fromCallable(Callable<? extends R> callable, Scheduler scheduler) {
+        return create(OperationFromFunctionals.fromCallable(callable)).subscribeOn(scheduler);
+    }
+    
+    /**
+     * Return an Observable which calls the given Runnable and emits the given
+     * result when an Observer subscribes.
+     * 
+     * @param <R> the return type
+     * @param run the runnable to invoke on each subscription
+     * @param scheduler the scheduler where the function is called and the result is emitted
+     * @param result the result to emit to observers
+     * @return an Observable which calls the given Runnable and emits the given
+     * result when an Observer subscribes
+     */
+    public static <R> Observable<R> fromRunnable(final Runnable run, final R result, Scheduler scheduler) {
+        return create(OperationFromFunctionals.fromRunnable(run, result)).subscribeOn(scheduler);
+    }
+    
     /**
      * Applies a timeout policy for each item emitted by the Observable, using
      * the specified scheduler to run timeout timers. If the next item isn't

--- a/rxjava-core/src/main/java/rx/operators/OperationFromFunctionals.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationFromFunctionals.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.operators;
+
+import java.util.concurrent.Callable;
+import rx.Observable.OnSubscribeFunc;
+import rx.Observer;
+import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
+import rx.util.functions.Actions;
+import rx.util.functions.Func0;
+
+/**
+ * Operators that invoke a function or action if
+ * an observer subscribes.
+ * Asynchrony can be achieved by using subscribeOn or observeOn.
+ */
+public final class OperationFromFunctionals {
+    /** Utility class. */
+    private OperationFromFunctionals() { throw new IllegalStateException("No instances!"); }
+    
+    /** Subscriber function that invokes an action and returns the given result. */
+    public static <R> OnSubscribeFunc<R> fromAction(Action0 action, R result) {
+        return new InvokeAsync<R>(Actions.toFunc(action, result));
+    }
+    
+    /** Subscriber function that invokes a function and returns its value. */
+    public static <R> OnSubscribeFunc<R> fromFunc0(Func0<? extends R> function) {
+        return new InvokeAsync<R>(function);
+    }
+    
+    /** 
+     * Subscriber function that invokes the callable and returns its value or
+     * propagates its checked exception.
+     */
+    public static <R> OnSubscribeFunc<R> fromCallable(Callable<? extends R> callable) {
+        return new InvokeAsyncCallable<R>(callable);
+    }
+    /** Subscriber function that invokes a runnable and returns the given result. */
+    public static <R> OnSubscribeFunc<R> fromRunnable(final Runnable run, final R result) {
+        return new InvokeAsync(new Func0<R>() {
+            @Override
+            public R call() {
+                run.run();
+                return result;
+            }
+        });
+    }
+    
+    /**
+     * Invokes a function when an observer subscribes.
+     * @param <R> the return type
+     */
+    static final class InvokeAsync<R> implements OnSubscribeFunc<R> {
+        final Func0<? extends R> function;
+        public InvokeAsync(Func0<? extends R> function) {
+            if (function == null) {
+                throw new NullPointerException("function");
+            }
+            this.function = function;
+        }
+        @Override
+        public Subscription onSubscribe(Observer<? super R> t1) {
+            Subscription s = Subscriptions.empty();
+            try {
+                t1.onNext(function.call());
+            } catch (Throwable t) {
+                t1.onError(t);
+                return s;
+            }
+            t1.onCompleted();
+            return s;
+        }
+    }
+    /**
+     * Invokes a java.util.concurrent.Callable when an observer subscribes.
+     * @param <R> the return type
+     */
+    static final class InvokeAsyncCallable<R> implements OnSubscribeFunc<R> {
+        final Callable<? extends R> callable;
+        public InvokeAsyncCallable(Callable<? extends R> callable) {
+            if (callable == null) {
+                throw new NullPointerException("function");
+            }
+            this.callable = callable;
+        }
+        @Override
+        public Subscription onSubscribe(Observer<? super R> t1) {
+            Subscription s = Subscriptions.empty();
+            try {
+                t1.onNext(callable.call());
+            } catch (Throwable t) {
+                t1.onError(t);
+                return s;
+            }
+            t1.onCompleted();
+            return s;
+        }
+    }
+}

--- a/rxjava-core/src/test/java/rx/operators/OperationFromFunctionalsTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationFromFunctionalsTest.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import static org.mockito.Mockito.*;
+import rx.Observable;
+import rx.Observer;
+import rx.schedulers.TestScheduler;
+import rx.util.functions.Action0;
+import rx.util.functions.Func0;
+
+public class OperationFromFunctionalsTest {
+    TestScheduler scheduler;
+    @Before
+    public void before() {
+        scheduler = new TestScheduler();
+    }
+    private void testRunShouldThrow(Observable<Integer> source, Class<? extends Throwable> exception) {
+        for (int i = 0; i < 3; i++) {
+            
+            Observer<Object> observer = mock(Observer.class);
+            source.subscribe(observer);
+
+            InOrder inOrder = inOrder(observer);
+
+            inOrder.verify(observer, never()).onError(any(Throwable.class));
+
+            scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+            inOrder.verify(observer, times(1)).onError(any(exception));
+            verify(observer, never()).onNext(any());
+            verify(observer, never()).onCompleted();
+            inOrder.verifyNoMoreInteractions();
+        }
+    }
+    @Test
+    public void testFromAction() {
+        final AtomicInteger value = new AtomicInteger();
+        
+        Action0 action = new Action0() {
+            @Override
+            public void call() {
+                value.set(2);
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromAction(action, 1, scheduler);
+        
+        for (int i = 0; i < 3; i++) {
+            
+            value.set(0);
+            
+            Observer<Object> observer = mock(Observer.class);
+            source.subscribe(observer);
+
+            InOrder inOrder = inOrder(observer);
+
+            inOrder.verify(observer, never()).onNext(any());
+            inOrder.verify(observer, never()).onCompleted();
+
+            scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+            inOrder.verify(observer, times(1)).onNext(1);
+            inOrder.verify(observer, times(1)).onCompleted();
+            inOrder.verifyNoMoreInteractions();
+            verify(observer, never()).onError(any(Throwable.class));
+
+            Assert.assertEquals(2, value.get());
+        }
+    }
+    @Test
+    public void testFromActionThrows() {
+        Action0 action = new Action0() {
+            @Override
+            public void call() {
+                throw new RuntimeException("Forced failure!");
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromAction(action, 1, scheduler);
+        
+        testRunShouldThrow(source, RuntimeException.class);
+    }
+    @Test
+    public void testFromFunc0() {
+        Func0<Integer> func = new Func0<Integer>() {
+            @Override
+            public Integer call() {
+                return 1;
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromFunc0(func, scheduler);
+        
+        for (int i = 0; i < 3; i++) {
+            
+            Observer<Object> observer = mock(Observer.class);
+            source.subscribe(observer);
+
+            InOrder inOrder = inOrder(observer);
+
+            inOrder.verify(observer, never()).onNext(any());
+            inOrder.verify(observer, never()).onCompleted();
+
+            scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+            inOrder.verify(observer, times(1)).onNext(1);
+            inOrder.verify(observer, times(1)).onCompleted();
+            inOrder.verifyNoMoreInteractions();
+            verify(observer, never()).onError(any(Throwable.class));
+        }
+    }
+    
+    @Test
+    public void testFromFunc0Throws() {
+        Func0<Integer> func = new Func0<Integer>() {
+            @Override
+            public Integer call() {
+                throw new RuntimeException("Forced failure!");
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromFunc0(func, scheduler);
+        
+        testRunShouldThrow(source, RuntimeException.class);
+    }
+    @Test
+    public void testFromRunnable() {
+        final AtomicInteger value = new AtomicInteger();
+        
+        Runnable action = new Runnable() {
+            @Override
+            public void run() {
+                value.set(2);
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromRunnable(action, 1, scheduler);
+        
+        for (int i = 0; i < 3; i++) {
+            
+            value.set(0);
+            
+            Observer<Object> observer = mock(Observer.class);
+            source.subscribe(observer);
+
+            InOrder inOrder = inOrder(observer);
+
+            inOrder.verify(observer, never()).onNext(any());
+            inOrder.verify(observer, never()).onCompleted();
+
+            scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+            inOrder.verify(observer, times(1)).onNext(1);
+            inOrder.verify(observer, times(1)).onCompleted();
+            inOrder.verifyNoMoreInteractions();
+            verify(observer, never()).onError(any(Throwable.class));
+
+            Assert.assertEquals(2, value.get());
+        }
+    }
+    @Test
+    public void testFromRunnableThrows() {
+        Runnable action = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException("Forced failure!");
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromRunnable(action, 1, scheduler);
+        
+        testRunShouldThrow(source, RuntimeException.class);
+    }
+    @Test
+    public void testFromCallable() {
+        Callable<Integer> callable = new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return 1;
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromCallable(callable, scheduler);
+        
+        for (int i = 0; i < 3; i++) {
+            
+            Observer<Object> observer = mock(Observer.class);
+            source.subscribe(observer);
+
+            InOrder inOrder = inOrder(observer);
+
+            inOrder.verify(observer, never()).onNext(any());
+            inOrder.verify(observer, never()).onCompleted();
+
+            scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+            inOrder.verify(observer, times(1)).onNext(1);
+            inOrder.verify(observer, times(1)).onCompleted();
+            inOrder.verifyNoMoreInteractions();
+            verify(observer, never()).onError(any(Throwable.class));
+        }
+    }
+    
+    @Test
+    public void testFromCallableThrows() {
+        Callable<Integer> callable = new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                throw new IOException("Forced failure!");
+            }
+        };
+        
+        Observable<Integer> source = Observable.fromCallable(callable, scheduler);
+        
+        testRunShouldThrow(source, IOException.class);
+    }
+}


### PR DESCRIPTION
...ble)

I've created 4 operators that turn ordinary action/function calls into Observables, but unlike start and Async, the functions are called on each subscription instead of only once. They can be thought of a more generalized from(T value). Each method is named according to the accepted type to avoid overload issues with Java 8 & various dynamic languages.

The 4 additional overloads lets the user specify the scheduler where the function is called. By default, the functions are called on the threadPoolForComputation.

I don't know if there are Rx.NET equivalents of these (or they ever existed).
