### PR TITLE
Properly wired up SynchronizedObserver within MergeDelayError operator

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationMergeDelayError.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationMergeDelayError.java
@@ -168,7 +168,7 @@ public final class OperationMergeDelayError {
             /**
              * Subscribe to the parent Observable to get to the children Observables
              */
-            completeSubscription.add(sequences.subscribe(new ParentObserver(actualObserver)));
+            completeSubscription.add(sequences.subscribe(new ParentObserver(synchronizedObserver)));
 
             /* return our subscription to allow unsubscribing */
             return completeSubscription;


### PR DESCRIPTION
Previous pull request for this issue (https://github.com/Netflix/RxJava/pull/615) missed the step of connecting SynchronizedObserver to ParentObserver
