### PR TITLE
Operators BO.chunkify, BO.collect, O.forIterable

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -2460,6 +2460,21 @@ public class Observable<T> {
             }
         });
     }
+    
+    /**
+     * Return an Observable which concatenates the observable sequences obtained by running the
+     * resultSelector for each element in the given Iterable source.
+     * @param <T> the Iterable sequence value type
+     * @param <R> the result type
+     * @param source the source iterable
+     * @param resultSelector the selector function that returns an Observable
+     *                       sequence for each value of the {@code source} iterable sequence
+     * @return an Observable which concatenates the observable sequences obtained by running the
+     * resultSelector for each element in the given Iterable source.
+     */
+    public static <T, R> Observable<R> forIterable(Iterable<? extends T> source, Func1<? super T, ? extends Observable<? extends R>> resultSelector) {
+        return create(OperationConcat.forIterable(source, resultSelector));
+    }
 
     /**
      * Returns an Observable that emits a Boolean value that indicates whether

--- a/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
@@ -16,6 +16,7 @@
 package rx.observables;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
+import rx.operators.OperationCollect;
 import rx.operators.OperationMostRecent;
 import rx.operators.OperationNext;
 import rx.operators.OperationToFuture;
@@ -30,7 +32,9 @@ import rx.operators.OperationToIterator;
 import rx.operators.SafeObservableSubscription;
 import rx.operators.SafeObserver;
 import rx.util.functions.Action1;
+import rx.util.functions.Func0;
 import rx.util.functions.Func1;
+import rx.util.functions.Func2;
 
 /**
  * An extension of {@link Observable} that provides blocking operators.
@@ -353,5 +357,29 @@ public class BlockingObservable<T> {
                 return getIterator();
             }
         };
+    }
+    
+    /**
+     * Return an Iterable sequence that returns elements 
+     * collected/aggregated from the source sequence between consecutive next calls.
+     * @param <U> the type of the collector
+     * @param initialCollector factory function to create the initial collector
+     * @param merger function that merges the current collector with the observed value and returns a (new) collector
+     * @param replaceCollector function that replaces the current collector with a new collector when the current collector is consumed by an Iterator.next()
+     * @return an Iterable sequence that returns elements 
+     *         collected/aggregated from the source sequence between
+     *         consecutive next calls.
+     */
+    public <U> Iterable<U> collect(Func0<? extends U> initialCollector,
+            Func2<? super U, ? super T, ? extends U> merger,
+            Func1<? super U, ? extends U> replaceCollector) {
+        return OperationCollect.collect(o, initialCollector, merger, replaceCollector);
+    }
+    /**
+     * Return an Iterable that produces a sequence of consecutive (possibly empty) chunks of this Observable sequence.
+     * @return an Iterable that produces a sequence of consecutive (possibly empty) chunks of this Observable sequence.
+     */
+    public Iterable<List<T>> chunkify() {
+        return OperationCollect.chunkify(o);
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationCollect.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationCollect.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.operators;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import rx.Observable;
+import rx.Observer;
+import rx.Subscription;
+import rx.subscriptions.SingleAssignmentSubscription;
+import rx.util.Exceptions;
+import rx.util.functions.Func0;
+import rx.util.functions.Func1;
+import rx.util.functions.Func2;
+
+/**
+ * Observable to iterable mapping by using custom collector, merger and
+ * collector-replacer functions.
+ */
+public final class OperationCollect {
+    /** Utility class. */
+    private OperationCollect() { throw new IllegalStateException("No instances!"); }
+    
+    /**
+     * Produces an Iterable sequence that returns elements 
+     * collected/aggregated from the source sequence between consecutive next calls.
+     * @param <T> the source value type
+     * @param <U> the aggregation type
+     * @param source the source Observable
+     * @param initialCollector the factory to create the initial collector
+     * @param merger the merger that combines the current collector with the observed value and returns a (new) collector
+     * @param replaceCollector the function that replaces the current collector with a new collector.
+     * @return the iterable sequence
+     */
+    public static <T, U> Iterable<U> collect(
+            final Observable<? extends T> source,
+            final Func0<? extends U> initialCollector,
+            final Func2<? super U, ? super T, ? extends U> merger,
+            final Func1<? super U, ? extends U> replaceCollector) {
+        return new Iterable<U>() {
+            @Override
+            public Iterator<U> iterator() {
+                SingleAssignmentSubscription sas = new SingleAssignmentSubscription();
+                Collect<T, U> collect = new Collect<T, U>(initialCollector, merger, replaceCollector, sas);
+                if (!sas.isUnsubscribed()) {
+                    sas.set(source.subscribe(collect));
+                }
+                return collect;
+            }
+        };
+    }
+    
+    /**
+     * Produces an Iterable sequence of consecutive (possibly empty) chunks of the source sequence.
+     * @param <T> the source value type
+     * @param source the source Observable
+     * @return an iterable sequence of the chunks
+     */
+    public static <T> Iterable<List<T>> chunkify(final Observable<? extends T> source) {
+        ListManager<T> na = new ListManager<T>();
+        return collect(source, na, na, na);
+    }
+    /** Creates a new ArrayList and manages its content. */
+    private static final class ListManager<T> implements Func1<List<T>, List<T>>, Func0<List<T>>, Func2<List<T>, T, List<T>> {
+        @Override
+        public List<T> call() {
+            return new ArrayList<T>();
+        }
+
+        @Override
+        public List<T> call(List<T> t1) {
+            return call();
+        }
+        @Override
+        public List<T> call(List<T> t1, T t2) {
+            t1.add(t2);
+            return t1;
+        }
+    }
+    
+    /** The observer and iterator. */
+    private static final class Collect<T, U> implements Observer<T>, Iterator<U> {
+        final Func2<? super U, ? super T, ? extends U> merger;
+        final Func1<? super U, ? extends U> replaceCollector;
+        final Subscription cancel;
+        final Lock lock = new ReentrantLock();
+        U current;
+        boolean hasDone;
+        boolean hasError;
+        Throwable error;
+        /** Iterator's current collector. */
+        U iCurrent;
+        /** Iterator has unclaimed collector. */
+        boolean iHasValue;
+        /** Iterator completed. */
+        boolean iDone;
+        /** Iterator error. */
+        Throwable iError;
+        
+        public Collect(final Func0<? extends U> initialCollector,
+                final Func2<? super U, ? super T, ? extends U> merger,
+                final Func1<? super U, ? extends U> replaceCollector,
+                final Subscription cancel) {
+            this.merger = merger;
+            this.replaceCollector = replaceCollector;
+            this.cancel = cancel;
+            try {
+                current = initialCollector.call();
+            } catch (Throwable t) {
+                hasError = true;
+                error = t;
+                cancel.unsubscribe();
+            }
+        }
+        
+        @Override
+        public void onNext(T args) {
+            boolean unsubscribe = false;
+            lock.lock();
+            try {
+                if (hasDone || hasError) {
+                    return;
+                }
+                try {
+                    current = merger.call(current, args);
+                } catch (Throwable t) {
+                    error = t;
+                    hasError = true;
+                    unsubscribe = true;
+                }
+            } finally {
+                lock.unlock();
+            }
+            if (unsubscribe) {
+                cancel.unsubscribe();
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            boolean unsubscribe = false;
+            lock.lock();
+            try {
+                if (hasDone || hasError) {
+                    return;
+                }
+                hasDone = true;
+                unsubscribe = true;
+            } finally {
+                lock.unlock();
+            }
+            if (unsubscribe) {
+                cancel.unsubscribe();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            boolean unsubscribe = false;
+            lock.lock();
+            try {
+                if (hasDone || hasError) {
+                    return;
+                }
+                hasError = true;
+                error = e;
+                unsubscribe = true;
+            } finally {
+                lock.unlock();
+            }
+            if (unsubscribe) {
+                cancel.unsubscribe();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (iError != null) {
+                throw Exceptions.propagate(iError);
+            }
+            if (!iHasValue) {
+                if (!iDone) {
+                    lock.lock();
+                    try {
+                        if (hasError) {
+                            iError = error;
+                            iDone = true;
+                            current = null;
+                            iCurrent = null;
+                        } else {
+                            iCurrent = current;
+                            iHasValue = true;
+                            if (hasDone) {
+                                current = null;
+                                iDone = true;
+                            } else {
+                                try {
+                                    current = replaceCollector.call(iCurrent);
+                                } catch (Throwable t) {
+                                    iError = t;
+                                    iDone = true;
+                                }
+                            }
+                        }
+                    } finally {
+                        lock.unlock();
+                    }
+                    if (iDone && iError != null) {
+                        cancel.unsubscribe();
+                        throw Exceptions.propagate(iError);
+                    }
+                    return true;
+                }
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public U next() {
+            if (hasNext()) {
+                U value = iCurrent;
+                iCurrent = null;
+                iHasValue = false;
+                return value;
+            }
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("Read-only sequence");
+        }
+    }
+}

--- a/rxjava-core/src/test/java/rx/operators/OperationCollectTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationCollectTest.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.operators;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import rx.Observable;
+import rx.subjects.PublishSubject;
+import rx.util.functions.Func0;
+import rx.util.functions.Func1;
+import rx.util.functions.Func2;
+
+public class OperationCollectTest {
+    @Test
+    public void testChunkify() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        Iterable<List<Integer>> iterable = source.toBlockingObservable().chunkify();
+
+        Iterator<List<Integer>> it = iterable.iterator();
+        
+        assertEquals(Arrays.<Integer>asList(), it.next());
+        
+        source.onNext(1);
+
+        assertEquals(Arrays.asList(1), it.next());
+
+        source.onNext(2);
+        source.onNext(3);
+
+        assertEquals(Arrays.asList(2, 3), it.next());
+
+        assertEquals(Arrays.<Integer>asList(), it.next());
+        
+        source.onNext(4);
+        source.onNext(5);
+        source.onNext(6);
+        
+        it.hasNext();
+
+        source.onNext(7);
+        source.onNext(8);
+        source.onNext(9);
+        source.onNext(10);
+        
+        it.hasNext();
+        assertEquals(Arrays.asList(4, 5, 6), it.next());
+        
+        assertEquals(Arrays.asList(7, 8, 9, 10), it.next());
+        
+        source.onCompleted();
+
+        assertEquals(Arrays.<Integer>asList(), it.next());
+
+        try {
+            it.next();
+            fail("Should have thrown NoSuchElementException");
+        } catch (NoSuchElementException ex) {
+            // this is fine
+        }
+    }
+    @Test
+    public void testIterateManyTimes() {
+        Observable<Integer> source = Observable.from(1, 2, 3);
+        
+        Iterable<List<Integer>> iter = source.toBlockingObservable().chunkify();
+        
+        for (int i = 0; i < 3; i++) {
+            Iterator<List<Integer>> it = iter.iterator();
+            
+            assertTrue(it.hasNext());
+         
+            List<Integer> list = it.next();
+            
+            assertEquals(Arrays.asList(1, 2, 3), list);
+        }
+    }
+    static final class CustomException extends RuntimeException {
+        public CustomException(String message) {
+            super(message);
+        }
+    }
+    @Test
+    public void testInitialBufferThrows() {
+        Observable<Integer> source = Observable.from(1, 2, 3);
+        
+        Func0<Integer> initialBuffer = new Func0<Integer>() {
+            @Override
+            public Integer call() {
+                throw new CustomException("Forced failure!");
+            }
+        };
+        
+        Func2<Integer, Integer, Integer> collector = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return t1 + t2;
+            }
+        };
+        
+        Func1<Integer, Integer> replaceBuffer = new Func1<Integer, Integer>() {
+
+            @Override
+            public Integer call(Integer t1) {
+                return 0;
+            }
+            
+        };
+        
+        Iterable<Integer> iter = source.toBlockingObservable().collect(initialBuffer, collector, replaceBuffer);
+        
+        Iterator<Integer> it = iter.iterator();
+        
+        try {
+            it.next();
+            fail("Failed to throw CustomException");
+        } catch (CustomException ex) {
+            // okay to get here
+            
+        }
+    }
+    
+    @Test
+    public void testCollectorThrows() {
+        Observable<Integer> source = Observable.from(1, 2, 3);
+        
+        Func0<Integer> initialBuffer = new Func0<Integer>() {
+            @Override
+            public Integer call() {
+                return 0;
+            }
+        };
+        
+        Func2<Integer, Integer, Integer> collector = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                throw new CustomException("Forced failure!");
+            }
+        };
+        
+        Func1<Integer, Integer> replaceBuffer = new Func1<Integer, Integer>() {
+
+            @Override
+            public Integer call(Integer t1) {
+                return 0;
+            }
+            
+        };
+        
+        Iterable<Integer> iter = source.toBlockingObservable().collect(initialBuffer, collector, replaceBuffer);
+        
+        Iterator<Integer> it = iter.iterator();
+        
+        try {
+            it.next();
+            fail("Failed to throw CustomException");
+        } catch (CustomException ex) {
+            // okay to get here
+        }
+    }
+    @Test
+    public void testReplaceBufferThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        Func0<Integer> initialBuffer = new Func0<Integer>() {
+            @Override
+            public Integer call() {
+                return 0;
+            }
+        };
+        
+        Func2<Integer, Integer, Integer> collector = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return t1 + t2;
+            }
+        };
+        
+        Func1<Integer, Integer> replaceBuffer = new Func1<Integer, Integer>() {
+
+            @Override
+            public Integer call(Integer t1) {
+                throw new CustomException("Forced failure!");
+            }
+            
+        };
+        
+        Iterable<Integer> iter = source.toBlockingObservable().collect(initialBuffer, collector, replaceBuffer);
+        
+        Iterator<Integer> it = iter.iterator();
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+        
+        try {
+            it.next();
+            fail("Failed to throw CustomException");
+        } catch (CustomException ex) {
+            // okay to get here
+        }
+    }
+}


### PR DESCRIPTION
Issue #634

Any suggestions for a name instead of `forIterable`?
