### PR TITLE
TestScheduler infrastructure enhancements

### DIFF
--- a/rxjava-core/src/main/java/rx/observables/ColdObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/ColdObservable.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observables;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import rx.Notification;
+import rx.Observer;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.schedulers.TestScheduler;
+import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.Recorded;
+import rx.util.RecordedSubscription;
+import rx.util.functions.Func2;
+
+/**
+ * An observable which replays notification in a timed fashion by
+ * using a TestScheduler, whenever an Observer subscribes.
+ */
+public final class ColdObservable<T> extends TestableObservable<T> {
+    /**
+     * Create a ColdObservable instance with the given TestScheduler and recorded messages.
+     * @param <T> the value type
+     * @param scheduler the test scheduler
+     * @param messages the recorded messages
+     * @return the created ColdObservable
+     */
+    public static <T> ColdObservable<T> create(TestScheduler scheduler, Recorded<Notification<T>>... messages) {
+        ColdState<T> state = new ColdState<T>(scheduler, Arrays.asList(messages));
+        return new ColdObservable<T>(new ColdObservableSubscribe<T>(state), state);
+    }
+    
+    /**
+     * Create a ColdObservable instance with the given TestScheduler and recorded messages.
+     * @param <T> the value type
+     * @param scheduler the test scheduler
+     * @param messages the recorded messages
+     * @return the created ColdObservable
+     */
+    public static <T> ColdObservable<T> create(TestScheduler scheduler, Iterable<? extends Recorded<Notification<T>>> messages) {
+        List<Recorded<Notification<T>>> messagesList = new ArrayList<Recorded<Notification<T>>>();
+        for (Recorded<Notification<T>> r : messages) {
+            messagesList.add(r);
+        }
+        ColdState<T> state = new ColdState<T>(scheduler, messagesList);
+        return new ColdObservable<T>(new ColdObservableSubscribe<T>(state), state);
+    }
+    
+    /** The Observable's and Subscriber's state. */
+    static class ColdState<T> {
+        final TestScheduler scheduler;
+        final List<RecordedSubscription> subscriptions = new ArrayList<RecordedSubscription>();
+        final List<Recorded<Notification<T>>> messages;
+        /** The latest time among the notifications. */
+        long maxTime = Long.MIN_VALUE;
+        public ColdState(TestScheduler scheduler, List<Recorded<Notification<T>>> messages) {
+            this.scheduler = scheduler;
+            this.messages = messages;
+            for (Recorded<?> r : messages) {
+                maxTime = Math.max(maxTime, r.time());
+            }
+        }
+    }
+    final ColdState<T> state;
+
+    private ColdObservable(OnSubscribeFunc<T> onSubscribe, ColdState<T> state) {
+        super(onSubscribe);
+        this.state = state;
+    }
+    
+    @Override
+    public List<Recorded<Notification<T>>> messages() {
+        return state.messages;
+    }
+
+    @Override
+    public List<RecordedSubscription> subscriptions() {
+        return state.subscriptions;
+    }
+
+    @Override
+    public void runTo(long time) {
+        state.scheduler.advanceTimeTo(time, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void runToEnd() {
+        state.scheduler.advanceTimeBy(state.maxTime, TimeUnit.MILLISECONDS);
+    }
+    
+    /** The subscription function which replays the notifications. */
+    static final class ColdObservableSubscribe<T> implements OnSubscribeFunc<T> {
+        final ColdState<T> state;
+
+        public ColdObservableSubscribe(ColdState<T> state) {
+            this.state = state;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super T> t1) {
+            int index = state.subscriptions.size();
+            state.subscriptions.add(new RecordedSubscription(state.scheduler.now()));
+            
+            CompositeSubscription csub = new CompositeSubscription();
+            
+            for (Recorded<Notification<T>> rn : state.messages) {
+                csub.add(state.scheduler.scheduleRelative(t1, rn.time(), new EmitMessage<T>(rn.value(), t1)));
+            }
+            return new RemoveSubscription<T>(state, index, csub);
+        }
+        
+        /** Emits a notification to all currently registered observers of the state object. */
+        private static final class EmitMessage<T> implements Func2<Scheduler, Object, Subscription> {
+            final Notification<T> notification;
+            final Observer<? super T> observer;
+            public EmitMessage(Notification<T> notification, Observer<? super T> observer) {
+                this.notification = notification;
+                this.observer = observer;
+            }
+
+            @Override
+            public Subscription call(Scheduler scheduler, Object o) {
+                notification.accept(observer);
+                return Subscriptions.empty();
+            }
+        }
+        /** 
+         * Remove the observer from the state. 
+         * TODO FIXME extend BooleanSubscription...
+         */
+        static final class RemoveSubscription<T> implements Subscription {
+            final ColdState<T> state;
+            final int index;
+            final Subscription cancel;
+            final AtomicBoolean unsubscribed = new AtomicBoolean();
+
+            public RemoveSubscription(ColdState<T> state, int index, Subscription cancel) {
+                this.state = state;
+                this.index = index;
+                this.cancel = cancel;
+            }
+
+            @Override
+            public void unsubscribe() {
+                if (unsubscribed.compareAndSet(false, true)) {
+                    RecordedSubscription rs = state.subscriptions.get(index);
+                    state.subscriptions.set(index, new RecordedSubscription(rs.subscribed(), state.scheduler.now()));
+
+                    cancel.unsubscribe();
+                }
+            }
+        }
+    }
+}

--- a/rxjava-core/src/main/java/rx/observables/HotObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/HotObservable.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observables;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import rx.Notification;
+import rx.Observer;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.schedulers.TestScheduler;
+import rx.subscriptions.Subscriptions;
+import rx.util.Recorded;
+import rx.util.RecordedSubscription;
+import rx.util.functions.Func2;
+import rx.observables.ColdObservable.ColdState;
+
+/**
+ * An observable which replays notifications in a timed fashion by using a
+ * TestScheduler, immediately on creation.
+ * @param <T> the value type
+ */
+public class HotObservable<T> extends TestableObservable<T> {
+    /** The observer's state shared with the subscriber function. */
+    static final class HotState<T> extends ColdState<T> {
+        final List<Observer<? super T>> observers = new ArrayList<Observer<? super T>>();
+
+        public HotState(TestScheduler scheduler, List<Recorded<Notification<T>>> messages) {
+            super (scheduler, messages);
+        }
+        
+    }
+    
+    /**
+     * Create a HotObservable instance with the given TestScheduler and recorded messages.
+     * @param <T> the value type
+     * @param scheduler the test scheduler
+     * @param messages the recorded messages
+     * @return the created HotObservable
+     */
+    public static <T> HotObservable<T> create(TestScheduler scheduler, Recorded<Notification<T>>... messages) {
+        HotState<T> state = new HotState<T>(scheduler, Arrays.asList(messages));
+        return new HotObservable<T>(new HotObservableSubscribe<T>(state), state);
+    }
+    
+    /**
+     * Create a HotObservable instance with the given TestScheduler and recorded messages.
+     * @param <T> the value type
+     * @param scheduler the test scheduler
+     * @param messages the recorded messages
+     * @return the created HotObservable
+     */
+    public static <T> HotObservable<T> create(TestScheduler scheduler, Iterable<? extends Recorded<Notification<T>>> messages) {
+        List<Recorded<Notification<T>>> messagesList = new ArrayList<Recorded<Notification<T>>>();
+        for (Recorded<Notification<T>> r : messages) {
+            messagesList.add(r);
+        }
+        HotState<T> state = new HotState<T>(scheduler, messagesList);
+        return new HotObservable<T>(new HotObservableSubscribe<T>(state), state);
+    }
+    
+    final HotState<T> state;
+    private HotObservable(OnSubscribeFunc<T> onSubscribeFunc, HotState<T> state) {
+        super(onSubscribeFunc);
+        this.state = state;
+        
+        for (Recorded<Notification<T>> message : state.messages) {
+            state.scheduler.scheduleAbsolute(state, 
+                    message.time(), new EmitMessage<T>(message.value()));
+        }
+    }
+    /** Emits a notification to all currently registered observers of the state object. */
+    private static final class EmitMessage<T> implements Func2<Scheduler, HotState<T>, Subscription> {
+        final Notification<T> notification;
+        public EmitMessage(Notification<T> notification) {
+            this.notification = notification;
+        }
+
+        @Override
+        public Subscription call(Scheduler scheduler, HotState<T> state) {
+            List<Observer<? super T>> list = new ArrayList<Observer<? super T>>(state.observers);
+            for (Observer<? super T> o : list) {
+                notification.accept(o);
+            }
+            return Subscriptions.empty();
+        }
+    }
+
+    @Override
+    public List<Recorded<Notification<T>>> messages() {
+        return state.messages;
+    }
+
+    @Override
+    public List<RecordedSubscription> subscriptions() {
+        return state.subscriptions;
+    }
+
+    @Override
+    public void runTo(long time) {
+        state.scheduler.advanceTimeTo(time, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void runToEnd() {
+        state.scheduler.advanceTimeTo(state.maxTime, TimeUnit.MILLISECONDS);
+    }
+    
+    /** The subscription function of the HotObservable. */
+    static final class HotObservableSubscribe<T> implements OnSubscribeFunc<T> {
+        final HotState<T> state;
+        public HotObservableSubscribe(HotState<T> state) {
+            this.state = state;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super T> t1) {
+            state.observers.add(t1);
+            int index = state.subscriptions.size();
+            state.subscriptions.add(new RecordedSubscription(state.scheduler.now()));
+            return new RemoveSubscription<T>(state, t1, index);
+        }
+    }
+    
+    /** 
+     * Remove the observer from the state. 
+     * TODO FIXME extend BooleanSubscription...
+     */
+    static final class RemoveSubscription<T> implements Subscription {
+        final HotState<T> state;
+        final Observer<? super T> observer;
+        final int index;
+        final AtomicBoolean unsubscribed = new AtomicBoolean();
+
+        public RemoveSubscription(HotState<T> state, Observer<? super T> observer, int index) {
+            this.state = state;
+            this.observer = observer;
+            this.index = index;
+        }
+
+        @Override
+        public void unsubscribe() {
+            if (unsubscribed.compareAndSet(false, true)) {
+                state.observers.remove(observer);
+                RecordedSubscription rs = state.subscriptions.get(index);
+                state.subscriptions.set(index, new RecordedSubscription(rs.subscribed(), state.scheduler.now()));
+            }
+        }
+    }
+}

--- a/rxjava-core/src/main/java/rx/observables/TestableObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/TestableObservable.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observables;
+
+import java.util.List;
+import rx.Notification;
+import rx.Observable;
+import rx.util.Recorded;
+import rx.util.RecordedSubscription;
+
+/**
+ * Observable sequence that records subscription lifetimes and timestamped
+ * notification messages sent to observers
+ * @param <T> the value type
+ */
+public abstract class TestableObservable<T> extends Observable<T> {
+    /**
+     * Create a TestableObservable instance.
+     * @param onSubscribe the subscription function
+     */
+    public TestableObservable(OnSubscribeFunc<T> onSubscribe) {
+        super(onSubscribe);
+    }
+    /**
+     * Return a list of all subscriptions to the observable, including their lifetimes.
+     * @return a list of all subscriptions to the observable
+     */
+    public abstract List<RecordedSubscription> subscriptions();
+    /**
+     * Return the recorded timestamped notification messages that were sent
+     * by the observable to its observers.
+     * @return the recorded timestamped notification messages
+     */
+    public abstract List<Recorded<Notification<T>>> messages();
+    /**
+     * Advance the parent TestScheduler so all recorded notifications are emitted.
+     */
+    public abstract void runToEnd();
+    /**
+     * Advance the parent TestScheduler so all recorded notifications up to a certain time are emitted.
+     * @param time the target time to move the TestScheduler
+     */
+    public abstract void runTo(long time);
+}

--- a/rxjava-core/src/main/java/rx/observers/TestObserver.java
+++ b/rxjava-core/src/main/java/rx/observers/TestObserver.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import java.util.ArrayList;
+import java.util.List;
+import rx.Notification;
+import rx.schedulers.TestScheduler;
+import rx.util.Recorded;
+
+/**
+ * Observer implementation that records events received and timestamps
+ * them with the help of a TestScheduler.
+ * @param <T> the observed value type
+ */
+public class TestObserver<T> implements TestableObserver<T> {
+    /** The parent test scheduler. */
+    protected final TestScheduler scheduler;
+    /** The list of notifications. */
+    protected final List<Recorded<Notification<T>>> messages;
+
+    public TestObserver(TestScheduler scheduler) {
+        this.scheduler = scheduler;
+        this.messages = new ArrayList<Recorded<Notification<T>>>();
+    }
+
+    @Override
+    public void onNext(T args) {
+        messages.add(Recorded.onNext(scheduler.now(), args));
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        messages.add(Recorded.<T>onError(scheduler.now(), e));
+    }
+
+    @Override
+    public void onCompleted() {
+        messages.add(Recorded.<T>onCompleted(scheduler.now()));
+    }
+
+    @Override
+    public List<Recorded<Notification<T>>> messages() {
+        return messages;
+    }
+    
+}

--- a/rxjava-core/src/main/java/rx/observers/TestableObserver.java
+++ b/rxjava-core/src/main/java/rx/observers/TestableObserver.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import java.util.List;
+import rx.Notification;
+import rx.Observer;
+import rx.util.Recorded;
+
+/**
+ * Observer that records received notification events and their timestamps.
+ * @param <T> the element type
+ */
+public interface TestableObserver<T> extends Observer<T> {
+    /**
+     * Return the list of received notifications.
+     * @return the list of received notifications
+     */
+    List<Recorded<Notification<T>>> messages();
+}

--- a/rxjava-core/src/main/java/rx/util/Recorded.java
+++ b/rxjava-core/src/main/java/rx/util/Recorded.java
@@ -1,0 +1,311 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util;
+
+import rx.Notification;
+import rx.Observer;
+import rx.util.functions.Action0;
+import rx.util.functions.Action1;
+import rx.util.functions.Func0;
+import rx.util.functions.Func1;
+
+/**
+ * Record of a value including the virtual time it was produced on.
+ * <p>
+ * You can static import the class to access the convenient
+ * onNext, onError and onCompleted factory methods to create timed events.
+ * @param <T> the value type
+ */
+public final class Recorded<T> {
+    private final long time;
+    private final T value;
+    /**
+     * Returns the virtual time the record was produced on.
+     * @return the virtual time
+     */
+    public long time() {
+        return time;
+    }
+    /**
+     * Returns the recorded value.
+     * @return the recorded value
+     */
+    public T value() {
+        return value;
+    }
+    /**
+     * Constructs a Recorded instance with the time and value as contents.
+     * @param time the virtual time the record was produced on
+     * @param value  the recorded value
+     */
+    public Recorded(long time, T value) {
+        this.time = time;
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof Recorded<?>) {
+            Recorded<?> r = (Recorded<?>)obj;
+            
+            return time == r.time &&
+                    (value == r.value || (value != null && value.equals(r.value)));
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int)(((time >>> 32) ^ time) * 31 + (value != null ? value.hashCode() : 0));
+    }
+
+    @Override
+    public String toString() {
+        return value + "@" + time;
+    }
+
+    /**
+     * Factory method to create an onNext notification at the specified time point.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param value the value
+     * @return a Recorded onNext notification
+     */
+    public static <T> Recorded<Notification<T>> onNext(long time, T value) {
+        return new Recorded<Notification<T>>(time, new Notification<T>(value));
+    }
+    /**
+     * Factory method to create an assert that checks for an OnNext notification record
+     * at the given time, using the specified predicate to check the actual value.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param predicate the predicate function to check the onNext value against an expected value
+     * @return a Recorded onNext notification with predicate
+     */
+    public static <T> Recorded<Notification<T>> onNext(long time, Func1<Object, Boolean> predicate) {
+        if (predicate == null) {
+            throw new NullPointerException("predicate");
+        }
+        return new Recorded<Notification<T>>(time, new OnNextPredicate<T>(predicate));
+    }
+    /**
+     * Factory method to create an assert that checks for an OnNext notification record
+     * at the given time, using the specified predicate to check the actual value,
+     * with the help of a type witness.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param predicate the predicate function to check the onNext value against an expected value
+     * @param typeWitness the type witness to help the compiler infer the type T
+     * @return a Recorded onNext notification with predicate
+     */
+    public static <T> Recorded<Notification<T>> onNext(long time, Func1<Object, Boolean> predicate, T typeWitness) {
+        if (predicate == null) {
+            throw new NullPointerException("predicate");
+        }
+        return new Recorded<Notification<T>>(time, new OnNextPredicate<T>(predicate));
+    }
+    /**
+     * Factory method to create an onCompleted notification at the specified time point.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @return a Recorded onCompleted notification
+     */
+    public static <T> Recorded<Notification<T>> onCompleted(long time) {
+        return new Recorded<Notification<T>>(time, Notification.<T>createOnCompleted());
+    }
+    /**
+     * Factory method to create an onCompleted notification at the specified time point,
+     * with the help of a type witness.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param typeWitness the type witness to help the compiler infer the type T
+     * @return a Recorded onCompleted notification
+     */
+    public static <T> Recorded<Notification<T>> onCompleted(long time, T typeWitness) {
+        return new Recorded<Notification<T>>(time, Notification.createOnCompleted(typeWitness));
+    }
+    /**
+     * Factory method to create an onError notification at the specified time point.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param error th exception
+     * @return a Recorded onError notification
+     */
+    public static <T> Recorded<Notification<T>> onError(long time, Throwable error) {
+        if (error == null) {
+            throw new NullPointerException("error");
+        }
+        return new Recorded<Notification<T>>(time, new Notification<T>(error));
+    }
+    /**
+     * Factory method to create an assert that checks for an OnError notification record
+     * at the given time, using the specified predicate to check the actual Throwable value.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param predicate the predicate function to check the onCompleted value against an expected value
+     * @return  a Recorded onError notification with predicate
+     */
+    public static <T> Recorded<Notification<T>> onError(long time, Func1<? super Throwable, Boolean> predicate) {
+        if (predicate == null) {
+            throw new NullPointerException("predicate");
+        }
+        return new Recorded<Notification<T>>(time, new OnErrorPredicate<T>(predicate));
+    }
+    /**
+     * Factory method to create an onError notification at the specified time point,
+     * with the help of a type witness.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param error th exception
+     * @param typeWitness the type witness to help the compiler infer the type T
+     * @return a Recorded onError notification
+     */
+    public static <T> Recorded<Notification<T>> onError(long time, Throwable error, T typeWitness) {
+        if (error == null) {
+            throw new NullPointerException("error");
+        }
+        return new Recorded<Notification<T>>(time, new Notification<T>(error));
+    }
+    /**
+     * Factory method to create an assert that checks for an OnError notification record
+     * at the given time, using the specified predicate to check the actual Throwable value,
+     * with the help of a type witness.
+     * @param <T> the value type
+     * @param time the absolute time
+     * @param predicate the predicate function to check the onCompleted value against an expected value
+     * @param typeWitness the type witness to help the compiler infer the type T
+     * @return  a Recorded onError notification with predicate
+     */
+    public static <T> Recorded<Notification<T>> onError(long time, Func1<? super Throwable, Boolean> predicate, T typeWitness) {
+        if (predicate == null) {
+            throw new NullPointerException("predicate");
+        }
+        return new Recorded<Notification<T>>(time, new OnErrorPredicate<T>(predicate));
+    }
+    /** A predicate based onNext notification. */
+    private static final class OnNextPredicate<T> extends PredicateNotification<T> {
+        final Func1<Object, Boolean> predicate;
+        public OnNextPredicate(Func1<Object, Boolean> predicate) {
+            this.predicate = predicate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof Notification<?>) {
+                Notification<?> other = (Notification<?>)obj;
+                if (other.getKind() == Notification.Kind.OnNext) {
+                    return predicate.call(other.getValue());
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+        
+    }
+    /** A predicate based onError notification. */
+    private static final class OnErrorPredicate<T> extends PredicateNotification<T> {
+        final Func1<? super Throwable, Boolean> predicate;
+        public OnErrorPredicate(Func1<? super Throwable, Boolean> predicate) {
+            this.predicate = predicate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof Notification<?>) {
+                Notification<?> other = (Notification<?>)obj;
+                if (other.getKind() == Notification.Kind.OnError) {
+                    return predicate.call(other.getThrowable());
+                }
+            }
+            return false;
+        }
+        
+        @Override
+        public int hashCode() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+    }
+    /** Base class for predicated notification tests, deliberately not implemented. */
+    private static abstract class PredicateNotification<T> extends Notification<T> {
+        @Override
+        public void accept(Observer<? super T> observer) {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public Kind getKind() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public Throwable getThrowable() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public T getValue() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public boolean hasThrowable() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public boolean hasValue() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public boolean isOnCompleted() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public boolean isOnError() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public boolean isOnNext() {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public void accept(Action1<? super T> onNext, Action1<? super Throwable> onError, Action0 onCompleted) {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+
+        @Override
+        public <R> R accept(Func1<? super T, ? extends R> onNext, Func1<? super Throwable, ? extends R> onError, Func0<? extends R> onCompleted) {
+            throw new UnsupportedOperationException("Not implemented by design.");
+        }
+    }
+}

--- a/rxjava-core/src/main/java/rx/util/RecordedSubscription.java
+++ b/rxjava-core/src/main/java/rx/util/RecordedSubscription.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util;
+
+/**
+ * Records information about subscriptions and unsubscriptions.
+ * <p>
+ * You may static import the class to access the convenient factory methods
+ * for creating finite and never unsubscribed subscriptions.
+ */
+public final class RecordedSubscription {
+    /** Indicates that the unsubscription never took place. */
+    public static final long NEVER_UNSUBSCRIBED = Long.MAX_VALUE;
+    /** The subscription virtual time. */
+    private final long subscribed;
+    /** The unsubscription virtual time. */
+    private final long unsubscribed;
+    /**
+     * Creates a RecordedSubscription instance with the given virtual
+     * subscription time an NEVER_UNSUBSCRIBED as the virtual 
+     * unsubscription time.
+     * @param subscribed the virtual subscription time
+     */
+    public RecordedSubscription(long subscribed) {
+        this(subscribed, NEVER_UNSUBSCRIBED);
+    }
+    /**
+     * Creates a RecordedSubscription instance with the given virtual
+     * subscription and unsubscription times.
+     * @param subscribed the virtual subscription time
+     * @param unsubscribed the virtual unsubscription time
+     */
+    public RecordedSubscription(long subscribed, long unsubscribed) {
+        this.subscribed = subscribed;
+        this.unsubscribed = unsubscribed;
+    }
+    /**
+     * Return the recorded virtual subscription time.
+     * @return the recorded virtual subscription time
+     */
+    public long subscribed() {
+        return subscribed;
+    }
+    /**
+     * Return the recorded virtual unsubscription time.
+     * @return the recorded virtual unsubscription time 
+     */
+    public long unsubscribed() {
+        return unsubscribed;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof RecordedSubscription) {
+            RecordedSubscription r = (RecordedSubscription)obj;
+            return subscribed == r.subscribed && unsubscribed == r.unsubscribed; 
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 0;
+        h = h * 31 + (int)((subscribed >>> 32) ^ subscribed);
+        h = h * 31 + (int)((unsubscribed >>> 32) ^ unsubscribed);
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        if (unsubscribed == NEVER_UNSUBSCRIBED) {
+            return "(" + subscribed + ", Never)";
+        }
+        return "(" + subscribed + ", " + unsubscribed + ")";
+    }
+    /**
+     * Factory method to record a given subscription time.
+     * @param start the virtual time of the subscription
+     * @return the recorded subscription
+     */
+    public static RecordedSubscription subscribe(long start) {
+        return new RecordedSubscription(start);
+    }
+    /**
+     * Factory method to record a given subscription and unsubscription time.
+     * @param start the virtual time of the subscription
+     * @param end the virtual time of the unsubscription
+     * @return the recorded subscription and unsubscription
+     */
+    public static RecordedSubscription subscribe(long start, long end) {
+        return new RecordedSubscription(start, end);
+        
+    }
+}

--- a/rxjava-core/src/test/java/rx/schedulers/TestSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/TestSchedulerTest.java
@@ -1,0 +1,331 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.schedulers;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+import rx.Observable;
+import rx.Observer;
+import rx.observables.TestableObservable;
+import rx.observers.TestableObserver;
+import static rx.util.Recorded.*;
+import static rx.util.RecordedSubscription.subscribe;
+import rx.util.functions.Func0;
+
+/**
+ * Who tests the testers?
+ */
+public class TestSchedulerTest {
+    TestScheduler scheduler;
+    @Mock
+    Observer<Object> observer;
+    @Before
+    public void before() {
+        scheduler = new TestScheduler();
+        MockitoAnnotations.initMocks(this);
+    }
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testHotObservable() {
+        
+        TestableObserver<Integer> testable = scheduler.createObserver();
+        
+        TestableObservable<Integer> source = scheduler.createHotObservable(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onCompleted(500, 5)
+        );
+        
+        source.subscribe(observer);
+        source.subscribe(testable);
+        
+        source.runToEnd();
+        
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onNext(3);
+        inOrder.verify(observer, times(1)).onNext(4);
+        inOrder.verify(observer, times(1)).onCompleted();
+        
+        verify(observer, never()).onError(any(Throwable.class));
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onCompleted(500, 5)
+        ), testable.messages());
+        
+        Observer<Object> o2 = mock(Observer.class);
+        InOrder io2 = inOrder(o2);
+        
+        source.subscribe(o2);
+        
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        io2.verifyNoMoreInteractions();
+
+        TestableObserver<Integer> testable2 = scheduler.createObserver();
+ 
+        source.subscribe(testable2);
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500),
+                subscribe(500),
+                subscribe(1500)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(), testable2.messages());
+        
+    }
+    static class CustomException extends RuntimeException {
+        
+    }
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testThrowingHotObservable() {
+        TestableObserver<Integer> testable = scheduler.createObserver();
+        
+        CustomException ex = new CustomException();
+        
+        TestableObservable<Integer> source = scheduler.createHotObservable(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onError(500, ex, 5)
+        );
+        
+        source.subscribe(observer);
+        source.subscribe(testable);
+        
+        source.runToEnd();
+        
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onNext(3);
+        inOrder.verify(observer, times(1)).onNext(4);
+        inOrder.verify(observer, times(1)).onError(ex);
+        
+        verify(observer, never()).onCompleted();
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onError(500, ex, 5)
+        ), testable.messages());
+        
+        Observer<Object> o2 = mock(Observer.class);
+        InOrder io2 = inOrder(o2);
+        
+        source.subscribe(o2);
+        
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        io2.verifyNoMoreInteractions();
+        
+                TestableObserver<Integer> testable2 = scheduler.createObserver();
+ 
+        source.subscribe(testable2);
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500),
+                subscribe(500),
+                subscribe(1500)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(), testable2.messages());
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testColdObservable() {
+        
+        TestableObserver<Integer> testable = scheduler.createObserver();
+        
+        TestableObservable<Integer> source = scheduler.createColdObservable(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onCompleted(500, 5)
+        );
+        
+        source.subscribe(observer);
+        source.subscribe(testable);
+        
+        source.runToEnd();
+        
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onNext(3);
+        inOrder.verify(observer, times(1)).onNext(4);
+        inOrder.verify(observer, times(1)).onCompleted();
+        
+        verify(observer, never()).onError(any(Throwable.class));
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onCompleted(500, 5)
+        ), testable.messages());
+        
+        TestableObserver<Integer> testable2 = scheduler.createObserver();
+ 
+        source.subscribe(testable2);
+        source.runToEnd();
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500),
+                subscribe(500, 1000)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(
+                onNext(600, 1),
+                onNext(700, 2),
+                onNext(800, 3),
+                onNext(900, 4),
+                onCompleted(1000, 5)
+        ), testable2.messages());
+
+    }
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testThrowingColdObservable() {
+        CustomException ex = new CustomException();
+        
+        TestableObserver<Integer> testable = scheduler.createObserver();
+        
+        TestableObservable<Integer> source = scheduler.createColdObservable(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onError(500, ex, 5)
+        );
+        
+        source.subscribe(observer);
+        source.subscribe(testable);
+        
+        source.runToEnd();
+        
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onNext(3);
+        inOrder.verify(observer, times(1)).onNext(4);
+        inOrder.verify(observer, times(1)).onError(ex);
+        
+        verify(observer, never()).onCompleted();
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(
+                onNext(100, 1),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 4),
+                onError(500, ex, 5)
+        ), testable.messages());
+        
+        TestableObserver<Integer> testable2 = scheduler.createObserver();
+ 
+        source.subscribe(testable2);
+        source.runToEnd();
+        
+        assertEquals(Arrays.asList(
+                subscribe(0, 500),
+                subscribe(0, 500),
+                subscribe(500, 1000)
+        ), source.subscriptions());
+        
+        assertEquals(Arrays.asList(
+                onNext(600, 1),
+                onNext(700, 2),
+                onNext(800, 3),
+                onNext(900, 4),
+                onError(1000, ex, 5)
+        ), testable2.messages());
+
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testStart() {
+        final Observable<Long> source = Observable.interval(100, TimeUnit.MILLISECONDS, scheduler).take(10);
+        
+        Func0<Observable<Long>> func = new Func0<Observable<Long>>() {
+            @Override
+            public Observable<Long> call() {
+                return source;
+            }
+        };
+        
+        TestableObserver<Long> testable = scheduler.start(func, 100, 200, 950);
+        
+        assertEquals(Arrays.asList(
+                onNext(300, 0L),
+                onNext(400, 1L),
+                onNext(500, 2L),
+                onNext(600, 3L),
+                onNext(700, 4L),
+                onNext(800, 5L),
+                onNext(900, 6L)
+        ), testable.messages());
+    }
+}


### PR DESCRIPTION
Enhanced TestScheduler.

Mentioned in issue #634, and in the forum [HistoricalScheduler](https://groups.google.com/forum/#!topic/rxjava/4vmsg5Rs5sU).

Notes:
- Inspired by Rx.NET.
- `HistoricalScheduler` appears to be just a variant of the `TestScheduler` where times are absolute `DateTimeOffset`s. Since we don't do `java.util.Date` overloads anywhere, I didn't implement this. If you need to work with real time (i.e., `System.currentTimeMillis()`) just advance the `TestScheduler` by ctm. before doing anything else.
- The `Recorded` class, the `TestScheduler.scheduleAbsolute` and `TestScheduler.scheduleRelative` methods use millisecond resolution time due to two reasons:
  - `TestScheduler.now()` is in milliseconds
  - No real need of higher resolution, as TestScheduler operates on virtual time and aimed for testing purposes only. Virtual time can be scaled up or down as neccessary.
- Added the package `rx.observers`. I guess we can move the `SafeObserver`, `ObserverBase` and `SynchronizedObserver` into these packages (not done in this PR). The package's JavaDoc visibility can be decided independently.
- I put the new `ColdObservable`, `HotObservable` and `TestableObservable` types into `rx.observables`. Do we have a main distribution and a test distribution of RxJava (i.e., if someone wants to use these types to test his/her own operators, does he/she need to download a different library)?
- Added some behavior to `Notification`. In addition, I suggested the deprecation of `new Notification()` to create an OnCompleted kind of notification, since virtually there is no way (or reason) to distinguish between one OnCompleted event from another, I've added a factory method instead which returns a single constant instance. I haven't changed any use place of the old constructor.
- See `TestSchedulerTest` for the use cases.
