### PR TITLE
Operations Aggregate, Average and Sum with selector

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -32,6 +32,7 @@ import rx.joins.Plan0;
 import rx.observables.BlockingObservable;
 import rx.observables.ConnectableObservable;
 import rx.observables.GroupedObservable;
+import rx.operators.OperationAggregate;
 import rx.operators.OperationAll;
 import rx.operators.OperationAmb;
 import rx.operators.OperationAny;
@@ -4118,6 +4119,54 @@ public class Observable<T> {
         return OperationSum.sumDoubles(source);
     }
 
+        /**
+     * Create an Observable that extracts integer values from this Observable via
+     * the provided function and computes the integer sum of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an integer from this Observable
+     * @return an Observable that extracts integer values from this Observable via
+     * the provided function and computes the integer sum of the value sequence.
+     */
+    public Observable<Integer> sumInteger(Func1<? super T, Integer> valueExtractor) {
+        return create(new OperationSum.SumIntegerExtractor<T>(this, valueExtractor));
+    }
+
+    /**
+     * Create an Observable that extracts long values from this Observable via
+     * the provided function and computes the long sum of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an long from this Observable
+     * @return an Observable that extracts long values from this Observable via
+     * the provided function and computes the long sum of the value sequence.
+     */
+    public Observable<Long> sumLong(Func1<? super T, Long> valueExtractor) {
+        return create(new OperationSum.SumLongExtractor<T>(this, valueExtractor));
+    }
+
+    /**
+     * Create an Observable that extracts float values from this Observable via
+     * the provided function and computes the float sum of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an float from this Observable
+     * @return an Observable that extracts float values from this Observable via
+     * the provided function and computes the float sum of the value sequence.
+     */
+    public Observable<Float> sumFloat(Func1<? super T, Float> valueExtractor) {
+        return create(new OperationSum.SumFloatExtractor<T>(this, valueExtractor));
+    }
+
+    /**
+     * Create an Observable that extracts double values from this Observable via
+     * the provided function and computes the double sum of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an double from this Observable
+     * @return an Observable that extracts double values from this Observable via
+     * the provided function and computes the double sum of the value sequence.
+     */
+    public Observable<Double> sumDouble(Func1<? super T, Double> valueExtractor) {
+        return create(new OperationSum.SumDoubleExtractor<T>(this, valueExtractor));
+    }
+    
     /**
      * Returns an Observable that computes the average of the Integers emitted
      * by the source Observable.
@@ -4181,6 +4230,54 @@ public class Observable<T> {
      */
     public static Observable<Double> averageDoubles(Observable<Double> source) {
         return OperationAverage.averageDoubles(source);
+    }
+
+    /**
+     * Create an Observable that extracts integer values from this Observable via
+     * the provided function and computes the integer average of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an integer from this Observable
+     * @return an Observable that extracts integer values from this Observable via
+     * the provided function and computes the integer average of the value sequence.
+     */
+    public Observable<Integer> averageInteger(Func1<? super T, Integer> valueExtractor) {
+        return create(new OperationAverage.AverageIntegerExtractor<T>(this, valueExtractor));
+    }
+
+    /**
+     * Create an Observable that extracts long values from this Observable via
+     * the provided function and computes the long average of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an long from this Observable
+     * @return an Observable that extracts long values from this Observable via
+     * the provided function and computes the long average of the value sequence.
+     */
+    public Observable<Long> averageLong(Func1<? super T, Long> valueExtractor) {
+        return create(new OperationAverage.AverageLongExtractor<T>(this, valueExtractor));
+    }
+
+    /**
+     * Create an Observable that extracts float values from this Observable via
+     * the provided function and computes the float average of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an float from this Observable
+     * @return an Observable that extracts float values from this Observable via
+     * the provided function and computes the float average of the value sequence.
+     */
+    public Observable<Float> averageFloat(Func1<? super T, Float> valueExtractor) {
+        return create(new OperationAverage.AverageFloatExtractor<T>(this, valueExtractor));
+    }
+
+    /**
+     * Create an Observable that extracts double values from this Observable via
+     * the provided function and computes the double average of the value sequence.
+     * 
+     * @param valueExtractor the function to extract an double from this Observable
+     * @return an Observable that extracts double values from this Observable via
+     * the provided function and computes the double average of the value sequence.
+     */
+    public Observable<Double> averageDouble(Func1<? super T, Double> valueExtractor) {
+        return create(new OperationAverage.AverageDoubleExtractor<T>(this, valueExtractor));
     }
 
     /**
@@ -4953,6 +5050,49 @@ public class Observable<T> {
      */
     public <R> Observable<R> aggregate(R initialValue, Func2<R, ? super T, R> accumulator) {
         return reduce(initialValue, accumulator);
+    }
+    
+    /**
+     * Create an Observable that aggregates the source values with the given accumulator
+     * function and projects the final result via the resultselector.
+     * <p>
+     * Works like the {@link #aggregate(java.lang.Object, rx.util.functions.Func2)} projected
+     * with {@link #map(rx.util.functions.Func1)} without the overhead of some helper
+     * operators.
+     * @param <U> the intermediate (accumulator) type
+     * @param <V> the result type
+     * @param seed the initial value of the accumulator
+     * @param accumulator the function that takes the current accumulator value,
+     *                    the current emitted value and returns a (new) accumulated value.
+     * @param resultSelector the selector to project the final value of the accumulator
+     * @return an Observable that aggregates the source values with the given accumulator
+     *         function and projects the final result via the resultselector
+     */
+    public <U, V> Observable<V> aggregate(
+            U seed, Func2<U, ? super T, U> accumulator, 
+            Func1<? super U, ? extends V> resultSelector) {
+        return create(new OperationAggregate.AggregateSelector<T, U, V>(this, seed, accumulator, resultSelector));
+    }
+    
+    /**
+     * Create an Observable that aggregates the source values with the given indexed accumulator
+     * function and projects the final result via the indexed resultselector.
+     * 
+     * @param <U> the intermediate (accumulator) type
+     * @param <V> the result type
+     * @param seed the initial value of the accumulator
+     * @param accumulator the function that takes the current accumulator value,
+     *                    the current emitted value and returns a (new) accumulated value.
+     * @param resultSelector the selector to project the final value of the accumulator, where
+     *                       the second argument is the total number of elements accumulated
+     * @return an Observable that aggregates the source values with the given indexed accumulator
+     * function and projects the final result via the indexed resultselector.
+     */
+    public <U, V> Observable<V> aggregateIndexed(
+            U seed, Func3<U, ? super T, ? super Integer, U> accumulator,
+        Func2<? super U, ? super Integer, ? extends V> resultSelector
+    ) {
+        return create(new OperationAggregate.AggregateIndexedSelector<T, U, V>(this, seed, accumulator, resultSelector));
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/operators/OperationAggregate.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationAggregate.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
+import rx.Observer;
+import rx.Subscription;
+import rx.util.functions.Func1;
+import rx.util.functions.Func2;
+import rx.util.functions.Func3;
+
+/**
+ * Aggregate overloads with index and selector functions.
+ */
+public final class OperationAggregate {
+    /** Utility class. */
+    private OperationAggregate() { throw new IllegalStateException("No instances!"); }
+    
+    /**
+     * Aggregate and emit a value after running it through a selector.
+     * @param <T> the input value type
+     * @param <U> the intermediate value type
+     * @param <V> the result value type
+     */
+    public static final class AggregateSelector<T, U, V> implements OnSubscribeFunc<V> {
+        final Observable<? extends T> source;
+        final U seed;
+        final Func2<U, ? super T, U> aggregator;
+        final Func1<? super U, ? extends V> resultSelector;
+
+        public AggregateSelector(
+                Observable<? extends T> source, U seed, 
+                Func2<U, ? super T, U> aggregator, 
+                Func1<? super U, ? extends V> resultSelector) {
+            this.source = source;
+            this.seed = seed;
+            this.aggregator = aggregator;
+            this.resultSelector = resultSelector;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super V> t1) {
+            return source.subscribe(new AggregatorObserver(t1, seed));
+        }
+        /** The aggregator observer of the source. */
+        private final class AggregatorObserver implements Observer<T> {
+            final Observer<? super V> observer;
+            U accumulator;
+            public AggregatorObserver(Observer<? super V> observer, U seed) {
+                this.observer = observer;
+                this.accumulator = seed;
+            }
+
+            @Override
+            public void onNext(T args) {
+                accumulator = aggregator.call(accumulator, args);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                accumulator = null;
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                U a = accumulator;
+                accumulator = null;
+                try {
+                    observer.onNext(resultSelector.call(a));
+                } catch (Throwable t) {
+                    observer.onError(t);
+                    return;
+                }
+                observer.onCompleted();
+            }
+        }
+    }
+    /**
+     * Indexed aggregate and emit a value after running it through an indexed selector.
+     * @param <T> the input value type
+     * @param <U> the intermediate value type
+     * @param <V> the result value type
+     */
+    public static final class AggregateIndexedSelector<T, U, V> implements OnSubscribeFunc<V> {
+        final Observable<? extends T> source;
+        final U seed;
+        final Func3<U, ? super T, ? super Integer, U> aggregator;
+        final Func2<? super U, ? super Integer, ? extends V> resultSelector;
+
+        public AggregateIndexedSelector(
+                Observable<? extends T> source, 
+                U seed, 
+                Func3<U, ? super T, ? super Integer, U> aggregator, 
+                Func2<? super U, ? super Integer, ? extends V> resultSelector) {
+            this.source = source;
+            this.seed = seed;
+            this.aggregator = aggregator;
+            this.resultSelector = resultSelector;
+        }
+
+        
+        
+        @Override
+        public Subscription onSubscribe(Observer<? super V> t1) {
+            return source.subscribe(new AggregatorObserver(t1, seed));
+        }
+        /** The aggregator observer of the source. */
+        private final class AggregatorObserver implements Observer<T> {
+            final Observer<? super V> observer;
+            U accumulator;
+            int index;
+            public AggregatorObserver(Observer<? super V> observer, U seed) {
+                this.observer = observer;
+                this.accumulator = seed;
+            }
+
+            @Override
+            public void onNext(T args) {
+                accumulator = aggregator.call(accumulator, args, index++);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                accumulator = null;
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                U a = accumulator;
+                accumulator = null;
+                try {
+                    observer.onNext(resultSelector.call(a, index));
+                } catch (Throwable t) {
+                    observer.onError(t);
+                    return;
+                }
+                observer.onCompleted();
+            }
+        }
+    }
+}

--- a/rxjava-core/src/main/java/rx/operators/OperationAverage.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationAverage.java
@@ -16,6 +16,9 @@
 package rx.operators;
 
 import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
+import rx.Observer;
+import rx.Subscription;
 import rx.util.functions.Func1;
 import rx.util.functions.Func2;
 
@@ -101,5 +104,229 @@ public final class OperationAverage {
                 return result.current / result.count;
             }
         });
+    }
+    
+    /**
+     * Compute the average by extracting integer values from the source via an
+     * extractor function.
+     * @param <T> the source value type
+     */
+    public static final class AverageIntegerExtractor<T> implements OnSubscribeFunc<Integer> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Integer> valueExtractor;
+
+        public AverageIntegerExtractor(Observable<? extends T> source, Func1<? super T, Integer> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Integer> t1) {
+            return source.subscribe(new AverageObserver(t1));
+        }
+        /** Computes the average. */
+        private final class AverageObserver implements Observer<T> {
+            final Observer<? super Integer> observer;
+            int sum;
+            int count;
+            public AverageObserver(Observer<? super Integer> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                count++;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (count > 0) {
+                    try {
+                        observer.onNext(sum / count);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     * Compute the average by extracting long values from the source via an
+     * extractor function. 
+     * @param <T> the source value type
+     */
+    public static final class AverageLongExtractor<T> implements OnSubscribeFunc<Long> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Long> valueExtractor;
+
+        public AverageLongExtractor(Observable<? extends T> source, Func1<? super T, Long> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Long> t1) {
+            return source.subscribe(new AverageObserver(t1));
+        }
+        /** Computes the average. */
+        private final class AverageObserver implements Observer<T> {
+            final Observer<? super Long> observer;
+            long sum;
+            int count;
+            public AverageObserver(Observer<? super Long> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                count++;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (count > 0) {
+                    try {
+                        observer.onNext(sum / count);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     * Compute the average by extracting float values from the source via an
+     * extractor function. 
+     * @param <T> the source value type
+     */
+    public static final class AverageFloatExtractor<T> implements OnSubscribeFunc<Float> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Float> valueExtractor;
+
+        public AverageFloatExtractor(Observable<? extends T> source, Func1<? super T, Float> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Float> t1) {
+            return source.subscribe(new AverageObserver(t1));
+        }
+        /** Computes the average. */
+        private final class AverageObserver implements Observer<T> {
+            final Observer<? super Float> observer;
+            float sum;
+            int count;
+            public AverageObserver(Observer<? super Float> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                count++;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (count > 0) {
+                    try {
+                        observer.onNext(sum / count);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     * Compute the average by extracting double values from the source via an
+     * extractor function. 
+     * @param <T> the source value type
+     */
+    public static final class AverageDoubleExtractor<T> implements OnSubscribeFunc<Double> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Double> valueExtractor;
+
+        public AverageDoubleExtractor(Observable<? extends T> source, Func1<? super T, Double> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Double> t1) {
+            return source.subscribe(new AverageObserver(t1));
+        }
+        /** Computes the average. */
+        private final class AverageObserver implements Observer<T> {
+            final Observer<? super Double> observer;
+            double sum;
+            int count;
+            public AverageObserver(Observer<? super Double> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                count++;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (count > 0) {
+                    try {
+                        observer.onNext(sum / count);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationSum.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSum.java
@@ -16,6 +16,10 @@
 package rx.operators;
 
 import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
+import rx.Observer;
+import rx.Subscription;
+import rx.util.functions.Func1;
 import rx.util.functions.Func2;
 
 /**
@@ -59,4 +63,229 @@ public final class OperationSum {
             }
         });
     }
+    
+    /**
+     * Compute the sum by extracting integer values from the source via an
+     * extractor function.
+     * @param <T> the source value type
+     */
+    public static final class SumIntegerExtractor<T> implements Observable.OnSubscribeFunc<Integer> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Integer> valueExtractor;
+
+        public SumIntegerExtractor(Observable<? extends T> source, Func1<? super T, Integer> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Integer> t1) {
+            return source.subscribe(new SumObserver(t1));
+        }
+        /** Computes the average. */
+        private final class SumObserver implements Observer<T> {
+            final Observer<? super Integer> observer;
+            int sum;
+            boolean hasValue;
+            public SumObserver(Observer<? super Integer> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                hasValue = true;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (hasValue) {
+                    try {
+                        observer.onNext(sum);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     * Compute the sum by extracting long values from the source via an
+     * extractor function.
+     * @param <T> the source value type
+     */
+    public static final class SumLongExtractor<T> implements Observable.OnSubscribeFunc<Long> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Long> valueExtractor;
+
+        public SumLongExtractor(Observable<? extends T> source, Func1<? super T, Long> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Long> t1) {
+            return source.subscribe(new SumObserver(t1));
+        }
+        /** Computes the average. */
+        private final class SumObserver implements Observer<T> {
+            final Observer<? super Long> observer;
+            long sum;
+            boolean hasValue;
+            public SumObserver(Observer<? super Long> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                hasValue = true;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (hasValue) {
+                    try {
+                        observer.onNext(sum);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     * Compute the sum by extracting float values from the source via an
+     * extractor function.
+     * @param <T> the source value type
+     */
+    public static final class SumFloatExtractor<T> implements Observable.OnSubscribeFunc<Float> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Float> valueExtractor;
+
+        public SumFloatExtractor(Observable<? extends T> source, Func1<? super T, Float> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Float> t1) {
+            return source.subscribe(new SumObserver(t1));
+        }
+        /** Computes the average. */
+        private final class SumObserver implements Observer<T> {
+            final Observer<? super Float> observer;
+            float sum;
+            boolean hasValue;
+            public SumObserver(Observer<? super Float> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                hasValue = true;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (hasValue) {
+                    try {
+                        observer.onNext(sum);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+
+    /**
+     * Compute the sum by extracting float values from the source via an
+     * extractor function.
+     * @param <T> the source value type
+     */
+    public static final class SumDoubleExtractor<T> implements Observable.OnSubscribeFunc<Double> {
+        final Observable<? extends T> source;
+        final Func1<? super T, Double> valueExtractor;
+
+        public SumDoubleExtractor(Observable<? extends T> source, Func1<? super T, Double> valueExtractor) {
+            this.source = source;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public Subscription onSubscribe(Observer<? super Double> t1) {
+            return source.subscribe(new SumObserver(t1));
+        }
+        /** Computes the average. */
+        private final class SumObserver implements Observer<T> {
+            final Observer<? super Double> observer;
+            double sum;
+            boolean hasValue;
+            public SumObserver(Observer<? super Double> observer) {
+                this.observer = observer;
+            }
+
+            @Override
+            public void onNext(T args) {
+                sum += valueExtractor.call(args);
+                hasValue = true;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                if (hasValue) {
+                    try {
+                        observer.onNext(sum);
+                    } catch (Throwable t) {
+                        observer.onError(t);
+                        return;
+                    }
+                    observer.onCompleted();
+                } else {
+                    observer.onError(new IllegalArgumentException("Sequence contains no elements"));
+                }
+            }
+            
+        }
+    }
+
 }

--- a/rxjava-core/src/test/java/rx/operators/OperationAggregateTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationAggregateTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.*;
+import rx.Observable;
+import rx.Observer;
+import rx.util.functions.Func1;
+import rx.util.functions.Func2;
+import rx.util.functions.Func3;
+import rx.util.functions.Functions;
+
+public class OperationAggregateTest {
+    @Mock
+    Observer<Object> observer;
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+    Func2<Integer, Integer, Integer> sum = new Func2<Integer, Integer, Integer>() {
+        @Override
+        public Integer call(Integer t1, Integer t2) {
+            return t1 + t2;
+        }
+    };
+    
+    @Test
+    public void testAggregateAsIntSum() {
+        
+        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5).aggregate(0, sum, Functions.<Integer>identity());
+        
+        result.subscribe(observer);
+        
+        verify(observer).onNext(1 + 2 + 3 + 4 + 5);
+        verify(observer).onCompleted();
+        verify(observer, never()).onError(any(Throwable.class));
+        
+    }
+    
+    @Test
+    public void testAggregateIndexedAsAverage() {
+        Func3<Integer, Integer, Integer, Integer> sumIndex = new Func3<Integer, Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer acc, Integer value, Integer index) {
+                return acc + (index + 1) + value;
+            }
+        };
+        Func2<Integer, Integer, Integer> selectIndex = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer count) {
+                return t1 + count;
+            }
+            
+        };
+        
+        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5)
+            .aggregateIndexed(0, sumIndex, selectIndex);
+        
+        result.subscribe(observer);
+        
+        verify(observer).onNext(2 + 4 + 6 + 8 + 10 + 5);
+        verify(observer).onCompleted();
+        verify(observer, never()).onError(any(Throwable.class));
+        
+    }
+    
+    static class CustomException extends RuntimeException { }
+    
+    @Test
+    public void testAggregateAsIntSumSourceThrows() {
+        Observable<Integer> result = Observable.concat(Observable.from(1, 2, 3, 4, 5),
+            Observable.<Integer>error(new CustomException()))
+            .aggregate(0, sum, Functions.<Integer>identity());
+        
+        result.subscribe(observer);
+        
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onCompleted();
+        verify(observer, times(1)).onError(any(CustomException.class));
+    }
+    
+    @Test
+    public void testAggregateAsIntSumAccumulatorThrows() {
+        Func2<Integer, Integer, Integer> sumErr = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                throw new CustomException();
+            }
+        };
+        
+        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5)
+            .aggregate(0, sumErr, Functions.<Integer>identity());
+        
+        result.subscribe(observer);
+        
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onCompleted();
+        verify(observer, times(1)).onError(any(CustomException.class));
+    }
+
+    @Test
+    public void testAggregateAsIntSumResultSelectorThrows() {
+        
+        Func1<Integer, Integer> error = new Func1<Integer, Integer>() {
+
+            @Override
+            public Integer call(Integer t1) {
+                throw new CustomException();
+            }
+        };
+        
+        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5)
+            .aggregate(0, sum, error);
+        
+        result.subscribe(observer);
+        
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onCompleted();
+        verify(observer, times(1)).onError(any(CustomException.class));
+    }
+
+}

--- a/rxjava-core/src/test/java/rx/operators/OperationAverageTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationAverageTest.java
@@ -15,7 +15,6 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static rx.operators.OperationAverage.*;
 
@@ -23,6 +22,8 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Observer;
+import rx.operators.OperationAggregateTest.CustomException;
+import rx.util.functions.Func1;
 
 public class OperationAverageTest {
 
@@ -117,5 +118,208 @@ public class OperationAverageTest {
         verify(wd, never()).onNext(anyDouble());
         verify(wd, times(1)).onError(isA(IllegalArgumentException.class));
         verify(wd, never()).onCompleted();
+    }
+    
+    void testThrows(Observer<Object> o, Class<? extends Throwable> errorClass) {
+        verify(o, never()).onNext(any());
+        verify(o, never()).onCompleted();
+        verify(o, times(1)).onError(any(errorClass));
+    }
+    <N extends Number> void testValue(Observer<Object> o, N value) {
+        verify(o, times(1)).onNext(value);
+        verify(o, times(1)).onCompleted();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    @Test
+    public void testIntegerAverageSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Integer> length = new Func1<String, Integer>() {
+            @Override
+            public Integer call(String t1) {
+                return t1.length();
+            }
+        };
+        
+        Observable<Integer> result = source.averageInteger(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 2);
+    }
+    @Test
+    public void testLongAverageSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Long> length = new Func1<String, Long>() {
+            @Override
+            public Long call(String t1) {
+                return (long)t1.length();
+            }
+        };
+        
+        Observable<Long> result = source.averageLong(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 2L);
+    }
+    @Test
+    public void testFloatAverageSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Float> length = new Func1<String, Float>() {
+            @Override
+            public Float call(String t1) {
+                return (float)t1.length();
+            }
+        };
+        
+        Observable<Float> result = source.averageFloat(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 2.5f);
+    }
+    @Test
+    public void testDoubleAverageSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Double> length = new Func1<String, Double>() {
+            @Override
+            public Double call(String t1) {
+                return (double)t1.length();
+            }
+        };
+        
+        Observable<Double> result = source.averageDouble(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 2.5d);
+    }
+    @Test
+    public void testIntegerAverageSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Integer> length = new Func1<String, Integer>() {
+            @Override
+            public Integer call(String t1) {
+                return t1.length();
+            }
+        };
+        
+        Observable<Integer> result = source.averageInteger(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testLongAverageSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Long> length = new Func1<String, Long>() {
+            @Override
+            public Long call(String t1) {
+                return (long)t1.length();
+            }
+        };
+        
+        Observable<Long> result = source.averageLong(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testFloatAverageSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Float> length = new Func1<String, Float>() {
+            @Override
+            public Float call(String t1) {
+                return (float)t1.length();
+            }
+        };
+        
+        Observable<Float> result = source.averageFloat(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testDoubleAverageSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Double> length = new Func1<String, Double>() {
+            @Override
+            public Double call(String t1) {
+                return (double)t1.length();
+            }
+        };
+        
+        Observable<Double> result = source.averageDouble(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testIntegerAverageSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Integer> length = new Func1<String, Integer>() {
+            @Override
+            public Integer call(String t1) {
+                throw new CustomException();
+            }
+        };
+        
+        Observable<Integer> result = source.averageInteger(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, CustomException.class);
+    }
+    @Test
+    public void testLongAverageSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Long> length = new Func1<String, Long>() {
+            @Override
+            public Long call(String t1) {
+                throw new CustomException();
+            }
+        };
+        
+        Observable<Long> result = source.averageLong(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, CustomException.class);
+    }
+    @Test
+    public void testFloatAverageSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Float> length = new Func1<String, Float>() {
+            @Override
+            public Float call(String t1) {
+                throw new CustomException();
+            }
+        };
+        
+        Observable<Float> result = source.averageFloat(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, CustomException.class);
+    }
+    @Test
+    public void testDoubleAverageSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Double> length = new Func1<String, Double>() {
+            @Override
+            public Double call(String t1) {
+                throw new CustomException();
+            }
+        };
+        
+        Observable<Double> result = source.averageDouble(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, CustomException.class);
     }
 }

--- a/rxjava-core/src/test/java/rx/operators/OperationSumTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationSumTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Observer;
+import rx.util.functions.Func1;
 
 public class OperationSumTest {
 
@@ -121,5 +122,209 @@ public class OperationSumTest {
         verify(wd).onNext(0.0d);
         verify(wd, never()).onError(any(Throwable.class));
         verify(wd, times(1)).onCompleted();
+    }
+    
+    void testThrows(Observer<Object> o, Class<? extends Throwable> errorClass) {
+        verify(o, never()).onNext(any());
+        verify(o, never()).onCompleted();
+        verify(o, times(1)).onError(any(errorClass));
+    }
+    <N extends Number> void testValue(Observer<Object> o, N value) {
+        verify(o, times(1)).onNext(value);
+        verify(o, times(1)).onCompleted();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    
+    @Test
+    public void testIntegerSumSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Integer> length = new Func1<String, Integer>() {
+            @Override
+            public Integer call(String t1) {
+                return t1.length();
+            }
+        };
+        
+        Observable<Integer> result = source.sumInteger(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 10);
+    }
+    @Test
+    public void testLongSumSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Long> length = new Func1<String, Long>() {
+            @Override
+            public Long call(String t1) {
+                return (long)t1.length();
+            }
+        };
+        
+        Observable<Long> result = source.sumLong(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 10L);
+    }
+    @Test
+    public void testFloatSumSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Float> length = new Func1<String, Float>() {
+            @Override
+            public Float call(String t1) {
+                return (float)t1.length();
+            }
+        };
+        
+        Observable<Float> result = source.sumFloat(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 10f);
+    }
+    @Test
+    public void testDoubleSumSelector() {
+        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Func1<String, Double> length = new Func1<String, Double>() {
+            @Override
+            public Double call(String t1) {
+                return (double)t1.length();
+            }
+        };
+        
+        Observable<Double> result = source.sumDouble(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testValue(o, 10d);
+    }
+    @Test
+    public void testIntegerSumSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Integer> length = new Func1<String, Integer>() {
+            @Override
+            public Integer call(String t1) {
+                return t1.length();
+            }
+        };
+        
+        Observable<Integer> result = source.sumInteger(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testLongSumSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Long> length = new Func1<String, Long>() {
+            @Override
+            public Long call(String t1) {
+                return (long)t1.length();
+            }
+        };
+        
+        Observable<Long> result = source.sumLong(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testFloatSumSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Float> length = new Func1<String, Float>() {
+            @Override
+            public Float call(String t1) {
+                return (float)t1.length();
+            }
+        };
+        
+        Observable<Float> result = source.sumFloat(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testDoubleSumSelectorEmpty() {
+        Observable<String> source = Observable.empty();
+        Func1<String, Double> length = new Func1<String, Double>() {
+            @Override
+            public Double call(String t1) {
+                return (double)t1.length();
+            }
+        };
+        
+        Observable<Double> result = source.sumDouble(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, IllegalArgumentException.class);
+    }
+    @Test
+    public void testIntegerSumSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Integer> length = new Func1<String, Integer>() {
+            @Override
+            public Integer call(String t1) {
+                throw new OperationAggregateTest.CustomException();
+            }
+        };
+        
+        Observable<Integer> result = source.sumInteger(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, OperationAggregateTest.CustomException.class);
+    }
+    @Test
+    public void testLongSumSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Long> length = new Func1<String, Long>() {
+            @Override
+            public Long call(String t1) {
+                throw new OperationAggregateTest.CustomException();
+            }
+        };
+        
+        Observable<Long> result = source.sumLong(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, OperationAggregateTest.CustomException.class);
+    }
+    @Test
+    public void testFloatSumSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Float> length = new Func1<String, Float>() {
+            @Override
+            public Float call(String t1) {
+                throw new OperationAggregateTest.CustomException();
+            }
+        };
+        
+        Observable<Float> result = source.sumFloat(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, OperationAggregateTest.CustomException.class);
+    }
+    @Test
+    public void testDoubleSumSelectorThrows() {
+        Observable<String> source = Observable.from("a");
+        Func1<String, Double> length = new Func1<String, Double>() {
+            @Override
+            public Double call(String t1) {
+                throw new OperationAggregateTest.CustomException();
+            }
+        };
+        
+        Observable<Double> result = source.sumDouble(length);
+        Observer<Object> o = mock(Observer.class);
+        result.subscribe(o);
+        
+        testThrows(o, OperationAggregateTest.CustomException.class);
     }
 }


### PR DESCRIPTION
Issue #653

Remarks:
- I know we can combine ops to get one of the new aggregate variant, but I think it might be worth having a direct version which avoids nesting several layers of Observables, Observers and Subscriptions.
- The `averageInteger` and `sumInteger` (and the other types) are handy if we want to use chained operation invocations (with less overhead):

``` java
Observable.from("a", "bb", "ccc").sumInteger(s -> s.length())
    .toBlockingObservable().single();
```

instead of

``` java
Observable.sumIntegers(Observable.from("a", "bb", "ccc").map(s -> s.length()))
    .toBlockingObservable().single();
```
