### PR TITLE
Improve Error Handling and Stacktraces When Unsubscribe Fails

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -334,7 +334,6 @@ public class Observable<T> {
 
             @Override
             public void onError(Throwable e) {
-                handleError(e);
                 throw new OnErrorNotImplementedException(e);
             }
 
@@ -373,7 +372,6 @@ public class Observable<T> {
 
             @Override
             public void onError(Throwable e) {
-                handleError(e);
                 throw new OnErrorNotImplementedException(e);
             }
 
@@ -430,7 +428,6 @@ public class Observable<T> {
 
             @Override
             public void onError(Throwable e) {
-                handleError(e);
                 onError.call(e);
             }
 
@@ -491,7 +488,6 @@ public class Observable<T> {
 
             @Override
             public void onError(Throwable e) {
-                handleError(e);
                 onError.call(e);
             }
 
@@ -560,16 +556,6 @@ public class Observable<T> {
             final Func0<? extends Subject<? super T, ? extends TIntermediate>> subjectFactory, 
             final Func1<? super Observable<TIntermediate>, ? extends Observable<TResult>> selector) {
         return OperationMulticast.multicast(this, subjectFactory, selector);
-    }
-    /**
-     * Allow the {@link RxJavaErrorHandler} to receive the exception from
-     * onError.
-     * 
-     * @param e
-     */
-    private void handleError(Throwable e) {
-        // onError should be rare so we'll only fetch when needed
-        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/rxjava-core/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -30,6 +30,8 @@ public abstract class RxJavaErrorHandler {
 
     /**
      * Receives all Exceptions from an {@link Observable} passed to {@link Observer#onError(Throwable)}.
+     * <p>
+     * This should NEVER throw an Exception. Make sure to try/catch(Throwable) all code inside this method implementation.
      * 
      * @param e
      *            Exception

--- a/rxjava-core/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/rxjava-core/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -32,12 +32,17 @@ public class RxJavaPlugins {
     private final AtomicReference<RxJavaErrorHandler> errorHandler = new AtomicReference<RxJavaErrorHandler>();
     private final AtomicReference<RxJavaObservableExecutionHook> observableExecutionHook = new AtomicReference<RxJavaObservableExecutionHook>();
 
+    public static RxJavaPlugins getInstance() {
+        return INSTANCE;
+    }
+
     /* package accessible for unit tests */RxJavaPlugins() {
 
     }
-
-    public static RxJavaPlugins getInstance() {
-        return INSTANCE;
+    
+    /* package accessible for ujnit tests */ void reset() {
+        INSTANCE.errorHandler.set(null);
+        INSTANCE.observableExecutionHook.set(null);
     }
 
     /**
@@ -74,7 +79,7 @@ public class RxJavaPlugins {
      */
     public void registerErrorHandler(RxJavaErrorHandler impl) {
         if (!errorHandler.compareAndSet(null, impl)) {
-            throw new IllegalStateException("Another strategy was already registered.");
+            throw new IllegalStateException("Another strategy was already registered: " + errorHandler.get());
         }
     }
 
@@ -112,7 +117,7 @@ public class RxJavaPlugins {
      */
     public void registerObservableExecutionHook(RxJavaObservableExecutionHook impl) {
         if (!observableExecutionHook.compareAndSet(null, impl)) {
-            throw new IllegalStateException("Another strategy was already registered.");
+            throw new IllegalStateException("Another strategy was already registered: " + observableExecutionHook.get());
         }
     }
 

--- a/rxjava-core/src/test/java/rx/operators/SafeObserverTest.java
+++ b/rxjava-core/src/test/java/rx/operators/SafeObserverTest.java
@@ -22,6 +22,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import rx.Observer;
+import rx.subscriptions.Subscriptions;
+import rx.util.CompositeException;
+import rx.util.OnErrorNotImplementedException;
+import rx.util.functions.Action0;
 
 public class SafeObserverTest {
 
@@ -32,8 +36,9 @@ public class SafeObserverTest {
             OBSERVER_ONNEXT_FAIL(onError).onNext("one");
             fail("expects exception to be thrown");
         } catch (Exception e) {
-            // expected
             assertNull(onError.get());
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onNextFail", e.getMessage());
         }
     }
 
@@ -43,6 +48,8 @@ public class SafeObserverTest {
         try {
             new SafeObserver<String>(OBSERVER_ONNEXT_FAIL(onError)).onNext("one");
             assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeObserverTestException);
+            assertEquals("onNextFail", onError.get().getMessage());
         } catch (Exception e) {
             fail("expects exception to be passed to onError");
         }
@@ -55,8 +62,9 @@ public class SafeObserverTest {
             OBSERVER_ONCOMPLETED_FAIL(onError).onCompleted();
             fail("expects exception to be thrown");
         } catch (Exception e) {
-            // expected
             assertNull(onError.get());
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onCompletedFail", e.getMessage());
         }
     }
 
@@ -66,6 +74,8 @@ public class SafeObserverTest {
         try {
             new SafeObserver<String>(OBSERVER_ONCOMPLETED_FAIL(onError)).onCompleted();
             assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeObserverTestException);
+            assertEquals("onCompletedFail", onError.get().getMessage());
         } catch (Exception e) {
             fail("expects exception to be passed to onError");
         }
@@ -74,41 +84,260 @@ public class SafeObserverTest {
     @Test
     public void onErrorFailure() {
         try {
-            OBSERVER_ONERROR_FAIL().onError(new RuntimeException("error!"));
+            OBSERVER_ONERROR_FAIL().onError(new SafeObserverTestException("error!"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
-            // expected
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e.getMessage());
         }
     }
 
     @Test
     public void onErrorFailureSafe() {
         try {
-            new SafeObserver<String>(OBSERVER_ONERROR_FAIL()).onError(new RuntimeException("error!"));
+            new SafeObserver<String>(OBSERVER_ONERROR_FAIL()).onError(new SafeObserverTestException("error!"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
-            // expected since onError fails so SafeObserver can't help
+            e.printStackTrace();
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Observer.onError", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            assertEquals("Chain of Causes for CompositeException In Order Received =>", e2.getCause().getMessage());
+
+            Throwable e3 = e2.getCause();
+            assertTrue(e3.getCause() instanceof SafeObserverTestException);
+            assertEquals("error!", e3.getCause().getMessage());
+
+            Throwable e4 = e3.getCause();
+            assertTrue(e4.getCause() instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e4.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void onErrorNotImplementedFailureSafe() {
+        try {
+            new SafeObserver<String>(OBSERVER_ONERROR_NOTIMPLEMENTED()).onError(new SafeObserverTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof OnErrorNotImplementedException);
+            assertTrue(e.getCause() instanceof SafeObserverTestException);
+            assertEquals("error!", e.getCause().getMessage());
         }
     }
 
     @Test
     public void onNextOnErrorFailure() {
         try {
-            OBSERVER_ONNEXT_ONERROR_FAIL().onError(new RuntimeException("error!"));
+            OBSERVER_ONNEXT_ONERROR_FAIL().onNext("one");
             fail("expects exception to be thrown");
         } catch (Exception e) {
-            // expected
+            e.printStackTrace();
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onNextFail", e.getMessage());
         }
     }
 
     @Test
     public void onNextOnErrorFailureSafe() {
         try {
-            new SafeObserver<String>(OBSERVER_ONNEXT_ONERROR_FAIL()).onError(new RuntimeException("error!"));
+            new SafeObserver<String>(OBSERVER_ONNEXT_ONERROR_FAIL()).onNext("one");
             fail("expects exception to be thrown");
         } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Observer.onError", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            assertEquals("Chain of Causes for CompositeException In Order Received =>", e2.getCause().getMessage());
+
+            Throwable e3 = e2.getCause();
+            assertTrue(e3.getCause() instanceof SafeObserverTestException);
+            assertEquals("onNextFail", e3.getCause().getMessage());
+
+            Throwable e4 = e3.getCause();
+            assertTrue(e4.getCause() instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e4.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void onCompleteSuccessWithUnsubscribeFailure() {
+        SafeObservableSubscription s = null;
+        try {
+            s = new SafeObservableSubscription(Subscriptions.create(new Action0() {
+
+                @Override
+                public void call() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+            }));
+            new SafeObserver<String>(s, OBSERVER_SUCCESS()).onCompleted();
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            assertTrue(s.isUnsubscribed());
+
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e.getMessage());
             // expected since onError fails so SafeObserver can't help
         }
+    }
+
+    @Test
+    public void onErrorSuccessWithUnsubscribeFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        SafeObservableSubscription s = null;
+        try {
+            s = new SafeObservableSubscription(Subscriptions.create(new Action0() {
+
+                @Override
+                public void call() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+            }));
+            new SafeObserver<String>(s, OBSERVER_SUCCESS(onError)).onError(new SafeObserverTestException("failed"));
+            fail("we expect the unsubscribe failure to cause an exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            assertTrue(s.isUnsubscribed());
+
+            // we still expect onError to have received something before unsubscribe blew up
+            assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeObserverTestException);
+            assertEquals("failed", onError.get().getMessage());
+
+            // now assert the exception that was thrown
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e.getMessage());
+        }
+    }
+
+    @Test
+    public void onErrorFailureWithUnsubscribeFailure() {
+        SafeObservableSubscription s = null;
+        try {
+            s = new SafeObservableSubscription(Subscriptions.create(new Action0() {
+
+                @Override
+                public void call() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+            }));
+            new SafeObserver<String>(s, OBSERVER_ONERROR_FAIL()).onError(new SafeObserverTestException("onError failure"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            assertTrue(s.isUnsubscribed());
+
+            // assertions for what is expected for the actual failure propagated to onError which then fails
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Observer.onError and during unsubscription.", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            assertEquals("Chain of Causes for CompositeException In Order Received =>", e2.getCause().getMessage());
+
+            Throwable e3 = e2.getCause();
+            assertTrue(e3.getCause() instanceof SafeObserverTestException);
+            assertEquals("onError failure", e3.getCause().getMessage());
+
+            Throwable e4 = e3.getCause();
+            assertTrue(e4.getCause() instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e4.getCause().getMessage());
+
+            Throwable e5 = e4.getCause();
+            assertTrue(e5.getCause() instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e5.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void onErrorNotImplementedFailureWithUnsubscribeFailure() {
+        SafeObservableSubscription s = null;
+        try {
+            s = new SafeObservableSubscription(Subscriptions.create(new Action0() {
+
+                @Override
+                public void call() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+            }));
+            new SafeObserver<String>(s, OBSERVER_ONERROR_NOTIMPLEMENTED()).onError(new SafeObserverTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            assertTrue(s.isUnsubscribed());
+
+            // assertions for what is expected for the actual failure propagated to onError which then fails
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Observer.onError not implemented and error while unsubscribing.", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            assertEquals("Chain of Causes for CompositeException In Order Received =>", e2.getCause().getMessage());
+
+            Throwable e3 = e2.getCause();
+            assertTrue(e3.getCause() instanceof SafeObserverTestException);
+            assertEquals("error!", e3.getCause().getMessage());
+
+            Throwable e4 = e3.getCause();
+            assertTrue(e4.getCause() instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e4.getCause().getMessage());
+        }
+    }
+
+    private static Observer<String> OBSERVER_SUCCESS() {
+        return new Observer<String>() {
+
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+        };
+
+    }
+
+    private static Observer<String> OBSERVER_SUCCESS(final AtomicReference<Throwable> onError) {
+        return new Observer<String>() {
+
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+        };
+
     }
 
     private static Observer<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
@@ -126,7 +355,7 @@ public class SafeObserverTest {
 
             @Override
             public void onNext(String args) {
-                throw new RuntimeException("onNextFail");
+                throw new SafeObserverTestException("onNextFail");
             }
         };
 
@@ -142,12 +371,12 @@ public class SafeObserverTest {
 
             @Override
             public void onError(Throwable e) {
-                throw new RuntimeException("onErrortFail");
+                throw new SafeObserverTestException("onErrorFail");
             }
 
             @Override
             public void onNext(String args) {
-                throw new RuntimeException("onNextFail");
+                throw new SafeObserverTestException("onNextFail");
             }
 
         };
@@ -163,7 +392,28 @@ public class SafeObserverTest {
 
             @Override
             public void onError(Throwable e) {
-                throw new RuntimeException("onErrorFail");
+                throw new SafeObserverTestException("onErrorFail");
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    private static Observer<String> OBSERVER_ONERROR_NOTIMPLEMENTED() {
+        return new Observer<String>() {
+
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new OnErrorNotImplementedException(e);
             }
 
             @Override
@@ -179,7 +429,7 @@ public class SafeObserverTest {
 
             @Override
             public void onCompleted() {
-                throw new RuntimeException("onCompletedFail");
+                throw new SafeObserverTestException("onCompletedFail");
             }
 
             @Override
@@ -193,5 +443,12 @@ public class SafeObserverTest {
             }
 
         };
+    }
+
+    @SuppressWarnings("serial")
+    private static class SafeObserverTestException extends RuntimeException {
+        public SafeObserverTestException(String message) {
+            super(message);
+        }
     }
 }

--- a/rxjava-core/src/test/java/rx/plugins/RxJavaPluginsTest.java
+++ b/rxjava-core/src/test/java/rx/plugins/RxJavaPluginsTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2013 Netflix, Inc.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,24 @@ package rx.plugins;
 
 import static org.junit.Assert.*;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import rx.Observable;
+import rx.Observer;
+
 public class RxJavaPluginsTest {
+
+    @Before
+    public void resetBefore() {
+        RxJavaPlugins.getInstance().reset();
+    }
+
+    @After
+    public void resetAfter() {
+        RxJavaPlugins.getInstance().reset();
+    }
 
     @Test
     public void testErrorHandlerDefaultImpl() {
@@ -50,7 +65,17 @@ public class RxJavaPluginsTest {
 
     // inside test so it is stripped from Javadocs
     public static class RxJavaErrorHandlerTestImpl extends RxJavaErrorHandler {
-        // just use defaults
+
+        @SuppressWarnings("unused")
+        private volatile Throwable e;
+        private volatile int count = 0;
+
+        @Override
+        public void handleError(Throwable e) {
+            this.e = e;
+            count++;
+        }
+
     }
 
     @Test
@@ -79,6 +104,45 @@ public class RxJavaPluginsTest {
         } finally {
             System.clearProperty("rxjava.plugin.RxJavaObservableExecutionHook.implementation");
         }
+    }
+
+    @Test
+    public void testOnErrorWhenImplementedViaSubscribe() {
+        RxJavaErrorHandlerTestImpl errorHandler = new RxJavaErrorHandlerTestImpl();
+        RxJavaPlugins.getInstance().registerErrorHandler(errorHandler);
+
+        RuntimeException re = new RuntimeException("test onError");
+        Observable.error(re).subscribe(new Observer<Object>() {
+
+            @Override
+            public void onCompleted() {
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onNext(Object args) {
+            }
+        });
+        assertEquals(re, errorHandler.e);
+        assertEquals(1, errorHandler.count);
+    }
+
+    @Test
+    public void testOnErrorWhenNotImplemented() {
+        RxJavaErrorHandlerTestImpl errorHandler = new RxJavaErrorHandlerTestImpl();
+        RxJavaPlugins.getInstance().registerErrorHandler(errorHandler);
+
+        RuntimeException re = new RuntimeException("test onError");
+        try {
+            Observable.error(re).subscribe();
+        } catch (Throwable e) {
+            // ignore as we expect it to throw
+        }
+        assertEquals(re, errorHandler.e);
+        assertEquals(1, errorHandler.count);
     }
 
     // inside test so it is stripped from Javadocs


### PR DESCRIPTION
The stacktraces were a mess when onError failed or was not implemented and unsubscribe also failed.
That is a far edge case and means code is broken and breaking the Rx contracts … but that’s just when we need clear stacktraces.
The CompositeException and SafeObserver class now do a dance and wire together a causal chain to provide a stacktrace that can identity all the points of error.
Also standardized and simplified the RxJavaPlugin.onErrorHandler while working in the vicinity.

This came about after I was asked to help debug a problem and couldn’t do it by looking at the thrown exception, I had to use a debugger and step through.
