### PR TITLE
Careful With That Global Search And Replace, Eugene.

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -148,7 +148,7 @@ import rx.util.functions.Functions;
  * The documentation for this class makes use of marble diagrams. The following legend explains
  * these diagrams:
  * <p>
- * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/legend.png">
+ * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/legend.png">
  * <p>
  * For more information see the
  * <a href="https://github.com/Netflix/RxJava/wiki/Observable">RxJava Wiki</a>
@@ -178,7 +178,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that will execute the specified function when an {@link Observer} subscribes to it.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/create.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/create.png">
      * <p>
      * Write the function you pass to {@code create} so that it behaves as an Observable: It should
      * invoke the Observer's {@link Observer#onNext onNext}, {@link Observer#onError onError}, and {@link Observer#onCompleted onCompleted} methods appropriately.
@@ -256,13 +256,13 @@ public class Observable<T> {
     /**
      * Mirror the one Observable in an Iterable of several Observables that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param sources
      *            an Iterable of Observable sources competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229115.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Iterable<? extends Observable<? extends T>> sources) {
@@ -272,7 +272,7 @@ public class Observable<T> {
     /**
      * Given two Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -280,7 +280,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2) {
@@ -290,7 +290,7 @@ public class Observable<T> {
     /**
      * Given three Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -300,7 +300,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3) {
@@ -310,7 +310,7 @@ public class Observable<T> {
     /**
      * Given four Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -322,7 +322,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3, Observable<? extends T> o4) {
@@ -332,7 +332,7 @@ public class Observable<T> {
     /**
      * Given five Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -346,7 +346,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3, Observable<? extends T> o4, Observable<? extends T> o5) {
@@ -356,7 +356,7 @@ public class Observable<T> {
     /**
      * Given six Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -372,7 +372,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3, Observable<? extends T> o4, Observable<? extends T> o5, Observable<? extends T> o6) {
@@ -382,7 +382,7 @@ public class Observable<T> {
     /**
      * Given seven Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -400,7 +400,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3, Observable<? extends T> o4, Observable<? extends T> o5, Observable<? extends T> o6, Observable<? extends T> o7) {
@@ -410,7 +410,7 @@ public class Observable<T> {
     /**
      * Given eight Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -430,7 +430,7 @@ public class Observable<T> {
      *            an observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3, Observable<? extends T> o4, Observable<? extends T> o5, Observable<? extends T> o6, Observable<? extends T> o7, Observable<? extends T> o8) {
@@ -440,7 +440,7 @@ public class Observable<T> {
     /**
      * Given nine Observables, mirror the one that first emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/amb.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/amb.png">
      * 
      * @param o1
      *            an Observable competing to react first
@@ -462,7 +462,7 @@ public class Observable<T> {
      *            an Observable competing to react first
      * @return an Observable that emits the same sequence of items as whichever of the source
      *         Observables first emitted an item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#amb">RxJava Wiki: amb()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#amb">RxJava Wiki: amb()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229733.aspx">MSDN: Observable.Amb</a>
      */
     public final static <T> Observable<T> amb(Observable<? extends T> o1, Observable<? extends T> o2, Observable<? extends T> o3, Observable<? extends T> o4, Observable<? extends T> o5, Observable<? extends T> o6, Observable<? extends T> o7, Observable<? extends T> o8, Observable<? extends T> o9) {
@@ -480,13 +480,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the average of the Doubles emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
      * @param source
      *            source Observable to compute the average of
      * @return an Observable that emits a single item: the average of all the Doubles emitted
      *         by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageDouble()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageDouble()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final static Observable<Double> averageDouble(Observable<Double> source) {
@@ -496,13 +496,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the average of the Floats emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
      * @param source
      *            source Observable to compute the average of
      * @return an Observable that emits a single item: the average of all the Floats emitted by
      *         the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageFloat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageFloat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final static Observable<Float> averageFloat(Observable<Float> source) {
@@ -513,7 +513,7 @@ public class Observable<T> {
      * Returns an Observable that emits the average of the Integers emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
      * @param source
      *            source Observable to compute the average of
@@ -521,7 +521,7 @@ public class Observable<T> {
      *         by the source Observable
      * @throws IllegalArgumentException
      *             if the source Observable emits no items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageInteger()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageInteger()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final static Observable<Integer> averageInteger(Observable<Integer> source) {
@@ -531,13 +531,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the average of the Longs emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.png">
      * 
      * @param source
      *            source Observable to compute the average of
      * @return an Observable that emits a single item: the average of all the Longs emitted by
      *         the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageLong()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageLong()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final static Observable<Long> averageLong(Observable<Long> source) {
@@ -549,7 +549,7 @@ public class Observable<T> {
      * of the source Observables each time an item is received from either of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -571,7 +571,7 @@ public class Observable<T> {
      * each of the source Observables each time an item is received from any of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -595,7 +595,7 @@ public class Observable<T> {
      * each of the source Observables each time an item is received from any of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -622,7 +622,7 @@ public class Observable<T> {
      * each of the source Observables each time an item is received from any of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -651,7 +651,7 @@ public class Observable<T> {
      * of the source Observables each time an item is received from any of the source Observables,
      * where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -682,7 +682,7 @@ public class Observable<T> {
      * each of the source Observables each time an item is received from any of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -715,7 +715,7 @@ public class Observable<T> {
      * each of the source Observables each time an item is received from any of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -750,7 +750,7 @@ public class Observable<T> {
      * each of the source Observables each time an item is received from any of the source
      * Observables, where this aggregation is defined by a specified function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/combineLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/combineLatest.png">
      * 
      * @param o1
      *            the first source Observable
@@ -787,12 +787,12 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by each of the Observables emitted by an
      * Observable, one after the other, without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param observables
      *            an Observable that emits Observables
      * @return an Observable that emits items all of the items emitted by the Observables emitted by {@code observables}, one after the other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends Observable<? extends T>> observables) {
@@ -803,7 +803,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by two Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -811,7 +811,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the two source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -824,7 +824,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by three Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -834,7 +834,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the three source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -847,7 +847,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by four Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -859,7 +859,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the four source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -872,7 +872,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by five Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -886,7 +886,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the five source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -899,7 +899,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by six Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -915,7 +915,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the six source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -928,7 +928,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by seven Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -946,7 +946,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the seven source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -959,7 +959,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by eight Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -979,7 +979,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the eight source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -992,7 +992,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by nine Observables, one after the other,
      * without interleaving them.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concat.png">
      * 
      * @param t1
      *            an Observable to be concatenated
@@ -1014,7 +1014,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @return an Observable that emits items emitted by the nine source Observables, one after the
      *         other, without interleaving them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#concat">RxJava Wiki: concat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#concat">RxJava Wiki: concat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     @SuppressWarnings("unchecked")
@@ -1028,7 +1028,7 @@ public class Observable<T> {
      * Observer that subscribes. That is, for each subscriber, the actual Observable that subscriber
      * observs is determined by the factory function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/defer.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/defer.png">
      * <p>
      * The defer Observer allows you to defer or delay emitting items from an Observable until such
      * time as an Observer subscribes to the Observable. This allows an {@link Observer} to easily
@@ -1050,7 +1050,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits no items to the {@link Observer} and immediately invokes its {@link Observer#onCompleted onCompleted} method.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/empty.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/empty.png">
      * 
      * @param <T>
      *            the type of the items (ostensibly) emitted by the Observable
@@ -1065,7 +1065,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits no items to the {@link Observer} and immediately invokes its {@link Observer#onCompleted onCompleted} method on the specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/empty.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/empty.s.png">
      * 
      * @param scheduler
      *            the scheduler to use to call the {@link Observer#onCompleted onCompleted} method
@@ -1083,7 +1083,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that invokes an {@link Observer}'s {@link Observer#onError onError} method when the Observer subscribes to it.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/error.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/error.png">
      * 
      * @param exception
      *            the particular Throwable to pass to {@link Observer#onError onError}
@@ -1100,7 +1100,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that invokes an {@link Observer}'s {@link Observer#onError onError} method on the specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/error.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/error.s.png">
      * 
      * @param exception
      *            the particular Throwable to pass to {@link Observer#onError onError}
@@ -1119,7 +1119,7 @@ public class Observable<T> {
     /**
      * Converts a {@link Future} into an Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.Future.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.Future.png">
      * <p>
      * You can convert any object that supports the {@link Future} interface into an Observable that
      * emits the return value of the {@link Future#get} method of that object, by passing the object
@@ -1142,7 +1142,7 @@ public class Observable<T> {
     /**
      * Converts a {@link Future} into an Observable, with a timeout on the Future.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.Future.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.Future.png">
      * <p>
      * You can convert any object that supports the {@link Future} interface into an Observable that
      * emits the return value of the {@link Future#get} method of that object, by passing the object
@@ -1169,7 +1169,7 @@ public class Observable<T> {
     /**
      * Converts a {@link Future}, operating on a specified {@link Scheduler}, into an Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.Future.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.Future.s.png">
      * <p>
      * You can convert any object that supports the {@link Future} interface into an Observable that
      * emits the return value of the {@link Future#get} method of that object, by passing the object
@@ -1194,7 +1194,7 @@ public class Observable<T> {
      * Converts an {@link Iterable} sequence into an Observable that emits the items in the
      * sequence.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the entire iterable sequence is immediately emitted each time an {@link Observer} subscribes. Since this occurs before the {@link Subscription} is returned, it is not possible
      * to unsubscribe from the sequence before it completes.
@@ -1215,7 +1215,7 @@ public class Observable<T> {
      * Converts an {@link Iterable} sequence into an Observable that operates on the specified
      * scheduler, emitting each item from the sequence.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.s.png">
      * 
      * @param iterable
      *            the source {@link Iterable} sequence
@@ -1236,7 +1236,7 @@ public class Observable<T> {
     /**
      * Converts an item into an Observable that emits that item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the item is immediately emitted each time an {@link Observer} subscribes. Since this
      * occurs before the {@link Subscription} is returned, it is not possible to unsubscribe from
@@ -1257,7 +1257,7 @@ public class Observable<T> {
     /**
      * Converts two items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1282,7 +1282,7 @@ public class Observable<T> {
     /**
      * Converts three items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1309,7 +1309,7 @@ public class Observable<T> {
     /**
      * Converts four items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1338,7 +1338,7 @@ public class Observable<T> {
     /**
      * Converts five items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1369,7 +1369,7 @@ public class Observable<T> {
     /**
      * Converts six items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1402,7 +1402,7 @@ public class Observable<T> {
     /**
      * Converts seven items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1437,7 +1437,7 @@ public class Observable<T> {
     /**
      * Converts eight items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1474,7 +1474,7 @@ public class Observable<T> {
     /**
      * Converts nine items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * Note: the items will be immediately emitted each time an {@link Observer} subscribes. Since
      * this occurs before the {@link Subscription} is returned, it is not possible to unsubscribe
@@ -1513,7 +1513,7 @@ public class Observable<T> {
     /**
      * Converts ten items into an Observable that emits those items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * 
      * @param t1
@@ -1551,7 +1551,7 @@ public class Observable<T> {
     /**
      * Converts an Array into an Observable that emits the items in the Array.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * <em>Note:</em> the entire array is immediately emitted each time an {@link Observer} subscribes. Since this occurs before the {@link Subscription} is returned, it is not possible
      * to unsubscribe from the sequence before it completes.
@@ -1573,7 +1573,7 @@ public class Observable<T> {
      * Converts an Array into an Observable that emits the items in the Array on a specified
      * scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/from.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png">
      * <p>
      * <em>Note:</em> the entire array is immediately emitted each time an {@link Observer} subscribes. Since this occurs before the {@link Subscription} is returned, it is not
      * possible to unsubscribe from the sequence before it completes.
@@ -1595,7 +1595,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits a sequential number every specified interval of time.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/interval.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/interval.png">
      * 
      * @param interval
      *            interval size in time units (see below)
@@ -1613,7 +1613,7 @@ public class Observable<T> {
      * Returns an Observable that emits a sequential number every specified interval of time, on a
      * specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/interval.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/interval.s.png">
      * 
      * @param interval
      *            interval size in time units (see below)
@@ -1632,7 +1632,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits a single item and then completes.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/just.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/just.png">
      * <p>
      * To convert any object into an Observable that emits that object, pass that object into the {@code just} method.
      * <p>
@@ -1656,7 +1656,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits a single item and then completes, on a specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/just.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/just.s.png">
      * <p>
      * This is a scheduler version of {@link #just(Object)}.
      * 
@@ -1681,14 +1681,14 @@ public class Observable<T> {
      * maximum numeric value. If there is more than one item with the same maximum value, it emits
      * the last-emitted of these.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/max.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/max.png">
      * 
      * @param source
      *            an Observable to scan for the maximum emitted item
      * @return an Observable that emits this maximum item
      * @throws IllegalArgumentException
      *             if the source is empty
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#max">RxJava Wiki: max()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#max">RxJava Wiki: max()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211837.aspx">MSDN: Observable.Max</a>
      */
     public final static <T extends Comparable<? super T>> Observable<T> max(Observable<T> source) {
@@ -1698,7 +1698,7 @@ public class Observable<T> {
     /**
      * Flattens an Iterable of Observables into one Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine the items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1718,7 +1718,7 @@ public class Observable<T> {
      * Flattens an Iterable of Observables into one Observable, without any transformation, while
      * limiting the number of concurrent subscriptions to these Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine the items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1742,7 +1742,7 @@ public class Observable<T> {
      * limiting the number of concurrent subscriptions to these Observables, and subscribing to
      * these Observables on a specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine the items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1767,7 +1767,7 @@ public class Observable<T> {
      * Flattens an Iterable of Observables into one Observable, without any transformation,
      * subscribing to these Observables on a specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine the items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1789,7 +1789,7 @@ public class Observable<T> {
      * Flattens an Observable that emits Observables into a single Observable that emits the items
      * emitted by those Observables, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.oo.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.oo.png">
      * <p>
      * You can combine the items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1810,7 +1810,7 @@ public class Observable<T> {
      * emitted by those Observables, without any transformation, while limiting the maximum number
      * of concurrent subscriptions to these Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.oo.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.oo.png">
      * <p>
      * You can combine the items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1832,7 +1832,7 @@ public class Observable<T> {
     /**
      * Flattens two Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1852,7 +1852,7 @@ public class Observable<T> {
     /**
      * Flattens three Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1874,7 +1874,7 @@ public class Observable<T> {
     /**
      * Flattens four Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1898,7 +1898,7 @@ public class Observable<T> {
     /**
      * Flattens five Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1924,7 +1924,7 @@ public class Observable<T> {
     /**
      * Flattens six Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1952,7 +1952,7 @@ public class Observable<T> {
     /**
      * Flattens seven Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -1982,7 +1982,7 @@ public class Observable<T> {
     /**
      * Flattens eight Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -2015,7 +2015,7 @@ public class Observable<T> {
     /**
      * Flattens nine Observables into a single Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -2050,7 +2050,7 @@ public class Observable<T> {
     /**
      * Flattens an array of Observables into one Observable, without any transformation.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.io.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.io.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -2069,7 +2069,7 @@ public class Observable<T> {
      * Flattens an array of Observables into one Observable, without any transformation, traversing
      * the array on a specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/merge.ios.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/merge.ios.png">
      * <p>
      * You can combine items emitted by multiple Observables so that they appear as a single
      * Observable, by using the {@code merge} method.
@@ -2092,7 +2092,7 @@ public class Observable<T> {
      * from propagating that error notification until all of the merged Observables have finished
      * emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2114,7 +2114,7 @@ public class Observable<T> {
      * Observables notify of an error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that error notification until all of the merged Observables
      * have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if both merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2141,7 +2141,7 @@ public class Observable<T> {
      * the merged Observables notify of an error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that error notification until all of
      * the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2169,7 +2169,7 @@ public class Observable<T> {
      * if any of the merged Observables notify of an error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that error notification until all of
      * the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2199,7 +2199,7 @@ public class Observable<T> {
      * , {@code mergeDelayError} will refrain from propagating that
      * error notification until all of the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2231,7 +2231,7 @@ public class Observable<T> {
      * {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
      * error notification until all of the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2265,7 +2265,7 @@ public class Observable<T> {
      * {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
      * error notification until all of the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2301,7 +2301,7 @@ public class Observable<T> {
      * via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
      * error notification until all of the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2339,7 +2339,7 @@ public class Observable<T> {
      * of an error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
      * error notification until all of the merged Observables have finished emitting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeDelayError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeDelayError.png">
      * <p>
      * Even if multiple merged Observables send {@code onError} notifications, {@code mergeDelayError} will only invoke the {@code onError} method of its Observers once.
      * <p>
@@ -2378,7 +2378,7 @@ public class Observable<T> {
      * Returns an Observable that emits the single numerically minimum item emitted by the source
      * Observable. If there is more than one such item, it returns the last-emitted one.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/min.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/min.png">
      * 
      * @param source
      *            an Observable to determine the minimum item of
@@ -2394,7 +2394,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that never sends any items or notifications to an {@link Observer}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/never.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/never.png">
      * <p>
      * This Observable is useful primarily for testing purposes.
      * 
@@ -2414,7 +2414,7 @@ public class Observable<T> {
      * For example, if the original {@code Observable<Observable<T>>} emits 100 Observables and {@code parallelObservables} is 8, the items emitted by the 100 original Observables will be
      * distributed among 8 Observables emitted by the resulting Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/parallelMerge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/parallelMerge.png">
      * <p>
      * This is a mechanism for efficiently processing <i>n</i> number of Observables on a smaller
      * <i>m</i> number of resources (typically CPU cores).
@@ -2435,7 +2435,7 @@ public class Observable<T> {
      * For example, if the original {@code Observable<Observable<T>>} emits 100 Observables and {@code parallelObservables} is 8, the items emitted by the 100 original Observables will be
      * distributed among 8 Observables emitted by the resulting Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/parallelMerge.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/parallelMerge.png">
      * <p>
      * This is a mechanism for efficiently processing <i>n</i> number of Observables on a smaller
      * <i>m</i> number of resources (typically CPU cores).
@@ -2454,7 +2454,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits a sequence of Integers within a specified range.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/range.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/range.png">
      * 
      * @param start
      *            the value of the first Integer in the sequence
@@ -2472,7 +2472,7 @@ public class Observable<T> {
      * Returns an Observable that emits a sequence of Integers within a specified range, on a
      * specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/range.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/range.s.png">
      * 
      * @param start
      *            the value of the first Integer in the sequence
@@ -2492,7 +2492,7 @@ public class Observable<T> {
      * Returns an Observable that emits a Boolean value that indicates whether two Observable
      * sequences are the same by comparing the items emitted by each Observable pairwise.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sequenceEqual.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sequenceEqual.png">
      * 
      * @param first
      *            the first Observable to compare
@@ -2502,7 +2502,7 @@ public class Observable<T> {
      *            the type of items emitted by each Observable
      * @return an Observable that emits a Boolean value that indicates whether the two sequences are
      *         the same
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#sequenceequal">RxJava Wiki: sequenceEqual()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#sequenceequal">RxJava Wiki: sequenceEqual()</a>
      */
     public final static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> first, Observable<? extends T> second) {
         return sequenceEqual(first, second, new Func2<T, T, Boolean>() {
@@ -2521,7 +2521,7 @@ public class Observable<T> {
      * sequences are the same by comparing the items emitted by each Observable pairwise based on
      * the results of a specified equality function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sequenceEqual.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sequenceEqual.png">
      * 
      * @param first
      *            the first Observable to compare
@@ -2533,7 +2533,7 @@ public class Observable<T> {
      *            the type of items emitted by each Observable
      * @return an Observable that emits a Boolean value that indicates whether the two Observable
      *         two sequences are the same according to the specified function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#sequenceequal">RxJava Wiki: sequenceEqual()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#sequenceequal">RxJava Wiki: sequenceEqual()</a>
      */
     public final static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> first, Observable<? extends T> second, Func2<? super T, ? super T, Boolean> equality) {
         return OperationSequenceEqual.sequenceEqual(first, second, equality);
@@ -2550,13 +2550,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the sum of all the Doubles emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source
      *            the source Observable to compute the sum of
      * @return an Observable that emits a single item: the sum of all the Doubles emitted by the
      *         source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumDouble()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumDouble()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final static Observable<Double> sumDouble(Observable<Double> source) {
@@ -2566,13 +2566,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the sum of all the Floats emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source
      *            the source Observable to compute the sum of
      * @return an Observable that emits a single item: the sum of all the Floats emitted by the
      *         source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumFloat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumFloat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final static Observable<Float> sumFloat(Observable<Float> source) {
@@ -2583,13 +2583,13 @@ public class Observable<T> {
      * Returns an Observable that emits the sum of all the Integers emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source
      *            source Observable to compute the sum of
      * @return an Observable that emits a single item: the sum of all the Integers emitted by the
      *         source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumInteger()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumInteger()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final static Observable<Integer> sumInteger(Observable<Integer> source) {
@@ -2599,13 +2599,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the sum of all the Longs emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.png">
      * 
      * @param source
      *            source Observable to compute the sum of
      * @return an Observable that emits a single item: the sum of all the Longs emitted by the
      *         source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumLong()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumLong()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final static Observable<Long> sumLong(Observable<Long> source) {
@@ -2616,7 +2616,7 @@ public class Observable<T> {
      * Given an Observable that emits Observables, returns an Observable that emits the items
      * emitted by the most recently emitted of those Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/switchDo.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/switchDo.png">
      * 
      * @param sequenceOfSequences
      *            the source Observable that emits Observables
@@ -2634,7 +2634,7 @@ public class Observable<T> {
      * Given an Observable that emits Observables, returns an Observable that emits the items
      * emitted by the most recently emitted of those Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/switchLatest.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/switchLatest.png">
      * 
      * @param sequenceOfSequences
      *            the source Observable that emits Observables
@@ -2651,7 +2651,7 @@ public class Observable<T> {
      * Given an Observable that emits Observables, returns an Observable that emits the items
      * emitted by the most recently emitted of those Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/switchDo.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/switchDo.png">
      * 
      * @param sequenceOfSequences
      *            the source Observable that emits Observables
@@ -2675,7 +2675,7 @@ public class Observable<T> {
      * Return an Observable that emits a 0L after the {@code initialDelay} and ever increasing
      * numbers after each {@code period} of time thereafter.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timer.p.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.p.png">
      * 
      * @param initialDelay
      *            the initial delay time to wait before emitting the first value of 0L
@@ -2696,7 +2696,7 @@ public class Observable<T> {
      * Return an Observable that emits a 0L after the {@code initialDelay} and ever increasing
      * numbers after each {@code period} of time thereafter, on a specified Scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timer.ps.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.ps.png">
      * 
      * @param initialDelay
      *            the initial delay time to wait before emitting the first value of 0L
@@ -2718,7 +2718,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits one item after a specified delay, and then completes.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timer.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.png">
      * 
      * @param delay
      *            the initial delay before emitting a single 0L
@@ -2734,7 +2734,7 @@ public class Observable<T> {
      * Returns an Observable that emits one item after a specified delay, on a specified scheduler,
      * and then completes.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timer.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.s.png">
      * 
      * @param delay
      *            the initial delay before emitting a single 0L
@@ -2751,14 +2751,14 @@ public class Observable<T> {
     /**
      * Constructs an Observable that creates a dependent resource object.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/using.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/using.png">
      * 
      * @param resourceFactory
      *            the factory function to create a resource object that depends on the Observable
      * @param observableFactory
      *            the factory function to obtain an Observable
      * @return the Observable whose lifetime controls the lifetime of the dependent resource object
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#using">RxJava Wiki: using()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#using">RxJava Wiki: using()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229585.aspx">MSDN: Observable.Using</a>
      */
     public final static <T, RESOURCE extends Subscription> Observable<T> using(Func0<RESOURCE> resourceFactory, Func1<RESOURCE, Observable<T>> observableFactory) {
@@ -2768,7 +2768,7 @@ public class Observable<T> {
     /**
      * Joins together the results from several patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param plans
      *            a series of plans created by use of the {@link #then} Observer on patterns
@@ -2788,7 +2788,7 @@ public class Observable<T> {
     /**
      * Joins together the results from several patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param plans
      *            a series of plans created by use of the {@link #then} Observer on patterns
@@ -2805,7 +2805,7 @@ public class Observable<T> {
     /**
      * Joins the results from a pattern via its plan.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            the plan to join, created by use of the {@link #then} Observer on a pattern
@@ -2821,7 +2821,7 @@ public class Observable<T> {
     /**
      * Joins together the results from two patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2839,7 +2839,7 @@ public class Observable<T> {
     /**
      * Joins together the results from three patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2859,7 +2859,7 @@ public class Observable<T> {
     /**
      * Joins together the results from four patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2881,7 +2881,7 @@ public class Observable<T> {
     /**
      * Joins together the results from five patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2905,7 +2905,7 @@ public class Observable<T> {
     /**
      * Joins together the results from six patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2931,7 +2931,7 @@ public class Observable<T> {
     /**
      * Joins together the results from seven patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2959,7 +2959,7 @@ public class Observable<T> {
     /**
      * Joins together the results from eight patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -2989,7 +2989,7 @@ public class Observable<T> {
     /**
      * Joins together the results from nine patterns via their plans.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param p1
      *            a plan, created by use of the {@link #then} Observer on a pattern
@@ -3030,7 +3030,7 @@ public class Observable<T> {
      * many times as the number of {@code onNext} invokations of the source Observable that emits
      * the fewest items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * 
      * @param ws
      *            an Iterable of source Observables
@@ -3058,7 +3058,7 @@ public class Observable<T> {
      * many times as the number of {@code onNext} invokations of the source Observable that emits
      * the fewest items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.o.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.o.png">
      * 
      * @param ws
      *            an Observable of source Observables
@@ -3082,7 +3082,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of two items emitted, in sequence, by two other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted by {@code o1} and the first item emitted by {@code o2}; the second item emitted by the new Observable will
      * be the result of the function applied to the second item emitted by {@code o1} and the second
@@ -3109,7 +3109,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of three items emitted, in sequence, by three other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted by {@code o1}, the first item emitted by {@code o2}, and the first item emitted by {@code o3};
      * the second item emitted by the new Observable will be the result of the function applied to
@@ -3139,7 +3139,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of four items emitted, in sequence, by four other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted by {@code o1}, the first item emitted by {@code o2}, the first item emitted by {@code o3}, and
      * the first item emitted by {@code 04}; the second item emitted by the new Observable will be
@@ -3171,7 +3171,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of five items emitted, in sequence, by five other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted by {@code o1}, the first item emitted by {@code o2}, the first item emitted by {@code o3}, the
      * first item emitted by {@code o4}, and the first item emitted by {@code o5}; the second item
@@ -3205,7 +3205,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of six items emitted, in sequence, by six other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted each source
      * Observable, the second item emitted by the new Observable will be the result of the function
@@ -3241,7 +3241,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of seven items emitted, in sequence, by seven other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted each source
      * Observable, the second item emitted by the new Observable will be the result of the function
@@ -3279,7 +3279,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of eight items emitted, in sequence, by eight other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted each source
      * Observable, the second item emitted by the new Observable will be the result of the function
@@ -3319,7 +3319,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a function of your choosing applied to
      * combinations of nine items emitted, in sequence, by nine other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * <p> {@code zip} applies this function in strict sequence, so the first item emitted by the new
      * Observable will be the result of the function applied to the first item emitted each source
      * Observable, the second item emitted by the new Observable will be the result of the function
@@ -3360,9 +3360,9 @@ public class Observable<T> {
     /**
      * Synonymous with {@code reduce()}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/aggregate.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/aggregate.png">
      * 
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#reduce">RxJava Wiki: reduce()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#reduce">RxJava Wiki: reduce()</a>
      * @see #reduce(Func2)
      * @deprecated use #reduce(Func2)
      */
@@ -3374,9 +3374,9 @@ public class Observable<T> {
     /**
      * Synonymous with {@code reduce()}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/aggregateSeed.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/aggregateSeed.png">
      * 
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#reduce">RxJava Wiki: reduce()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#reduce">RxJava Wiki: reduce()</a>
      * @see #reduce(Object, Func2)
      * @deprecated use #reduce(Object, Func2)
      */
@@ -3389,13 +3389,13 @@ public class Observable<T> {
      * Returns an Observable that emits a Boolean that indicates whether all of the items emitted by
      * the source Observable satisfy a condition.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/all.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/all.png">
      * 
      * @param predicate
      *            a function that evaluates an item and returns a Boolean
      * @return an Observable that emits {@code true} if all items emitted by the source Observable
      *         satisfy the predicate; otherwise, {@code false}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#all">RxJava Wiki: all()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#all">RxJava Wiki: all()</a>
      */
     public final Observable<Boolean> all(Func1<? super T, Boolean> predicate) {
         return create(OperationAll.all(this, predicate));
@@ -3404,7 +3404,7 @@ public class Observable<T> {
     /**
      * Returns a Pattern that matches when both Observables emit an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param right
      *            an Observable to match with the source Observable
@@ -3434,14 +3434,14 @@ public class Observable<T> {
      * using a function you provide and then emits the Double average of the complete sequence of
      * transformed values.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.f.png">
      * 
      * @param valueExtractor
      *            the function to transform an item emitted by the source Observable into a Double
      * @return an Observable that emits a single item: the Double average of the complete sequence
      *         of items emitted by the source Observable when transformed into Doubles by the
      *         specified function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageDouble()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageDouble()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final Observable<Double> averageDouble(Func1<? super T, Double> valueExtractor) {
@@ -3453,14 +3453,14 @@ public class Observable<T> {
      * using a function you provide and then emits the Float average of the complete sequence of
      * transformed values.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.f.png">
      * 
      * @param valueExtractor
      *            the function to transform an item emitted by the source Observable into a Float
      * @return an Observable that emits a single item: the Float average of the complete sequence of
      *         items emitted by the source Observable when transformed into Floats by the specified
      *         function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageFloat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageFloat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final Observable<Float> averageFloat(Func1<? super T, Float> valueExtractor) {
@@ -3472,14 +3472,14 @@ public class Observable<T> {
      * using a function you provide and then emits the Integer average of the complete sequence of
      * transformed values.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.f.png">
      * 
      * @param valueExtractor
      *            the function to transform an item emitted by the source Observable into an Integer
      * @return an Observable that emits a single item: the Integer average of the complete sequence
      *         of items emitted by the source Observable when transformed into Integers by the
      *         specified function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageInteger()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageInteger()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final Observable<Integer> averageInteger(Func1<? super T, Integer> valueExtractor) {
@@ -3491,14 +3491,14 @@ public class Observable<T> {
      * using a function you provide and then emits the Long average of the complete sequence of
      * transformed values.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/average.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/average.f.png">
      * 
      * @param valueExtractor
      *            the function to transform an item emitted by the source Observable into a Long
      * @return an Observable that emits a single item: the Long average of the complete sequence of
      *         items emitted by the source Observable when transformed into Longs by the specified
      *         function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageLong()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#averageinteger-averagelong-averagefloat-and-averagedouble">RxJava Wiki: averageLong()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.average.aspx">MSDN: Observable.Average</a>
      */
     public final Observable<Long> averageLong(Func1<? super T, Long> valueExtractor) {
@@ -3511,7 +3511,7 @@ public class Observable<T> {
      * buffer and replaces it with a new buffer when the Observable produced by the specified {@code bufferClosingSelector} emits an item. It then uses the {@code bufferClosingSelector} to create a
      * new Observable to observe to indicate the end of the next buffer.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer1.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer1.png">
      * 
      * @param bufferClosingSelector
      *            a {@link Func0} that produces an Observable for each buffer created. When
@@ -3531,7 +3531,7 @@ public class Observable<T> {
      * resulting Observable emits the current buffer and propagates the notification from the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer3.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer3.png">
      * 
      * @param count
      *            the maximum number of items in each buffer before it should be emitted
@@ -3549,7 +3549,7 @@ public class Observable<T> {
      * resulting Observable emits the current buffer and propagates the notification from the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer4.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer4.png">
      * 
      * @param count
      *            the maximum size of each buffer before it should be emitted
@@ -3572,7 +3572,7 @@ public class Observable<T> {
      * resulting Observable emits the current buffer and propagates the notification from the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer7.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer7.png">
      * 
      * @param timespan
      *            the period of time each buffer collects items before it is emitted
@@ -3595,7 +3595,7 @@ public class Observable<T> {
      * Observable completes or encounters an error, the resulting Observable emits the current
      * buffer propagates the notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer7.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer7.s.png">
      * 
      * @param timespan
      *            the period of time each buffer collects items before it is emitted
@@ -3620,7 +3620,7 @@ public class Observable<T> {
      * encounters an error, the resulting Observable emits the current buffer and propagates the
      * notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer5.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer5.png">
      * 
      * @param timespan
      *            the period of time each buffer collects items before it is emitted and replaced
@@ -3642,7 +3642,7 @@ public class Observable<T> {
      * error, the resulting Observable emits the current buffer and propagates the notification from
      * the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer6.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer6.png">
      * 
      * @param timespan
      *            the period of time each buffer collects items before it is emitted and replaced
@@ -3668,7 +3668,7 @@ public class Observable<T> {
      * source Observable completes or encounters an error, the resulting Observable emits the
      * current buffer and propagates the notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer6.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer6.s.png">
      * 
      * @param timespan
      *            the period of time each buffer collects items before it is emitted and replaced
@@ -3695,7 +3695,7 @@ public class Observable<T> {
      * source Observable completes or encounters an error, the resulting Observable emits the
      * current buffer and propagates the notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer5.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer5.s.png">
      * 
      * @param timespan
      *            the period of time each buffer collects items before it is emitted and replaced
@@ -3717,7 +3717,7 @@ public class Observable<T> {
      * The resulting Observable emits buffers that it creates when the specified {@code bufferOpenings} Observable emits an item, and closes when the Observable returned from
      * {@code bufferClosingSelector} emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer2.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer2.png">
      * 
      * @param bufferOpenings
      *            the Observable that, when it emits an item, causes a new buffer to be
@@ -3739,7 +3739,7 @@ public class Observable<T> {
      * Returns an Observable that emits non-overlapping buffered items from the source Observable
      * each time the specified boundary Observable emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer8.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer8.png">
      * <p>
      * Completion of either the source or the boundary Observable causes the returned Observable
      * to emit the latest buffer and complete.
@@ -3761,7 +3761,7 @@ public class Observable<T> {
      * Returns an Observable that emits non-overlapping buffered items from the source Observable
      * each time the specified boundary Observable emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/buffer8.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/buffer8.png">
      * <p>
      * Completion of either the source or the boundary Observable causes the returned Observable
      * to emit the latest buffer and complete.
@@ -3785,7 +3785,7 @@ public class Observable<T> {
      * This method has similar behavior to {@link #replay} except that this auto-subscribes to the
      * source Observable rather than returning a {@link ConnectableObservable}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/cache.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/cache.png">
      * <p>
      * This is useful when you want an Observable to cache responses and you can't control the
      * subscribe/unsubscribe behavior of all the {@link Observer}s.
@@ -3798,7 +3798,7 @@ public class Observable<T> {
      * 
      * @return an Observable that, when first subscribed to, caches all of its items and
      *         notifications for the benefit of subsequent observers
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#cache">RxJava Wiki: cache()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#cache">RxJava Wiki: cache()</a>
      */
     public final Observable<T> cache() {
         return create(OperationCache.cache(this));
@@ -3808,7 +3808,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by the source Observable, converted to the
      * specified type.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/cast.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/cast.png">
      * 
      * @param klass
      *            the target class type that the items emitted by the source Observable will be
@@ -3853,7 +3853,7 @@ public class Observable<T> {
      * to each item emitted by the source Observable, where that function returns an Observable, and
      * then emitting the items that result from concatinating those resulting Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/concatMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/concatMap.png">
      * 
      * @param func
      *            a function that, when applied to an item emitted by the source Observable, returns
@@ -3870,14 +3870,14 @@ public class Observable<T> {
      * Returns an Observable that emits a Boolean that indicates whether the source Observable
      * emitted a specified item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/contains.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/contains.png">
      * 
      * @param element
      *            the item to search for in the emissions from the source Observable
      * @return an Observable that emits {@code true} if the specified item is emitted by the source
      *         Observable, or {@code false} if the source Observable completes without emitting that
      *         item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#contains">RxJava Wiki: contains()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#contains">RxJava Wiki: contains()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228965.aspx">MSDN: Observable.Contains</a>
      */
     public final Observable<Boolean> contains(final T element) {
@@ -3892,11 +3892,11 @@ public class Observable<T> {
      * Returns an Observable emits the count of the total number of items emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/count.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/count.png">
      * 
      * @return an Observable that emits a single item: the number of elements emitted by the
      *         source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#count-and-longcount">RxJava Wiki: count()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#count-and-longcount">RxJava Wiki: count()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229470.aspx">MSDN: Observable.Count</a>
      * @see #longCount()
      */
@@ -3914,7 +3914,7 @@ public class Observable<T> {
      * by the source Observable that are followed by another item within a computed debounce
      * duration.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/debounce.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/debounce.f.png">
      * 
      * @param <U>
      *            the debounce value type (ignored)
@@ -3935,7 +3935,7 @@ public class Observable<T> {
      * <em>Note:</em> If items keep being emitted by the source Observable faster than the timeout
      * then no items will be emitted by the resulting Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/debounce.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/debounce.png">
      * <p>
      * Information on debounce vs throttle:
      * <p>
@@ -3967,7 +3967,7 @@ public class Observable<T> {
      * <em>Note:</em> If items keep being emitted by the source Observable faster than the timeout
      * then no items will be emitted by the resulting Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/debounce.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/debounce.s.png">
      * <p>
      * Information on debounce vs throttle:
      * <p>
@@ -3998,13 +3998,13 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by the source Observable or a specified
      * default item if the source Observable is empty.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/defaultIfEmpty.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/defaultIfEmpty.png">
      * 
      * @param defaultValue
      *            the item to emit if the source Observable emits no items
      * @return an Observable that emits either the specified default item if the source Observable
      *         emits no items, or the items emitted by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#defaultifempty">RxJava Wiki: defaultIfEmpty()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#defaultifempty">RxJava Wiki: defaultIfEmpty()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229624.aspx">MSDN: Observable.DefaultIfEmpty</a>
      */
     public final Observable<T> defaultIfEmpty(T defaultValue) {
@@ -4015,7 +4015,7 @@ public class Observable<T> {
      * Returns an Observable that delays the subscription to and emissions from the souce Observable
      * via another Observable on a per-item basis.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/delay.oo.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.oo.png">
      * <p>
      * <em>Note:</code> the resulting Observable will immediately propagate any {@code onError} notification from the source Observable.
      * 
@@ -4043,7 +4043,7 @@ public class Observable<T> {
      * Returns an Observable that delays the emissions of the source Observable via another
      * Observable on a per-item basis.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/delay.o.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.o.png">
      * <p>
      * <em>Note:</code> the resulting Observable will immediately propagate any {@code onError} notification from the source Observable.
      * 
@@ -4064,14 +4064,14 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by the source Observable shifted forward
      * in time by a specified delay. Error notifications from the source Observable are not delayed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/delay.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.png">
      * 
      * @param delay
      *            the delay to shift the source by
      * @param unit
      *            the {@link TimeUnit} in which {@code period} is defined
      * @return the source Observable shifted in time by the specified delay
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#delay">RxJava Wiki: delay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#delay">RxJava Wiki: delay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229810.aspx">MSDN: Observable.Delay</a>
      */
     public final Observable<T> delay(long delay, TimeUnit unit) {
@@ -4082,7 +4082,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by the source Observable shifted forward
      * in time by a specified delay. Error notifications from the source Observable are not delayed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/delay.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.s.png">
      * 
      * @param delay
      *            the delay to shift the source by
@@ -4091,7 +4091,7 @@ public class Observable<T> {
      * @param scheduler
      *            the {@link Scheduler} to use for delaying
      * @return the source Observable shifted in time by the specified delay
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#delay">RxJava Wiki: delay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#delay">RxJava Wiki: delay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229280.aspx">MSDN: Observable.Delay</a>
      */
     public final Observable<T> delay(long delay, TimeUnit unit, Scheduler scheduler) {
@@ -4102,7 +4102,7 @@ public class Observable<T> {
      * Return an Observable that delays the subscription to the source Observable by a given amount
      * of time.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/delaySubscription.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delaySubscription.png">
      * 
      * @param delay
      *            the time to delay the subscription
@@ -4119,7 +4119,7 @@ public class Observable<T> {
      * Return an Observable that delays the subscription to the source Observable by a given amount
      * of time, both waiting and subscribing on a given Scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/delaySubscription.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delaySubscription.s.png">
      * 
      * @param delay
      *            the time to delay the subscription
@@ -4139,12 +4139,12 @@ public class Observable<T> {
      * transforming the {@link Notification} objects emitted by the source Observable into the items
      * or notifications they represent.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/dematerialize.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/dematerialize.png">
      * 
      * @return an Observable that emits the items and notifications embedded in the {@link Notification} objects emitted by the source Observable
      * @throws Throwable
      *             if the source Observable is not of type {@code Observable<Notification<T>>}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#dematerialize">RxJava Wiki: dematerialize()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dematerialize">RxJava Wiki: dematerialize()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229047.aspx">MSDN: Observable.dematerialize</a>
      */
     @SuppressWarnings("unchecked")
@@ -4156,7 +4156,7 @@ public class Observable<T> {
      * Returns an Observable that emits all items emitted by the source Observable that are
      * distinct.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/distinct.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.png">
      * 
      * @return an Observable that emits only those items emitted by the source Observable that are
      *         distinct from each other
@@ -4171,7 +4171,7 @@ public class Observable<T> {
      * Returns an Observable that emits all items emitted by the source Observable that are distinct
      * according to a key selector function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/distinct.key.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinct.key.png">
      * 
      * @param keySelector
      *            a function that projects an emitted item to a key value that is used to decide
@@ -4189,7 +4189,7 @@ public class Observable<T> {
      * Returns an Observable that emits all items emitted by the source Observable that are distinct
      * from their immediate predecessors.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/distinctUntilChanged.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinctUntilChanged.png">
      * 
      * @return an Observable that emits those items from the source Observable that are distinct
      *         from their immediate predecessors
@@ -4204,7 +4204,7 @@ public class Observable<T> {
      * Returns an Observable that emits all items emitted by the source Observable that are distinct
      * from their immediate predecessors, according to a key selector function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/distinctUntilChanged.key.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/distinctUntilChanged.key.png">
      * 
      * @param keySelector
      *            a function that projects an emitted item to a key value that is used to decide
@@ -4221,12 +4221,12 @@ public class Observable<T> {
     /**
      * Modifies an Observable so that it invokes an action when it calls {@code onCompleted}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/doOnCompleted.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnCompleted.png">
      * 
      * @param onCompleted
      *            the action to invoke when the source Observable calls {@code onCompleted}
      * @return the source Observable with the side-effecting behavior applied
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#dooncompleted">RxJava Wiki: doOnCompleted()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooncompleted">RxJava Wiki: doOnCompleted()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
      */
     public final Observable<T> doOnCompleted(final Action0 onCompleted) {
@@ -4252,12 +4252,12 @@ public class Observable<T> {
     /**
      * Modifies an Observable so that it invokes an action for each item it emits.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/doOnEach.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnEach.png">
      * 
      * @param observer
      *            the action to invoke for each item emitted by the source Observable
      * @return the source Observable with the side-effecting behavior applied
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#dooneach">RxJava Wiki: doOnEach()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnEach()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229307.aspx">MSDN: Observable.Do</a>
      */
     public final Observable<T> doOnEach(final Action1<Notification<? super T>> onNotification) {
@@ -4285,12 +4285,12 @@ public class Observable<T> {
     /**
      * Modifies an Observable so that it notifies an Observer for each item it emits.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/doOnEach.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnEach.png">
      * 
      * @param observer
      *            the action to invoke for each item emitted by the source Observable
      * @return the source Observable with the side-effecting behavior applied
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#dooneach">RxJava Wiki: doOnEach()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnEach()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229307.aspx">MSDN: Observable.Do</a>
      */
     public final Observable<T> doOnEach(Observer<? super T> observer) {
@@ -4300,12 +4300,12 @@ public class Observable<T> {
     /**
      * Modifies an Observable so that it invokes an action if it calls {@code onError}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/doOnError.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnError.png">
      * 
      * @param onError
      *            the action to invoke if the source Observable calls {@code onError}
      * @return the source Observable with the side-effecting behavior applied
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#doonerror">RxJava Wiki: doOnError()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#doonerror">RxJava Wiki: doOnError()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
      */
     public final Observable<T> doOnError(final Action1<Throwable> onError) {
@@ -4331,12 +4331,12 @@ public class Observable<T> {
     /**
      * Modifies an Observable so that it invokes an action when it calls {@code onNext}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/doOnNext.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/doOnNext.png">
      * 
      * @param onNext
      *            the action to invoke when the source Observable calls {@code onNext}
      * @return the source Observable with the side-effecting behavior applied
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#dooneach">RxJava Wiki: doOnNext()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#dooneach">RxJava Wiki: doOnNext()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
      */
     public final Observable<T> doOnNext(final Action1<? super T> onNext) {
@@ -4363,7 +4363,7 @@ public class Observable<T> {
      * Returns an Observable that emits the single item at a specified index in a sequence of
      * emissions from a source Observbable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/elementAt.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/elementAt.png">
      * 
      * @param index
      *            the zero-based index of the item to retrieve
@@ -4384,7 +4384,7 @@ public class Observable<T> {
      * Returns an Observable that emits the item found at a specified index in a sequence of
      * emissions from a source Observable, or a default item if that index is out of range.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/elementAtOrDefault.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/elementAtOrDefault.png">
      * 
      * @param index
      *            the zero-based index of the item to retrieve
@@ -4405,7 +4405,7 @@ public class Observable<T> {
      * Returns an Observable that emits {@code true} if any item emitted by the source Observable
      * satisfies a specified condition, otherwise {@code false}. <em>Note:</em> this always emits {@code false} if the source Observable is empty.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/exists.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/exists.png">
      * <p>
      * In Rx.Net this is the {@code any} Observer but we renamed it in RxJava to better match Java
      * naming idioms.
@@ -4414,7 +4414,7 @@ public class Observable<T> {
      *            the condition to test items emitted by the source Observable
      * @return an Observable that emits a Boolean that indicates whether any item emitted by the
      *         source Observable satisfies the {@code predicate}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#exists-and-isempty">RxJava Wiki: exists()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#exists-and-isempty">RxJava Wiki: exists()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211993.aspx" >MSDN: Observable.Any</a> Note: the description in this page was wrong at the time of this writing.
      */
     public final Observable<Boolean> exists(Func1<? super T, Boolean> predicate) {
@@ -4424,7 +4424,7 @@ public class Observable<T> {
     /**
      * Filter items emitted by an Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/filter.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/filter.png">
      * 
      * @param predicate
      *            a function that evaluates the items emitted by the source Observable, returning {@code true} if they pass the filter
@@ -4439,12 +4439,12 @@ public class Observable<T> {
     /**
      * Registers an {@link Action0} to be called when this Observable invokes either {@link Observer#onCompleted onCompleted} or {@link Observer#onError onError}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/finallyDo.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/finallyDo.png">
      * 
      * @param action
      *            an {@link Action0} to be invoked when the source Observable finishes
      * @return an Observable that emits the same items as the source Observable, then invokes the {@link Action0}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#finallydo">RxJava Wiki: finallyDo()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#finallydo">RxJava Wiki: finallyDo()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212133.aspx">MSDN: Observable.Finally</a>
      */
     public final Observable<T> finallyDo(Action0 action) {
@@ -4455,7 +4455,7 @@ public class Observable<T> {
      * Returns an Observable that emits only the very first item emitted by the source Observable,
      * or raises an {@code IllegalArgumentException} if the source Observable is empty.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/first.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/first.png">
      * 
      * @return an Observable that emits only the very first item emitted by the source Observable,
      *         or raises an {@code IllegalArgumentException} if the source Observable is empty
@@ -4471,7 +4471,7 @@ public class Observable<T> {
      * that satisfies a specified condition, or raises an {@code IllegalArgumentException} if no
      * such items are emitted.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/firstN.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/firstN.png">
      * 
      * @param predicate
      *            the condition that an item emitted by the source Observable has to satisfy
@@ -4488,7 +4488,7 @@ public class Observable<T> {
      * Returns an Observable that emits only the very first item emitted by the source Observable,
      * or a default item if the source Observable completes without emitting anything.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/firstOrDefault.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/firstOrDefault.png">
      * 
      * @param defaultValue
      *            the default item to emit if the source Observable doesn't emit anything
@@ -4506,7 +4506,7 @@ public class Observable<T> {
      * that satisfies a specified condition, or a default item if the source Observable emits no
      * such items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/firstOrDefaultN.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/firstOrDefaultN.png">
      * 
      * @param predicate
      *            the condition any item emitted by the source Observable has to satisfy
@@ -4528,7 +4528,7 @@ public class Observable<T> {
      * item emitted by the source Observable, where that function returns an Observable, and then
      * merging those resulting Observables and emitting the results of this merger.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/flatMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/flatMap.png">
      * <p>
      * <em>Note:</em> {@code mapMany} and {@code flatMap} are equivalent.
      * 
@@ -4549,7 +4549,7 @@ public class Observable<T> {
      * Groups the items emitted by an Observable according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s, one {@code GroupedObservable} per group.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/groupBy.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupBy.png">
      * 
      * @param keySelector
      *            a function that extracts the key for each item
@@ -4568,7 +4568,7 @@ public class Observable<T> {
      * Groups the items emitted by an Observable according to a specified criterion, and emits these
      * grouped items, transformed by a selector, within {@link GroupedObservable}s, one {@code GroupedObservable} per group.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/groupBy.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupBy.png">
      * 
      * @param keySelector
      *            a function that extracts the key from an item
@@ -4591,7 +4591,7 @@ public class Observable<T> {
      * Groups the items emitted by an Observable according to a specified key selector function
      * until the duration Observable expires for the key.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/groupByUntil.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupByUntil.png">
      * 
      * @param keySelector
      *            a function to extract the key for each item
@@ -4611,7 +4611,7 @@ public class Observable<T> {
      * Groups the items emitted by an Observable (transformed by a selector) according to a
      * specified key selector function until the duration Observable expires for the key.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/groupByUntil.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupByUntil.png">
      * 
      * @param keySelector
      *            a function to extract the key for each item
@@ -4634,7 +4634,7 @@ public class Observable<T> {
      * Return an Observable that correlates two Observables when they overlap in time and groups the
      * results.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/groupJoin.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupJoin.png">
      * 
      * @param right
      *            the other Observable to correlate items from the source Observable with
@@ -4661,7 +4661,7 @@ public class Observable<T> {
     /**
      * Ignores all items emitted by the source Observable and only calls {@code onCompleted} or {@code onError}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/ignoreElements.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/ignoreElements.png">
      * 
      * @return an empty Observable that only calls {@code onCompleted} or {@code onError}, based on
      *         which one is called by the source Observable
@@ -4678,10 +4678,10 @@ public class Observable<T> {
      * In Rx.Net this is negated as the {@code any} Observer but we renamed this in RxJava to better
      * match Java naming idioms.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/isEmpty.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/isEmpty.png">
      * 
      * @return an Observable that emits a Boolean
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#exists-and-isempty">RxJava Wiki: isEmpty()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#exists-and-isempty">RxJava Wiki: isEmpty()</a>
      * @see <a href= "http://msdn.microsoft.com/en-us/library/hh229905.aspx">MSDN: Observable.Any</a>
      */
     public final Observable<Boolean> isEmpty() {
@@ -4691,7 +4691,7 @@ public class Observable<T> {
     /**
      * Correlates the items emitted by two Observables based on overlapping durations.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/join_.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/join_.png">
      * 
      * @param right
      *            the second Observable to join items from
@@ -4718,11 +4718,11 @@ public class Observable<T> {
      * Returns an Observable that emits the last item emitted by the source Observable or notifies
      * observers of an {@code IllegalArgumentException} if the source Observable is empty.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/last.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/last.png">
      * 
      * @return an Observable that emits the last item from the source Observable or notifies
      *         observers of an error
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observable-Observers#last">RxJava Wiki: last()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observable-Operators#last">RxJava Wiki: last()</a>
      * @see MSDN: {@code Observable.lastAsync()}
      */
     public final Observable<T> last() {
@@ -4734,7 +4734,7 @@ public class Observable<T> {
      * satisfies a given condition, or an {@code IllegalArgumentException} if no such items are
      * emitted.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/last.p.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/last.p.png">
      * 
      * @param predicate
      *            the condition any source emitted item has to satisfy
@@ -4742,7 +4742,7 @@ public class Observable<T> {
      *         source, or an {@code IllegalArgumentException} if no such items are emitted
      * @throws IllegalArgumentException
      *             if no items that match the predicate are emitted by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observable-Observers#last">RxJava Wiki: last()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Filtering-Observable-Operators#last">RxJava Wiki: last()</a>
      * @see MSDN: {@code Observable.lastAsync()}
      */
     public final Observable<T> last(Func1<? super T, Boolean> predicate) {
@@ -4753,7 +4753,7 @@ public class Observable<T> {
      * Returns an Observable that emits only the last item emitted by the source Observable, or a
      * default item if the source Observable completes without emitting any items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/lastOrDefault.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/lastOrDefault.png">
      * 
      * @param defaultValue
      *            the default item to emit if the source Observable is empty
@@ -4771,7 +4771,7 @@ public class Observable<T> {
      * satisfies a specified condition, or a default item if no such item is emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/lastOrDefault.p.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/lastOrDefault.p.png">
      * 
      * @param defaultValue
      *            the default item to emit if the source Observable doesn't emit anything that
@@ -4792,11 +4792,11 @@ public class Observable<T> {
      * Returns an Observable that counts the total number of items emitted by the source Observable
      * and emits this count as a 64-bit Long.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/longCount.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/longCount.png">
      * 
      * @return an Observable that emits a single item: the number of items emitted by the source
      *         Observable as a 64-bit Long item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#count-and-longcount">RxJava Wiki: count()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#count-and-longcount">RxJava Wiki: count()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229120.aspx">MSDN: Observable.LongCount</a>
      * @see #count()
      */
@@ -4813,7 +4813,7 @@ public class Observable<T> {
      * Returns an Observable that applies a specified function to each item emitted by the source
      * Observable and emits the results of these function applications.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/map.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/map.png">
      * 
      * @param func
      *            a function to apply to each item emitted by the Observable
@@ -4831,7 +4831,7 @@ public class Observable<T> {
      * source Observable, where that function returns an Observable, and then merging those
      * resulting Observables and emitting the results of this merger.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mapMany.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mapMany.png">
      * <p>
      * <em>Note:</em> {@code mapMany} and {@code flatMap} are equivalent.
      * 
@@ -4854,11 +4854,11 @@ public class Observable<T> {
      * Turns all of the emissions and notifications from a source Observable into emissions marked
      * with their original types within {@link Notification} objects.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/materialize.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/materialize.png">
      * 
      * @return an Observable that emits items that are the result of materializing the items and
      *         notifications of the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#materialize">RxJava Wiki: materialize()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#materialize">RxJava Wiki: materialize()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229453.aspx">MSDN: Observable.materialize</a>
      */
     public final Observable<Notification<T>> materialize() {
@@ -4870,7 +4870,7 @@ public class Observable<T> {
      * to the specified comparator. If there is more than one item with the same maximum value, it
      * emits the last-emitted of these.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/max.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/max.png">
      * 
      * @param comparator
      *            the comparer used to compare items
@@ -4878,7 +4878,7 @@ public class Observable<T> {
      *         to the specified comparator
      * @throws IllegalArgumentException
      *             if the source is empty
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#max">RxJava Wiki: max()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#max">RxJava Wiki: max()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211635.aspx">MSDN: Observable.Max</a>
      */
     public final Observable<T> max(Comparator<? super T> comparator) {
@@ -4890,13 +4890,13 @@ public class Observable<T> {
      * the maximum key value. For a source Observable that emits no items, the resulting Observable
      * emits an empty List.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/maxBy.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/maxBy.png">
      * 
      * @param selector
      *            this function accepts an item emitted by the source Observable and returns a key
      * @return an Observable that emits a List of those items emitted by the source Observable that
      *         had the largest key value of all of the emitted items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#maxby">RxJava Wiki: maxBy()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#maxby">RxJava Wiki: maxBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229058.aspx">MSDN: Observable.MaxBy</a>
      */
     public final <R extends Comparable<? super R>> Observable<List<T>> maxBy(Func1<T, R> selector) {
@@ -4908,7 +4908,7 @@ public class Observable<T> {
      * the maximum key value according to a specified comparator. For a source Observable that emits
      * no items, the resulting Observable emits an empty List.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/maxBy.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/maxBy.png">
      * 
      * @param selector
      *            this function accepts an item emitted by the source Observable and returns a key
@@ -4917,7 +4917,7 @@ public class Observable<T> {
      * @return an Observable that emits a List of those items emitted by the source Observable that
      *         had the largest key value of all of the emitted items according to the specified
      *         comparator
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#maxby">RxJava Wiki: maxBy()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#maxby">RxJava Wiki: maxBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh244330.aspx">MSDN: Observable.MaxBy</a>
      */
     public final <R> Observable<List<T>> maxBy(Func1<T, R> selector, Comparator<? super R> comparator) {
@@ -4929,7 +4929,7 @@ public class Observable<T> {
      * emitted by the source Observable, where that function returns an Observable, and then merging
      * those resulting Observables and emitting the results of this merger.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeMap.png">
      * 
      * @param func
      *            a function that, when applied to an item emitted by the source Observable, returns
@@ -4949,7 +4949,7 @@ public class Observable<T> {
      * the source Observable and then flattens the Observables returned from these functions and
      * emits the resulting items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeMap.nce.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeMap.nce.png">
      * 
      * @param <R>
      *            the result type
@@ -4977,7 +4977,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of a specified function to the pair of values
      * emitted by the source Observable and a specified collection Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeMap.r.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeMap.r.png">
      * 
      * @param <U>
      *            the type of items emitted by the collection Observable
@@ -5001,7 +5001,7 @@ public class Observable<T> {
      * Returns an Observable that merges each item emitted by the source Observable with the values
      * in an Iterable corresponding to that item that is generated by a selector.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeMapIterable.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeMapIterable.png">
      * 
      * @param <R>
      *            the type of item emitted by the resulting Observable
@@ -5021,7 +5021,7 @@ public class Observable<T> {
      * from the source Observable and an Iterable corresponding to that item that is generated by
      * a selector.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/mergeMapIterable.r.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/mergeMapIterable.r.png">
      * 
      * @param <U>
      *            the collection element type
@@ -5046,7 +5046,7 @@ public class Observable<T> {
      * to a specified comparator. If there is more than one such item, it returns the last-emitted
      * one.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/min.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/min.png">
      * 
      * @param comparator
      *            the comparer used to compare elements
@@ -5054,7 +5054,7 @@ public class Observable<T> {
      *         to the specified comparator
      * @throws IllegalArgumentException
      *             if the source is empty
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#min">RxJava Wiki: min()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#min">RxJava Wiki: min()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229095.aspx">MSDN: Observable.Min</a>
      */
     public final Observable<T> min(Comparator<? super T> comparator) {
@@ -5066,13 +5066,13 @@ public class Observable<T> {
      * the minimum key value. For a source Observable that emits no items, the resulting Observable
      * emits an empty List.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/minBy.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/minBy.png">
      * 
      * @param selector
      *            the key selector function
      * @return an Observable that emits a List of all of the items from the source Observable that
      *         had the lowest key value of any items emitted by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#minby">RxJava Wiki: minBy()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#minby">RxJava Wiki: minBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228970.aspx">MSDN: Observable.MinBy</a>
      */
     public final <R extends Comparable<? super R>> Observable<List<T>> minBy(Func1<T, R> selector) {
@@ -5084,7 +5084,7 @@ public class Observable<T> {
      * the minimum key value according to a given comparator function. For a source Observable that
      * emits no items, the resulting Observable emits an empty List.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/minBy.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/minBy.png">
      * 
      * @param selector
      *            the key selector function
@@ -5093,7 +5093,7 @@ public class Observable<T> {
      * @return an Observable that emits a List of all of the items from the source Observable that
      *         had the lowest key value of any items emitted by the source Observable according to
      *         the specified comparator
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#minby">RxJava Wiki: minBy()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#minby">RxJava Wiki: minBy()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228970.aspx">MSDN: Observable.MinBy</a>
      */
     public final <R> Observable<List<T>> minBy(Func1<T, R> selector, Comparator<? super R> comparator) {
@@ -5111,7 +5111,7 @@ public class Observable<T> {
      *            the policies enforced by the created {@code Subject}
      * @return an Observable that emits the items produced by multicasting the source Observable
      *         within a selector function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablepublish-and-observablemulticast">RxJava: Observable.publish() and Observable.multicast()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablepublish-and-observablemulticast">RxJava: Observable.publish() and Observable.multicast()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229708.aspx">MSDN: Observable.Multicast</a>
      */
     public final <TIntermediate, TResult> Observable<TResult> multicast(
@@ -5131,7 +5131,7 @@ public class Observable<T> {
      *            the type of items emitted by the resulting {@code ConnectableObservable}
      * @return a {@link ConnectableObservable} that upon connection causes the source Observable to
      *         push results into the specified {@link Subject}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablepublish-and-observablemulticast">RxJava Wiki: Observable.publish() and Observable.multicast()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablepublish-and-observablemulticast">RxJava Wiki: Observable.publish() and Observable.multicast()</a>
      */
     public final <R> ConnectableObservable<R> multicast(Subject<? super T, ? extends R> subject) {
         return OperationMulticast.multicast(this, subject);
@@ -5141,13 +5141,13 @@ public class Observable<T> {
      * Modify the source Observable so that it asynchronously notifies {@link Observer}s on the
      * specified {@link Scheduler}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/observeOn.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/observeOn.png">
      * 
      * @param scheduler
      *            the {@link Scheduler} to notify {@link Observer}s on
      * @return the source Observable modified so that its {@link Observer}s are notified on the
      *         specified {@link Scheduler}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#observeon">RxJava Wiki: observeOn()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#observeon">RxJava Wiki: observeOn()</a>
      */
     public final Observable<T> observeOn(Scheduler scheduler) {
         return create(OperationObserveOn.observeOn(this, scheduler));
@@ -5156,7 +5156,7 @@ public class Observable<T> {
     /**
      * Filters the items emitted by an Observable, only emitting those of the specified type.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/ofClass.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/ofClass.png">
      * 
      * @param klass
      *            the class type to filter the items emitted by the source Observable
@@ -5175,7 +5175,7 @@ public class Observable<T> {
     /**
      * Instruct an Observable to pass control to another Observable rather than invoking {@link Observer#onError onError} if it encounters an error.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/onErrorResumeNext.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/onErrorResumeNext.png">
      * <p>
      * By default, when an Observable encounters an error that prevents it from emitting the
      * expected item to its {@link Observer}, the Observable invokes its Observer's {@code onError} method, and then quits without invoking any more of its Observer's methods. The
@@ -5194,7 +5194,7 @@ public class Observable<T> {
      *            a function that returns an Observable that will take over if the source Observable
      *            encounters an error
      * @return the original Observable, with appropriately modified behavior
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Observers#onerrorresumenext">RxJava Wiki: onErrorResumeNext()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#onerrorresumenext">RxJava Wiki: onErrorResumeNext()</a>
      */
     public final Observable<T> onErrorResumeNext(final Func1<Throwable, ? extends Observable<? extends T>> resumeFunction) {
         return create(OperationOnErrorResumeNextViaFunction.onErrorResumeNextViaFunction(this, resumeFunction));
@@ -5203,7 +5203,7 @@ public class Observable<T> {
     /**
      * Instruct an Observable to pass control to another Observable rather than invoking {@link Observer#onError onError} if it encounters an error.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/onErrorResumeNext.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/onErrorResumeNext.png">
      * <p>
      * By default, when an Observable encounters an error that prevents it from emitting the
      * expected item to its {@link Observer}, the Observable invokes its Observer's {@code onError} method, and then quits without invoking any more of its Observer's methods. The
@@ -5221,7 +5221,7 @@ public class Observable<T> {
      *            a function that returns an Observable that will take over if the source Observable
      *            encounters an error
      * @return the original Observable, with appropriately modified behavior
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Observers#onerrorresumenext">RxJava Wiki: onErrorResumeNext()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#onerrorresumenext">RxJava Wiki: onErrorResumeNext()</a>
      */
     public final Observable<T> onErrorResumeNext(final Observable<? extends T> resumeSequence) {
         return create(OperationOnErrorResumeNextViaObservable.onErrorResumeNextViaObservable(this, resumeSequence));
@@ -5231,7 +5231,7 @@ public class Observable<T> {
      * Instruct an Observable to emit an item (returned by a specified function) rather than
      * invoking {@link Observer#onError onError} if it encounters an error.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/onErrorReturn.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/onErrorReturn.png">
      * <p>
      * By default, when an Observable encounters an error that prevents it from emitting the
      * expected item to its {@link Observer}, the Observable invokes its Observer's {@code onError} method, and then quits without invoking any more of its Observer's methods. The
@@ -5247,7 +5247,7 @@ public class Observable<T> {
      *            a function that returns an item that the new Observable will emit if the source
      *            Observable encounters an error
      * @return the original Observable with appropriately modified behavior
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Observers#onerrorreturn">RxJava Wiki: onErrorReturn()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#onerrorreturn">RxJava Wiki: onErrorReturn()</a>
      */
     public final Observable<T> onErrorReturn(Func1<Throwable, ? extends T> resumeFunction) {
         return create(OperationOnErrorReturn.onErrorReturn(this, resumeFunction));
@@ -5258,7 +5258,7 @@ public class Observable<T> {
      * <p>
      * This differs from {@link #onErrorResumeNext} in that this one does not handle {@link java.lang.Throwable} or {@link java.lang.Error} but lets those continue through.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/onExceptionResumeNextViaObservable.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/onExceptionResumeNextViaObservable.png">
      * <p>
      * By default, when an Observable encounters an exception that prevents it from emitting the
      * expected item to its {@link Observer}, the Observable invokes its Observer's {@code onError} method, and then quits without invoking any more of its Observer's methods. The
@@ -5276,7 +5276,7 @@ public class Observable<T> {
      *            a function that returns an Observable that will take over if the source Observable
      *            encounters an exception
      * @return the original Observable, with appropriately modified behavior
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Observers#onexceptionresumenext">RxJava Wiki: onExceptionResumeNext()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#onexceptionresumenext">RxJava Wiki: onExceptionResumeNext()</a>
      */
     public final Observable<T> onExceptionResumeNext(final Observable<? extends T> resumeSequence) {
         return create(OperationOnExceptionResumeNextViaObservable.onExceptionResumeNextViaObservable(this, resumeSequence));
@@ -5285,14 +5285,14 @@ public class Observable<T> {
     /**
      * Perform work on the source {@code Observable<T>} in parallel by sharding it on a {@link Schedulers#threadPoolForComputation()} {@link Scheduler}, and return the resulting {@code Observable<R>}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/parallel.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/parallel.png">
      * 
      * @param f
      *            a {@link Func1} that applies Observable Observers to {@code Observable<T>} in
      *            parallel and returns an {@code Observable<R>}
      * @return an Observable that emits the results of applying {@link Func1} to the items emitted
      *         by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#parallel">RxJava Wiki: parallel()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#parallel">RxJava Wiki: parallel()</a>
      */
     public final <R> Observable<R> parallel(Func1<Observable<T>, Observable<R>> f) {
         return lift(new OperatorParallel<T, R>(f, Schedulers.computation()));
@@ -5301,7 +5301,7 @@ public class Observable<T> {
     /**
      * Perform work on the source {@code Observable<T>} in parallel by sharding it on a {@link Scheduler}, and return the resulting {@code Observable<R>}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/parallel.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/parallel.png">
      * 
      * @param f
      *            a {@link Func1} that applies Observable Observers to {@code Observable<T>} in
@@ -5310,7 +5310,7 @@ public class Observable<T> {
      *            a {@link Scheduler} to perform the work on
      * @return an Observable that emits the results of applying {@link Func1} to the items emitted
      *         by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#parallel">RxJava Wiki: parallel()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#parallel">RxJava Wiki: parallel()</a>
      */
     public final <R> Observable<R> parallel(final Func1<Observable<T>, Observable<R>> f, final Scheduler s) {
         return lift(new OperatorParallel<T, R>(f, s));
@@ -5331,11 +5331,11 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable}, which waits until its {@link ConnectableObservable#connect connect} method is called before it begins emitting
      * items to those {@link Observer}s that have subscribed to it.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/publishConnect.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishConnect.png">
      * 
      * @return a {@link ConnectableObservable} that upon connection causes the source Observable to
      *         emit items to its {@link Observer}s
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablepublish-and-observablemulticast">RxJava Wiki: publish()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablepublish-and-observablemulticast">RxJava Wiki: publish()</a>
      */
     public final ConnectableObservable<T> publish() {
         return OperationMulticast.multicast(this, PublishSubject.<T> create());
@@ -5346,7 +5346,7 @@ public class Observable<T> {
      * emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying sequence.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/publishConnect.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishConnect.f.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5374,7 +5374,7 @@ public class Observable<T> {
      * underlying Observable that shares a single subscription to the underlying sequence and starts
      * with {@code initialValue}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/publishConnect.if.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishConnect.if.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5402,7 +5402,7 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the underlying
      * Observable and starts with {@code initialValue}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/publishConnect.i.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishConnect.i.png">
      * 
      * @param initialValue
      *            the initial value of the underlying {@link BehaviorSubject}
@@ -5417,11 +5417,11 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that emits only the last item emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/publishLast.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishLast.png">
      * 
      * @return a {@link ConnectableObservable} that emits only the last item emitted by the source
      *         Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablepublishlast">RxJava Wiki: publishLast()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablepublishlast">RxJava Wiki: publishLast()</a>
      */
     public final ConnectableObservable<T> publishLast() {
         return OperationMulticast.multicast(this, AsyncSubject.<T> create());
@@ -5432,7 +5432,7 @@ public class Observable<T> {
      * items emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying sequence but contains only its last emission.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/publishLast.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/publishLast.f.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5459,7 +5459,7 @@ public class Observable<T> {
      * emitted by the source Observable, and emits the final result from the final call to your
      * function as its sole item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/reduce.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/reduce.png">
      * <p>
      * This technique, which is called "reduce" here, is sometimes called "aggregate," "fold,"
      * "accumulate," "compress," or "inject" in other programming contexts. Groovy, for instance,
@@ -5472,7 +5472,7 @@ public class Observable<T> {
      *         emitted by the source Observable
      * @throws IllegalArgumentException
      *             if the source Observable emits no items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#reduce">RxJava Wiki: reduce()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#reduce">RxJava Wiki: reduce()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229154.aspx">MSDN: Observable.Aggregate</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
      */
@@ -5494,7 +5494,7 @@ public class Observable<T> {
      * items have been emitted by the source Observable, emitting the final result from the final
      * call to your function as its sole item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/reduceSeed.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/reduceSeed.png">
      * <p>
      * This technique, which is called "reduce" here, is sometimec called "aggregate," "fold,"
      * "accumulate," "compress," or "inject" in other programming contexts. Groovy, for instance,
@@ -5507,7 +5507,7 @@ public class Observable<T> {
      *            Observable, the result of which will be used in the next accumulator call
      * @return an Observable that emits a single item that is the result of accumulating the output
      *         from the items emitted by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#reduce">RxJava Wiki: reduce()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#reduce">RxJava Wiki: reduce()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229154.aspx">MSDN: Observable.Aggregate</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
      */
@@ -5519,7 +5519,7 @@ public class Observable<T> {
      * Returns an Observable that repeats the sequence of items emitted by the source Observable
      * indefinitely.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/repeat.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/repeat.png">
      * 
      * @return an Observable that emits the items emitted by the source Observable repeatedly and in
      *         sequence
@@ -5534,7 +5534,7 @@ public class Observable<T> {
      * Returns an Observable that repeats the sequence of items emitted by the source Observable
      * indefinitely, on a particular scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/repeat.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/repeat.s.png">
      * 
      * @param scheduler
      *            the scheduler to emit the items on
@@ -5551,11 +5551,11 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the underlying
      * Observable that will replay all of its items and notifications to any future {@link Observer}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.png">
      * 
      * @return a {@link ConnectableObservable} that upon connection causes the source Observable to
      *         emit its items to its {@link Observer}s
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      */
     public final ConnectableObservable<T> replay() {
         return OperationMulticast.multicast(this, ReplaySubject.<T> create());
@@ -5566,7 +5566,7 @@ public class Observable<T> {
      * on the items emitted by a {@link ConnectableObservable} that shares a single subscription to
      * the underlying Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.f.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5575,7 +5575,7 @@ public class Observable<T> {
      *            needed, without causing multiple subscriptions to the Observable
      * @return an Observable that emits items that are the results of invoking the selector on a {@link ConnectableObservable} that shares a single subscription to the underlying
      *         Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229653.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector) {
@@ -5592,7 +5592,7 @@ public class Observable<T> {
      * on items emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying Observable, replaying {@code bufferSize} notifications.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.fn.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fn.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5605,7 +5605,7 @@ public class Observable<T> {
      * @return an Observable that emits items that are the results of invoking the selector on
      *         items emitted by a {@link ConnectableObservable} that shares a single subscription to
      *         the underlying Observable replaying no more than {@code bufferSize} items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211675.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize) {
@@ -5623,7 +5623,7 @@ public class Observable<T> {
      * underlying Observable, replaying no more than {@code bufferSize} items that were emitted
      * within a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.fnt.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fnt.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5641,7 +5641,7 @@ public class Observable<T> {
      *         emitted by a {@link ConnectableObservable} that shares a single subscription to the
      *         underlying Observable, and replay no more than {@code bufferSize} items that were
      *         emitted within the window defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228952.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, int bufferSize, long time, TimeUnit unit) {
@@ -5654,7 +5654,7 @@ public class Observable<T> {
      * underlying Observable, replaying no more than {@code bufferSize} items that were emitted
      * within a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.fnts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fnts.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5674,7 +5674,7 @@ public class Observable<T> {
      *         emitted by a {@link ConnectableObservable} that shares a single subscription to the
      *         underlying Observable, and replay no more than {@code bufferSize} items that were
      *         emitted within the window defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229404.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
@@ -5694,7 +5694,7 @@ public class Observable<T> {
      * on items emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying Observable, replaying a maximum of {@code bufferSize} items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.fns.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fns.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5709,7 +5709,7 @@ public class Observable<T> {
      * @return an Observable that emits items that are the results of invoking the selector on items
      *         emitted by a {@link ConnectableObservable} that shares a single subscription to the
      *         underlying Observable, replaying no more than {@code bufferSize} notifications
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229928.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize, final Scheduler scheduler) {
@@ -5726,7 +5726,7 @@ public class Observable<T> {
      * on items emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying Observable, replaying all items that were emitted within a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.ft.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.ft.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5741,7 +5741,7 @@ public class Observable<T> {
      *         emitted by a {@link ConnectableObservable} that shares a single subscription to the
      *         underlying Observable, replaying all items that were emitted within the window
      *         defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229526.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, long time, TimeUnit unit) {
@@ -5753,7 +5753,7 @@ public class Observable<T> {
      * on items emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying Observable, replaying all items that were emitted within a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.fts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fts.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5770,7 +5770,7 @@ public class Observable<T> {
      *         emitted by a {@link ConnectableObservable} that shares a single subscription to the
      *         underlying Observable, replaying all items that were emitted within the window
      *         defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh244327.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
@@ -5787,7 +5787,7 @@ public class Observable<T> {
      * on items emitted by a {@link ConnectableObservable} that shares a single subscription to the
      * underlying Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.fs.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fs.png">
      * 
      * @param <R>
      *            the type of items emitted by the resulting Observable
@@ -5799,7 +5799,7 @@ public class Observable<T> {
      * @return an Observable that emits items that are the results of invoking the selector on items
      *         emitted by a {@link ConnectableObservable} that shares a single subscription to the
      *         underlying Observable, replaying all items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211644.aspx">MSDN: Observable.Replay</a>
      */
     public final <R> Observable<R> replay(Func1<? super Observable<T>, ? extends Observable<R>> selector, final Scheduler scheduler) {
@@ -5815,13 +5815,13 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the source
      * Observable that replays at most {@code bufferSize} items emitted by that Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.n.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.n.png">
      * 
      * @param bufferSize
      *            the buffer size that limits the number of items that can be replayed
      * @return a {@link ConnectableObservable} that shares a single subscription to the source
      *         Observable and replays at most {@code bufferSize} items emitted by that Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211976.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(int bufferSize) {
@@ -5833,7 +5833,7 @@ public class Observable<T> {
      * Observable and replays at most {@code bufferSize} items that were emitted during a specified
      * time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.nt.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.nt.png">
      * 
      * @param bufferSize
      *            the buffer size that limits the number of items that can be replayed
@@ -5844,7 +5844,7 @@ public class Observable<T> {
      * @return a {@link ConnectableObservable} that shares a single subscription to the underlying
      *         Observable and replays at most {@code bufferSize} items that were emitted during the
      *         window defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229874.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(int bufferSize, long time, TimeUnit unit) {
@@ -5856,7 +5856,7 @@ public class Observable<T> {
      * Observable and that replays a maximum of {@code bufferSize} items that are emitted within
      * a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.nts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.nts.png">
      * 
      * @param bufferSize
      *            the buffer size that limits the number of items that can be replayed
@@ -5869,7 +5869,7 @@ public class Observable<T> {
      * @return a {@link ConnectableObservable} that shares a single subscription to the underlying
      *         Observable and replays at most {@code bufferSize} items that were emitted during the
      *         window defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211759.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(int bufferSize, long time, TimeUnit unit, Scheduler scheduler) {
@@ -5883,7 +5883,7 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the source
      * Observable and replays at most {@code bufferSize} items emitted by that Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.ns.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.ns.png">
      * 
      * @param bufferSize
      *            the buffer size that limits the number of items that can be replayed
@@ -5892,7 +5892,7 @@ public class Observable<T> {
      * @return a {@link ConnectableObservable} that shares a single subscription to the underlying
      *         Observable and replays at most {@code bufferSize} items that were emitted by the
      *         Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229814.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(int bufferSize, Scheduler scheduler) {
@@ -5905,7 +5905,7 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the source
      * Observable and replays all items emitted by that Observable within a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.t.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.t.png">
      * 
      * @param time
      *            the duration of the window in which the replayed items must have been emitted
@@ -5913,7 +5913,7 @@ public class Observable<T> {
      *            the time unit of {@code time}
      * @return a {@link ConnectableObservable} that shares a single subscription to the underlying
      *         Observable and replays the items that were emitted during the window defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229232.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(long time, TimeUnit unit) {
@@ -5924,7 +5924,7 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the source
      * Observable and replays all items emitted by that Observable within a specified time window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.ts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.ts.png">
      * 
      * @param time
      *            the duration of the window in which the replayed items must have been emitted
@@ -5934,7 +5934,7 @@ public class Observable<T> {
      *            the scheduler that is the time source for the window
      * @return a {@link ConnectableObservable} that shares a single subscription to the underlying
      *         Observable and replays the items that were emitted during the window defined by {@code time}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211811.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(long time, TimeUnit unit, Scheduler scheduler) {
@@ -5945,13 +5945,13 @@ public class Observable<T> {
      * Returns a {@link ConnectableObservable} that shares a single subscription to the underlying
      * Observable that will replay all of its items and notifications to any future {@link Observer} on the given {@link Scheduler}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/replay.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.s.png">
      * 
      * @param scheduler
      *            the scheduler on which the Observers will observe the emitted items
      * @return a {@link ConnectableObservable} that shares a single subscription to the source
      *         Observable that will replay all of its items and notifications to any future {@link Observer} on the given {@link Scheduler}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Observers#observablereplay">RxJava Wiki: replay()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava Wiki: replay()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211699.aspx">MSDN: Observable.Replay</a>
      */
     public final ConnectableObservable<T> replay(Scheduler scheduler) {
@@ -5961,7 +5961,7 @@ public class Observable<T> {
     /**
      * Return an Observable that mirrors the source Observable, resubscribing to it if it calls {@code onError} (infinite retry count).
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/retry.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/retry.png">
      * <p>
      * If the source Observable calls {@link Observer#onError}, this method will resubscribe to the
      * source Observable.
@@ -5972,7 +5972,7 @@ public class Observable<T> {
      * {@code [1, 2, 1, 2, 3, 4, 5, onCompleted]}.
      * 
      * @return the source Observable modified with retry logic
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Observers#retry">RxJava Wiki: retry()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#retry">RxJava Wiki: retry()</a>
      */
     public final Observable<T> retry() {
         return create(OperationRetry.retry(this));
@@ -5981,7 +5981,7 @@ public class Observable<T> {
     /**
      * Return an Observable that mirrors the source Observable, resubscribing to it if it calls {@code onError} up to a certain number of retries.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/retry.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/retry.png">
      * <p>
      * If the source Observable calls {@link Observer#onError}, this method will resubscribe to the
      * source Observable for a maximum of {@code retryCount} resubscriptions.
@@ -5994,7 +5994,7 @@ public class Observable<T> {
      * @param retryCount
      *            number of retry attempts before failing
      * @return the source Observable modified with retry logic
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Observers#retry">RxJava Wiki: retry()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#retry">RxJava Wiki: retry()</a>
      */
     public final Observable<T> retry(int retryCount) {
         return create(OperationRetry.retry(this, retryCount));
@@ -6004,7 +6004,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of sampling the items emitted by the source
      * Observable at a specified time interval.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sample.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sample.png">
      * 
      * @param period
      *            the sampling rate
@@ -6022,7 +6022,7 @@ public class Observable<T> {
      * Returns an Observable that emits the results of sampling the items emitted by the source
      * Observable at a specified time interval.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sample.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sample.s.png">
      * 
      * @param period
      *            the sampling rate
@@ -6042,7 +6042,7 @@ public class Observable<T> {
      * Return an Observable that emits the results of sampling the items emitted by the source
      * Observable whenever the specified {@code sampler} Observable emits an item or completes.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sample.o.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sample.o.png">
      * 
      * @param sampler
      *            the Observable to use for sampling the source Observable
@@ -6060,7 +6060,7 @@ public class Observable<T> {
      * by the source Observable into the same function, and so on until all items have been emitted
      * by the source Observable, emitting the result of each of these iterations.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/scan.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/scan.png">
      * <p>
      * This sort of function is sometimes called an accumulator.
      * 
@@ -6082,7 +6082,7 @@ public class Observable<T> {
      * items have been emitted by the source Observable, emitting the result of each of these
      * iterations.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/scanSeed.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/scanSeed.png">
      * <p>
      * This sort of function is sometimes called an accumulator.
      * <p>
@@ -6107,12 +6107,12 @@ public class Observable<T> {
      * that emits that item. If the source Observable emits more than one item or no items, throw
      * an {@code IllegalArgumentException}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/single.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/single.png">
      * 
      * @return an Observable that emits the single item emitted by the source Observable
      * @throws IllegalArgumentException
      *             if the source emits more than one item or no items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#single-and-singleordefault">RxJava Wiki: single()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#single-and-singleordefault">RxJava Wiki: single()</a>
      * @see MSDN: {@code Observable.singleAsync()}
      */
     public final Observable<T> single() {
@@ -6124,7 +6124,7 @@ public class Observable<T> {
      * return an Observable that emits that item. If the source Observable emits more than one such
      * item or no such items, throw an {@code IllegalArgumentException}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/single.p.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/single.p.png">
      * 
      * @param predicate
      *            a predicate function to evaluate items emitted by the source Observable
@@ -6133,7 +6133,7 @@ public class Observable<T> {
      * @throws IllegalArgumentException
      *             if the source Observable emits either more than one item that matches the
      *             predicate or no items that match the predicate
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#single-and-singleordefault">RxJava Wiki: single()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#single-and-singleordefault">RxJava Wiki: single()</a>
      * @see MSDN: {@code Observable.singleAsync()}
      */
     public final Observable<T> single(Func1<? super T, Boolean> predicate) {
@@ -6144,7 +6144,7 @@ public class Observable<T> {
      * If the source Observable completes after emitting a single item, return an Observable that
      * emits that item; if the source Observable is empty, return an Observable that emits a default
      * item. If the source Observable emits more than one item, throw an {@code IllegalArgumentException.} <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/singleOrDefault.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/singleOrDefault.png">
      * 
      * @param defaultValue
      *            a default value to emit if the source Observable emits no item
@@ -6152,7 +6152,7 @@ public class Observable<T> {
      *         default item if the source Observable is empty
      * @throws IllegalArgumentException
      *             if the source Observable emits more than one item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#single-and-singleordefault">RxJava Wiki: single()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#single-and-singleordefault">RxJava Wiki: single()</a>
      * @see MSDN: {@code Observable.singleOrDefaultAsync()}
      */
     public final Observable<T> singleOrDefault(T defaultValue) {
@@ -6165,7 +6165,7 @@ public class Observable<T> {
      * Observable that emits a default item. If the source Observable emits more than one such item,
      * throw an {@code IllegalArgumentException}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/singleOrDefault.p.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/singleOrDefault.p.png">
      * 
      * @param defaultValue
      *            a default item to emit if the source Observable emits no matching items
@@ -6175,7 +6175,7 @@ public class Observable<T> {
      *         matches the predicate, or the default item if no emitted item matches the predicate
      * @throws IllegalArgumentException
      *             if the source Observable emits more than one item that matches the predicate
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#single-and-singleordefault">RxJava Wiki: single()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#single-and-singleordefault">RxJava Wiki: single()</a>
      * @see MSDN: {@code Observable.singleOrDefaultAsync()}
      */
     public final Observable<T> singleOrDefault(T defaultValue, Func1<? super T, Boolean> predicate) {
@@ -6186,7 +6186,7 @@ public class Observable<T> {
      * Returns an Observable that skips the first {@code num} items emitted by the source Observable
      * and emits the remainder.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skip.png">
      * 
      * @param num
      *            the number of items to skip
@@ -6202,7 +6202,7 @@ public class Observable<T> {
      * Returns an Observable that skips values emitted by the source Observable before a specified
      * time window elapses.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skip.t.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skip.t.png">
      * 
      * @param time
      *            the length of the time window to skip
@@ -6220,7 +6220,7 @@ public class Observable<T> {
      * Returns an Observable that skips values emitted by the source Observable before a specified
      * time window on a specified {@link Scheduler} elapses.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skip.ts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skip.ts.png">
      * 
      * @param time
      *            the length of the time window to skip
@@ -6240,7 +6240,7 @@ public class Observable<T> {
      * Returns an Observable that drops a specified number of items from the end of the sequence
      * emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skipLast.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipLast.png">
      * <p>
      * This Observer accumulates a queue long enough to store the first {@code count} items. As more
      * items are received, items are taken from the front of the queue and emitted by the returned
@@ -6263,7 +6263,7 @@ public class Observable<T> {
      * Returns an Observable that drops items emitted by the source Observable during a specified
      * time window before the source completes.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skipLast.t.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipLast.t.png">
      * 
      * @param time
      *            the length of the time window
@@ -6282,7 +6282,7 @@ public class Observable<T> {
      * Returns an Observable that drops items emitted by the source Observable during a specified
      * time window (defined on a specified scheduler) before the source completes.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skipLast.ts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipLast.ts.png">
      * 
      * @param time
      *            the length of the time window
@@ -6303,7 +6303,7 @@ public class Observable<T> {
      * Returns an Observable that skips items emitted by the source Observable until a second
      * Observable emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skipUntil.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipUntil.png">
      * 
      * @param other
      *            the second Observable that has to emit an item before the source Observable's
@@ -6322,13 +6322,13 @@ public class Observable<T> {
      * specified condition holds true, but emits all further source items as soon as the condition
      * becomes false.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skipWhile.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipWhile.png">
      * 
      * @param predicate
      *            a function to test each item emitted from the source Observable
      * @return an Observable that begins emitting items emitted by the source Observable when the
      *         specified predicate becomes false
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#skipwhile-and-skipwhilewithindex">RxJava Wiki: skipWhile()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#skipwhile-and-skipwhilewithindex">RxJava Wiki: skipWhile()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229685.aspx">MSDN: Observable.SkipWhile</a>
      */
     public final Observable<T> skipWhile(Func1<? super T, Boolean> predicate) {
@@ -6340,7 +6340,7 @@ public class Observable<T> {
      * specified condition holds true, but emits all further source items as soon as the condition
      * becomes false.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/skipWhileWithIndex.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipWhileWithIndex.png">
      * 
      * @param predicate
      *            a function to test each item emitted from the source Observable. It takes the
@@ -6348,7 +6348,7 @@ public class Observable<T> {
      *            as a second parameter.
      * @return an Observable that begins emitting items emitted by the source Observable when the
      *         specified predicate becomes false
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#skipwhile-and-skipwhilewithindex">RxJava Wiki: skipWhileWithIndex()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#skipwhile-and-skipwhilewithindex">RxJava Wiki: skipWhileWithIndex()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh211631.aspx">MSDN: Observable.SkipWhile</a>
      */
     public final Observable<T> skipWhileWithIndex(Func2<? super T, Integer, Boolean> predicate) {
@@ -6359,7 +6359,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items in a specified {@link Iterable} before it begins
      * to emit items emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param values
      *            an Iterable that contains the items you want the modified Observable to emit first
@@ -6374,7 +6374,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits the items in a specified {@link Iterable}, on a specified {@link Scheduler} before it begins to emit items emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.s.png">
      * 
      * @param values
      *            an Iterable that contains the items you want the modified Observable to emit first
@@ -6393,7 +6393,7 @@ public class Observable<T> {
      * Returns an Observable that emits a specified item before it begins to emit items emitted by
      * the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the item to emit
@@ -6409,7 +6409,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6427,7 +6427,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6447,7 +6447,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6469,7 +6469,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6493,7 +6493,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6519,7 +6519,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6547,7 +6547,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6577,7 +6577,7 @@ public class Observable<T> {
      * Returns an Observable that emits the specified items before it begins to emit items emitted
      * by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.png">
      * 
      * @param t1
      *            the first item to emit
@@ -6609,7 +6609,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items from a specified array, on a specified scheduler,
      * before it begins to emit items emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/startWith.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/startWith.s.png">
      * 
      * @param values
      *            the items you want the modified Observable to emit first
@@ -6942,13 +6942,13 @@ public class Observable<T> {
     /**
      * Asynchronously subscribes and unsubscribes Observers to this Observable on the specified {@link Scheduler}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/subscribeOn.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/subscribeOn.png">
      * 
      * @param scheduler
      *            the {@link Scheduler} to perform subscription and unsubscription actions on
      * @return the source Observable modified so that its subscriptions and unsubscriptions happen
      *         on the specified {@link Scheduler}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#subscribeon">RxJava Wiki: subscribeOn()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#subscribeon">RxJava Wiki: subscribeOn()</a>
      */
     public final Observable<T> subscribeOn(Scheduler scheduler) {
         return create(OperationSubscribeOn.subscribeOn(this, scheduler));
@@ -6958,13 +6958,13 @@ public class Observable<T> {
      * Returns an Observable that extracts a Double from each of the items emitted by the source
      * Observable via a function you specify, and then emits the sum of these Doubles.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.f.png">
      * 
      * @param valueExtractor
      *            the function to extract a Double from each item emitted by the source Observable
      * @return an Observable that emits the Double sum of the Double values corresponding to the
      *         items emitted by the source Observable as transformed by the provided function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumDouble()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumDouble()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final Observable<Double> sumDouble(Func1<? super T, Double> valueExtractor) {
@@ -6975,13 +6975,13 @@ public class Observable<T> {
      * Returns an Observable that extracts a Float from each of the items emitted by the source
      * Observable via a function you specify, and then emits the sum of these Floats.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.f.png">
      * 
      * @param valueExtractor
      *            the function to extract a Float from each item emitted by the source Observable
      * @return an Observable that emits the Float sum of the Float values corresponding to the items
      *         emitted by the source Observable as transformed by the provided function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumFloat()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumFloat()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final Observable<Float> sumFloat(Func1<? super T, Float> valueExtractor) {
@@ -6992,13 +6992,13 @@ public class Observable<T> {
      * Returns an Observable that extracts an Integer from each of the items emitted by the source
      * Observable via a function you specify, and then emits the sum of these Integers.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.f.png">
      * 
      * @param valueExtractor
      *            the function to extract an Integer from each item emitted by the source Observable
      * @return an Observable that emits the Integer sum of the Integer values corresponding to the
      *         items emitted by the source Observable as transformed by the provided function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumInteger()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumInteger()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final Observable<Integer> sumInteger(Func1<? super T, Integer> valueExtractor) {
@@ -7009,13 +7009,13 @@ public class Observable<T> {
      * Returns an Observable that extracts a Long from each of the items emitted by the source
      * Observable via a function you specify, and then emits the sum of these Longs.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/sum.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/sum.f.png">
      * 
      * @param valueExtractor
      *            the function to extract a Long from each item emitted by the source Observable
      * @return an Observable that emits the Long sum of the Long values corresponding to the items
      *         emitted by the source Observable as transformed by the provided function
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumLong()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#suminteger-sumlong-sumfloat-and-sumdouble">RxJava Wiki: sumLong()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.sum.aspx">MSDN: Observable.Sum</a>
      */
     public final Observable<Long> sumLong(Func1<? super T, Long> valueExtractor) {
@@ -7027,7 +7027,7 @@ public class Observable<T> {
      * source Observable that returns an Observable, and then emitting the items emitted by the
      * most recently emitted of these Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/switchMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/switchMap.png">
      * 
      * @param func
      *            a function that, when applied to an item emitted by the source Observable, returns
@@ -7042,7 +7042,7 @@ public class Observable<T> {
      * Wraps the source Observable in another Observable that ensures that the resulting Observable
      * is chronologically well-behaved.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/synchronize.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/synchronize.png">
      * <p>
      * A well-behaved Observable does not interleave its invocations of the {@link Observer#onNext onNext}, {@link Observer#onCompleted onCompleted}, and {@link Observer#onError onError} methods of
      * its {@link Observer}s; it invokes either {@code onCompleted} or {@code onError} only once; and it never invokes {@code onNext} after
@@ -7051,7 +7051,7 @@ public class Observable<T> {
      * 
      * @return an Observable that is a chronologically well-behaved version of the source
      *         Observable, and that synchronously notifies its {@link Observer}s
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#synchronize">RxJava Wiki: synchronize()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#synchronize">RxJava Wiki: synchronize()</a>
      */
     public final Observable<T> synchronize() {
         return create(OperationSynchronize.synchronize(this));
@@ -7062,7 +7062,7 @@ public class Observable<T> {
      * is chronologically well-behaved by acquiring a mutual-exclusion lock for the object provided
      * as the {@code lock} parameter.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/synchronize.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/synchronize.png">
      * <p>
      * A well-behaved Observable does not interleave its invocations of the {@link Observer#onNext onNext}, {@link Observer#onCompleted onCompleted}, and {@link Observer#onError onError} methods of
      * its {@link Observer}s; it invokes either {@code onCompleted} or {@code onError} only once; and it never invokes {@code onNext} after
@@ -7073,7 +7073,7 @@ public class Observable<T> {
      *            the lock object to synchronize each observer call on
      * @return an Observable that is a chronologically well-behaved version of the source
      *         Observable, and that synchronously notifies its {@link Observer}s
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#synchronize">RxJava Wiki: synchronize()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#synchronize">RxJava Wiki: synchronize()</a>
      */
     public final Observable<T> synchronize(Object lock) {
         return create(OperationSynchronize.synchronize(this, lock));
@@ -7083,7 +7083,7 @@ public class Observable<T> {
      * Returns an Observable that emits only the first {@code num} items emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/take.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/take.png">
      * <p>
      * This method returns an Observable that will invoke a subscribing {@link Observer}'s {@link Observer#onNext onNext} function a maximum of {@code num} times before invoking
      * {@link Observer#onCompleted onCompleted}.
@@ -7103,7 +7103,7 @@ public class Observable<T> {
      * Returns an Observable that emits those items emitted by source Observable before a specified
      * time runs out.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/take.t.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/take.t.png">
      * 
      * @param time
      *            the length of the time window
@@ -7121,7 +7121,7 @@ public class Observable<T> {
      * Returns an Observable that emits those items emitted by source Observable before a specified
      * time (on a specified scheduler) runs out.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/take.ts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/take.ts.png">
      * 
      * @param time
      *            the length of the time window
@@ -7140,7 +7140,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits only the very first item emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeFirst.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeFirst.png">
      * 
      * @return an Observable that emits only the very first item emitted by the source Observable,
      *         or an empty Observable if the source Observable completes without emitting a single
@@ -7158,7 +7158,7 @@ public class Observable<T> {
      * Returns an Observable that emits only the very first item emitted by the source Observable
      * that satisfies a specified condition.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeFirstN.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeFirstN.png">
      * 
      * @param predicate
      *            the condition any item emitted by the source Observable has to satisfy
@@ -7176,7 +7176,7 @@ public class Observable<T> {
      * Returns an Observable that emits only the last {@code count} items emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLast.n.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLast.n.png">
      * 
      * @param count
      *            the number of items to emit from the end of the sequence of items emitted by the
@@ -7193,7 +7193,7 @@ public class Observable<T> {
      * Return an Observable that emits at most a specified number of items from the source
      * Observable that were emitted in a specified window of time before the Observable completed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLast.tn.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLast.tn.png">
      * 
      * @param count
      *            the maximum number of items to emit
@@ -7213,7 +7213,7 @@ public class Observable<T> {
      * Observable that were emitted in a specified window of time before the Observable
      * completed, where the timing information is provided by a given scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLast.tns.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLast.tns.png">
      * 
      * @param count
      *            the maximum number of items to emit
@@ -7238,7 +7238,7 @@ public class Observable<T> {
      * Return an Observable that emits the items from the source Observable that were emitted in a
      * specified window of time before the Observable completed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLast.t.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLast.t.png">
      * 
      * @param time
      *            the length of the time window
@@ -7256,7 +7256,7 @@ public class Observable<T> {
      * specified window of time before the Observable completed, where the timing information is
      * provided by a specified scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLast.ts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLast.ts.png">
      * 
      * @param time
      *            the length of the time window
@@ -7276,7 +7276,7 @@ public class Observable<T> {
      * Return an Observable that emits a single List containing the last {@code count} elements
      * emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLastBuffer.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLastBuffer.png">
      * 
      * @param count
      *            the number of items to emit in the list
@@ -7292,7 +7292,7 @@ public class Observable<T> {
      * the source Observable that were emitted during a specified window of time before the
      * source Observable completed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLastBuffer.tn.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLastBuffer.tn.png">
      * 
      * @param count
      *            the maximum number of items to emit
@@ -7313,7 +7313,7 @@ public class Observable<T> {
      * the source Observable that were emitted during a specified window of time (on a specified
      * scheduler) before the source Observable completed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLastBuffer.tns.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLastBuffer.tns.png">
      * 
      * @param count
      *            the maximum number of items to emit
@@ -7336,7 +7336,7 @@ public class Observable<T> {
      * Observable that were emitted during a specified window of time before the source Observable
      * completed.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLastBuffer.t.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLastBuffer.t.png">
      * 
      * @param time
      *            the length of the time window
@@ -7355,7 +7355,7 @@ public class Observable<T> {
      * Observable that were emitted during a specified window of time before the source Observable
      * completed, where the timing information is provided by the given Scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeLastBuffer.ts.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLastBuffer.ts.png">
      * 
      * @param time
      *            the length of the time window
@@ -7375,7 +7375,7 @@ public class Observable<T> {
      * Returns an Observable that emits the items emitted by the source Observable until a second
      * Observable emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeUntil.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeUntil.png">
      * 
      * @param other
      *            the Observable whose first emitted item will cause {@code takeUntil} to stop
@@ -7384,7 +7384,7 @@ public class Observable<T> {
      *            the type of items emitted by {@code other}
      * @return an Observable that emits the items emitted by the source Observable until such time
      *         as {@code other} emits its first item
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#takeuntil">RxJava Wiki: takeUntil()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#takeuntil">RxJava Wiki: takeUntil()</a>
      */
     public final <E> Observable<T> takeUntil(Observable<? extends E> other) {
         return OperationTakeUntil.takeUntil(this, other);
@@ -7395,14 +7395,14 @@ public class Observable<T> {
      * satisfied a specified condition, and then completes as soon as this condition is not
      * satisfied.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeWhile.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeWhile.png">
      * 
      * @param predicate
      *            a function that evaluates an item emitted by the source Observable and returns a
      *            Boolean
      * @return an Observable that emits the items from the source Observable so long as each item
      *         satisfies the condition defined by {@code predicate}, then completes
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#takewhile-and-takewhilewithindex">RxJava Wiki: takeWhile()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#takewhile-and-takewhilewithindex">RxJava Wiki: takeWhile()</a>
      */
     public final Observable<T> takeWhile(final Func1<? super T, Boolean> predicate) {
         return create(OperationTakeWhile.takeWhile(this, predicate));
@@ -7413,7 +7413,7 @@ public class Observable<T> {
      * predicate remains true, where the predicate operates on both the item and its index relative
      * to the complete sequence of emitted items.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/takeWhileWithIndex.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeWhileWithIndex.png">
      * 
      * @param predicate
      *            a function to test each item emitted by the source Observable for a condition; the
@@ -7421,7 +7421,7 @@ public class Observable<T> {
      *            item; it returns a Boolean
      * @return an Observable that emits items from the source Observable so long as the predicate
      *         continues to return {@code true} for each item, then completes
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Observers#takewhile-and-takewhilewithindex">RxJava Wiki: takeWhileWithIndex()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#takewhile-and-takewhilewithindex">RxJava Wiki: takeWhileWithIndex()</a>
      */
     public final Observable<T> takeWhileWithIndex(final Func2<? super T, ? super Integer, Boolean> predicate) {
         return create(OperationTakeWhile.takeWhileWithIndex(this, predicate));
@@ -7431,7 +7431,7 @@ public class Observable<T> {
      * Matches when the Observable has an available item and projects the item by invoking the
      * selector function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/and_then_when.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/and_then_when.png">
      * 
      * @param selector
      *            selector that will be invoked for items emitted by the source Observable
@@ -7452,7 +7452,7 @@ public class Observable<T> {
      * <p>
      * This differs from {@link #throttleLast} in that this only tracks passage of time whereas {@link #throttleLast} ticks at scheduled intervals.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/throttleFirst.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleFirst.png">
      * 
      * @param windowDuration
      *            time to wait before emitting another item after emitting the last item
@@ -7472,7 +7472,7 @@ public class Observable<T> {
      * <p>
      * This differs from {@link #throttleLast} in that this only tracks passage of time whereas {@link #throttleLast} ticks at scheduled intervals.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/throttleFirst.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleFirst.s.png">
      * 
      * @param skipDuration
      *            time to wait before emitting another item after emitting the last item
@@ -7495,7 +7495,7 @@ public class Observable<T> {
      * This differs from {@link #throttleFirst} in that this ticks along at a scheduled interval
      * whereas {@link #throttleFirst} does not tick, it just tracks passage of time.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/throttleLast.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleLast.png">
      * 
      * @param intervalDuration
      *            duration of windows within which the last item emitted by the source Observable
@@ -7518,7 +7518,7 @@ public class Observable<T> {
      * This differs from {@link #throttleFirst} in that this ticks along at a scheduled interval
      * whereas {@link #throttleFirst} does not tick, it just tracks passage of time.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/throttleLast.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleLast.s.png">
      * 
      * @param intervalDuration
      *            duration of windows within which the last item emitted by the source Observable
@@ -7543,7 +7543,7 @@ public class Observable<T> {
      * <em>Note:</em> If the source Observable keeps emitting items more frequently than the length
      * of the time window then no items will be emitted by the resulting Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/throttleWithTimeout.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleWithTimeout.png">
      * <p>
      * Information on debounce vs throttle:
      * <p>
@@ -7575,7 +7575,7 @@ public class Observable<T> {
      * <em>Note:</em> If the source Observable keeps emitting items more frequently than the length
      * of the time window then no items will be emitted by the resulting Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/throttleWithTimeout.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/throttleWithTimeout.s.png">
      * <p>
      * Information on debounce vs throttle:
      * <p>
@@ -7606,10 +7606,10 @@ public class Observable<T> {
      * Returns an Observable that emits records of the time interval between consecutive items
      * emitted by the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeInterval.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeInterval.png">
      * 
      * @return an Observable that emits time interval information items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#timeinterval">RxJava Wiki: timeInterval()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#timeinterval">RxJava Wiki: timeInterval()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212107.aspx">MSDN: Observable.TimeInterval</a>
      */
     public final Observable<TimeInterval<T>> timeInterval() {
@@ -7620,12 +7620,12 @@ public class Observable<T> {
      * Returns an Observable that emits records of the time interval between consecutive items
      * emitted by the source Observable, where this interval is computed on a specified Scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeInterval.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeInterval.s.png">
      * 
      * @param scheduler
      *            the {@link Scheduler} used to compute time intervals
      * @return an Observable that emits time interval information items
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#timeinterval">RxJava Wiki: timeInterval()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#timeinterval">RxJava Wiki: timeInterval()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212107.aspx">MSDN: Observable.TimeInterval</a>
      */
     public final Observable<TimeInterval<T>> timeInterval(Scheduler scheduler) {
@@ -7637,7 +7637,7 @@ public class Observable<T> {
      * Observable or any subsequent item don't arrive within time windows defined by other
      * Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout5.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout5.png">
      * 
      * @param <U>
      *            the first timeout value type (ignored)
@@ -7665,7 +7665,7 @@ public class Observable<T> {
      * Observable if either the first item emitted by the source Observable or any subsequent item
      * don't arrive within time windows defined by other Observables.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout6.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout6.png">
      * 
      * @param <U>
      *            the first timeout value type (ignored)
@@ -7699,7 +7699,7 @@ public class Observable<T> {
      * previous item, where that period of time is measured by an Observable that is a function
      * of the previous item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout3.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout3.png">
      * <p>
      * The arrival of the first source item is never timed out.
      * 
@@ -7722,7 +7722,7 @@ public class Observable<T> {
      * after the emission of the previous item, where that period of time is measured by an
      * Observable that is a function of the previous item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout4.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout4.png">
      * <p>
      * The arrival of the first source item is never timed out.
      * 
@@ -7750,7 +7750,7 @@ public class Observable<T> {
      * starting from its predecessor, the resulting Observable terminates and notifies observers of
      * a {@code TimeoutException}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout.1.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1.png">
      * 
      * @param timeout
      *            maximum duration between emitted items before a timeout occurs
@@ -7771,7 +7771,7 @@ public class Observable<T> {
      * starting from its predecessor, the resulting Observable begins instead to mirror a fallback
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout.2.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.2.png">
      * 
      * @param timeout
      *            maximum duration between items before a timeout occurs
@@ -7794,7 +7794,7 @@ public class Observable<T> {
      * specified timeout duration starting from its predecessor, the resulting Observable begins
      * instead to mirror a fallback Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout.2s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.2s.png">
      * 
      * @param timeout
      *            maximum duration between items before a timeout occurs
@@ -7819,7 +7819,7 @@ public class Observable<T> {
      * isn't emitted within the specified timeout duration starting from its predecessor, the
      * resulting Observable terminates and notifies observers of a {@code TimeoutException}.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timeout.1s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1s.png">
      * 
      * @param timeout
      *            maximum duration between items before a timeout occurs
@@ -7839,10 +7839,10 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits each item emitted by the source Observable, wrapped in a {@link Timestamped} object.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timestamp.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timestamp.png">
      * 
      * @return an Observable that emits timestamped items from the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#timestamp">RxJava Wiki: timestamp()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#timestamp">RxJava Wiki: timestamp()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229003.aspx">MSDN: Observable.Timestamp</a>
      */
     public final Observable<Timestamped<T>> timestamp() {
@@ -7852,13 +7852,13 @@ public class Observable<T> {
     /**
      * Returns an Observable that emits each item emitted by the source Observable, wrapped in a {@link Timestamped} object whose timestamps are provided by a specified Scheduler.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/timestamp.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timestamp.s.png">
      * 
      * @param scheduler
      *            the {@link Scheduler} to use as a time source
      * @return an Observable that emits timestamped items from the source Observable with timestamps
      *         provided by the {@code scheduler}
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Observers#timestamp">RxJava Wiki: timestamp()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#timestamp">RxJava Wiki: timestamp()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229003.aspx">MSDN: Observable.Timestamp</a>
      */
     public final Observable<Timestamped<T>> timestamp(Scheduler scheduler) {
@@ -7870,7 +7870,7 @@ public class Observable<T> {
      * Observers).
      * 
      * @return a {@code BlockingObservable} version of this Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Blocking-Observable-Observers">RxJava Wiki: Blocking Observable Observers</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Blocking-Observable-Operators">RxJava Wiki: Blocking Observable Observers</a>
      */
     public final BlockingObservable<T> toBlockingObservable() {
         return BlockingObservable.from(this);
@@ -7880,7 +7880,7 @@ public class Observable<T> {
      * Returns an Observable that emits a single item, a list composed of all the items emitted by
      * the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toList.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toList.png">
      * <p>
      * Normally, an Observable that returns multiple items will do so by invoking its {@link Observer}'s {@link Observer#onNext onNext} method for each such item. You can change
      * this behavior, instructing the Observable to compose a list of all of these items and then to
@@ -7892,7 +7892,7 @@ public class Observable<T> {
      * 
      * @return an Observable that emits a single item: a List containing all of the items emitted by
      *         the source Observable.
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tolist">RxJava Wiki: toList()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tolist">RxJava Wiki: toList()</a>
      */
     public final Observable<List<T>> toList() {
         return lift(new OperatorToObservableList<T>());
@@ -7902,7 +7902,7 @@ public class Observable<T> {
      * Return an Observable that emits a single HashMap containing all items emitted by the source
      * Observable, mapped by the keys returned by a specified {@code keySelector} function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
      * <p>
      * If more than one source item maps to the same key, the HashMap will contain the latest of
      * those items.
@@ -7911,7 +7911,7 @@ public class Observable<T> {
      *            the function that extracts the key from a source item to be used in the HashMap
      * @return an Observable that emits a single item: a HashMap containing the mapped items from
      *         the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229137.aspx">MSDN: Observable.ToDictionary</a>
      */
     public final <K> Observable<Map<K, T>> toMap(Func1<? super T, ? extends K> keySelector) {
@@ -7922,7 +7922,7 @@ public class Observable<T> {
      * Return an Observable that emits a single HashMap containing values corresponding to items
      * emitted by the source Observable, mapped by the keys returned by a specified {@code keySelector} function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
      * <p>
      * If more than one source item maps to the same key, the HashMap will contain a single entry
      * that corresponds to the latest of those items.
@@ -7933,7 +7933,7 @@ public class Observable<T> {
      *            the function that extracts the value from a source item to be used in the HashMap
      * @return an Observable that emits a single item: a HashMap containing the mapped items from
      *         the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212075.aspx">MSDN: Observable.ToDictionary</a>
      */
     public final <K, V> Observable<Map<K, V>> toMap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector) {
@@ -7944,7 +7944,7 @@ public class Observable<T> {
      * Return an Observable that emits a single Map, returned by a specified {@code mapFactory} function, that contains keys and values extracted from the items emitted by the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
      * 
      * @param keySelector
      *            the function that extracts the key from a source item to be used in the Map
@@ -7955,7 +7955,7 @@ public class Observable<T> {
      *            the function that returns a Map instance to be used
      * @return an Observable that emits a single item: a Map that contains the mapped items emitted
      *         by the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      */
     public final <K, V> Observable<Map<K, V>> toMap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func0<? extends Map<K, V>> mapFactory) {
         return create(OperationToMap.toMap(this, keySelector, valueSelector, mapFactory));
@@ -7965,14 +7965,14 @@ public class Observable<T> {
      * Return an Observable that emits a single HashMap that contains an ArrayList of items emitted
      * by the source Observable keyed by a specified {@code keySelector} function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMultiMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMultiMap.png">
      * 
      * @param keySelector
      *            the function that extracts the key from the source items to be used as key in the
      *            HashMap
      * @return an Observable that emits a single item: a HashMap that contains an ArrayList of items
      *         mapped from the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212098.aspx">MSDN: Observable.ToLookup</a>
      */
     public final <K> Observable<Map<K, Collection<T>>> toMultimap(Func1<? super T, ? extends K> keySelector) {
@@ -7984,7 +7984,7 @@ public class Observable<T> {
      * extracted by a specified {@code valueSelector} function from items emitted by the source
      * Observable, keyed by a specified {@code keySelector} function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMultiMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMultiMap.png">
      * 
      * @param keySelector
      *            the function that extracts a key from the source items to be used as key in the
@@ -7994,7 +7994,7 @@ public class Observable<T> {
      *            the HashMap
      * @return an Observable that emits a single item: a HashMap that contains an ArrayList of items
      *         mapped from the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229101.aspx">MSDN: Observable.ToLookup</a>
      */
     public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector) {
@@ -8005,7 +8005,7 @@ public class Observable<T> {
      * Return an Observable that emits a single Map, returned by a specified {@code mapFactory} function, that contains an ArrayList of values, extracted by a specified {@code valueSelector} function
      * from items emitted by the source Observable and keyed by the {@code keySelector} function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMultiMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMultiMap.png">
      * 
      * @param keySelector
      *            the function that extracts a key from the source items to be used as the key in
@@ -8017,7 +8017,7 @@ public class Observable<T> {
      *            the function that returns a Map instance to be used
      * @return an Observable that emits a single item: a Map that contains a list items mapped
      *         from the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      */
     public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func0<? extends Map<K, Collection<V>>> mapFactory) {
         return create(OperationToMultimap.toMultimap(this, keySelector, valueSelector, mapFactory));
@@ -8027,7 +8027,7 @@ public class Observable<T> {
      * Return an Observable that emits a single Map, returned by a specified {@code mapFactory} function, that contains a custom collection of values, extracted by a specified {@code valueSelector}
      * function from items emitted by the source Observable, and keyed by the {@code keySelector} function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toMultiMap.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMultiMap.png">
      * 
      * @param keySelector
      *            the function that extracts a key from the source items to be used as the key in
@@ -8042,7 +8042,7 @@ public class Observable<T> {
      *            the Map
      * @return an Observable that emits a single item: a Map that contains the collection of mapped
      *         items from the source Observable
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tomap-and-tomultimap">RxJava Wiki: toMap()</a>
      */
     public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func0<? extends Map<K, Collection<V>>> mapFactory, Func1<? super K, ? extends Collection<V>> collectionFactory) {
         return create(OperationToMultimap.toMultimap(this, keySelector, valueSelector, mapFactory, collectionFactory));
@@ -8052,14 +8052,14 @@ public class Observable<T> {
      * Returns an Observable that emits a list that contains the items emitted by the source
      * Observable, in a sorted order. Each item emitted by the Observable must implement {@link Comparable} with respect to all other items in the sequence.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toSortedList.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toSortedList.png">
      * 
      * @throws ClassCastException
      *             if any item emitted by the Observable does not implement {@link Comparable} with
      *             respect to all other items emitted by the Observable
      * @return an Observable that emits a list that contains the items emitted by the source
      *         Observable in sorted order
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tosortedlist">RxJava Wiki: toSortedList()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tosortedlist">RxJava Wiki: toSortedList()</a>
      */
     public final Observable<List<T>> toSortedList() {
         return lift(new OperatorToObservableSortedList<T>());
@@ -8069,14 +8069,14 @@ public class Observable<T> {
      * Returns an Observable that emits a list that contains the items emitted by the source
      * Observable, in a sorted order based on a specified comparison function.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/toSortedList.f.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toSortedList.f.png">
      * 
      * @param sortFunction
      *            a function that compares two items emitted by the source Observable and returns an
      *            Integer that indicates their sort order
      * @return an Observable that emits a list that contains the items emitted by the source
      *         Observable in sorted order
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Observers#tosortedlist">RxJava Wiki: toSortedList()</a>
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#tosortedlist">RxJava Wiki: toSortedList()</a>
      */
     public final Observable<List<T>> toSortedList(Func2<? super T, ? super T, Integer> sortFunction) {
         return lift(new OperatorToObservableSortedList<T>(sortFunction));
@@ -8085,7 +8085,7 @@ public class Observable<T> {
     /**
      * Returns an Observable that represents a filtered version of the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/where.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/where.png">
      * 
      * @param predicate
      *            a function that evaluates an item emitted by the source Observable, returning {@code true} if it passes the filter
@@ -8105,7 +8105,7 @@ public class Observable<T> {
      * window and opens a new one when the Observable produced by the specified {@code closingSelector} emits an item. The {@code closingSelector} then creates a new
      * Observable to generate the closer of the next window.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window1.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window1.png">
      * 
      * @param closingSelector
      *            a {@link Func0} that produces an Observable for every window created. When this
@@ -8125,7 +8125,7 @@ public class Observable<T> {
      * resulting Observable emits the current window and propagates the notification from the source
      * Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window3.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window3.png">
      * 
      * @param count
      *            the maximum size of each window before it should be emitted
@@ -8143,7 +8143,7 @@ public class Observable<T> {
      * error, the resulting Observable emits the current window and propagates the notification from
      * the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window4.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window4.png">
      * 
      * @param count
      *            the maximum size of each window before it should be emitted
@@ -8163,7 +8163,7 @@ public class Observable<T> {
      * encounters an error, the resulting Observable emits the current window and propagates the
      * notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window7.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window7.png">
      * 
      * @param timespan
      *            the period of time each window collects items before it should be emitted
@@ -8185,7 +8185,7 @@ public class Observable<T> {
      * encounters an error, the resulting Observable emits the current window and propagates the
      * notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window7.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window7.s.png">
      * 
      * @param timespan
      *            the period of time each window collects items before it should be emitted
@@ -8209,7 +8209,7 @@ public class Observable<T> {
      * encounters an error, the resulting Observable emits the current window and propagates the
      * notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window5.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window5.png">
      * 
      * @param timespan
      *            the period of time each window collects items before it should be emitted and
@@ -8231,7 +8231,7 @@ public class Observable<T> {
      * encounters an error, the resulting Observable emits the current window and propagates the
      * notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window6.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window6.png">
      * 
      * @param timespan
      *            the period of time each window collects items before it should be emitted and
@@ -8256,7 +8256,7 @@ public class Observable<T> {
      * error, the resulting Observable emits the current window and propagates the notification from
      * the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window6.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window6.s.png">
      * 
      * @param timespan
      *            the period of time each window collects items before it should be emitted and
@@ -8283,7 +8283,7 @@ public class Observable<T> {
      * encounters an error, the resulting Observable emits the current window and propagates the
      * notification from the source Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window5.s.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window5.s.png">
      * 
      * @param timespan
      *            the period of time each window collects items before it should be emitted and
@@ -8306,7 +8306,7 @@ public class Observable<T> {
      * Observable between the time when the {@code windowOpenings} Observable emits an item and when
      * the Observable returned by {@code closingSelector} emits an item.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window2.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window2.png">
      * 
      * @param windowOpenings
      *            an Observable that, when it emits an item, causes another window to be created
@@ -8326,7 +8326,7 @@ public class Observable<T> {
      * source observable where the boundary of each window is determined by the items emitted from
      * a specified boundary-governing Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/window8.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window8.png">
      * 
      * @param <U>
      *            the window element type (ignored)
@@ -8344,7 +8344,7 @@ public class Observable<T> {
      * Returns an Observable that emits items that are the result of applying a specified function
      * to pairs of values, one each from the source Observable and a specified Iterable sequence.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.i.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.i.png">
      * <p>
      * Note that the {@code other} Iterable is evaluated as items are observed from the source
      * Observable; it is not pre-consumed. This allows you to zip infinite streams on either side.
@@ -8368,7 +8368,7 @@ public class Observable<T> {
      * Returns an Observable that emits items that are the result of applying a specified function
      * to pairs of values, one each from the source Observable and another specified Observable.
      * <p>
-     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-Observers/zip.png">
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/zip.png">
      * 
      * @param <T2>
      *            the type of items emitted by the {@code other} Observable


### PR DESCRIPTION
restoring the working URLs of RxJava wiki pages and marble diagrams in the javadocs
http://www.youtube.com/watch?v=AYMyxTFwuz8
