### PR TITLE
Add Subscription.isUnsubscribed()

### DIFF
--- a/language-adaptors/rxjava-groovy/src/examples/groovy/rx/lang/groovy/examples/RxExamples.groovy
+++ b/language-adaptors/rxjava-groovy/src/examples/groovy/rx/lang/groovy/examples/RxExamples.groovy
@@ -19,6 +19,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
 import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0
 import rx.util.functions.Func1;
 
 // --------------------------------------------------
@@ -123,13 +124,13 @@ def customObservableNonBlocking() {
             });
             t.start();
         
-            return new Subscription() {
-                public void unsubscribe() {
+            return Subscriptions.create(new Action0() {
+                public void call() {
                     // Ask the thread to stop doing work.
                     // For this simple example it just interrupts.
                     t.interrupt();
                 }
-            };
+            });
         };
     });
 }

--- a/language-adaptors/rxjava-groovy/src/test/groovy/rx/lang/groovy/ObservableTests.groovy
+++ b/language-adaptors/rxjava-groovy/src/test/groovy/rx/lang/groovy/ObservableTests.groovy
@@ -530,12 +530,7 @@ def class ObservableTests {
             observer.onNext("hello_" + count);
             observer.onCompleted();
 
-            return new Subscription() {
-
-                public void unsubscribe() {
-                    // unregister ... will never be called here since we are executing synchronously
-                }
-            };
+            return Subscriptions.empty();
         }
     }
 }

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Subscription.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Subscription.scala
@@ -44,6 +44,7 @@ trait Subscription {
   private [scala] val unsubscribed = new AtomicBoolean(false)
   private [scala] val asJavaSubscription: rx.Subscription = new rx.Subscription {
     override def unsubscribe() { unsubscribed.compareAndSet(false, true) }
+    override def isUnsubscribed(): Boolean = { unsubscribed.get() }
   }
 
 
@@ -81,6 +82,7 @@ object Subscription {
   def apply(u: => Unit): Subscription = new Subscription() {
     override val asJavaSubscription = new rx.Subscription {
       override def unsubscribe() { if(unsubscribed.compareAndSet(false, true)) { u } }
+      override def isUnsubscribed(): Boolean = { unsubscribed.get() }
     }
   }
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperationObserveFromAndroidComponent.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperationObserveFromAndroidComponent.java
@@ -19,6 +19,8 @@ import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 import android.app.Activity;
 import android.os.Looper;
 import android.util.Log;
@@ -94,14 +96,14 @@ public class OperationObserveFromAndroidComponent {
                     }
                 }
             });
-            return new Subscription() {
+            return Subscriptions.create(new Action0() {
                 @Override
-                public void unsubscribe() {
+                public void call() {
                     log("unsubscribing from source sequence");
                     releaseReferences();
                     sourceSub.unsubscribe();
                 }
-            };
+            });
         }
 
         private void releaseReferences() {

--- a/rxjava-core/src/main/java/rx/Subscription.java
+++ b/rxjava-core/src/main/java/rx/Subscription.java
@@ -32,5 +32,7 @@ public interface Subscription {
      * This allows unregistering an {@link Subscriber} before it has finished receiving all events (ie. before onCompleted is called).
      */
     public void unsubscribe();
+    
+    public boolean isUnsubscribed();
 
 }

--- a/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
+++ b/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
@@ -156,6 +156,7 @@ public class ChunkedOperation {
         private final long maxTime;
         private final TimeUnit unit;
         private final int maxSize;
+        private volatile boolean unsubscribed = false;
 
         public TimeAndSizeBasedChunks(Observer<? super C> observer, Func0<? extends Chunk<T, C>> chunkMaker, int maxSize, long maxTime, TimeUnit unit, Scheduler scheduler) {
             super(observer, chunkMaker);
@@ -210,9 +211,15 @@ public class ChunkedOperation {
 
         @Override
         public void unsubscribe() {
+            unsubscribed = true;
             for (Subscription s : subscriptions.values()) {
                 s.unsubscribe();
             }
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return unsubscribed;
         }
     }
 
@@ -232,6 +239,7 @@ public class ChunkedOperation {
         private final Scheduler scheduler;
         private final long time;
         private final TimeUnit unit;
+        private volatile boolean unsubscribed = false;
 
         public TimeBasedChunks(Observer<? super C> observer, Func0<? extends Chunk<T, C>> chunkMaker, long time, TimeUnit unit, Scheduler scheduler) {
             super(observer, chunkMaker);
@@ -260,9 +268,15 @@ public class ChunkedOperation {
 
         @Override
         public void unsubscribe() {
+            unsubscribed = true;
             for (Subscription s : subscriptions.values()) {
                 s.unsubscribe();
             }
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return unsubscribed;
         }
 
     }

--- a/rxjava-core/src/main/java/rx/operators/OperationBuffer.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationBuffer.java
@@ -393,6 +393,11 @@ public final class OperationBuffer extends ChunkedOperation {
                 cc0.stop();
             }
         }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return done.get();
+        }
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/operators/OperationConcat.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationConcat.java
@@ -23,6 +23,8 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 
 /**
  * Returns an Observable that emits the items emitted by two or more Observables, one after the
@@ -153,9 +155,9 @@ public final class OperationConcat {
                 }
             }));
 
-            return new Subscription() {
+            return Subscriptions.create(new Action0() {
                 @Override
-                public void unsubscribe() {
+                public void call() {
                     Subscription q;
                     synchronized (nextSequences) {
                         q = innerSubscription;
@@ -165,7 +167,7 @@ public final class OperationConcat {
                     }
                     outerSubscription.unsubscribe();
                 }
-            };
+            });
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationGroupJoin.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationGroupJoin.java
@@ -99,6 +99,11 @@ public class OperationGroupJoin<T1, T2, D1, D2, R> implements OnSubscribeFunc<R>
         public void unsubscribe() {
             cancel.unsubscribe();
         }
+        
+        @Override
+        public boolean isUnsubscribed() {
+            return cancel.isUnsubscribed();
+        }
 
         void groupsOnCompleted() {
             List<Observer<T2>> list = new ArrayList<Observer<T2>>(leftMap.values());
@@ -299,6 +304,7 @@ public class OperationGroupJoin<T1, T2, D1, D2, R> implements OnSubscribeFunc<R>
                 onCompleted();
             }
         }
+
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/operators/OperationMergeDelayError.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationMergeDelayError.java
@@ -25,8 +25,11 @@ import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
 import rx.observers.SynchronizedObserver;
+import rx.subscriptions.BooleanSubscription;
 import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.Subscriptions;
 import rx.util.CompositeException;
+import rx.util.functions.Action0;
 
 /**
  * This behaves like {@link OperatorMerge} except that if any of the merged Observables notify of
@@ -69,29 +72,22 @@ public final class OperationMergeDelayError {
 
     public static <T> OnSubscribeFunc<T> mergeDelayError(final Observable<? extends T>... sequences) {
         return mergeDelayError(Observable.create(new OnSubscribeFunc<Observable<? extends T>>() {
-            private volatile boolean unsubscribed = false;
+            private final BooleanSubscription s = new BooleanSubscription();
 
             @Override
             public Subscription onSubscribe(Observer<? super Observable<? extends T>> observer) {
                 for (Observable<? extends T> o : sequences) {
-                    if (!unsubscribed) {
+                    if (!s.isUnsubscribed()) {
                         observer.onNext(o);
                     } else {
                         // break out of the loop if we are unsubscribed
                         break;
                     }
                 }
-                if (!unsubscribed) {
+                if (!s.isUnsubscribed()) {
                     observer.onCompleted();
                 }
-                return new Subscription() {
-
-                    @Override
-                    public void unsubscribe() {
-                        unsubscribed = true;
-                    }
-
-                };
+                return s;
             }
         }));
     }
@@ -99,30 +95,23 @@ public final class OperationMergeDelayError {
     public static <T> OnSubscribeFunc<T> mergeDelayError(final List<? extends Observable<? extends T>> sequences) {
         return mergeDelayError(Observable.create(new OnSubscribeFunc<Observable<? extends T>>() {
 
-            private volatile boolean unsubscribed = false;
+            private final BooleanSubscription s = new BooleanSubscription();
 
             @Override
             public Subscription onSubscribe(Observer<? super Observable<? extends T>> observer) {
                 for (Observable<? extends T> o : sequences) {
-                    if (!unsubscribed) {
+                    if (!s.isUnsubscribed()) {
                         observer.onNext(o);
                     } else {
                         // break out of the loop if we are unsubscribed
                         break;
                     }
                 }
-                if (!unsubscribed) {
+                if (!s.isUnsubscribed()) {
                     observer.onCompleted();
                 }
 
-                return new Subscription() {
-
-                    @Override
-                    public void unsubscribe() {
-                        unsubscribed = true;
-                    }
-
-                };
+                return s;
             }
         }));
     }
@@ -200,6 +189,11 @@ public final class OperationMergeDelayError {
                     // another thread beat us
                     return false;
                 }
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return stopped.get();
             }
         }
 

--- a/rxjava-core/src/main/java/rx/operators/OperationMulticast.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationMulticast.java
@@ -24,6 +24,7 @@ import rx.observables.ConnectableObservable;
 import rx.subjects.Subject;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 import rx.util.functions.Func0;
 import rx.util.functions.Func1;
 
@@ -73,9 +74,9 @@ public class OperationMulticast {
                 }
             }
 
-            return new Subscription() {
+            return Subscriptions.create(new Action0() {
                 @Override
-                public void unsubscribe() {
+                public void call() {
                     synchronized (lock) {
                         if (subscription != null) {
                             subscription.unsubscribe();
@@ -83,7 +84,7 @@ public class OperationMulticast {
                         }
                     }
                 }
-            };
+            });
         }
 
     }

--- a/rxjava-core/src/main/java/rx/operators/OperationOnErrorResumeNextViaFunction.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationOnErrorResumeNextViaFunction.java
@@ -22,7 +22,9 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
 import rx.util.CompositeException;
+import rx.util.functions.Action0;
 import rx.util.functions.Func1;
 
 /**
@@ -103,15 +105,15 @@ public final class OperationOnErrorResumeNextViaFunction<T> {
                 }
             })));
 
-            return new Subscription() {
-                public void unsubscribe() {
+            return Subscriptions.create(new Action0() {
+                public void call() {
                     // this will get either the original, or the resumeSequence one and unsubscribe on it
                     Subscription s = subscriptionRef.getAndSet(null);
                     if (s != null) {
                         s.unsubscribe();
                     }
                 }
-            };
+            });
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationOnErrorResumeNextViaObservable.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationOnErrorResumeNextViaObservable.java
@@ -21,6 +21,8 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 
 /**
  * Instruct an Observable to pass control to another Observable rather than invoking
@@ -97,15 +99,15 @@ public final class OperationOnErrorResumeNextViaObservable<T> {
                 }
             }));
 
-            return new Subscription() {
-                public void unsubscribe() {
+            return Subscriptions.create(new Action0() {
+                public void call() {
                     // this will get either the original, or the resumeSequence one and unsubscribe on it
                     Subscription s = subscriptionRef.getAndSet(null);
                     if (s != null) {
                         s.unsubscribe();
                     }
                 }
-            };
+            });
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationOnErrorReturn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationOnErrorReturn.java
@@ -22,7 +22,9 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
 import rx.util.CompositeException;
+import rx.util.functions.Action0;
 import rx.util.functions.Func1;
 
 /**
@@ -107,15 +109,15 @@ public final class OperationOnErrorReturn<T> {
                 }
             }));
 
-            return new Subscription() {
-                public void unsubscribe() {
+            return Subscriptions.create(new Action0() {
+                public void call() {
                     // this will get either the original, or the resumeSequence one and unsubscribe on it
                     Subscription s = subscriptionRef.getAndSet(null);
                     if (s != null) {
                         s.unsubscribe();
                     }
                 }
-            };
+            });
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationOnExceptionResumeNextViaObservable.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationOnExceptionResumeNextViaObservable.java
@@ -21,6 +21,8 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 
 /**
  * Instruct an Observable to pass control to another Observable rather than invoking
@@ -104,15 +106,15 @@ public final class OperationOnExceptionResumeNextViaObservable<T> {
                 }
             }));
 
-            return new Subscription() {
-                public void unsubscribe() {
+            return Subscriptions.create(new Action0() {
+                public void call() {
                     // this will get either the original, or the resumeSequence one and unsubscribe on it
                     Subscription s = subscriptionRef.getAndSet(null);
                     if (s != null) {
                         s.unsubscribe();
                     }
                 }
-            };
+            });
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationReplay.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationReplay.java
@@ -594,6 +594,11 @@ public final class OperationReplay {
                     }
                 }
 
+                @Override
+                public boolean isUnsubscribed() {
+                    return once.get();
+                }
+
             };
             Replayer rp = new Replayer(obs, s);
             replayers.put(s, rp);

--- a/rxjava-core/src/main/java/rx/operators/OperationSkipUntil.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSkipUntil.java
@@ -74,6 +74,11 @@ public class OperationSkipUntil<T, U> implements OnSubscribeFunc<T> {
         public void unsubscribe() {
             cancel.unsubscribe();
         }
+        
+        @Override
+        public boolean isUnsubscribed() {
+            return cancel.isUnsubscribed();
+        }
 
         @Override
         public void onNext(T args) {
@@ -123,5 +128,6 @@ public class OperationSkipUntil<T, U> implements OnSubscribeFunc<T> {
             }
 
         }
+
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSubscribeOn.java
@@ -57,6 +57,7 @@ public class OperationSubscribeOn {
     private static class ScheduledSubscription implements Subscription {
         private final Subscription underlying;
         private final Scheduler scheduler;
+        private volatile boolean unsubscribed = false;
 
         private ScheduledSubscription(Subscription underlying, Scheduler scheduler) {
             this.underlying = underlying;
@@ -65,12 +66,18 @@ public class OperationSubscribeOn {
 
         @Override
         public void unsubscribe() {
+            unsubscribed = true;
             scheduler.schedule(new Action0() {
                 @Override
                 public void call() {
                     underlying.unsubscribe();
                 }
             });
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return unsubscribed;
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperationZip.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationZip.java
@@ -294,6 +294,11 @@ public final class OperationZip {
             public void unsubscribe() {
                 toSource.unsubscribe();
             }
+            
+            @Override
+            public boolean isUnsubscribed() {
+                return toSource.isUnsubscribed();
+            }
 
             private void runCollector() {
                 if (rwLock.writeLock().tryLock()) {
@@ -330,6 +335,7 @@ public final class OperationZip {
                     }
                 }
             }
+
         }
     }
 

--- a/rxjava-core/src/main/java/rx/operators/SafeObservableSubscription.java
+++ b/rxjava-core/src/main/java/rx/operators/SafeObservableSubscription.java
@@ -33,6 +33,11 @@ public final class SafeObservableSubscription implements Subscription {
         public void unsubscribe()
         {
         }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return true;
+        }
     };
     private final AtomicReference<Subscription> actualSubscription = new AtomicReference<Subscription>();
 

--- a/rxjava-core/src/main/java/rx/schedulers/CurrentThreadScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/CurrentThreadScheduler.java
@@ -135,6 +135,11 @@ public class CurrentThreadScheduler extends Scheduler {
             childSubscription.unsubscribe();
         }
 
+        @Override
+        public boolean isUnsubscribed() {
+            return childSubscription.isUnsubscribed();
+        }
+
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/schedulers/DiscardableAction.java
+++ b/rxjava-core/src/main/java/rx/schedulers/DiscardableAction.java
@@ -54,4 +54,9 @@ import rx.util.functions.Func2;
         wrapper.unsubscribe();
     }
 
+    @Override
+    public boolean isUnsubscribed() {
+        return wrapper.isUnsubscribed();
+    }
+
 }

--- a/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -243,6 +243,11 @@ public class ExecutorScheduler extends Scheduler {
             childSubscription.unsubscribe();
         }
 
+        @Override
+        public boolean isUnsubscribed() {
+            return childSubscription.isUnsubscribed();
+        }
+
     }
 
 }

--- a/rxjava-core/src/main/java/rx/schedulers/TestScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/TestScheduler.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import rx.Scheduler;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 import rx.util.functions.Func2;
 
 public class TestScheduler extends Scheduler {
@@ -110,11 +112,12 @@ public class TestScheduler extends Scheduler {
         final TimedAction<T> timedAction = new TimedAction<T>(this, time + unit.toNanos(delayTime), action, state);
         queue.add(timedAction);
 
-        return new Subscription() {
+        return Subscriptions.create(new Action0() {
+
             @Override
-            public void unsubscribe() {
+            public void call() {
                 timedAction.cancel();
             }
-        };
+        });
     }
 }

--- a/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -25,6 +25,8 @@ import rx.Subscriber;
 import rx.Subscription;
 import rx.Observable.OnSubscribe;
 import rx.operators.SafeObservableSubscription;
+import rx.subscriptions.Subscriptions;
+import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 /* package */class SubjectSubscriptionManager<T> {
@@ -71,9 +73,10 @@ import rx.util.functions.Action1;
                         final SafeObservableSubscription subscription = new SafeObservableSubscription();
                         actualOperator.add(subscription); // add to parent if the Subject itself is unsubscribed
                         addedObserver = true;
-                        subscription.wrap(new Subscription() {
+                        subscription.wrap(Subscriptions.create(new Action0() {
+
                             @Override
-                            public void unsubscribe() {
+                            public void call() {
                                 State<T> current;
                                 State<T> newState;
                                 do {
@@ -82,7 +85,7 @@ import rx.util.functions.Action1;
                                     newState = current.removeObserver(subscription);
                                 } while (!state.compareAndSet(current, newState));
                             }
-                        });
+                        }));
 
                         // on subscribe add it to the map of outbound observers to notify
                         newState = current.addObserver(subscription, observer);

--- a/rxjava-core/src/main/java/rx/subscriptions/RefCountSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/RefCountSubscription.java
@@ -131,5 +131,10 @@ public final class RefCountSubscription implements Subscription {
                 unsubscribeActualIfApplicable(newState);
             }
         }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return innerDone.get();
+        }
     };
 }

--- a/rxjava-core/src/main/java/rx/subscriptions/Subscriptions.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/Subscriptions.java
@@ -44,9 +44,17 @@ public final class Subscriptions {
     public static Subscription create(final Action0 unsubscribe) {
         return new SafeObservableSubscription(new Subscription() {
 
+            private volatile boolean unsubscribed = false;
+
             @Override
             public void unsubscribe() {
+                unsubscribed = true;
                 unsubscribe.call();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return unsubscribed;
             }
 
         });
@@ -68,24 +76,9 @@ public final class Subscriptions {
                 f.cancel(true);
             }
 
-        };
-    }
-
-    /**
-     * A {@link Subscription} that wraps a {@link Future} and cancels it when unsubscribed.
-     * 
-     * 
-     * @param f
-     *            {@link Future}
-     * @return {@link Subscription}
-     * @deprecated Use {@link #from(Future)} instead
-     */
-    public static Subscription create(final Future<?> f) {
-        return new Subscription() {
-
             @Override
-            public void unsubscribe() {
-                f.cancel(true);
+            public boolean isUnsubscribed() {
+                return f.isCancelled();
             }
 
         };
@@ -104,23 +97,15 @@ public final class Subscriptions {
     }
 
     /**
-     * A {@link Subscription} that groups multiple Subscriptions together and unsubscribes from all of them together.
-     * 
-     * @param subscriptions
-     *            Subscriptions to group together
-     * @return {@link Subscription}
-     * @deprecated Use {@link #from(Subscription...)} instead
-     */
-
-    public static CompositeSubscription create(Subscription... subscriptions) {
-        return new CompositeSubscription(subscriptions);
-    }
-
-    /**
      * A {@link Subscription} that does nothing when its unsubscribe method is called.
      */
     private static Subscription EMPTY = new Subscription() {
         public void unsubscribe() {
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return false;
         }
     };
 }

--- a/rxjava-core/src/test/java/rx/operators/OperationConcatTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationConcatTest.java
@@ -35,6 +35,7 @@ import rx.Observer;
 import rx.Subscription;
 import rx.schedulers.TestScheduler;
 import rx.subscriptions.BooleanSubscription;
+import rx.subscriptions.Subscriptions;
 
 public class OperationConcatTest {
 
@@ -95,14 +96,7 @@ public class OperationConcatTest {
                 observer.onNext(even);
                 observer.onCompleted();
 
-                return new Subscription() {
-
-                    @Override
-                    public void unsubscribe() {
-                        // unregister ... will never be called here since we are executing synchronously
-                    }
-
-                };
+                return Subscriptions.empty();
             }
 
         });
@@ -348,13 +342,7 @@ public class OperationConcatTest {
                 observer.onNext(Observable.create(w2));
                 observer.onCompleted();
 
-                return new Subscription() {
-
-                    @Override
-                    public void unsubscribe() {
-                    }
-
-                };
+                return Subscriptions.empty();
             }
 
         });
@@ -480,6 +468,11 @@ public class OperationConcatTest {
             @Override
             public void unsubscribe() {
                 subscribed = false;
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return subscribed;
             }
 
         };

--- a/rxjava-core/src/test/java/rx/operators/OperationMaterializeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationMaterializeTest.java
@@ -29,6 +29,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
 
 public class OperationMaterializeTest {
 
@@ -154,14 +155,7 @@ public class OperationMaterializeTest {
             });
             t.start();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 }

--- a/rxjava-core/src/test/java/rx/operators/OperationMergeDelayErrorTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationMergeDelayErrorTest.java
@@ -31,6 +31,7 @@ import org.mockito.MockitoAnnotations;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
+import rx.subscriptions.Subscriptions;
 import rx.util.CompositeException;
 
 public class OperationMergeDelayErrorTest {
@@ -225,14 +226,7 @@ public class OperationMergeDelayErrorTest {
                 observer.onNext(o2);
                 observer.onCompleted();
 
-                return new Subscription() {
-
-                    @Override
-                    public void unsubscribe() {
-                        // unregister ... will never be called here since we are executing synchronously
-                    }
-
-                };
+                return Subscriptions.empty();
             }
 
         });
@@ -330,14 +324,7 @@ public class OperationMergeDelayErrorTest {
             observer.onNext("hello");
             observer.onCompleted();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-                    // unregister ... will never be called here since we are executing synchronously
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 
@@ -357,14 +344,7 @@ public class OperationMergeDelayErrorTest {
             });
             t.start();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 
@@ -381,6 +361,11 @@ public class OperationMergeDelayErrorTest {
             public void unsubscribe() {
                 unsubscribed = true;
 
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return unsubscribed;
             }
 
         };
@@ -434,14 +419,7 @@ public class OperationMergeDelayErrorTest {
                 observer.onCompleted();
             }
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-                    // unregister ... will never be called here since we are executing synchronously
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 
@@ -482,14 +460,7 @@ public class OperationMergeDelayErrorTest {
             });
             t.start();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 

--- a/rxjava-core/src/test/java/rx/operators/OperationSynchronizeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationSynchronizeTest.java
@@ -216,6 +216,11 @@ public class OperationSynchronizeTest {
                     System.out.println("==> SynchronizeTest unsubscribe that does nothing!");
                 }
 
+                @Override
+                public boolean isUnsubscribed() {
+                    return false;
+                }
+
             };
         }
 

--- a/rxjava-core/src/test/java/rx/operators/OperationUsingTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationUsingTest.java
@@ -102,6 +102,11 @@ public class OperationUsingTest {
                     public void unsubscribe() {
                     }
 
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+
                 };
             }
         };

--- a/rxjava-core/src/test/java/rx/operators/OperatorMergeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMergeTest.java
@@ -66,14 +66,7 @@ public class OperatorMergeTest {
                 observer.onNext(o2);
                 observer.onCompleted();
 
-                return new Subscription() {
-
-                    @Override
-                    public void unsubscribe() {
-                        // unregister ... will never be called here since we are executing synchronously
-                    }
-
-                };
+                return Subscriptions.empty();
             }
 
         });
@@ -329,14 +322,7 @@ public class OperatorMergeTest {
             observer.onNext("hello");
             observer.onCompleted();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-                    // unregister ... will never be called here since we are executing synchronously
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 
@@ -360,14 +346,7 @@ public class OperatorMergeTest {
             });
             t.start();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 
@@ -384,6 +363,11 @@ public class OperatorMergeTest {
             public void unsubscribe() {
                 unsubscribed = true;
 
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return unsubscribed;
             }
 
         };
@@ -432,14 +416,7 @@ public class OperatorMergeTest {
             }
             observer.onCompleted();
 
-            return new Subscription() {
-
-                @Override
-                public void unsubscribe() {
-                    // unregister ... will never be called here since we are executing synchronously
-                }
-
-            };
+            return Subscriptions.empty();
         }
     }
 

--- a/rxjava-core/src/test/java/rx/operators/OperatorTakeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorTakeTest.java
@@ -145,6 +145,11 @@ public class OperatorTakeTest {
                     public void unsubscribe() {
                         unSubscribed.set(true);
                     }
+
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return unSubscribed.get();
+                    }
                 };
             }
         });

--- a/rxjava-core/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
+++ b/rxjava-core/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
@@ -39,6 +39,11 @@ public class CompositeSubscriptionTest {
             public void unsubscribe() {
                 counter.incrementAndGet();
             }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
+            }
         });
 
         s.add(new Subscription() {
@@ -46,6 +51,11 @@ public class CompositeSubscriptionTest {
             @Override
             public void unsubscribe() {
                 counter.incrementAndGet();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
             }
         });
 
@@ -67,6 +77,11 @@ public class CompositeSubscriptionTest {
                 @Override
                 public void unsubscribe() {
                     counter.incrementAndGet();
+                }
+
+                @Override
+                public boolean isUnsubscribed() {
+                    return false;
                 }
             });
         }
@@ -106,6 +121,11 @@ public class CompositeSubscriptionTest {
             public void unsubscribe() {
                 throw new RuntimeException("failed on first one");
             }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
+            }
         });
 
         s.add(new Subscription() {
@@ -113,6 +133,11 @@ public class CompositeSubscriptionTest {
             @Override
             public void unsubscribe() {
                 counter.incrementAndGet();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
             }
         });
 
@@ -138,6 +163,11 @@ public class CompositeSubscriptionTest {
             public void unsubscribe() {
                 throw new RuntimeException("failed on first one");
             }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
+            }
         });
 
         s.add(new Subscription() {
@@ -146,6 +176,11 @@ public class CompositeSubscriptionTest {
             public void unsubscribe() {
                 throw new RuntimeException("failed on second one too");
             }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
+            }
         });
 
         s.add(new Subscription() {
@@ -153,6 +188,11 @@ public class CompositeSubscriptionTest {
             @Override
             public void unsubscribe() {
                 counter.incrementAndGet();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
             }
         });
 
@@ -220,6 +260,11 @@ public class CompositeSubscriptionTest {
             public void unsubscribe() {
                 counter.incrementAndGet();
             }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
+            }
         });
 
         s.unsubscribe();
@@ -243,6 +288,11 @@ public class CompositeSubscriptionTest {
             @Override
             public void unsubscribe() {
                 counter.incrementAndGet();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return false;
             }
         });
 


### PR DESCRIPTION
With the new model of injecting `Subscription` into functions for synchronous loops to check `isUnsubscribed()` it now makes sense for this to be on the interface of all `Subscription` implementations.
