### PR TITLE
Add testMultipleWithSameCause UnitTest

### DIFF
--- a/rxjava-core/src/test/java/rx/util/CompositeExceptionTest.java
+++ b/rxjava-core/src/test/java/rx/util/CompositeExceptionTest.java
@@ -17,10 +17,11 @@ package rx.util;
 
 import static org.junit.Assert.*;
 
-import org.junit.Test;
-
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Test;
 
 public class CompositeExceptionTest {
 
@@ -28,48 +29,60 @@ public class CompositeExceptionTest {
     private final Throwable ex2 = new Throwable("Ex2", ex1);
     private final Throwable ex3 = new Throwable("Ex3", ex2);
 
-    private final CompositeException compositeEx;
-
     public CompositeExceptionTest() {
         ex1.initCause(ex2);
+    }
+
+    private CompositeException getNewCompositeExceptionWithEx123() {
         List<Throwable> throwables = new ArrayList<Throwable>();
         throwables.add(ex1);
         throwables.add(ex2);
         throwables.add(ex3);
-        compositeEx = new CompositeException(throwables);
+        return new CompositeException(throwables);
     }
 
-    @Test
+    @Test(timeout = 1000)
+    public void testMultipleWithSameCause() {
+        Throwable rootCause = new Throwable("RootCause");
+        Throwable e1 = new Throwable("1", rootCause);
+        Throwable e2 = new Throwable("2", rootCause);
+        Throwable e3 = new Throwable("3", rootCause);
+        CompositeException ce = new CompositeException("3 failures with same root cause", Arrays.asList(e1, e2, e3));
+    }
+
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackParentThenChild() {
         CompositeException.attachCallingThreadStack(ex1, ex2);
         assertEquals("Ex2", ex1.getCause().getMessage());
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackChildThenParent() {
         CompositeException.attachCallingThreadStack(ex2, ex1);
         assertEquals("Ex1", ex2.getCause().getMessage());
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackAddComposite() {
-        CompositeException.attachCallingThreadStack(ex1, compositeEx);
+        CompositeException.attachCallingThreadStack(ex1, getNewCompositeExceptionWithEx123());
         assertEquals("Ex2", ex1.getCause().getMessage());
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackAddToComposite() {
+        CompositeException compositeEx = getNewCompositeExceptionWithEx123();
         CompositeException.attachCallingThreadStack(compositeEx, ex1);
         assertEquals(CompositeException.CompositeExceptionCausalChain.MESSAGE, compositeEx.getCause().getMessage());
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackAddCompositeToItself() {
+        CompositeException compositeEx = getNewCompositeExceptionWithEx123();
         CompositeException.attachCallingThreadStack(compositeEx, compositeEx);
         assertEquals(CompositeException.CompositeExceptionCausalChain.MESSAGE, compositeEx.getCause().getMessage());
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackAddExceptionsToEachOther() {
         CompositeException.attachCallingThreadStack(ex1, ex2);
         CompositeException.attachCallingThreadStack(ex2, ex1);


### PR DESCRIPTION
Also make tests capable of failing with timeouts. Before the constructor would immediately go into an infinite loop and hang the tests.
