### PR TITLE
Fixed OperationSubscribeOn so OperationConditionalsTest works again.

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSubscribeOn.java
@@ -84,7 +84,7 @@ public class OperationSubscribeOn {
                 public void call(Inner inner) {
                     underlying.unsubscribe();
                     // tear down this subscription as well now that we're done
-                    inner.unsubscribe();
+//                    inner.unsubscribe();
                 }
             });
         }


### PR DESCRIPTION
Commenting out the inner makes the `OperationConditionalsTest` pass.

Unfortunately, I'm not sure whether this change affects non-Trampolined schedulers in any way or why was there a need to unsubscribe an inner scheduler. It is possible the actual bug is in TrampolineScheduler.
