### PR TITLE
RunAsync method for outputting multiple values

### DIFF
--- a/rxjava-contrib/rxjava-async-util/src/main/java/rx/util/async/StoppableObservable.java
+++ b/rxjava-contrib/rxjava-async-util/src/main/java/rx/util/async/StoppableObservable.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.util.async;
+
+import rx.Observable;
+import rx.Subscription;
+
+/**
+ * An Observable which provides a Subscription interface to signal a stop
+ * condition to an asynchronous task.
+ */
+public class StoppableObservable<T> extends Observable<T> implements Subscription {
+    private final Subscription token;
+    public StoppableObservable(Observable.OnSubscribe<T> onSubscribe, Subscription token) {
+        super(onSubscribe);
+        this.token = token;
+    }
+    
+    @Override
+    public boolean isUnsubscribed() {
+        return token.isUnsubscribed();
+    }
+    
+    @Override
+    public void unsubscribe() {
+        token.unsubscribe();
+    }
+}


### PR DESCRIPTION
Added `runAsync` method to allow producing multiple values while running an action on a scheduler.

The drawback is that the action is run immediately and observers might not get any or all of the produced values. An overload lets the client specify a subject (such as ReplaySubject) to reliably capture all values and replay them to Observers. Otherwise, it just acts as a cold observable with the additional option to cancel the schedule and/or the action.
