### PR TITLE
CompositeSubscription memory reduction

### DIFF
--- a/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -17,7 +17,6 @@ package rx.subscriptions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -34,7 +33,15 @@ public final class CompositeSubscription implements Subscription {
 
     private final AtomicReference<State> state = new AtomicReference<State>();
 
-    private static final State CLEAR_STATE = new State(false, new Subscription[0]);
+    /** Empty initial state. */
+    private static final State CLEAR_STATE;
+    /** Unsubscribed empty state. */
+    private static final State CLEAR_STATE_UNSUBSCRIBED;
+    static {
+        Subscription[] s0 = new Subscription[0];
+        CLEAR_STATE = new State(false, s0);
+        CLEAR_STATE_UNSUBSCRIBED = new State(true, s0);
+    }
 
     private static final class State {
         final boolean isUnsubscribed;
@@ -46,7 +53,7 @@ public final class CompositeSubscription implements Subscription {
         }
 
         State unsubscribe() {
-            return new State(true, subscriptions);
+            return CLEAR_STATE_UNSUBSCRIBED;
         }
 
         State add(Subscription s) {
@@ -66,7 +73,7 @@ public final class CompositeSubscription implements Subscription {
         }
 
         State clear() {
-            return new State(isUnsubscribed, new Subscription[0]);
+            return isUnsubscribed ? CLEAR_STATE_UNSUBSCRIBED : CLEAR_STATE;
         }
     }
 
@@ -78,6 +85,7 @@ public final class CompositeSubscription implements Subscription {
         state.set(new State(false, subscriptions));
     }
 
+    @Override
     public boolean isUnsubscribed() {
         return state.get().isUnsubscribed;
     }


### PR DESCRIPTION
Since CompositeSubscription is now used everywhere with Subscriber, I looked at the code again and tried to reduce memory consumption. I've added CLEAR_STATE_UNSUBSCRIBED singleton to transition into when unsubscribed. Note that the previous version kept the subscription array after the unsubscription, keeping references to other subscriptions alive (although unsubscribed); I'm not certain why unsubscription didn't simply discard the array before.

I've played with changing the `add` and `remove` methods (not included in this PR) to do more direct array manipulation with about 10-40% speed increase for tests like add directly followed by remove. The speed increase comes from:
- using arraycopy to avoid dynamic array creation in copyOf,
- handling case where CS contains a single item to be removed and transitions into CLEAR_STATE instead of creating a new empty state.

Similar memory reduction could be implemented in MAS and SAS.
