### PR TITLE
CompositeSubscription performance increase

### DIFF
--- a/rxjava-core/src/perf/java/rx/subscriptions/CompositeSubscriptionAddRemovePerf.java
+++ b/rxjava-core/src/perf/java/rx/subscriptions/CompositeSubscriptionAddRemovePerf.java
@@ -1,0 +1,50 @@
+
+package rx.subscriptions;
+
+import rx.perf.AbstractPerformanceTester;
+import rx.util.functions.Action0;
+
+public class CompositeSubscriptionAddRemovePerf extends AbstractPerformanceTester {
+    public static void main(String[] args) {
+        final CompositeSubscriptionAddRemovePerf spt = new CompositeSubscriptionAddRemovePerf();
+        try {
+            spt.runTest(new Action0() {
+                @Override
+                public void call() {
+                    spt.timeAddAndRemove();
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    /**
+     * Test simple add + remove on a composite.
+     * 
+     * With old Composite add/remove:
+     * 
+     * Run: 10 - 14 985 141 ops/sec 
+     * Run: 11 - 15 257 104 ops/sec 
+     * Run: 12 - 14 797 996 ops/sec 
+     * Run: 13 - 14 438 643 ops/sec 
+     * Run: 14 - 14 985 864 ops/sec 
+     * 
+     * With optimized Composite add/remove:
+     * 
+     * Run: 10 - 19 802 782 ops/sec 
+     * Run: 11 - 18 896 021 ops/sec 
+     * Run: 12 - 18 829 296 ops/sec 
+     * Run: 13 - 19 729 876 ops/sec 
+     * Run: 14 - 19 830 678 ops/sec 
+     * 
+     * about 32% increase
+     */
+    void timeAddAndRemove() {
+        CompositeSubscription csub = new CompositeSubscription();
+        BooleanSubscription bs = new BooleanSubscription();
+        for (int i = 0; i < REPETITIONS; i++) {
+            csub.add(bs);
+            csub.remove(bs);
+        }
+    }
+}


### PR DESCRIPTION
- Optimized the case when the composite holds only a single element.
- Replaced Arrays.copyOf with regular arraycopy to avoid the cost of reflective array creation
- Included perf test where I got 32% increase on my i7 4770K
