### PR TITLE
Add 'Fragment-Host' to rxjava-contrib modules for OSGi

### DIFF
--- a/rxjava-contrib/rxjava-android/build.gradle
+++ b/rxjava-contrib/rxjava-android/build.gradle
@@ -27,6 +27,7 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Fragment-Host', 'com.netflix.rxjava.core'
     }
 }
 

--- a/rxjava-contrib/rxjava-apache-http/build.gradle
+++ b/rxjava-contrib/rxjava-apache-http/build.gradle
@@ -16,5 +16,6 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Fragment-Host', 'com.netflix.rxjava.core'
     }
 }

--- a/rxjava-contrib/rxjava-async-util/build.gradle
+++ b/rxjava-contrib/rxjava-async-util/build.gradle
@@ -16,5 +16,6 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Fragment-Host', 'com.netflix.rxjava.core'
     }
 }

--- a/rxjava-contrib/rxjava-computation-expressions/build.gradle
+++ b/rxjava-contrib/rxjava-computation-expressions/build.gradle
@@ -16,5 +16,6 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Fragment-Host', 'com.netflix.rxjava.core'
     }
 }

--- a/rxjava-contrib/rxjava-string/build.gradle
+++ b/rxjava-contrib/rxjava-string/build.gradle
@@ -26,5 +26,6 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Fragment-Host', 'com.netflix.rxjava.core'
     }
 }

--- a/rxjava-contrib/rxjava-swing/build.gradle
+++ b/rxjava-contrib/rxjava-swing/build.gradle
@@ -25,5 +25,6 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Fragment-Host', 'com.netflix.rxjava.core'
     }
 }


### PR DESCRIPTION
avoid split packages
http://wiki.osgi.org/wiki/Split_Packages

see also discussion #154
