### PR TITLE
SchedulePeriodically Signature

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Scheduler.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Scheduler.scala
@@ -69,6 +69,7 @@ trait Scheduler {
          override def call(inner: rx.Scheduler.Inner): Unit = action(javaInnerToScalaInner(inner))
        },
        initialDelay.toNanos,
+       duration.NANOSECONDS,
        period.toNanos,
        duration.NANOSECONDS
      )

--- a/rxjava-contrib/rxjava-swing/src/test/java/rx/schedulers/SwingSchedulerTest.java
+++ b/rxjava-contrib/rxjava-swing/src/test/java/rx/schedulers/SwingSchedulerTest.java
@@ -49,16 +49,16 @@ public final class SwingSchedulerTest {
         final Action1<Inner> action = mock(Action1.class);
 
         exception.expect(IllegalArgumentException.class);
-        scheduler.schedulePeriodically(action, -1L, 100L, TimeUnit.SECONDS);
+        scheduler.schedulePeriodically(action, -1L, TimeUnit.SECONDS, 100L, TimeUnit.SECONDS);
 
         exception.expect(IllegalArgumentException.class);
-        scheduler.schedulePeriodically(action, 100L, -1L, TimeUnit.SECONDS);
+        scheduler.schedulePeriodically(action, 100L, TimeUnit.SECONDS, -1L, TimeUnit.SECONDS);
 
         exception.expect(IllegalArgumentException.class);
-        scheduler.schedulePeriodically(action, 1L + Integer.MAX_VALUE, 100L, TimeUnit.MILLISECONDS);
+        scheduler.schedulePeriodically(action, 1L + Integer.MAX_VALUE, TimeUnit.MILLISECONDS, 100L, TimeUnit.MILLISECONDS);
 
         exception.expect(IllegalArgumentException.class);
-        scheduler.schedulePeriodically(action, 100L, 1L + Integer.MAX_VALUE / 1000, TimeUnit.SECONDS);
+        scheduler.schedulePeriodically(action, 100L, TimeUnit.SECONDS, 1L + Integer.MAX_VALUE / 1000, TimeUnit.SECONDS);
     }
 
     @Test
@@ -80,7 +80,7 @@ public final class SwingSchedulerTest {
             }
         };
 
-        Subscription sub = scheduler.schedulePeriodically(action, 50, 200, TimeUnit.MILLISECONDS);
+        Subscription sub = scheduler.schedulePeriodically(action, 50, TimeUnit.MILLISECONDS, 200, TimeUnit.MILLISECONDS);
 
         if (!latch.await(5000, TimeUnit.MILLISECONDS)) {
             fail("timed out waiting for tasks to execute");

--- a/rxjava-core/src/main/java/rx/Scheduler.java
+++ b/rxjava-core/src/main/java/rx/Scheduler.java
@@ -71,14 +71,16 @@ public abstract class Scheduler {
      *            The action to execute periodically.
      * @param initialDelay
      *            Time to wait before executing the action for the first time.
+     * @param initialDelayUnit
+     *            The time unit the interval above is given in.
      * @param period
      *            The time interval to wait each time in between executing the action.
-     * @param unit
+     * @param periodUnit
      *            The time unit the interval above is given in.
      * @return A subscription to be able to unsubscribe from action.
      */
-    public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, long period, TimeUnit unit) {
-        final long periodInNanos = unit.toNanos(period);
+    public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, TimeUnit initialDelayUnit, long period, TimeUnit periodUnit) {
+        final long periodInNanos = periodUnit.toNanos(period);
 
         final Action1<Scheduler.Inner> recursiveAction = new Action1<Scheduler.Inner>() {
             @Override
@@ -91,7 +93,7 @@ public abstract class Scheduler {
                 }
             }
         };
-        return schedule(recursiveAction, initialDelay, unit);
+        return schedule(recursiveAction, initialDelay, initialDelayUnit);
     }
 
     public abstract static class Inner implements Subscription {

--- a/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
+++ b/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
@@ -573,7 +573,7 @@ public class ChunkedOperation {
                 public void call(Inner inner) {
                     chunks.emitAndReplaceChunk();
                 }
-            }, 0, time, unit));
+            }, 0, TimeUnit.MILLISECONDS, time, unit));
         }
 
         public TimeBasedChunkCreator(final OverlappingChunks<T, C> chunks, long time, TimeUnit unit, Scheduler scheduler) {
@@ -582,7 +582,7 @@ public class ChunkedOperation {
                 public void call(Inner inner) {
                     chunks.createChunk();
                 }
-            }, 0, time, unit));
+            }, 0, TimeUnit.MILLISECONDS, time, unit));
         }
 
         @Override

--- a/rxjava-core/src/main/java/rx/operators/OperationInterval.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationInterval.java
@@ -74,7 +74,7 @@ public final class OperationInterval {
                     observer.onNext(currentValue);
                     currentValue++;
                 }
-            }, period, period, unit);
+            }, period, unit, period, unit);
 
             return Subscriptions.create(new Action0() {
                 @Override

--- a/rxjava-core/src/main/java/rx/operators/OperationTimer.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationTimer.java
@@ -87,7 +87,7 @@ public final class OperationTimer {
                 public void call(Inner inner) {
                     t1.onNext(count++);
                 }
-            }, initialDelay, period, unit);
+            }, initialDelay, unit, period, unit);
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -60,7 +60,7 @@ public class ExecutorScheduler extends Scheduler {
     }
 
     @Override
-    public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, long period, TimeUnit unit) {
+    public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, TimeUnit delayUnit, long period, TimeUnit periodUnit) {
         if (executor instanceof ScheduledExecutorService) {
             final InnerExecutorScheduler inner = new InnerExecutorScheduler();
             ScheduledFuture<?> f = ((ScheduledExecutorService) executor).scheduleAtFixedRate(new Runnable() {
@@ -72,12 +72,12 @@ public class ExecutorScheduler extends Scheduler {
                     }
                     action.call(inner);
                 }
-            }, initialDelay, period, unit);
+            }, delayUnit.toMillis(initialDelay), periodUnit.toMillis(period), TimeUnit.MILLISECONDS);
 
             inner.innerSubscription.set(Subscriptions.from(f));
             return inner;
         } else {
-            return super.schedulePeriodically(action, initialDelay, period, unit);
+            return super.schedulePeriodically(action, initialDelay, delayUnit, period, periodUnit);
         }
     }
 

--- a/rxjava-core/src/test/java/rx/schedulers/TestSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/TestSchedulerTest.java
@@ -46,7 +46,7 @@ public class TestSchedulerTest {
                 System.out.println(scheduler.now());
                 calledOp.call(scheduler.now());
             }
-        }, 1, 2, TimeUnit.SECONDS);
+        }, 1, TimeUnit.SECONDS, 2, TimeUnit.SECONDS);
 
         verify(calledOp, never()).call(anyLong());
 


### PR DESCRIPTION
This pull requests adds `TimeUnit delayUnit` to the signature:

``` java
public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, TimeUnit delayUnit, long period, TimeUnit periodUnit)
```

This was derived from feedback from @headinthebox while writing the Scala APIs.

Reason for ... 
- it better matches languages that have a single object that represent both together such as Scala.
- Java 8 adds `Duration`: http://download.java.net/jdk8/docs/api/java/time/Duration.html 

Reason against ... 
- Java 7 and earlier doesn't do it this way on their Executor.
- Java 8 despite adding `Duration` still doesn't use it on their `ScheduledExecutorService`

Thoughts, concerns, opinions?
