### PR TITLE
Change Lift to use rx.Observable.Operator

### DIFF
--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/operators/DebugSubscriber.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/operators/DebugSubscriber.java
@@ -1,5 +1,6 @@
 package rx.operators;
 
+import rx.Observable.Operator;
 import rx.Observer;
 import rx.Subscriber;
 import rx.plugins.DebugNotification;

--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugHook.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugHook.java
@@ -2,10 +2,10 @@ package rx.plugins;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.operators.DebugSubscriber;
-import rx.operators.Operator;
 import rx.util.functions.Action1;
 import rx.util.functions.Actions;
 import rx.util.functions.Func1;

--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugNotification.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugNotification.java
@@ -2,11 +2,10 @@ package rx.plugins;
 
 import rx.Notification;
 import rx.Observable.OnSubscribe;
+import rx.Observable.Operator;
 import rx.Observer;
 import rx.observers.SafeSubscriber;
 import rx.operators.DebugSubscriber;
-import rx.operators.Operator;
-import rx.plugins.DebugNotification.Kind;
 
 public class DebugNotification<T> {
     public static enum Kind {

--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/NotificationEvent.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/NotificationEvent.java
@@ -2,10 +2,10 @@ package rx.plugins;
 
 import rx.Notification;
 import rx.Observable.OnSubscribe;
+import rx.Observable.Operator;
 import rx.Observer;
 import rx.observers.SafeSubscriber;
 import rx.operators.DebugSubscriber;
-import rx.operators.Operator;
 
 public class NotificationEvent<T> {
     public static enum Kind {

--- a/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
+++ b/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
@@ -31,8 +31,8 @@ import java.util.regex.Pattern;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.Observable.Operator;
 import rx.Subscriber;
-import rx.operators.Operator;
 import rx.util.functions.Func1;
 import rx.util.functions.Func2;
 

--- a/rxjava-core/src/main/java/rx/joins/JoinObserver1.java
+++ b/rxjava-core/src/main/java/rx/joins/JoinObserver1.java
@@ -25,7 +25,6 @@ import rx.Notification;
 import rx.Observable;
 import rx.Subscriber;
 import rx.observers.SafeSubscriber;
-import rx.operators.SafeObservableSubscription;
 import rx.util.functions.Action1;
 
 /**

--- a/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
@@ -29,7 +29,6 @@ import rx.operators.OperationMostRecent;
 import rx.operators.OperationNext;
 import rx.operators.OperationToFuture;
 import rx.operators.OperationToIterator;
-import rx.operators.SafeObservableSubscription;
 import rx.util.functions.Action1;
 import rx.util.functions.Func1;
 

--- a/rxjava-core/src/main/java/rx/observers/Observers.java
+++ b/rxjava-core/src/main/java/rx/observers/Observers.java
@@ -1,7 +1,6 @@
 package rx.observers;
 
 import rx.Observer;
-import rx.Subscriber;
 import rx.util.OnErrorNotImplementedException;
 import rx.util.functions.Action0;
 import rx.util.functions.Action1;

--- a/rxjava-core/src/main/java/rx/observers/TestObserver.java
+++ b/rxjava-core/src/main/java/rx/observers/TestObserver.java
@@ -16,7 +16,6 @@
 package rx.observers;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
+++ b/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
@@ -29,7 +29,6 @@ import rx.Observer;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscription;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 import rx.util.functions.Func0;
 import rx.util.functions.Func1;

--- a/rxjava-core/src/main/java/rx/operators/OperationDebounce.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationDebounce.java
@@ -28,7 +28,6 @@ import rx.observers.SynchronizedObserver;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.SerialSubscription;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 import rx.util.functions.Func1;
 

--- a/rxjava-core/src/main/java/rx/operators/OperationDelay.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationDelay.java
@@ -27,7 +27,6 @@ import rx.observables.ConnectableObservable;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.SerialSubscription;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 import rx.util.functions.Func0;
 import rx.util.functions.Func1;

--- a/rxjava-core/src/main/java/rx/operators/OperationMergeDelayError.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationMergeDelayError.java
@@ -27,9 +27,7 @@ import rx.Subscription;
 import rx.observers.SynchronizedObserver;
 import rx.subscriptions.BooleanSubscription;
 import rx.subscriptions.CompositeSubscription;
-import rx.subscriptions.Subscriptions;
 import rx.util.CompositeException;
-import rx.util.functions.Action0;
 
 /**
  * This behaves like {@link OperatorMerge} except that if any of the merged Observables notify of

--- a/rxjava-core/src/main/java/rx/operators/OperationSkip.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSkip.java
@@ -26,7 +26,6 @@ import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscription;
 import rx.subscriptions.CompositeSubscription;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 /**

--- a/rxjava-core/src/main/java/rx/operators/OperationTakeTimed.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationTakeTimed.java
@@ -26,7 +26,6 @@ import rx.Scheduler.Inner;
 import rx.Subscription;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 /**

--- a/rxjava-core/src/main/java/rx/operators/OperationTimer.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationTimer.java
@@ -22,7 +22,6 @@ import rx.Observer;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscription;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 /**

--- a/rxjava-core/src/main/java/rx/operators/Operator.java
+++ b/rxjava-core/src/main/java/rx/operators/Operator.java
@@ -1,8 +1,0 @@
-package rx.operators;
-
-import rx.Subscriber;
-import rx.util.functions.Func1;
-
-public interface Operator<R, T> extends Func1<Subscriber<? super R>, Subscriber<? super T>> {
-
-}

--- a/rxjava-core/src/main/java/rx/operators/OperatorCast.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorCast.java
@@ -15,6 +15,7 @@
  */
 package rx.operators;
 
+import rx.Observable.Operator;
 import rx.Subscriber;
 
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorDoOnEach.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorDoOnEach.java
@@ -15,6 +15,7 @@
  */
 package rx.operators;
 
+import rx.Observable.Operator;
 import rx.Observer;
 import rx.Subscriber;
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorFilter.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorFilter.java
@@ -15,11 +15,8 @@
  */
 package rx.operators;
 
-import rx.Observable;
-import rx.Observable.OnSubscribeFunc;
-import rx.Observer;
+import rx.Observable.Operator;
 import rx.Subscriber;
-import rx.Subscription;
 import rx.observables.GroupedObservable;
 import rx.util.functions.Func1;
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorGroupBy.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorGroupBy.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.Observable.OnSubscribe;
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.observables.GroupedObservable;
 import rx.subjects.PublishSubject;

--- a/rxjava-core/src/main/java/rx/operators/OperatorMap.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorMap.java
@@ -15,6 +15,7 @@
  */
 package rx.operators;
 
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.util.functions.Func1;
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorMerge.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorMerge.java
@@ -18,6 +18,7 @@ package rx.operators;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.Observable;
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.observers.SynchronizedSubscriber;
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorObserveOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorObserveOn.java
@@ -18,6 +18,7 @@ package rx.operators;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
+import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscriber;

--- a/rxjava-core/src/main/java/rx/operators/OperatorParallel.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorParallel.java
@@ -16,6 +16,7 @@
 package rx.operators;
 
 import rx.Observable;
+import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Subscriber;
 import rx.observables.GroupedObservable;

--- a/rxjava-core/src/main/java/rx/operators/OperatorRepeat.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorRepeat.java
@@ -17,6 +17,7 @@
 package rx.operators;
 
 import rx.Observable;
+import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscriber;

--- a/rxjava-core/src/main/java/rx/operators/OperatorSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorSubscribeOn.java
@@ -16,6 +16,7 @@
 package rx.operators;
 
 import rx.Observable;
+import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscriber;

--- a/rxjava-core/src/main/java/rx/operators/OperatorTake.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorTake.java
@@ -15,6 +15,7 @@
  */
 package rx.operators;
 
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.subscriptions.CompositeSubscription;
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorTimeoutBase.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorTimeoutBase.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Observable;
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.observers.SynchronizedSubscriber;

--- a/rxjava-core/src/main/java/rx/operators/OperatorTimestamp.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorTimestamp.java
@@ -15,6 +15,7 @@
  */
 package rx.operators;
 
+import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Subscriber;
 import rx.util.Timestamped;

--- a/rxjava-core/src/main/java/rx/operators/OperatorToObservableList.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorToObservableList.java
@@ -18,6 +18,7 @@ package rx.operators;
 import java.util.ArrayList;
 import java.util.List;
 
+import rx.Observable.Operator;
 import rx.Subscriber;
 
 /**

--- a/rxjava-core/src/main/java/rx/operators/OperatorToObservableSortedList.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorToObservableSortedList.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.util.functions.Func2;
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorZip.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorZip.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Observable;
+import rx.Observable.Operator;
 import rx.Observer;
 import rx.Subscriber;
 import rx.subscriptions.CompositeSubscription;

--- a/rxjava-core/src/main/java/rx/operators/OperatorZipIterable.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorZipIterable.java
@@ -17,6 +17,7 @@ package rx.operators;
 
 import java.util.Iterator;
 
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.observers.Subscribers;
 import rx.util.functions.Func2;

--- a/rxjava-core/src/main/java/rx/operators/SafeObserver.java
+++ b/rxjava-core/src/main/java/rx/operators/SafeObserver.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import rx.Observer;
 import rx.Subscription;
+import rx.observers.SynchronizedObserver;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.Subscriptions;
 import rx.util.CompositeException;

--- a/rxjava-core/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
+++ b/rxjava-core/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
@@ -18,9 +18,9 @@ package rx.plugins;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observable.OnSubscribeFunc;
+import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.operators.Operator;
 import rx.util.functions.Func1;
 
 /**

--- a/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -20,10 +20,10 @@ import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
+import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.Observable.OnSubscribe;
 import rx.operators.SafeObservableSubscription;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;

--- a/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -16,7 +16,6 @@
 package rx.subscriptions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/rxjava-core/src/perf/java/rx/operators/ObservableBenchmark.java
+++ b/rxjava-core/src/perf/java/rx/operators/ObservableBenchmark.java
@@ -11,6 +11,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.Observable.Operator;
 import rx.Observer;
 import rx.Subscriber;
 import rx.util.functions.Func1;

--- a/rxjava-core/src/test/java/rx/observers/SynchronizedObserverTest.java
+++ b/rxjava-core/src/test/java/rx/observers/SynchronizedObserverTest.java
@@ -36,8 +36,6 @@ import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.operators.SafeObservableSubscription;
-import rx.operators.SafeObserver;
 
 public class SynchronizedObserverTest {
 

--- a/rxjava-core/src/test/java/rx/operators/OperationBufferTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationBufferTest.java
@@ -38,7 +38,6 @@ import rx.Subscription;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 import rx.util.functions.Func0;
 import rx.util.functions.Func1;

--- a/rxjava-core/src/test/java/rx/operators/OperationDebounceTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationDebounceTest.java
@@ -31,7 +31,6 @@ import rx.Subscription;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 import rx.util.functions.Func1;
 

--- a/rxjava-core/src/test/java/rx/operators/OperationSampleTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationSampleTest.java
@@ -31,7 +31,6 @@ import rx.Subscription;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 public class OperationSampleTest {

--- a/rxjava-core/src/test/java/rx/operators/OperationSwitchTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationSwitchTest.java
@@ -30,7 +30,6 @@ import rx.Scheduler.Inner;
 import rx.Subscription;
 import rx.schedulers.TestScheduler;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 public class OperationSwitchTest {

--- a/rxjava-core/src/test/java/rx/operators/OperationWindowTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationWindowTest.java
@@ -35,7 +35,6 @@ import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 import rx.util.functions.Func0;
 import rx.util.functions.Func1;

--- a/rxjava-core/src/test/java/rx/operators/OperatorFromIterableTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorFromIterableTest.java
@@ -15,10 +15,8 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 

--- a/rxjava-core/src/test/java/rx/operators/OperatorSubscribeOnTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorSubscribeOnTest.java
@@ -15,10 +15,7 @@
  */
 package rx.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;

--- a/rxjava-core/src/test/java/rx/operators/OperatorTakeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorTakeTest.java
@@ -16,6 +16,7 @@
 package rx.operators;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/rxjava-core/src/test/java/rx/operators/OperatorTimeoutTests.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorTimeoutTests.java
@@ -15,13 +15,8 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -33,10 +28,10 @@ import org.mockito.InOrder;
 import org.mockito.MockitoAnnotations;
 
 import rx.Observable;
+import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.Observable.OnSubscribe;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 

--- a/rxjava-core/src/test/java/rx/operators/OperatorTimeoutWithSelectorTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorTimeoutWithSelectorTest.java
@@ -15,13 +15,8 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
@@ -20,7 +20,6 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +38,6 @@ import rx.Scheduler;
 import rx.Scheduler.Inner;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.subscriptions.BooleanSubscription;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;
 import rx.util.functions.Action1;


### PR DESCRIPTION
The generics insanity has to stop.

This pull request is a result of @abersnaze and I continuing to fail to make generics work with this signature:

``` java
Func1<Subscriber<? super R>, Subscriber<? super T>>
```

It all fell apart while trying to do things that needed the equivalent of:

``` java
Func1<Subscriber<? super R>, Subscriber<? super ? super T>>
```

... and other such variants.

With this change I can also finally get the `OperatorMerge` generics to work. 

Thus, the `Operator` type exists inside `Observable` just like `OnSubscribe` like this:

``` java
    /**
     * Operator function for lifting into an Observable.
     */
    public interface Operator<R, T> extends Func1<Subscriber<? super R>, Subscriber<? super T>> {
        // cover for generics insanity
    }
```

This gives us imports like this:

``` java
import rx.Observable;
import rx.Observable.OnSubscribe;
import rx.Observable.Operator;
```

I know it's not as pure as having `lift(Func1)` but this is far more usable.

``` java
public <R> Observable<R> lift(final Operator<R, T> bind)
```

If anyone has a different suggestion that still solves the generics issue please let me know.
