### PR TITLE
Proposed solution to the time gap, using unbounded buffering.

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -7062,7 +7062,25 @@ public class Observable<T> {
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#wiki-subscribeon">RxJava Wiki: subscribeOn()</a>
      */
     public final Observable<T> subscribeOn(Scheduler scheduler) {
-        return nest().lift(new OperatorSubscribeOn<T>(scheduler));
+        return nest().lift(new OperatorSubscribeOn<T>(scheduler, false));
+    }
+    /**
+     * Asynchronously subscribes and unsubscribes Observers to this Observable on the specified {@link Scheduler}
+     * and allows buffering the events emitted from the source in the time gap between the original and
+     * actual subscription.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/subscribeOn.png">
+     * 
+     * @param scheduler
+     *            the {@link Scheduler} to perform subscription and unsubscription actions on
+     * @param dontLoseEvents indicate that the operator should buffer events emitted in the time gap
+     *                       between the original and actual subscription and replay it to Observers
+     * @return the source Observable modified so that its subscriptions and unsubscriptions happen
+     *         on the specified {@link Scheduler}
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#wiki-subscribeon">RxJava Wiki: subscribeOn()</a>
+     */
+    public final Observable<T> subscribeOn(Scheduler scheduler, boolean dontLoseEvents) {
+        return nest().lift(new OperatorSubscribeOn<T>(scheduler, dontLoseEvents));
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/operators/BufferUntilSubscriber.java
+++ b/rxjava-core/src/main/java/rx/operators/BufferUntilSubscriber.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.operators;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import rx.Subscriber;
+import rx.subscriptions.CompositeSubscription;
+
+/**
+ * Buffers the incoming events until notified, then replays the
+ * buffered events and continues as a simple pass-through subscriber.
+ * @param <T> the streamed value type
+ */
+public class BufferUntilSubscriber<T> extends Subscriber<T> {
+    /** The actual subscriber. */
+    private final Subscriber<? super T> actual;
+    /** The mutual exclusion for the duration of the replay. */
+    private final Object gate = new Object();
+    /** Queued events. */
+    private final Queue<Object> queue = new LinkedList<Object>();
+    /** Indicate the pass-through mode. */
+    private volatile boolean passthroughMode;
+    /** Null sentinel (in case queue type is changed). */
+    private static final Object NULL_SENTINEL = new Object();
+    /** Complete sentinel. */
+    private static final Object COMPLETE_SENTINEL = new Object();
+    /**
+     * Container for an onError event.
+     */
+    private static final class ErrorSentinel {
+        final Throwable t;
+
+        public ErrorSentinel(Throwable t) {
+            this.t = t;
+        }
+        
+    }
+    /**
+     * Constructor that wraps the actual subscriber and shares its subscription.
+     * @param actual 
+     */
+    public BufferUntilSubscriber(Subscriber<? super T> actual) {
+        super(actual);
+        this.actual = actual;
+    }
+    /**
+     * Constructor that wraps the actual subscriber and uses the given composite
+     * subscription.
+     * @param actual
+     * @param cs 
+     */
+    public BufferUntilSubscriber(Subscriber<? super T> actual, CompositeSubscription cs) {
+        super(cs);
+        this.actual = actual;
+    }
+    
+    /**
+     * Call this method to replay the buffered events and continue as a pass-through subscriber.
+     * If already in pass-through mode, this method is a no-op.
+     */
+    public void enterPassthroughMode() {
+        if (!passthroughMode) {
+            synchronized (gate) {
+                if (!passthroughMode) {
+                    while (!queue.isEmpty()) {
+                        Object o = queue.poll();
+                        
+                        if (o == NULL_SENTINEL) {
+                            actual.onNext(null);
+                        } else
+                        if (o == COMPLETE_SENTINEL) {
+                            actual.onCompleted();
+                        } else
+                        if (o instanceof ErrorSentinel) {
+                            actual.onError(((ErrorSentinel)o).t);
+                        } else
+                        if (o != null) {
+                            @SuppressWarnings("unchecked")
+                            T v = (T)o;
+                            actual.onNext(v);
+                        } else {
+                            throw new NullPointerException();
+                        }
+                    }
+                    /* Test artificial back-pressure.
+                    try {
+                        TimeUnit.SECONDS.sleep(2);
+                    } catch (Throwable t) {
+                        
+                    }
+                    */
+                    passthroughMode = true;
+                }
+            }
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (!passthroughMode) {
+            synchronized (gate) {
+                if (!passthroughMode) {
+                    queue.offer(t != null ? t : NULL_SENTINEL);
+                    return;
+                }
+            }
+        }
+        actual.onNext(t);
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        if (!passthroughMode) {
+            synchronized (gate) {
+                if (!passthroughMode) {
+                    queue.offer(new ErrorSentinel(e));
+                    return;
+                }
+            }
+        }
+        actual.onError(e);
+    }
+
+    @Override
+    public void onCompleted() {
+        if (!passthroughMode) {
+            synchronized (gate) {
+                if (!passthroughMode) {
+                    queue.offer(COMPLETE_SENTINEL);
+                    return;
+                }
+            }
+        }
+        actual.onCompleted();
+    }
+}

--- a/rxjava-core/src/test/java/rx/operators/OperatorSubscribeOnTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorSubscribeOnTest.java
@@ -1,77 +1,88 @@
-/**
- * Copyright 2014 Netflix, Inc.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ /**
+  * Copyright 2014 Netflix, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package rx.operators;
 
+import java.util.ArrayList;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.Scheduler;
+import rx.Scheduler.Inner;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.observables.GroupedObservable;
 import rx.observers.TestObserver;
+import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
+import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.MultipleAssignmentSubscription;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;
+import rx.util.functions.Action1;
+import rx.util.functions.Func1;
 
 public class OperatorSubscribeOnTest {
-
+    
     private class ThreadSubscription implements Subscription {
         private volatile Thread thread;
-
+        
         private final CountDownLatch latch = new CountDownLatch(1);
-
+        
         private final Subscription s = Subscriptions.create(new Action0() {
-
+            
             @Override
             public void call() {
                 thread = Thread.currentThread();
                 latch.countDown();
             }
-
+            
         });
-
+        
         @Override
         public void unsubscribe() {
             s.unsubscribe();
         }
-
+        
         @Override
         public boolean isUnsubscribed() {
             return s.isUnsubscribed();
         }
-
+        
         public Thread getThread() throws InterruptedException {
             latch.await();
             return thread;
         }
     }
-
+    
     @Test
     public void testSubscribeOnAndVerifySubscribeAndUnsubscribeThreads()
             throws InterruptedException {
         final ThreadSubscription subscription = new ThreadSubscription();
         final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
         Observable<Integer> w = Observable.create(new OnSubscribe<Integer>() {
-
+            
             @Override
             public void call(Subscriber<? super Integer> t1) {
                 subscribeThread.set(Thread.currentThread());
@@ -81,33 +92,33 @@ public class OperatorSubscribeOnTest {
                 t1.onCompleted();
             }
         });
-
+        
         TestObserver<Integer> observer = new TestObserver<Integer>();
         w.subscribeOn(Schedulers.newThread()).subscribe(observer);
-
+        
         Thread unsubscribeThread = subscription.getThread();
-
+        
         assertNotNull(unsubscribeThread);
         assertNotSame(Thread.currentThread(), unsubscribeThread);
-
+        
         assertNotNull(subscribeThread.get());
         assertNotSame(Thread.currentThread(), subscribeThread.get());
         // True for Schedulers.newThread()
         assertTrue(unsubscribeThread == subscribeThread.get());
-
+        
         observer.assertReceivedOnNext(Arrays.asList(1, 2));
         observer.assertTerminalEvent();
     }
-
+    
     @Test
     public void testIssue813() throws InterruptedException {
         // https://github.com/Netflix/RxJava/issues/813
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
-
+        
         TestObserver<Integer> observer = new TestObserver<Integer>();
         final ThreadSubscription s = new ThreadSubscription();
-
+        
         final Subscription subscription = Observable
                 .create(new Observable.OnSubscribe<Integer>() {
                     @Override
@@ -132,7 +143,7 @@ public class OperatorSubscribeOnTest {
                         }
                     }
                 }).subscribeOn(Schedulers.computation()).subscribe(observer);
-
+        
         subscription.unsubscribe();
         // As unsubscribe is called in other thread, we need to wait for it.
         s.getThread();
@@ -140,5 +151,191 @@ public class OperatorSubscribeOnTest {
         doneLatch.await();
         assertEquals(0, observer.getOnErrorEvents().size());
         assertEquals(1, observer.getOnCompletedEvents().size());
+    }
+    
+     static class SlowScheduler extends Scheduler {
+        final Scheduler actual;
+        final long delay;
+        final TimeUnit unit;
+        public SlowScheduler() {
+            this(Schedulers.computation(), 2, TimeUnit.SECONDS);
+        }
+        public SlowScheduler(Scheduler actual, long delay, TimeUnit unit) {
+            this.actual = actual;
+            this.delay = delay;
+            this.unit = unit;
+        }
+
+        @Override
+        public Subscription schedule(final Action1<Scheduler.Inner> action) {
+            final CompositeSubscription cs = new CompositeSubscription();
+            final MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
+            cs.add(mas);
+            mas.set(actual.schedule(new Action1<Inner>() {
+
+                @Override
+                public void call(Inner t1) {
+//                    cs.delete(mas);
+                    cs.add(actual.schedule(action, delay, unit));
+                }
+                
+            }));
+            return cs;
+        }
+
+        @Override
+        public Subscription schedule(final Action1<Scheduler.Inner> action, final long delayTime, final TimeUnit delayUnit) {
+            final CompositeSubscription cs = new CompositeSubscription();
+            final MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
+            cs.add(mas);
+            mas.set(actual.schedule(new Action1<Inner>() {
+                @Override
+                public void call(Inner t1) {
+//                    cs.delete(mas);
+                    long nanos = unit.toNanos(delay) + delayUnit.toNanos(delayTime);
+                    cs.add(actual.schedule(action, nanos, TimeUnit.NANOSECONDS));
+                }
+            }));
+            return cs;
+        }
+    }
+    
+    @Test
+    public void testSubscribeOnPublishSubjectWithSlowScheduler() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ps.subscribeOn(new SlowScheduler()).subscribe(ts);
+        ps.onNext(1);
+        ps.onNext(2);
+        ps.onCompleted();
+        
+        ts.awaitTerminalEvent();
+        ts.assertReceivedOnNext(Arrays.asList(1, 2));
+    }
+    
+    @Test
+    public void testGroupsWithNestedSubscribeOn() throws InterruptedException {
+        final ArrayList<String> results = new ArrayList<String>();
+        Observable.create(new OnSubscribe<Integer>() {
+            
+            @Override
+            public void call(Subscriber<? super Integer> sub) {
+                sub.onNext(1);
+                sub.onNext(2);
+                sub.onNext(1);
+                sub.onNext(2);
+                sub.onCompleted();
+            }
+            
+        }).groupBy(new Func1<Integer, Integer>() {
+            
+            @Override
+            public Integer call(Integer t) {
+                return t;
+            }
+            
+        }).flatMap(new Func1<GroupedObservable<Integer, Integer>, Observable<String>>() {
+            
+            @Override
+            public Observable<String> call(final GroupedObservable<Integer, Integer> group) {
+                return group.subscribeOn(Schedulers.newThread()).map(new Func1<Integer, String>() {
+                    
+                    @Override
+                    public String call(Integer t1) {
+                        System.out.println("Received: " + t1 + " on group : " + group.getKey());
+                        return "first groups: " + t1;
+                    }
+                    
+                });
+            }
+            
+        }).toBlockingObservable().forEach(new Action1<String>() {
+            
+            @Override
+            public void call(String s) {
+                results.add(s);
+            }
+            
+        });
+        
+        System.out.println("Results: " + results);
+        assertEquals(4, results.size());
+    }
+    
+    @Test
+    public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenSubscribesOnAndDelaysAndThenCompletes() throws InterruptedException {
+        final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
+        final ArrayList<String> results = new ArrayList<String>();
+        Observable.create(new OnSubscribe<Integer>() {
+            
+            @Override
+            public void call(Subscriber<? super Integer> sub) {
+                sub.onNext(1);
+                sub.onNext(2);
+                sub.onNext(1);
+                sub.onNext(2);
+                try {
+                    first.await();
+                } catch (InterruptedException e) {
+                    sub.onError(e);
+                    return;
+                }
+                sub.onNext(3);
+                sub.onNext(3);
+                sub.onCompleted();
+            }
+            
+        }).groupBy(new Func1<Integer, Integer>() {
+            
+            @Override
+            public Integer call(Integer t) {
+                return t;
+            }
+            
+        }).flatMap(new Func1<GroupedObservable<Integer, Integer>, Observable<String>>() {
+            
+            @Override
+            public Observable<String> call(final GroupedObservable<Integer, Integer> group) {
+                if (group.getKey() < 3) {
+                    return group.map(new Func1<Integer, String>() {
+                        
+                        @Override
+                        public String call(Integer t1) {
+                            return "first groups: " + t1;
+                        }
+                        
+                    })
+                            // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
+                            .take(2).doOnCompleted(new Action0() {
+                                
+                                @Override
+                                public void call() {
+                                    first.countDown();
+                                }
+                                
+                            });
+                } else {
+                    return group.subscribeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS).map(new Func1<Integer, String>() {
+                        
+                        @Override
+                        public String call(Integer t1) {
+                            return "last group: " + t1;
+                        }
+                        
+                    });
+                }
+            }
+            
+        }).toBlockingObservable().forEach(new Action1<String>() {
+            
+            @Override
+            public void call(String s) {
+                results.add(s);
+            }
+            
+        });
+        
+        System.out.println("Results: " + results);
+        assertEquals(6, results.size());
     }
 }


### PR DESCRIPTION
This is a solution to the time gap problem for #844.
- Currently, it uses an unbounded buffer. I'll think about a bounded approach later on.
- I've added an subscribeOn overload where the user can explicitly request a buffering behavior. In addition, SubscribeOn checks the type of the Observable and enters buffering mode for GroupedObservable and PublishSubject. I think these code options should be mutually exclusive: 
  1. either we only check for Observable type, but then new kinds of observables or hidden observables won't work,
  2. or ask the programmer in the documentation/tutorial to explicitly request buffering in certain operator compositions.

I personally favor option 2).
