### PR TITLE
Correct synchronization guard in groupByUntil

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationGroupByUntil.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationGroupByUntil.java
@@ -102,7 +102,7 @@ public class OperationGroupByUntil<TSource, TKey, TResult, TDuration> implements
 
             GroupSubject<TKey, TResult> g;
             boolean newGroup = false;
-            synchronized (key) {
+            synchronized (gate) {
                 g = map.get(key);
                 if (g == null) {
                     g = create(key);


### PR DESCRIPTION
Can't see how `synchronized (key) { ... }` could have been correct here; `key` will hardly ever be the same instance for different invocations of `keySelector`, and the comment on line 73 clearly states `gate` to be the guard for `map`.
