### PR TITLE
Force ViewObservable be subscribed and unsubscribed in the UI thread

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/observables/ViewObservable.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/observables/ViewObservable.java
@@ -15,6 +15,7 @@
  */
 package rx.android.observables;
 
+import android.os.Looper;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.EditText;
@@ -37,5 +38,10 @@ public class ViewObservable {
         return Observable.create(new OperatorCompoundButtonInput(button, emitInitialValue));
     }
 
+    public static void assertUiThread() {
+        if (Looper.getMainLooper() != Looper.myLooper()) {
+            throw new IllegalStateException("Observers must subscribe from the main UI thread, but was " + Thread.currentThread());
+        }
+    }
 }
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperationObserveFromAndroidComponent.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperationObserveFromAndroidComponent.java
@@ -18,9 +18,11 @@ package rx.operators;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
+import rx.Scheduler.Inner;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;
+import rx.util.functions.Action1;
 import android.app.Activity;
 import android.os.Looper;
 import android.util.Log;
@@ -100,8 +102,15 @@ public class OperationObserveFromAndroidComponent {
                 @Override
                 public void call() {
                     log("unsubscribing from source sequence");
-                    releaseReferences();
-                    sourceSub.unsubscribe();
+                    AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
+
+                        @Override
+                        public void call(Inner t1) {
+                            releaseReferences();
+                            sourceSub.unsubscribe();
+                        }
+
+                    });
                 }
             });
         }

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorCompoundButtonInput.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorCompoundButtonInput.java
@@ -23,8 +23,12 @@ import java.util.WeakHashMap;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.Scheduler.Inner;
+import rx.android.observables.ViewObservable;
+import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;
+import rx.util.functions.Action1;
 import android.view.View;
 import android.widget.CompoundButton;
 
@@ -39,6 +43,7 @@ public class OperatorCompoundButtonInput implements Observable.OnSubscribe<Boole
 
     @Override
     public void call(final Subscriber<? super Boolean> observer) {
+        ViewObservable.assertUiThread();
         final CompositeOnCheckedChangeListener composite = CachedListeners.getFromViewOrCreate(button);
 
         final CompoundButton.OnCheckedChangeListener listener = new CompoundButton.OnCheckedChangeListener() {
@@ -51,7 +56,14 @@ public class OperatorCompoundButtonInput implements Observable.OnSubscribe<Boole
         final Subscription subscription = Subscriptions.create(new Action0() {
             @Override
             public void call() {
-                composite.removeOnCheckedChangeListener(listener);
+                AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
+
+                    @Override
+                    public void call(Inner t1) {
+                        composite.removeOnCheckedChangeListener(listener);
+                    }
+
+                });
             }
         });
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorEditTextInput.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorEditTextInput.java
@@ -18,8 +18,12 @@ package rx.operators;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.Scheduler.Inner;
+import rx.android.observables.ViewObservable;
+import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;
+import rx.util.functions.Action1;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.EditText;
@@ -35,6 +39,7 @@ public class OperatorEditTextInput implements Observable.OnSubscribe<String> {
 
     @Override
     public void call(final Subscriber<? super String> observer) {
+        ViewObservable.assertUiThread();
         final TextWatcher watcher = new SimpleTextWatcher() {
             @Override
             public void afterTextChanged(final Editable editable) {
@@ -45,7 +50,14 @@ public class OperatorEditTextInput implements Observable.OnSubscribe<String> {
         final Subscription subscription = Subscriptions.create(new Action0() {
             @Override
             public void call() {
-                input.removeTextChangedListener(watcher);
+                AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
+
+                    @Override
+                    public void call(Inner t1) {
+                        input.removeTextChangedListener(watcher);
+                    }
+
+                });
             }
         });
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorViewClick.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorViewClick.java
@@ -21,10 +21,14 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 import rx.Observable;
+import rx.Scheduler.Inner;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.android.observables.ViewObservable;
+import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.Subscriptions;
 import rx.util.functions.Action0;
+import rx.util.functions.Action1;
 import android.view.View;
 
 public final class OperatorViewClick implements Observable.OnSubscribe<View> {
@@ -38,6 +42,7 @@ public final class OperatorViewClick implements Observable.OnSubscribe<View> {
 
     @Override
     public void call(final Subscriber<? super View> observer) {
+        ViewObservable.assertUiThread();
         final CompositeOnClickListener composite = CachedListeners.getFromViewOrCreate(view);
 
         final View.OnClickListener listener = new View.OnClickListener() {
@@ -50,7 +55,14 @@ public final class OperatorViewClick implements Observable.OnSubscribe<View> {
         final Subscription subscription = Subscriptions.create(new Action0() {
             @Override
             public void call() {
-                composite.removeOnClickListener(listener);
+                AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
+
+                    @Override
+                    public void call(Inner t1) {
+                        composite.removeOnClickListener(listener);
+                    }
+
+                });
             }
         });
 


### PR DESCRIPTION
According to #869 , `unsubscribe` can run in any thread. However, that will cause some concurrent issues in rxjava-android.

This PR schedules the `unsubscribe` action to run in the UI thread to solve the problem.
