### PR TITLE
Make Subscriptions of SwingObservable thread-safe

### DIFF
--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/observables/SwingObservable.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/observables/SwingObservable.java
@@ -25,6 +25,7 @@ import java.awt.event.MouseEvent;
 import java.util.Set;
 
 import javax.swing.AbstractButton;
+import javax.swing.SwingUtilities;
 
 import rx.Observable;
 import rx.functions.Func1;
@@ -139,5 +140,16 @@ public enum SwingObservable { ; // no instances
      */
     public static Observable<Dimension> fromResizing(Component component) {
         return ComponentEventSource.fromResizing(component);
+    }
+
+    /**
+     * Check if the current thead is the event dispatch thread.
+     * 
+     * @throws IllegalStateException if the current thread is not the event dispatch thread.
+     */
+    public static void assertEventDispatchThread() {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            throw new IllegalStateException("Need to run in the event dispatch thread, but was " + Thread.currentThread());
+        }
     }
 }

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/subscriptions/SwingSubscriptions.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/subscriptions/SwingSubscriptions.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.subscriptions;
+
+import javax.swing.SwingUtilities;
+
+import rx.Scheduler.Inner;
+import rx.Subscription;
+import rx.schedulers.SwingScheduler;
+import rx.functions.Action0;
+import rx.functions.Action1;
+
+public final class SwingSubscriptions {
+
+    private SwingSubscriptions() {
+        // no instance
+    }
+
+    /**
+     * Create an Subscription that always runs <code>unsubscribe</code> in the event dispatch thread.
+     * 
+     * @param unsubscribe
+     * @return an Subscription that always runs <code>unsubscribe</code> in the event dispatch thread.
+     */
+    public static Subscription unsubscribeInEventDispatchThread(final Action0 unsubscribe) {
+        return Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                if (SwingUtilities.isEventDispatchThread()) {
+                    unsubscribe.call();
+                } else {
+                    SwingScheduler.getInstance().schedule(new Action1<Inner>() {
+                        @Override
+                        public void call(Inner inner) {
+                            unsubscribe.call();
+                        }
+                    });
+                }
+            }
+        });
+    }
+}

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/AbstractButtonSource.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/AbstractButtonSource.java
@@ -15,7 +15,10 @@
  */
 package rx.swing.sources;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -26,12 +29,13 @@ import org.junit.Test;
 import org.mockito.Matchers;
 
 import rx.Observable;
-import rx.Observable.OnSubscribeFunc;
-import rx.Observer;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
-import rx.subscriptions.Subscriptions;
+import rx.observables.SwingObservable;
+import rx.subscriptions.SwingSubscriptions;
 
 public enum AbstractButtonSource { ; // no instances
 
@@ -39,63 +43,70 @@ public enum AbstractButtonSource { ; // no instances
      * @see rx.observables.SwingObservable#fromButtonAction
      */
     public static Observable<ActionEvent> fromActionOf(final AbstractButton button) {
-        return Observable.create(new OnSubscribeFunc<ActionEvent>() {
+        return Observable.create(new OnSubscribe<ActionEvent>() {
             @Override
-            public Subscription onSubscribe(final Observer<? super ActionEvent> observer) {
+            public void call(final Subscriber<? super ActionEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
                 final ActionListener listener = new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        observer.onNext(e);
+                        subscriber.onNext(e);
                     }
                 };
                 button.addActionListener(listener);
-                
-                return Subscriptions.create(new Action0() {
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
                     @Override
                     public void call() {
                         button.removeActionListener(listener);
                     }
-                });
+                }));
             }
         });
     }
 
     public static class UnitTest {
         @Test
-        public void testObservingActionEvents() {
-            @SuppressWarnings("unchecked")
-            Action1<ActionEvent> action = mock(Action1.class);
-            @SuppressWarnings("unchecked")
-            Action1<Throwable> error = mock(Action1.class);
-            Action0 complete = mock(Action0.class);
-            
-            final ActionEvent event = new ActionEvent(this, 1, "command");
-            
-            @SuppressWarnings("serial")
-            class TestButton extends AbstractButton {
-                void testAction() {
-                    fireActionPerformed(event);
+        public void testObservingActionEvents() throws Throwable {
+            SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+                @Override
+                public void call() {
+                    @SuppressWarnings("unchecked")
+                    Action1<ActionEvent> action = mock(Action1.class);
+                    @SuppressWarnings("unchecked")
+                    Action1<Throwable> error = mock(Action1.class);
+                    Action0 complete = mock(Action0.class);
+
+                    final ActionEvent event = new ActionEvent(this, 1, "command");
+
+                    @SuppressWarnings("serial")
+                    class TestButton extends AbstractButton {
+                        void testAction() {
+                            fireActionPerformed(event);
+                        }
+                    }
+
+                    TestButton button = new TestButton();
+                    Subscription sub = fromActionOf(button).subscribe(action, error, complete);
+
+                    verify(action, never()).call(Matchers.<ActionEvent> any());
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
+
+                    button.testAction();
+                    verify(action, times(1)).call(Matchers.<ActionEvent> any());
+
+                    button.testAction();
+                    verify(action, times(2)).call(Matchers.<ActionEvent> any());
+
+                    sub.unsubscribe();
+                    button.testAction();
+                    verify(action, times(2)).call(Matchers.<ActionEvent> any());
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
                 }
-            }
-            
-            TestButton button = new TestButton();
-            Subscription sub = fromActionOf(button).subscribe(action, error, complete);
-            
-            verify(action, never()).call(Matchers.<ActionEvent>any());
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
-            
-            button.testAction();
-            verify(action, times(1)).call(Matchers.<ActionEvent>any());
-            
-            button.testAction();
-            verify(action, times(2)).call(Matchers.<ActionEvent>any());
-            
-            sub.unsubscribe();
-            button.testAction();
-            verify(action, times(2)).call(Matchers.<ActionEvent>any());
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
+
+            }).awaitTerminal();
         }
     }
 }

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/ComponentEventSource.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/ComponentEventSource.java
@@ -15,7 +15,7 @@
  */
 package rx.swing.sources;
 
-import static rx.swing.sources.ComponentEventSource.Predicate.*;
+import static rx.swing.sources.ComponentEventSource.Predicate.RESIZED;
 
 import java.awt.Component;
 import java.awt.Dimension;
@@ -23,13 +23,12 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 
 import rx.Observable;
-import rx.Observable.OnSubscribeFunc;
-import rx.Observer;
-import rx.Subscription;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.observables.SwingObservable;
-import rx.subscriptions.Subscriptions;
+import rx.subscriptions.SwingSubscriptions;
 
 public enum ComponentEventSource { ; // no instances
 
@@ -37,38 +36,38 @@ public enum ComponentEventSource { ; // no instances
      * @see rx.observables.SwingObservable#fromComponentEvents
      */
     public static Observable<ComponentEvent> fromComponentEventsOf(final Component component) {
-        return Observable.create(new OnSubscribeFunc<ComponentEvent>() {
+        return Observable.create(new OnSubscribe<ComponentEvent>() {
             @Override
-            public Subscription onSubscribe(final Observer<? super ComponentEvent> observer) {
+            public void call(final Subscriber<? super ComponentEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
                 final ComponentListener listener = new ComponentListener() {
                     @Override
                     public void componentHidden(ComponentEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void componentMoved(ComponentEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void componentResized(ComponentEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void componentShown(ComponentEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
                 };
                 component.addComponentListener(listener);
-                
-                return Subscriptions.create(new Action0() {
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
                     @Override
                     public void call() {
                         component.removeComponentListener(listener);
                     }
-                });
+                }));
             }
         });
     }

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/KeyEventSource.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/KeyEventSource.java
@@ -15,8 +15,12 @@
  */
 package rx.swing.sources;
 
-import static java.util.Arrays.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.awt.Component;
 import java.awt.event.KeyEvent;
@@ -32,14 +36,15 @@ import org.mockito.InOrder;
 import org.mockito.Matchers;
 
 import rx.Observable;
-import rx.Observable.OnSubscribeFunc;
-import rx.Observer;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.functions.Func2;
-import rx.subscriptions.Subscriptions;
+import rx.observables.SwingObservable;
+import rx.subscriptions.SwingSubscriptions;
 
 public enum KeyEventSource { ; // no instances
 
@@ -47,33 +52,34 @@ public enum KeyEventSource { ; // no instances
      * @see rx.observables.SwingObservable#fromKeyEvents(Component)
      */
     public static Observable<KeyEvent> fromKeyEventsOf(final Component component) {
-        return Observable.create(new OnSubscribeFunc<KeyEvent>() {
+        return Observable.create(new OnSubscribe<KeyEvent>() {
             @Override
-            public Subscription onSubscribe(final Observer<? super KeyEvent> observer) {
+            public void call(final Subscriber<? super KeyEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
                 final KeyListener listener = new KeyListener() {
                     @Override
                     public void keyPressed(KeyEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
-  
+
                     @Override
                     public void keyReleased(KeyEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
-  
+
                     @Override
                     public void keyTyped(KeyEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
                 };
                 component.addKeyListener(listener);
-                
-                return Subscriptions.create(new Action0() {
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
                     @Override
                     public void call() {
                         component.removeKeyListener(listener);
                     }
-                });
+                }));
             }
         });
     }
@@ -115,73 +121,87 @@ public enum KeyEventSource { ; // no instances
         private Component comp = new JPanel();
         
         @Test
-        public void testObservingKeyEvents() {
-            @SuppressWarnings("unchecked")
-            Action1<KeyEvent> action = mock(Action1.class);
-            @SuppressWarnings("unchecked")
-            Action1<Throwable> error = mock(Action1.class);
-            Action0 complete = mock(Action0.class);
-            
-            final KeyEvent event = mock(KeyEvent.class);
-            
-            Subscription sub = fromKeyEventsOf(comp).subscribe(action, error, complete);
-            
-            verify(action, never()).call(Matchers.<KeyEvent>any());
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
-            
-            fireKeyEvent(event);
-            verify(action, times(1)).call(Matchers.<KeyEvent>any());
-            
-            fireKeyEvent(event);
-            verify(action, times(2)).call(Matchers.<KeyEvent>any());
-            
-            sub.unsubscribe();
-            fireKeyEvent(event);
-            verify(action, times(2)).call(Matchers.<KeyEvent>any());
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
+        public void testObservingKeyEvents() throws Throwable {
+            SwingTestHelper.create().runInEventDispatchThread(new Action0(){
+
+                @Override
+                public void call() {
+                    @SuppressWarnings("unchecked")
+                    Action1<KeyEvent> action = mock(Action1.class);
+                    @SuppressWarnings("unchecked")
+                    Action1<Throwable> error = mock(Action1.class);
+                    Action0 complete = mock(Action0.class);
+
+                    final KeyEvent event = mock(KeyEvent.class);
+
+                    Subscription sub = fromKeyEventsOf(comp).subscribe(action, error, complete);
+
+                    verify(action, never()).call(Matchers.<KeyEvent> any());
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
+
+                    fireKeyEvent(event);
+                    verify(action, times(1)).call(Matchers.<KeyEvent> any());
+
+                    fireKeyEvent(event);
+                    verify(action, times(2)).call(Matchers.<KeyEvent> any());
+
+                    sub.unsubscribe();
+                    fireKeyEvent(event);
+                    verify(action, times(2)).call(Matchers.<KeyEvent> any());
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
+                }
+
+            }).awaitTerminal();
         }
-        
+
         @Test
-        public void testObservingPressedKeys() {
-            @SuppressWarnings("unchecked")
-            Action1<Set<Integer>> action = mock(Action1.class);
-            @SuppressWarnings("unchecked")
-            Action1<Throwable> error = mock(Action1.class);
-            Action0 complete = mock(Action0.class);
-            
-            Subscription sub = currentlyPressedKeysOf(comp).subscribe(action, error, complete);
-            
-            InOrder inOrder = inOrder(action);
-            inOrder.verify(action, times(1)).call(Collections.<Integer>emptySet());
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
-            
-            fireKeyEvent(keyEvent(1, KeyEvent.KEY_PRESSED));
-            inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1)));
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
+        public void testObservingPressedKeys() throws Throwable {
+            SwingTestHelper.create().runInEventDispatchThread(new Action0() {
 
-            fireKeyEvent(keyEvent(2, KeyEvent.KEY_PRESSED));
-            fireKeyEvent(keyEvent(KeyEvent.VK_UNDEFINED, KeyEvent.KEY_TYPED));
-            inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1, 2)));
+                @Override
+                public void call() {
+                    @SuppressWarnings("unchecked")
+                    Action1<Set<Integer>> action = mock(Action1.class);
+                    @SuppressWarnings("unchecked")
+                    Action1<Throwable> error = mock(Action1.class);
+                    Action0 complete = mock(Action0.class);
 
-            fireKeyEvent(keyEvent(2, KeyEvent.KEY_RELEASED));
-            inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1)));
+                    Subscription sub = currentlyPressedKeysOf(comp).subscribe(action, error, complete);
 
-            fireKeyEvent(keyEvent(3, KeyEvent.KEY_RELEASED));
-            inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1)));
+                    InOrder inOrder = inOrder(action);
+                    inOrder.verify(action, times(1)).call(Collections.<Integer> emptySet());
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
 
-            fireKeyEvent(keyEvent(1, KeyEvent.KEY_RELEASED));
-            inOrder.verify(action, times(1)).call(Collections.<Integer>emptySet());
+                    fireKeyEvent(keyEvent(1, KeyEvent.KEY_PRESSED));
+                    inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1)));
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
 
-            sub.unsubscribe();
+                    fireKeyEvent(keyEvent(2, KeyEvent.KEY_PRESSED));
+                    fireKeyEvent(keyEvent(KeyEvent.VK_UNDEFINED, KeyEvent.KEY_TYPED));
+                    inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1, 2)));
 
-            fireKeyEvent(keyEvent(1, KeyEvent.KEY_PRESSED));
-            inOrder.verify(action, never()).call(Matchers.<Set<Integer>>any());
-            verify(error, never()).call(Matchers.<Throwable>any());
-            verify(complete, never()).call();
+                    fireKeyEvent(keyEvent(2, KeyEvent.KEY_RELEASED));
+                    inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1)));
+
+                    fireKeyEvent(keyEvent(3, KeyEvent.KEY_RELEASED));
+                    inOrder.verify(action, times(1)).call(new HashSet<Integer>(asList(1)));
+
+                    fireKeyEvent(keyEvent(1, KeyEvent.KEY_RELEASED));
+                    inOrder.verify(action, times(1)).call(Collections.<Integer> emptySet());
+
+                    sub.unsubscribe();
+
+                    fireKeyEvent(keyEvent(1, KeyEvent.KEY_PRESSED));
+                    inOrder.verify(action, never()).call(Matchers.<Set<Integer>> any());
+                    verify(error, never()).call(Matchers.<Throwable> any());
+                    verify(complete, never()).call();
+                }
+
+            }).awaitTerminal();
         }
 
         private KeyEvent keyEvent(int keyCode, int id) {

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/MouseEventSource.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/MouseEventSource.java
@@ -15,7 +15,11 @@
  */
 package rx.swing.sources;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.awt.Component;
 import java.awt.Point;
@@ -30,92 +34,95 @@ import org.mockito.InOrder;
 import org.mockito.Matchers;
 
 import rx.Observable;
-import rx.Observable.OnSubscribeFunc;
-import rx.Observer;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
-import rx.functions.Func1;
 import rx.functions.Func2;
-import rx.subscriptions.Subscriptions;
+import rx.observables.SwingObservable;
+import rx.subscriptions.SwingSubscriptions;
 
-public enum MouseEventSource { ; // no instances
+public enum MouseEventSource {
+    ; // no instances
 
     /**
      * @see rx.observables.SwingObservable#fromMouseEvents
      */
     public static Observable<MouseEvent> fromMouseEventsOf(final Component component) {
-        return Observable.create(new OnSubscribeFunc<MouseEvent>() {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
             @Override
-            public Subscription onSubscribe(final Observer<? super MouseEvent> observer) {
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
                 final MouseListener listener = new MouseListener() {
                     @Override
                     public void mouseClicked(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void mousePressed(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void mouseReleased(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void mouseEntered(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void mouseExited(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
                 };
                 component.addMouseListener(listener);
-                
-                return Subscriptions.create(new Action0() {
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
                     @Override
                     public void call() {
                         component.removeMouseListener(listener);
                     }
-                });
+                }));
             }
         });
     }
-    
+
     /**
      * @see rx.observables.SwingObservable#fromMouseMotionEvents
      */
     public static Observable<MouseEvent> fromMouseMotionEventsOf(final Component component) {
-        return Observable.create(new OnSubscribeFunc<MouseEvent>() {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
             @Override
-            public Subscription onSubscribe(final Observer<? super MouseEvent> observer) {
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
                 final MouseMotionListener listener = new MouseMotionListener() {
                     @Override
                     public void mouseDragged(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
 
                     @Override
                     public void mouseMoved(MouseEvent event) {
-                        observer.onNext(event);
+                        subscriber.onNext(event);
                     }
                 };
                 component.addMouseMotionListener(listener);
-                
-                return Subscriptions.create(new Action0() {
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
                     @Override
                     public void call() {
                         component.removeMouseMotionListener(listener);
                     }
-                });
+                }));
             }
         });
     }
-    
+
     /**
      * @see rx.observables.SwingObservable#fromRelativeMouseMotion
      */
@@ -128,48 +135,55 @@ public enum MouseEventSource { ; // no instances
             }
         });
     }
-    
+
     public static class UnitTest {
         private Component comp = new JPanel();
-        
+
         @Test
-        public void testRelativeMouseMotion() {
-            @SuppressWarnings("unchecked")
-            Action1<Point> action = mock(Action1.class);
-            @SuppressWarnings("unchecked")
-            Action1<Throwable> error = mock(Action1.class);
-            Action0 complete = mock(Action0.class);
-            
-            Subscription sub = fromRelativeMouseMotion(comp).subscribe(action, error, complete);
-            
-            InOrder inOrder = inOrder(action);
-            
-            verify(action, never()).call(Matchers.<Point>any());
-            verify(error, never()).call(Matchers.<Exception>any());
-            verify(complete, never()).call();
-            
-            fireMouseEvent(mouseEvent(0, 0));
-            verify(action, never()).call(Matchers.<Point>any());
-            
-            fireMouseEvent(mouseEvent(10, -5));
-            inOrder.verify(action, times(1)).call(new Point(10, -5));
-            
-            fireMouseEvent(mouseEvent(6, 10));
-            inOrder.verify(action, times(1)).call(new Point(-4, 15));
-            
-            sub.unsubscribe();
-            fireMouseEvent(mouseEvent(0, 0));
-            inOrder.verify(action, never()).call(Matchers.<Point>any());
-            verify(error, never()).call(Matchers.<Exception>any());
-            verify(complete, never()).call();
+        public void testRelativeMouseMotion() throws Throwable {
+            SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+                @Override
+                public void call() {
+                    @SuppressWarnings("unchecked")
+                    Action1<Point> action = mock(Action1.class);
+                    @SuppressWarnings("unchecked")
+                    Action1<Throwable> error = mock(Action1.class);
+                    Action0 complete = mock(Action0.class);
+
+                    Subscription sub = fromRelativeMouseMotion(comp).subscribe(action, error, complete);
+
+                    InOrder inOrder = inOrder(action);
+
+                    verify(action, never()).call(Matchers.<Point> any());
+                    verify(error, never()).call(Matchers.<Exception> any());
+                    verify(complete, never()).call();
+
+                    fireMouseEvent(mouseEvent(0, 0));
+                    verify(action, never()).call(Matchers.<Point> any());
+
+                    fireMouseEvent(mouseEvent(10, -5));
+                    inOrder.verify(action, times(1)).call(new Point(10, -5));
+
+                    fireMouseEvent(mouseEvent(6, 10));
+                    inOrder.verify(action, times(1)).call(new Point(-4, 15));
+
+                    sub.unsubscribe();
+                    fireMouseEvent(mouseEvent(0, 0));
+                    inOrder.verify(action, never()).call(Matchers.<Point> any());
+                    verify(error, never()).call(Matchers.<Exception> any());
+                    verify(complete, never()).call();
+                }
+
+            }).awaitTerminal();
         }
-        
+
         private MouseEvent mouseEvent(int x, int y) {
             return new MouseEvent(comp, MouseEvent.MOUSE_MOVED, 1L, 0, x, y, 0, false);
         }
-        
+
         private void fireMouseEvent(MouseEvent event) {
-            for (MouseMotionListener listener: comp.getMouseMotionListeners()) {
+            for (MouseMotionListener listener : comp.getMouseMotionListeners()) {
                 listener.mouseMoved(event);
             }
         }

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/SwingTestHelper.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/SwingTestHelper.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.swing.sources;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import rx.Scheduler.Inner;
+import rx.schedulers.SwingScheduler;
+import rx.functions.Action0;
+import rx.functions.Action1;
+
+/* package-private */ final class SwingTestHelper { // only for test
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile Throwable error;
+
+    private SwingTestHelper() {
+    }
+
+    public static SwingTestHelper create() {
+        return new SwingTestHelper();
+    }
+
+    public SwingTestHelper runInEventDispatchThread(final Action0 action) {
+        SwingScheduler.getInstance().schedule(new Action1<Inner>() {
+
+            @Override
+            public void call(Inner inner) {
+                try {
+                    action.call();
+                } catch (Throwable e) {
+                    error = e;
+                }
+                latch.countDown();
+            }
+        });
+        return this;
+    }
+
+    public void awaitTerminal() throws Throwable {
+        latch.await();
+        if (error != null) {
+            throw error;
+        }
+    }
+
+    public void awaitTerminal(long timeout, TimeUnit unit) throws Throwable {
+        latch.await(timeout, unit);
+        if (error != null) {
+            throw error;
+        }
+    }
+
+}


### PR DESCRIPTION
Updated rxjava-swing according to the discussion in #869. Is it necessary to move the unit tests to src/test/java folder?
