### PR TITLE
Rewrite OperationObserveFromAndroidComponent to OperatorObserveFromAndro...

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/observables/AndroidObservable.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/observables/AndroidObservable.java
@@ -16,7 +16,7 @@
 package rx.android.observables;
 
 import rx.Observable;
-import rx.operators.OperationObserveFromAndroidComponent;
+import rx.operators.OperatorObserveFromAndroidComponent;
 import android.app.Activity;
 import android.app.Fragment;
 import android.os.Build;
@@ -59,7 +59,7 @@ public final class AndroidObservable {
      * @return a new observable sequence that will emit notifications on the main UI thread
      */
     public static <T> Observable<T> fromActivity(Activity activity, Observable<T> sourceObservable) {
-        return OperationObserveFromAndroidComponent.observeFromAndroidComponent(sourceObservable, activity);
+        return OperatorObserveFromAndroidComponent.observeFromAndroidComponent(sourceObservable, activity);
     }
 
     /**
@@ -88,9 +88,9 @@ public final class AndroidObservable {
      */
     public static <T> Observable<T> fromFragment(Object fragment, Observable<T> sourceObservable) {
         if (USES_SUPPORT_FRAGMENTS && fragment instanceof android.support.v4.app.Fragment) {
-            return OperationObserveFromAndroidComponent.observeFromAndroidComponent(sourceObservable, (android.support.v4.app.Fragment) fragment);
+            return OperatorObserveFromAndroidComponent.observeFromAndroidComponent(sourceObservable, (android.support.v4.app.Fragment) fragment);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && fragment instanceof Fragment) {
-            return OperationObserveFromAndroidComponent.observeFromAndroidComponent(sourceObservable, (Fragment) fragment);
+            return OperatorObserveFromAndroidComponent.observeFromAndroidComponent(sourceObservable, (Fragment) fragment);
         } else {
             throw new IllegalArgumentException("Target fragment is neither a native nor support library Fragment");
         }

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/subscriptions/AndroidSubscriptions.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/subscriptions/AndroidSubscriptions.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.subscriptions;
+
+import rx.Scheduler.Inner;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.subscriptions.Subscriptions;
+import android.os.Looper;
+
+public final class AndroidSubscriptions {
+
+    private AndroidSubscriptions() {
+        // no instance
+    }
+
+    /**
+     * Create an Subscription that always runs <code>unsubscribe</code> in the UI thread.
+     * 
+     * @param unsubscribe
+     * @return an Subscription that always runs <code>unsubscribe</code> in the UI thread.
+     */
+    public static Subscription unsubscribeInUiThread(final Action0 unsubscribe) {
+        return Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                if (Looper.getMainLooper() == Looper.myLooper()) {
+                    unsubscribe.call();
+                } else {
+                    AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
+                        @Override
+                        public void call(Inner inner) {
+                            unsubscribe.call();
+                        }
+                    });
+                }
+            }
+        });
+    }
+}

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorCompoundButtonInput.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorCompoundButtonInput.java
@@ -23,12 +23,9 @@ import java.util.WeakHashMap;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.Scheduler.Inner;
 import rx.android.observables.ViewObservable;
-import rx.android.schedulers.AndroidSchedulers;
+import rx.android.subscriptions.AndroidSubscriptions;
 import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.subscriptions.Subscriptions;
 import android.view.View;
 import android.widget.CompoundButton;
 
@@ -53,17 +50,10 @@ public class OperatorCompoundButtonInput implements Observable.OnSubscribe<Boole
             }
         };
 
-        final Subscription subscription = Subscriptions.create(new Action0() {
+        final Subscription subscription = AndroidSubscriptions.unsubscribeInUiThread(new Action0() {
             @Override
             public void call() {
-                AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
-
-                    @Override
-                    public void call(Inner t1) {
-                        composite.removeOnCheckedChangeListener(listener);
-                    }
-
-                });
+                composite.removeOnCheckedChangeListener(listener);
             }
         });
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorEditTextInput.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorEditTextInput.java
@@ -18,12 +18,9 @@ package rx.operators;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.Scheduler.Inner;
 import rx.android.observables.ViewObservable;
-import rx.android.schedulers.AndroidSchedulers;
+import rx.android.subscriptions.AndroidSubscriptions;
 import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.subscriptions.Subscriptions;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.EditText;
@@ -47,17 +44,10 @@ public class OperatorEditTextInput implements Observable.OnSubscribe<String> {
             }
         };
         
-        final Subscription subscription = Subscriptions.create(new Action0() {
+        final Subscription subscription = AndroidSubscriptions.unsubscribeInUiThread(new Action0() {
             @Override
             public void call() {
-                AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
-
-                    @Override
-                    public void call(Inner t1) {
-                        input.removeTextChangedListener(watcher);
-                    }
-
-                });
+                input.removeTextChangedListener(watcher);
             }
         });
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorViewClick.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorViewClick.java
@@ -21,14 +21,11 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 import rx.Observable;
-import rx.Scheduler.Inner;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.android.observables.ViewObservable;
-import rx.android.schedulers.AndroidSchedulers;
+import rx.android.subscriptions.AndroidSubscriptions;
 import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.subscriptions.Subscriptions;
 import android.view.View;
 
 public final class OperatorViewClick implements Observable.OnSubscribe<View> {
@@ -52,17 +49,10 @@ public final class OperatorViewClick implements Observable.OnSubscribe<View> {
             }
         };
 
-        final Subscription subscription = Subscriptions.create(new Action0() {
+        final Subscription subscription = AndroidSubscriptions.unsubscribeInUiThread(new Action0() {
             @Override
             public void call() {
-                AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
-
-                    @Override
-                    public void call(Inner t1) {
-                        composite.removeOnClickListener(listener);
-                    }
-
-                });
+                composite.removeOnClickListener(listener);
             }
         });
 

--- a/rxjava-contrib/rxjava-android/src/test/java/rx/android/schedulers/HandlerThreadSchedulerTest.java
+++ b/rxjava-contrib/rxjava-android/src/test/java/rx/android/schedulers/HandlerThreadSchedulerTest.java
@@ -15,8 +15,10 @@
  */
 package rx.android.schedulers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 
@@ -28,9 +30,7 @@ import org.robolectric.annotation.Config;
 
 import rx.Scheduler;
 import rx.Scheduler.Inner;
-import rx.Subscription;
 import rx.functions.Action1;
-import rx.functions.Func2;
 import android.os.Handler;
 
 @RunWith(RobolectricTestRunner.class)


### PR DESCRIPTION
This PR did the following things:
- Rewrite `OperationObserveFromAndroidComponent` to `OperatorObserveAndroidComponent`.
- Call `unsubscribe` at once if the current thread is the UI thread.
- Remove `itUnsubscribesFromTheSourceSequence` since it's meaningless in the new design.
