### PR TITLE
Fixed NullPointerException that may happen on timeout

### DIFF
--- a/rxjava-contrib/rxjava-apache-http/src/main/java/rx/apache/http/consumers/ResponseConsumerDelegate.java
+++ b/rxjava-contrib/rxjava-apache-http/src/main/java/rx/apache/http/consumers/ResponseConsumerDelegate.java
@@ -93,7 +93,9 @@ public class ResponseConsumerDelegate extends AbstractAsyncResponseConsumer<Http
 
     @Override
     protected void releaseResources() {
-        consumer._releaseResources();
+        if (consumer != null) {
+            consumer._releaseResources();
+        }
     }
 
 }


### PR DESCRIPTION
An unhandled NullPointerException is thrown in the releaseResources method in rx.apache.http.consumers.ResponseConsumerDelegate if a timeout occur. If a timeout occur then onResponseReceived is never called and thus consumer is null.
