### PR TITLE
Deprecate Direct Access to Scheduler Implementations

### DIFF
--- a/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -36,10 +36,20 @@ import rx.subscriptions.Subscriptions;
 public class ExecutorScheduler extends Scheduler {
     private final Executor executor;
 
+    /**
+     * @deprecated Use Schedulers.executor();
+     * @return
+     */
+    @Deprecated
     public ExecutorScheduler(Executor executor) {
         this.executor = executor;
     }
 
+    /**
+     * @deprecated Use Schedulers.executor();
+     * @return
+     */
+    @Deprecated
     public ExecutorScheduler(ScheduledExecutorService executor) {
         this.executor = executor;
     }
@@ -50,7 +60,6 @@ public class ExecutorScheduler extends Scheduler {
         inner.schedule(action);
         return inner.innerSubscription;
     }
-    
 
     @Override
     public Subscription schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {

--- a/rxjava-core/src/main/java/rx/schedulers/ImmediateScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ImmediateScheduler.java
@@ -28,7 +28,16 @@ import rx.subscriptions.BooleanSubscription;
 public final class ImmediateScheduler extends Scheduler {
     private static final ImmediateScheduler INSTANCE = new ImmediateScheduler();
 
+    /**
+     * @deprecated Use Schedulers.immediate();
+     * @return
+     */
+    @Deprecated
     public static ImmediateScheduler getInstance() {
+        return INSTANCE;
+    }
+
+    /* package */static ImmediateScheduler instance() {
         return INSTANCE;
     }
 
@@ -49,7 +58,6 @@ public final class ImmediateScheduler extends Scheduler {
         return inner.innerSubscription;
     }
 
-    
     private class InnerImmediateScheduler extends Scheduler.Inner implements Subscription {
 
         final BooleanSubscription innerSubscription = new BooleanSubscription();

--- a/rxjava-core/src/main/java/rx/schedulers/NewThreadScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/NewThreadScheduler.java
@@ -46,7 +46,16 @@ public class NewThreadScheduler extends Scheduler {
         }
     };
 
+    /**
+     * @deprecated Use Schedulers.newThread();
+     * @return
+     */
+    @Deprecated
     public static NewThreadScheduler getInstance() {
+        return INSTANCE;
+    }
+    
+    /* package */ static NewThreadScheduler instance() {
         return INSTANCE;
     }
 

--- a/rxjava-core/src/main/java/rx/schedulers/Schedulers.java
+++ b/rxjava-core/src/main/java/rx/schedulers/Schedulers.java
@@ -41,7 +41,7 @@ public class Schedulers {
      * @return {@link ImmediateScheduler} instance
      */
     public static Scheduler immediate() {
-        return ImmediateScheduler.getInstance();
+        return ImmediateScheduler.instance();
     }
 
     /**
@@ -52,7 +52,7 @@ public class Schedulers {
      */
     @Deprecated
     public static Scheduler currentThread() {
-        return TrampolineScheduler.getInstance();
+        return TrampolineScheduler.instance();
     }
 
     /**
@@ -61,7 +61,7 @@ public class Schedulers {
      * @return {@link TrampolineScheduler} instance
      */
     public static Scheduler trampoline() {
-        return TrampolineScheduler.getInstance();
+        return TrampolineScheduler.instance();
     }
     
     /**
@@ -70,7 +70,7 @@ public class Schedulers {
      * @return {@link NewThreadScheduler} instance
      */
     public static Scheduler newThread() {
-        return NewThreadScheduler.getInstance();
+        return NewThreadScheduler.instance();
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -30,7 +30,16 @@ import rx.subscriptions.BooleanSubscription;
 public class TrampolineScheduler extends Scheduler {
     private static final TrampolineScheduler INSTANCE = new TrampolineScheduler();
 
+    /**
+     * @deprecated Use Schedulers.trampoline();
+     * @return
+     */
+    @Deprecated
     public static TrampolineScheduler getInstance() {
+        return INSTANCE;
+    }
+    
+    /* package */ static TrampolineScheduler instance() {
         return INSTANCE;
     }
 


### PR DESCRIPTION
This enforces the convention of using `Schedulers.*` and then makes the RxJavaDefaultSchedulers plugin more reliable.
