### PR TITLE
Localized Operator Error Handling

### DIFF
--- a/rxjava-core/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/rxjava-core/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -59,6 +59,14 @@ public class OnErrorThrowable extends RuntimeException {
      * @return Throwable e passed in
      */
     public static Throwable addValueAsLastCause(Throwable e, Object value) {
+        Throwable lastCause = Exceptions.getFinalCause(e);
+        if (lastCause != null && lastCause instanceof OnNextValue) {
+            // purposefully using == for object reference check
+            if (((OnNextValue) lastCause).getValue() == value) {
+                // don't add another
+                return e;
+            }
+        }
         Exceptions.addCause(e, new OnNextValue(value));
         return e;
     }

--- a/rxjava-core/src/test/java/rx/operators/OperatorMapTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMapTest.java
@@ -29,6 +29,7 @@ import org.mockito.MockitoAnnotations;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
+import rx.exceptions.OnErrorNotImplementedException;
 import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.functions.Func2;
@@ -171,7 +172,7 @@ public class OperatorMapTest {
             public void call(Throwable t1) {
                 t1.printStackTrace();
             }
-            
+
         });
 
         m.subscribe(stringObserver);
@@ -255,7 +256,7 @@ public class OperatorMapTest {
         }).toBlockingObservable().single();
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = OnErrorNotImplementedException.class)
     public void verifyExceptionIsThrownIfThereIsNoExceptionHandler() {
 
         Observable.OnSubscribe<Object> creator = new Observable.OnSubscribe<Object>() {
@@ -273,7 +274,6 @@ public class OperatorMapTest {
 
             @Override
             public Observable<Object> call(Object object) {
-
                 return Observable.from(object);
             }
         };
@@ -299,7 +299,12 @@ public class OperatorMapTest {
             }
         };
 
-        Observable.create(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
+        try {
+            Observable.create(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw e;
+        }
     }
 
     private static Map<String, String> getMap(String prefix) {


### PR DESCRIPTION
Do error handling in the `lift` function rather than try/catch in `subscribe` since this catches at the operator level rather than for an entire sequence. This then allows `onErrorResumeNext` and siblings to handle the error instead of it only being emitted to the final `Subscriber`.

I derived this fix while working on Hystrix 1.4.
