### PR TITLE
correct link to maven search

### DIFF
--- a/rxjava-contrib/rxjava-android/README.md
+++ b/rxjava-contrib/rxjava-android/README.md
@@ -13,7 +13,7 @@ Android applications easy and hassle free. More specifically, it
 
 # Binaries
 
-Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22hystrix-servo-metrics-publisher%22).
+Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22rxjava-android%22).
 
 Example for [Maven](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22rxjava-android%22):
 


### PR DESCRIPTION
Fixes the link for the maven search, now pointing to artifact id `rxjava-android`.
