### PR TITLE
refactor the debug hooks before they become a breaking change.

### DIFF
--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/operators/DebugSubscription.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/operators/DebugSubscription.java
@@ -1,33 +1,27 @@
 package rx.operators;
 
 import rx.Subscription;
-import rx.functions.Action1;
-import rx.functions.Action2;
-import rx.functions.Func1;
 import rx.plugins.DebugNotification;
+import rx.plugins.DebugNotificationListener;
 
 final class DebugSubscription<T, C> implements Subscription {
     private final DebugSubscriber<T, C> debugObserver;
-    private final Func1<DebugNotification, C> start;
-    private final Action1<C> complete;
-    private final Action2<C, Throwable> error;
+    private DebugNotificationListener<C> listener;
 
-    DebugSubscription(DebugSubscriber<T, C> debugObserver, Func1<DebugNotification, C> start, Action1<C> complete, Action2<C, Throwable> error) {
+    DebugSubscription(DebugSubscriber<T, C> debugObserver, DebugNotificationListener<C> listener) {
         this.debugObserver = debugObserver;
-        this.start = start;
-        this.complete = complete;
-        this.error = error;
+        this.listener = listener;
     }
 
     @Override
     public void unsubscribe() {
-        final DebugNotification<T, C> n = DebugNotification.<T, C> createUnsubscribe(debugObserver.getActual(), debugObserver.getFrom(), debugObserver.getTo());
-        C context = start.call(n);
+        final DebugNotification<T> n = DebugNotification.<T> createUnsubscribe(debugObserver.getActual(), debugObserver.getFrom(), debugObserver.getTo());
+        C context = listener.start(n);
         try {
             debugObserver.unsubscribe();
-            complete.call(context);
+            listener.complete(context);
         } catch (Throwable e) {
-            error.call(context, e);
+            listener.error(context, e);
         }
     }
 

--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugNotificationListener.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugNotificationListener.java
@@ -1,0 +1,70 @@
+package rx.plugins;
+
+import rx.Observable;
+import rx.Observable.Operator;
+import rx.Observer;
+
+/**
+ * Subclasses of this are passed into the constructor of {@link DebugHook} to receive notification
+ * about all activity in Rx.
+ * 
+ * @author gscampbell
+ * 
+ * @param <C>
+ *            Context type that is returned from start and passed to either complete or error.
+ * @see DebugHook
+ */
+@SuppressWarnings("unused")
+public abstract class DebugNotificationListener<C> {
+    /**
+     * Override this to change the default behavior of returning the encapsulated value. This will
+     * only be invoked when the {@link DebugNotification#getKind()} is
+     * {@link DebugNotification.Kind#OnNext} and the value (null or not) is just about to be sent to
+     * next {@link Observer}. This can end up being called multiple times for
+     * the same value as it passes from {@link Operator} to {@link Operator} in the
+     * {@link Observable} chain.
+     * <p>
+     * This can be used to decorate or replace the values passed into any onNext function or just
+     * perform extra logging, metrics and other such things and pass-thru the function.
+     * 
+     * @param n
+     *            {@link DebugNotification} containing the data and context about what is happening.
+     * @return
+     */
+    public <T> T onNext(DebugNotification<T> n) {
+        return n.getValue();
+    }
+
+    /**
+     * For each {@link DebugNotification.Kind} start is invoked before the actual method is invoked.
+     * <p>
+     * This can be used to perform extra logging, metrics and other such things.
+     * 
+     * @param n
+     *            {@link DebugNotification} containing the data and context about what is happening.
+     * @return
+     *         A contextual object that the listener can use in the {@link #complete(C)} or
+     *         {@link #error(C, Throwable)} after the actual operation has ended.
+     */
+    public <T> C start(DebugNotification<T> n) {
+        return null;
+    }
+
+    /**
+     * After the actual operations has completed from {@link #start(DebugNotification)} this is
+     * invoked
+     * 
+     * @param context
+     */
+    public void complete(C context) {
+    }
+
+    /**
+     * After the actual operations has thrown an exception from {@link #start(DebugNotification)}
+     * this is invoked
+     * 
+     * @param context
+     */
+    public void error(C context, Throwable e) {
+    }
+}

--- a/rxjava-core/src/main/java/rx/functions/Actions.java
+++ b/rxjava-core/src/main/java/rx/functions/Actions.java
@@ -25,51 +25,63 @@ public final class Actions {
         throw new IllegalStateException("No instances!");
     }
 
-    public static final EmptyAction empty() {
-        return EMPTY_ACTION;
+    @SuppressWarnings("unchecked")
+    public static final <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> EmptyAction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> empty() {
+        return (EmptyAction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>) EMPTY_ACTION;
     }
 
     private static final EmptyAction EMPTY_ACTION = new EmptyAction();
 
-    private static final class EmptyAction implements Action0, Action1, Action2, Action3, Action4, Action5, Action6, Action7, Action8, Action9, ActionN {
+    private static final class EmptyAction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> implements
+            Action0,
+            Action1<T0>,
+            Action2<T0, T1>,
+            Action3<T0, T1, T2>,
+            Action4<T0, T1, T2, T3>,
+            Action5<T0, T1, T2, T3, T4>,
+            Action6<T0, T1, T2, T3, T4, T5>,
+            Action7<T0, T1, T2, T3, T4, T5, T6>,
+            Action8<T0, T1, T2, T3, T4, T5, T6, T7>,
+            Action9<T0, T1, T2, T3, T4, T5, T6, T7, T8>,
+            ActionN {
         @Override
         public void call() {
         }
 
         @Override
-        public void call(Object t1) {
+        public void call(T0 t1) {
         }
 
         @Override
-        public void call(Object t1, Object t2) {
+        public void call(T0 t1, T1 t2) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3) {
+        public void call(T0 t1, T1 t2, T2 t3) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3, Object t4) {
+        public void call(T0 t1, T1 t2, T2 t3, T3 t4) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3, Object t4, Object t5) {
+        public void call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6) {
+        public void call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6, Object t7) {
+        public void call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6, T6 t7) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6, Object t7, Object t8) {
+        public void call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6, T6 t7, T7 t8) {
         }
 
         @Override
-        public void call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6, Object t7, Object t8, Object t9) {
+        public void call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6, T6 t7, T7 t8, T8 t9) {
         }
 
         @Override

--- a/rxjava-core/src/main/java/rx/functions/Functions.java
+++ b/rxjava-core/src/main/java/rx/functions/Functions.java
@@ -358,4 +358,79 @@ public class Functions {
             return false;
         }
     }
+
+    @SuppressWarnings("unchecked")
+    public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> NullFunction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> returnNull() {
+        return (NullFunction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R>) NULL_FUNCTION;
+    }
+
+    private static final NullFunction NULL_FUNCTION = new NullFunction();
+
+    private static final class NullFunction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> implements
+            Func0<R>,
+            Func1<T0, R>,
+            Func2<T0, T1, R>,
+            Func3<T0, T1, T2, R>,
+            Func4<T0, T1, T2, T3, R>,
+            Func5<T0, T1, T2, T3, T4, R>,
+            Func6<T0, T1, T2, T3, T4, T5, R>,
+            Func7<T0, T1, T2, T3, T4, T5, T6, R>,
+            Func8<T0, T1, T2, T3, T4, T5, T6, T7, R>,
+            Func9<T0, T1, T2, T3, T4, T5, T6, T7, T8, R>,
+            FuncN<R> {
+        @Override
+        public R call() {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3, T3 t4) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6, T6 t7) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6, T6 t7, T7 t8) {
+            return null;
+        }
+
+        @Override
+        public R call(T0 t1, T1 t2, T2 t3, T3 t4, T4 t5, T5 t6, T6 t7, T7 t8, T8 t9) {
+            return null;
+        }
+
+        @Override
+        public R call(Object... args) {
+            return null;
+        }
+    }
 }

--- a/rxjava-core/src/main/java/rx/operators/OnSubscribeFromIterable.java
+++ b/rxjava-core/src/main/java/rx/operators/OnSubscribeFromIterable.java
@@ -42,6 +42,9 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
             }
             o.onNext(i);
         }
+        if (o.isUnsubscribed()) {
+            return;
+        }
         o.onCompleted();
     }
 

--- a/rxjava-core/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
+++ b/rxjava-core/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
@@ -17,85 +17,108 @@ package rx.plugins;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
-import rx.Observable.OnSubscribeFunc;
 import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Func1;
 
 /**
- * Abstract ExecutionHook with invocations at different lifecycle points of {@link Observable} execution with a default no-op implementation.
+ * Abstract ExecutionHook with invocations at different lifecycle points of {@link Observable}
+ * execution with a default no-op implementation.
  * <p>
  * See {@link RxJavaPlugins} or the RxJava GitHub Wiki for information on configuring plugins: <a
- * href="https://github.com/Netflix/RxJava/wiki/Plugins">https://github.com/Netflix/RxJava/wiki/Plugins</a>.
+ * href ="https://github.com/Netflix/RxJava/wiki/Plugins">https://github.com/Netflix/RxJava/wiki/
+ * Plugins </a>.
  * <p>
  * <b>Note on thread-safety and performance</b>
  * <p>
- * A single implementation of this class will be used globally so methods on this class will be invoked concurrently from multiple threads so all functionality must be thread-safe.
+ * A single implementation of this class will be used globally so methods on this class will be
+ * invoked concurrently from multiple threads so all functionality must be thread-safe.
  * <p>
- * Methods are also invoked synchronously and will add to execution time of the observable so all behavior should be fast. If anything time-consuming is to be done it should be spawned asynchronously
- * onto separate worker threads.
+ * Methods are also invoked synchronously and will add to execution time of the observable so all
+ * behavior should be fast. If anything time-consuming is to be done it should be spawned
+ * asynchronously onto separate worker threads.
  * 
- * */
+ */
 public abstract class RxJavaObservableExecutionHook {
+    /**
+     * Invoked during the construction by {@link Observable#create(OnSubscribe)}
+     * <p>
+     * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform
+     * extra logging, metrics and other such things and pass-thru the function.
+     * 
+     * @param onSubscribe
+     *            original {@link OnSubscribe}<{@code T}> to be executed
+     * @return {@link OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or
+     *         just returned as a pass-thru.
+     */
+    public <T> OnSubscribe<T> onCreate(OnSubscribe<T> f) {
+        return f;
+    }
+
     /**
      * Invoked before {@link Observable#subscribe(rx.Subscriber)} is about to be executed.
      * <p>
-     * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra logging, metrics and other such things and pass-thru the function.
+     * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform
+     * extra logging, metrics and other such things and pass-thru the function.
      * 
-     * @param observableInstance
-     *            The executing {@link Observable} instance.
      * @param onSubscribe
-     *            original {@link Func1}<{@link Subscriber}{@code <T>}, {@link Subscription}> to be executed
-     * @return {@link Func1}<{@link Subscriber}{@code <T>}, {@link Subscription}> function that can be modified, decorated, replaced or just returned as a pass-thru.
+     *            original {@link OnSubscribe}<{@code T}> to be executed
+     * @return {@link OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or
+     *         just returned as a pass-thru.
      */
-    public <T> OnSubscribe<T> onSubscribeStart(Observable<? extends T> observableInstance, final OnSubscribe<T> onSubscribe) {
+    public <T> OnSubscribe<T> onSubscribeStart(Observable<? extends T> observableInsance, final OnSubscribe<T> onSubscribe) {
         // pass-thru by default
         return onSubscribe;
     }
 
     /**
-     * Invoked after successful execution of {@link Observable#subscribe(rx.Subscriber)} with returned {@link Subscription}.
+     * Invoked after successful execution of {@link Observable#subscribe(rx.Subscriber)} with
+     * returned {@link Subscription}.
      * <p>
-     * This can be used to decorate or replace the {@link Subscription} instance or just perform extra logging, metrics and other such things and pass-thru the subscription.
+     * This can be used to decorate or replace the {@link Subscription} instance or just perform
+     * extra logging, metrics and other such things and pass-thru the subscription.
      * 
-     * @param observableInstance
-     *            The executing {@link Observable} instance.
      * @param subscription
      *            original {@link Subscription}
-     * @return {@link Subscription} subscription that can be modified, decorated, replaced or just returned as a pass-thru.
+     * @return {@link Subscription} subscription that can be modified, decorated, replaced or just
+     *         returned as a pass-thru.
      */
-    public <T> Subscription onSubscribeReturn(Observable<? extends T> observableInstance, Subscription subscription) {
+    public <T> Subscription onSubscribeReturn(Subscription subscription) {
         // pass-thru by default
         return subscription;
     }
 
     /**
-     * Invoked after failed execution of {@link Observable#subscribe(Subscriber)} with thrown Throwable.
+     * Invoked after failed execution of {@link Observable#subscribe(Subscriber)} with thrown
+     * Throwable.
      * <p>
-     * This is NOT errors emitted via {@link Subscriber#onError(Throwable)} but exceptions thrown when attempting
-     * to subscribe to a {@link Func1}<{@link Subscriber}{@code <T>}, {@link Subscription}>.
+     * This is NOT errors emitted via {@link Subscriber#onError(Throwable)} but exceptions thrown
+     * when attempting to subscribe to a {@link Func1}<{@link Subscriber}{@code <T>},
+     * {@link Subscription}>.
      * 
-     * @param observableInstance
-     *            The executing {@link Observable} instance.
      * @param e
      *            Throwable thrown by {@link Observable#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass-thru.
      */
-    public <T> Throwable onSubscribeError(Observable<? extends T> observableInstance, Throwable e) {
+    public <T> Throwable onSubscribeError(Throwable e) {
         // pass-thru by default
         return e;
     }
 
-    public <T> OnSubscribe<T> onCreate(OnSubscribe<T> f) {
-        return f;
-    }
-
-    public <T, R> Operator<? extends R, ? super T> onLift(final Operator<? extends R, ? super T> bind) {
-        return bind;
-    }
-
-    public <T> Subscription onAdd(Subscriber<T> subscriber, Subscription s) {
-        return s;
+    /**
+     * Invoked just as the operator functions is called to bind two operations together into a new
+     * {@link Observable} and the return value is used as the lifted function
+     * <p>
+     * This can be used to decorate or replace the {@link Operator} instance or just perform extra
+     * logging, metrics and other such things and pass-thru the onSubscribe.
+     * 
+     * @param lift
+     *            original {@link Operator}{@code<R, T>} ' * @return {@link Operator}{@code <R, T>}
+     *            function that can be modified, decorated, replaced or
+     *            just returned as a pass-thru.
+     */
+    public <T, R> Operator<? extends R, ? super T> onLift(final Operator<? extends R, ? super T> lift) {
+        return lift;
     }
 }


### PR DESCRIPTION
The number of call backs started at one and grew to four and managing them all separately was cumbersome.  This will bring some sanity back to the debug hook API.

I've made one to tiny change to `OnSubscribeFromIterable`. It now checks if the subscriber is unsubscribed before calling `onCompleted()`.
