### PR TITLE
Add support for Eclipse PDE

### DIFF
--- a/rxjava-core/build.gradle
+++ b/rxjava-core/build.gradle
@@ -29,6 +29,7 @@ jar {
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'
+        instruction 'Eclipse-ExtensibleAPI', 'true'
     }
 }
 


### PR DESCRIPTION
Add support for Eclipse PDE handling OSGi fragments.
http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fbundle_manifest.html

see also #849
