### PR TITLE
OperatorTimeoutBase unsubscribe from source

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperatorTimeoutBase.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorTimeoutBase.java
@@ -153,6 +153,7 @@ class OperatorTimeoutBase<T> implements Operator<T, T> {
             }
             if (timeoutWins) {
                 if (other == null) {
+                    serial.unsubscribe();
                     synchronizedSubscriber.onError(new TimeoutException());
                 } else {
                     serial.set(other.subscribe(synchronizedSubscriber));


### PR DESCRIPTION
If no other observable is supplied to the OperatorTimeout:

public final Observable<T> timeout(long timeout, java.util.concurrent.TimeUnit timeUnit)

then, it does not unsubscribe from the source in the event of a timeout.
