### PR TITLE
OperationToFuture must throw CancellationException on get() if cancelled

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationToFuture.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationToFuture.java
@@ -15,6 +15,7 @@
  */
 package rx.operators;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -120,6 +121,9 @@ public class OperationToFuture {
             private T getValue() throws ExecutionException {
                 if (error.get() != null) {
                     throw new ExecutionException("Observable onError", error.get());
+                } else if (cancelled) {
+                    // Contract of Future.get() requires us to throw this:
+                    throw new CancellationException("Subscription unsubscribed");
                 } else {
                     return value.get();
                 }


### PR DESCRIPTION
The JDK documentation for Future.get() and its overload requires these methods to throw CancellationException if the Future was cancelled before the task completed. The Futures returned by OperationToFuture.toFuture() did not respect this contract. Now they do.
