### PR TITLE
SubjectSubscriptionManager fix.

### DIFF
--- a/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
@@ -16,7 +16,6 @@
 package rx.subjects;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -299,4 +298,45 @@ public class PublishSubjectTest {
 
     private final Throwable testException = new Throwable();
 
+    @Test(timeout = 1000)
+    public void testUnsubscriptionCase() {
+        PublishSubject<String> src = PublishSubject.create();
+
+        for (int i = 0; i < 10; i++) {
+            @SuppressWarnings("unchecked")
+            final Observer<Object> o = mock(Observer.class);
+            InOrder inOrder = inOrder(o);
+            String v = "" + i;
+            System.out.printf("Turn: %d%n", i);
+            src.first()
+                .flatMap(new rx.util.functions.Func1<String, Observable<String>>() {
+
+                    @Override
+                    public Observable<String> call(String t1) {
+                        return Observable.from(t1 + ", " + t1);
+                    }
+                })
+                .subscribe(new Observer<String>() {
+                    @Override
+                    public void onNext(String t) {
+                        o.onNext(t);
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        o.onError(e);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        o.onCompleted();
+                    }
+                });
+            src.onNext(v);
+            
+            inOrder.verify(o).onNext(v + ", " + v);
+            inOrder.verify(o).onCompleted();
+            verify(o, never()).onError(any(Throwable.class));
+        }
+    }
 }


### PR DESCRIPTION
Fix for #961

If an already unsubscribed Subscriber is added, the subscription function ends up in an infinite loop as the inner unsubscription logic changes the state to another object before the outer state machine continues.
- The outer state machine loop now exits if unsubscription happened and doesn't attempt to modify the state.
- The removeObserver method is changed so that if the subscription to be removed is not in the array, it returns this instead of an unnecessary copy. In addition, copyOf calls have been replaced by arraycopy to avoid reflective array creation.
