### PR TITLE
Notifications for the allocation averse.

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/NotificationLite.java
+++ b/rxjava-core/src/main/java/rx/operators/NotificationLite.java
@@ -1,0 +1,167 @@
+package rx.operators;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+import rx.Notification;
+import rx.Notification.Kind;
+import rx.Observer;
+
+/**
+ * For use in internal operators that need something like materialize and dematerialize wholly
+ * within the implementation of the operator but don't want to incur the allocation cost of actually
+ * creating {@link rx.Notification} objects for every onNext and onComplete.
+ * 
+ * An object is allocated inside {@link #error(Throwable)} to wrap the {@link Throwable} but this
+ * shouldn't effect performance because exceptions should be exceptionally rare.
+ * 
+ * It's implemented as a singleton to maintain some semblance of type safety that is completely
+ * non-existent.
+ * 
+ * @author gscampbell
+ * 
+ * @param <T>
+ */
+public final class NotificationLite<T> {
+    private NotificationLite() {
+    }
+
+    private static final NotificationLite INSTANCE = new NotificationLite();
+
+    @SuppressWarnings("unchecked")
+    public static <T> NotificationLite<T> instance() {
+        return INSTANCE;
+    }
+
+    private static final Object ON_COMPLETED_SENTINEL = new Serializable() {
+        private static final long serialVersionUID = 1;
+    };
+
+    private static final Object ON_NEXT_NULL_SENTINEL = new Serializable() {
+        private static final long serialVersionUID = 2;
+    };
+
+    private static class OnErrorSentinel implements Serializable {
+        private static final long serialVersionUID = 3;
+        private final Throwable e;
+
+        public OnErrorSentinel(Throwable e) {
+            this.e = e;
+        }
+    }
+
+    /**
+     * Creates a lite onNext notification for the value passed in without doing any allocation. Can
+     * be unwrapped and sent with the {@link #accept} method.
+     * 
+     * @param t
+     * @return
+     */
+    public Object next(T t) {
+        if (t == null)
+            return ON_NEXT_NULL_SENTINEL;
+        else
+            return t;
+    }
+
+    /**
+     * Creates a lite onComplete notification without doing any allocation. Can be unwrapped and
+     * sent with the {@link #accept} method.
+     * 
+     * @return
+     */
+    public Object completed() {
+        return ON_COMPLETED_SENTINEL;
+    }
+
+    /**
+     * Create a lite onError notification. This call does new up an object to wrap the
+     * {@link Throwable} but since there should only be one of these the performance impact should
+     * be small. Can be unwrapped and sent with the {@link #accept} method.
+     * 
+     * @param e
+     * @return
+     */
+    public Object error(Throwable e) {
+        return new OnErrorSentinel(e);
+    }
+
+    /**
+     * Unwraps the lite notification and calls the appropriate method on the {@link Observer}.
+     * 
+     * @param o
+     *            the {@link Observer} to call onNext, onCompleted or onError.
+     * @param n
+     * @throws IllegalArgumentException
+     *             if the notification is null.
+     * @throws NullPointerException
+     *             if the {@link Observer} is null.
+     */
+    @SuppressWarnings("unchecked")
+    public void accept(Observer<? super T> o, Object n) {
+        switch (kind(n)) {
+        case OnNext:
+            o.onNext(getValue(n));
+            break;
+        case OnCompleted:
+            o.onCompleted();
+            break;
+        case OnError:
+            o.onError(getError(n));
+            break;
+        }
+    }
+
+    public boolean isCompleted(Object n) {
+        return n == ON_COMPLETED_SENTINEL;
+    }
+
+    public boolean isError(Object n) {
+        return n instanceof OnErrorSentinel;
+    }
+
+    /**
+     * If there is custom logic that isn't as simple as call the right method on an {@link Observer}
+     * then this method can be used to get the {@link Notification.Kind}
+     * 
+     * @param n
+     * @return
+     */
+    public Kind kind(Object n) {
+        if (n == null)
+            throw new IllegalArgumentException("The lite notification can not be null");
+        else if (n == ON_COMPLETED_SENTINEL)
+            return Kind.OnCompleted;
+        else if (n instanceof OnErrorSentinel)
+            return Kind.OnError;
+        else
+            // value or ON_NEXT_NULL_SENTINEL but either way it's an OnNext
+            return Kind.OnNext;
+    }
+
+    /**
+     * returns value passed in {@link #next(Object)} method call. Bad things happen if you call this
+     * the onComplete or onError notification type. For performance you are expected to use this
+     * when it is appropriate.
+     * 
+     * @param n
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public T getValue(Object n) {
+        return n == ON_NEXT_NULL_SENTINEL ? null : (T) n;
+    }
+
+    /**
+     * returns {@link Throwable} passed in {@link #error(Throwable)} method call. Bad things happen
+     * if you
+     * call this the onComplete or onNext notification type. For performance you are expected to use
+     * this when it is appropriate.
+     * 
+     * @param n
+     * @return The {@link Throwable} wrapped inside n
+     */
+    public Throwable getError(Object n) {
+        return ((OnErrorSentinel) n).e;
+    }
+}

--- a/rxjava-core/src/main/java/rx/operators/OperatorZip.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorZip.java
@@ -134,6 +134,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         };
     }
 
+    static final NotificationLite on = NotificationLite.instance();
     private static class Zip<R> {
         @SuppressWarnings("rawtypes")
         final Observable[] os;
@@ -141,9 +142,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         final Observer<? super R> observer;
         final FuncN<? extends R> zipFunction;
         final CompositeSubscription childSubscription = new CompositeSubscription();
-
-        static Object NULL_SENTINEL = new Object();
-        static Object COMPLETE_SENTINEL = new Object();
+        
 
         @SuppressWarnings("rawtypes")
         public Zip(Observable[] os, final Subscriber<? super R> observer, FuncN<? extends R> zipFunction) {
@@ -180,23 +179,26 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         void tick() {
             if (counter.getAndIncrement() == 0) {
                 do {
-                    Object[] vs = new Object[observers.length];
+                    final Object[] vs = new Object[observers.length];
                     boolean allHaveValues = true;
                     for (int i = 0; i < observers.length; i++) {
-                        vs[i] = ((InnerObserver) observers[i]).items.peek();
-                        if (vs[i] == NULL_SENTINEL) {
-                            // special handling for null
-                            vs[i] = null;
-                        } else if (vs[i] == COMPLETE_SENTINEL) {
-                            // special handling for onComplete
+                        Object n = ((InnerObserver) observers[i]).items.peek();
+
+                        if (n == null) {
+                            allHaveValues = false;
+                            continue;
+                        }
+
+                        switch (on.kind(n)) {
+                        case OnNext:
+                            vs[i] = on.getValue(n);
+                            break;
+                        case OnCompleted:
                             observer.onCompleted();
-                            // we need to unsubscribe from all children since children are independently subscribed
+                            // we need to unsubscribe from all children since children are
+                            // independently subscribed
                             childSubscription.unsubscribe();
                             return;
-                        } else if (vs[i] == null) {
-                            allHaveValues = false;
-                            // we continue as there may be an onCompleted on one of the others
-                            continue;
                         }
                     }
                     if (allHaveValues) {
@@ -211,7 +213,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
                         for (int i = 0; i < observers.length; i++) {
                             ((InnerObserver) observers[i]).items.poll();
                             // eagerly check if the next item on this queue is an onComplete
-                            if (((InnerObserver) observers[i]).items.peek() == COMPLETE_SENTINEL) {
+                            if (on.isCompleted(((InnerObserver) observers[i]).items.peek())) {
                                 // it is an onComplete so shut down
                                 observer.onCompleted();
                                 // we need to unsubscribe from all children since children are independently subscribed
@@ -235,7 +237,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
             @SuppressWarnings("unchecked")
             @Override
             public void onCompleted() {
-                items.add(COMPLETE_SENTINEL);
+                items.add(on.completed());
                 tick();
             }
 
@@ -248,11 +250,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
             @SuppressWarnings("unchecked")
             @Override
             public void onNext(Object t) {
-                if (t == null) {
-                    items.add(NULL_SENTINEL);
-                } else {
-                    items.add(t);
-                }
+                items.add(on.next(t));
                 tick();
             }
         };


### PR DESCRIPTION
I've seen and used the sentinel pattern in a couple of places in the implementation of operators.  I figured I'd formalize the hacks into one place where bugs can coalesce.  As a bonus the code that uses it looks a bit cleaner now.
