### PR TITLE
parallel-merge unit test assertions

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperationParallelMerge.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationParallelMerge.java
@@ -26,7 +26,7 @@ import rx.schedulers.Schedulers;
 public class OperationParallelMerge {
 
     public static <T> Observable<Observable<T>> parallelMerge(final Observable<Observable<T>> source, final int parallelObservables) {
-        return parallelMerge(source, parallelObservables, Schedulers.currentThread());
+        return parallelMerge(source, parallelObservables, Schedulers.immediate());
     }
 
     public static <T> Observable<Observable<T>> parallelMerge(final Observable<Observable<T>> source, final int parallelObservables, final Scheduler scheduler) {

--- a/rxjava-core/src/test/java/rx/operators/OperationParallelMergeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationParallelMergeTest.java
@@ -15,7 +15,8 @@
  */
 package rx.operators;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,7 +80,7 @@ public class OperationParallelMergeTest {
                     }
                 });
 
-        assertEquals(3, threads.keySet().size());
+        assertTrue(threads.keySet().size() <= 3); // can be less than since merge doesn't block threads and may not use all of them
     }
 
     @Test
@@ -98,7 +99,7 @@ public class OperationParallelMergeTest {
                     }
                 });
 
-        assertEquals(3, threads.keySet().size());
+        assertTrue(threads.keySet().size() <= 3); // can be less than since merge doesn't block threads and may not use all of them
     }
 
     private static Observable<Observable<String>> getStreams() {


### PR DESCRIPTION
Using serialize for merge allows less threads to be used under contention instead of blocking and using them all.
This changes the assertion to be <= 3 instead of == 3 because of that.
