### PR TITLE
Fix Non-Deterministic Pivot Test

### DIFF
--- a/rxjava-core/src/test/java/rx/operators/OperatorPivotTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorPivotTest.java
@@ -287,8 +287,10 @@ public class OperatorPivotTest {
         ts.awaitTerminalEvent();
 
         System.out.println("onNext [" + ts.getOnNextEvents().size() + "]: " + ts.getOnNextEvents());
-        System.out.println("max outer concurrency: " + maxOuterConcurrency.get());
-        assertTrue(maxOuterConcurrency.get() > 2); // should be 4 since we have 4 threads running but setting at 3 as this is somewhat non-deterministic
+        if (Runtime.getRuntime().availableProcessors() >= 4) {
+            System.out.println("max outer concurrency: " + maxOuterConcurrency.get());
+            assertTrue(maxOuterConcurrency.get() > 1); // should be 4 since we have 4 threads and cores running but setting at just > 1 as this is non-deterministic
+        }
         System.out.println("max group concurrency: " + maxGroupConcurrency.get());
         assertTrue(maxGroupConcurrency.get() == 1); // should always be 1
 


### PR DESCRIPTION
This fixes a test that failed on build servers (small, slow, single or dual-core machines).
