### PR TITLE
Fix premature garbage collection of subscriber

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorWeakBinding.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorWeakBinding.java
@@ -4,15 +4,17 @@ import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Func1;
 import rx.functions.Functions;
+import rx.operators.OperatorWeakBinding.BoundPayload;
 
 import android.util.Log;
 
 import java.lang.ref.WeakReference;
 
 /**
- * Ties a source sequence to the life-cycle of the given target object, and/or the subscriber
- * using weak references. When either object is gone, this operator automatically unsubscribes
- * from the source sequence.
+ * Ties a source sequence to the life-cycle of the given target object
+ * using weak references. When the object is gone, this operator automatically unsubscribes
+ * from the source sequence. The target object will be passed to the subscriber as well so
+ * that no references (which would extend the object life) need to be kept within the subscriber.
  * <p/>
  * You can also pass in an optional predicate function, which whenever it evaluates to false
  * on the target object, will also result in the operator unsubscribing from the sequence.
@@ -20,9 +22,44 @@ import java.lang.ref.WeakReference;
  * @param <T> the type of the objects emitted to a subscriber
  * @param <R> the type of the target object to bind to
  */
-public final class OperatorWeakBinding<T, R> implements Observable.Operator<T, T> {
+public final class OperatorWeakBinding<T, R> implements Observable.Operator<BoundPayload<R, T>, T> {
 
     private static final String LOG_TAG = "WeakBinding";
+
+    public static final class BoundPayload<Target, Payload> {
+        public final Target target;
+        public final Payload payload;
+
+        private BoundPayload(final Target target, final Payload payload) {
+            if (target == null) {
+                throw new IllegalArgumentException("target cannot be null");
+            }
+            this.target = target;
+            this.payload = payload;
+        }
+
+        public static <Target, Payload> BoundPayload<Target, Payload> of(final Target target, final Payload payload) {
+            return new BoundPayload<Target, Payload>(target, payload);
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (other instanceof BoundPayload<?, ?>) {
+                final BoundPayload<?, ?> otherPayload = (BoundPayload<?, ?>) other;
+                return otherPayload.target == target &&
+                        (payload == null ?
+                                otherPayload.payload == null :
+                                payload.equals(otherPayload.payload));
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return target.hashCode() ^ (payload != null ? payload.hashCode() : 0);
+        }
+
+    }
 
     final WeakReference<R> boundRef;
     private final Func1<? super R, Boolean> predicate;
@@ -38,65 +75,58 @@ public final class OperatorWeakBinding<T, R> implements Observable.Operator<T, T
     }
 
     @Override
-    public Subscriber<? super T> call(final Subscriber<? super T> child) {
-        return new WeakSubscriber(child);
+    public Subscriber<? super T> call(final Subscriber<? super BoundPayload<R, T>> child) {
+        return new ExtendedSubscriber(child);
     }
 
-    final class WeakSubscriber extends Subscriber<T> {
+    final class ExtendedSubscriber extends Subscriber<T> {
 
-        final WeakReference<Subscriber<? super T>> subscriberRef;
+        final Subscriber<? super BoundPayload<R, T>> subscriber;
 
-        private WeakSubscriber(Subscriber<? super T> source) {
+        private ExtendedSubscriber(Subscriber<? super BoundPayload<R, T>> source) {
             super(source);
-            subscriberRef = new WeakReference<Subscriber<? super T>>(source);
+            subscriber = source;
         }
 
         @Override
         public void onCompleted() {
-            final Subscriber<? super T> sub = subscriberRef.get();
-            if (shouldForwardNotification(sub)) {
-                sub.onCompleted();
+            if (shouldForwardNotification()) {
+                subscriber.onCompleted();
             } else {
-                handleLostBinding(sub, "onCompleted");
+                handleLostBinding("onCompleted");
             }
         }
 
         @Override
         public void onError(Throwable e) {
-            final Subscriber<? super T> sub = subscriberRef.get();
-            if (shouldForwardNotification(sub)) {
-                sub.onError(e);
+            if (shouldForwardNotification()) {
+                subscriber.onError(e);
             } else {
-                handleLostBinding(sub, "onError");
+                handleLostBinding("onError");
             }
         }
 
         @Override
         public void onNext(T t) {
-            final Subscriber<? super T> sub = subscriberRef.get();
-            if (shouldForwardNotification(sub)) {
-                sub.onNext(t);
+            final R target = boundRef.get();
+            if (target != null && predicate.call(target)) {
+                subscriber.onNext(BoundPayload.of(target, t));
             } else {
-                handleLostBinding(sub, "onNext");
+                handleLostBinding("onNext");
             }
         }
 
-        private boolean shouldForwardNotification(Subscriber<? super T> sub) {
+        private boolean shouldForwardNotification() {
             final R target = boundRef.get();
-            return sub != null && target != null && predicate.call(target);
+            return target != null && predicate.call(target);
         }
 
-        private void handleLostBinding(Subscriber<? super T> sub, String context) {
-            if (sub == null) {
-                log("subscriber gone; skipping " + context);
+        private void handleLostBinding(String context) {
+            if (boundRef.get() != null) {
+                // the predicate failed to validate
+                log("bound component has become invalid; skipping " + context);
             } else {
-                final R r = boundRef.get();
-                if (r != null) {
-                    // the predicate failed to validate
-                    log("bound component has become invalid; skipping " + context);
-                } else {
-                    log("bound component gone; skipping " + context);
-                }
+                log("bound component gone; skipping " + context);
             }
             log("unsubscribing...");
             unsubscribe();

--- a/rxjava-contrib/rxjava-android/src/test/java/rx/android/observables/AndroidObservableTest.java
+++ b/rxjava-contrib/rxjava-android/src/test/java/rx/android/observables/AndroidObservableTest.java
@@ -28,6 +28,7 @@ import org.robolectric.annotation.Config;
 import rx.Observable;
 import rx.Observer;
 import rx.observers.TestObserver;
+import rx.operators.OperatorWeakBinding.BoundPayload;
 
 import android.app.Activity;
 import android.app.Fragment;
@@ -53,7 +54,10 @@ public class AndroidObservableTest {
     private Fragment fragment;
 
     @Mock
-    private Observer<String> observer;
+    private Observer<BoundPayload<android.support.v4.app.Fragment, String>> fragmentV4Observer;
+
+    @Mock
+    private Observer<BoundPayload<Fragment, String>> fragmentObserver;
 
     @Before
     public void setup() {
@@ -69,21 +73,16 @@ public class AndroidObservableTest {
 
     @Test
     public void itSupportsFragmentsFromTheSupportV4Library() {
-        AndroidObservable.bindFragment(supportFragment, Observable.just("success")).subscribe(new TestObserver<String>(observer));
-        verify(observer).onNext("success");
-        verify(observer).onCompleted();
+        AndroidObservable.bindFragment(supportFragment, Observable.just("success")).subscribe(new TestObserver<BoundPayload<android.support.v4.app.Fragment, String>>(fragmentV4Observer));
+        verify(fragmentV4Observer).onNext(BoundPayload.of(supportFragment, "success"));
+        verify(fragmentV4Observer).onCompleted();
     }
 
     @Test
     public void itSupportsNativeFragments() {
-        AndroidObservable.bindFragment(fragment, Observable.just("success")).subscribe(new TestObserver<String>(observer));
-        verify(observer).onNext("success");
-        verify(observer).onCompleted();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void itThrowsIfObjectPassedIsNotAFragment() {
-        AndroidObservable.bindFragment("not a fragment", Observable.never());
+        AndroidObservable.bindFragment(fragment, Observable.just("success")).subscribe(new TestObserver<BoundPayload<Fragment, String>>(fragmentObserver));
+        verify(fragmentObserver).onNext(BoundPayload.of(fragment, "success"));
+        verify(fragmentObserver).onCompleted();
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Keeping a weak binding onto the subscriber makes it possible to prematurely get the subscriber garbage collected if there are no other references to it.

Here, we chose to pass around the component to which the subscriber is tied in form of a pair (`BoundPayload`). This allows the subscribers to get a reference on the (guaranteed non-collected) target without keeping it in the closure.

This introduces an interface change, but the current implementation is wrong and should never be used (see issues #979 and #1006).

An example usage can be seen at https://github.com/samueltardieu/cgeo/blob/bound-payload/main/src/cgeo/geocaching/PocketQueryList.java#L50 where `selectFromPocketQueries` references the target activity through `pocketQueryLists.target` in the subscriber.

cc @mttkay
