### PR TITLE
Scheduler with Recurse/Inner

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/subscriptions/AndroidSubscriptions.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/subscriptions/AndroidSubscriptions.java
@@ -15,7 +15,7 @@
  */
 package rx.android.subscriptions;
 
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action0;
@@ -42,9 +42,9 @@ public final class AndroidSubscriptions {
                 if (Looper.getMainLooper() == Looper.myLooper()) {
                     unsubscribe.call();
                 } else {
-                    AndroidSchedulers.mainThread().schedule(new Action1<Inner>() {
+                    AndroidSchedulers.mainThread().schedule(new Action1<Recurse>() {
                         @Override
-                        public void call(Inner inner) {
+                        public void call(Recurse inner) {
                             unsubscribe.call();
                         }
                     });

--- a/rxjava-contrib/rxjava-android/src/test/java/rx/android/schedulers/HandlerThreadSchedulerTest.java
+++ b/rxjava-contrib/rxjava-android/src/test/java/rx/android/schedulers/HandlerThreadSchedulerTest.java
@@ -29,7 +29,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.functions.Action1;
 import android.os.Handler;
 
@@ -41,7 +41,7 @@ public class HandlerThreadSchedulerTest {
     public void shouldScheduleImmediateActionOnHandlerThread() {
         final Handler handler = mock(Handler.class);
         @SuppressWarnings("unchecked")
-        final Action1<Inner> action = mock(Action1.class);
+        final Action1<Recurse> action = mock(Action1.class);
 
         Scheduler scheduler = new HandlerThreadScheduler(handler);
         scheduler.schedule(action);
@@ -52,14 +52,14 @@ public class HandlerThreadSchedulerTest {
 
         // verify that the given handler delegates to our action
         runnable.getValue().run();
-        verify(action).call(any(Inner.class));
+        verify(action).call(any(Recurse.class));
     }
 
     @Test
     public void shouldScheduleDelayedActionOnHandlerThread() {
         final Handler handler = mock(Handler.class);
         @SuppressWarnings("unchecked")
-        final Action1<Inner> action = mock(Action1.class);
+        final Action1<Recurse> action = mock(Action1.class);
 
         Scheduler scheduler = new HandlerThreadScheduler(handler);
         scheduler.schedule(action, 1L, TimeUnit.SECONDS);
@@ -70,6 +70,6 @@ public class HandlerThreadSchedulerTest {
 
         // verify that the given handler delegates to our action
         runnable.getValue().run();
-        verify(action).call(any(Inner.class));
+        verify(action).call(any(Recurse.class));
     }
 }

--- a/rxjava-contrib/rxjava-async-util/src/main/java/rx/util/async/Async.java
+++ b/rxjava-contrib/rxjava-async-util/src/main/java/rx/util/async/Async.java
@@ -22,7 +22,7 @@ import java.util.concurrent.FutureTask;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
@@ -599,9 +599,9 @@ public final class Async {
             @Override
             public Observable<R> call() {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call();
@@ -656,9 +656,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1);
@@ -715,9 +715,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2);
@@ -776,9 +776,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3);
@@ -839,9 +839,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3, final T4 t4) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3, t4);
@@ -904,9 +904,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3, t4, t5);
@@ -971,9 +971,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3, t4, t5, t6);
@@ -1040,9 +1040,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6, final T7 t7) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3, t4, t5, t6, t7);
@@ -1111,9 +1111,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6, final T7 t7, final T8 t8) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3, t4, t5, t6, t7, t8);
@@ -1184,9 +1184,9 @@ public final class Async {
             @Override
             public Observable<R> call(final T1 t1, final T2 t2, final T3 t3, final T4 t4, final T5 t5, final T6 t6, final T7 t7, final T8 t8, final T9 t9) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(t1, t2, t3, t4, t5, t6, t7, t8, t9);
@@ -1237,9 +1237,9 @@ public final class Async {
             @Override
             public Observable<R> call(final Object... args) {
                 final AsyncSubject<R> subject = AsyncSubject.create();
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         R result;
                         try {
                             result = func.call(args);
@@ -1764,9 +1764,9 @@ public final class Async {
             }
         }, csub);
         
-        csub.set(scheduler.schedule(new Action1<Inner>() {
+        csub.set(scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner t1) {
+            public void call(Recurse t1) {
                 if (!csub.isUnsubscribed()) {
                     action.call(subject, csub);
                 }

--- a/rxjava-contrib/rxjava-async-util/src/main/java/rx/util/async/operators/Functionals.java
+++ b/rxjava-contrib/rxjava-async-util/src/main/java/rx/util/async/operators/Functionals.java
@@ -16,7 +16,7 @@
 
 package rx.util.async.operators;
 
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.functions.Action0;
 import rx.functions.Action1;
 
@@ -66,14 +66,14 @@ public final class Functionals {
      * @param run the Runnable to run when the Action0 is called
      * @return the Action0 wrapping the Runnable
      */
-    public static Action1<Inner> fromRunnable(Runnable run) {
+    public static Action1<Recurse> fromRunnable(Runnable run) {
         if (run == null) {
             throw new NullPointerException("run");
         }
         return new ActionWrappingRunnable(run);
     }
     /** An Action1 which wraps and calls a Runnable. */
-    private static final class ActionWrappingRunnable implements Action1<Inner> {
+    private static final class ActionWrappingRunnable implements Action1<Recurse> {
         final Runnable run;
 
         public ActionWrappingRunnable(Runnable run) {
@@ -81,7 +81,7 @@ public final class Functionals {
         }
 
         @Override
-        public void call(Inner inner) {
+        public void call(Recurse inner) {
             run.run();
         }
         

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/schedulers/SwingScheduler.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/schedulers/SwingScheduler.java
@@ -45,24 +45,12 @@ public final class SwingScheduler extends Scheduler {
     }
 
     @Override
-    public Subscription schedule(Action1<Inner> action) {
-        InnerSwingScheduler inner = new InnerSwingScheduler();
-        inner.schedule(action);
-        return inner;
+    public Inner createInner() {
+        return new InnerSwingScheduler();
     }
-
-    @Override
-    public Subscription schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {
-        long delay = unit.toMillis(delayTime);
-        assertThatTheDelayIsValidForTheSwingTimer(delay);
-        InnerSwingScheduler inner = new InnerSwingScheduler();
-        inner.schedule(action, delayTime, unit);
-        return inner;
-    }
-
+    
     private static class InnerSwingScheduler extends Inner {
 
-        private final Inner _inner = this;
         private final CompositeSubscription innerSubscription = new CompositeSubscription();
 
         @Override
@@ -76,7 +64,7 @@ public final class SwingScheduler extends Scheduler {
         }
 
         @Override
-        public void schedule(final Action1<Inner> action, long delayTime, TimeUnit unit) {
+        public void schedule(final Action1<Recurse> action, long delayTime, TimeUnit unit) {
             final AtomicReference<Subscription> sub = new AtomicReference<Subscription>();
             long delay = unit.toMillis(delayTime);
             assertThatTheDelayIsValidForTheSwingTimer(delay);
@@ -95,7 +83,7 @@ public final class SwingScheduler extends Scheduler {
                     if (innerSubscription.isUnsubscribed()) {
                         return;
                     }
-                    action.call(_inner);
+                    action.call(Recurse.create(InnerSwingScheduler.this, action));
                     Subscription s = sf.get();
                     if (s != null) {
                         innerSubscription.remove(s);
@@ -125,7 +113,7 @@ public final class SwingScheduler extends Scheduler {
         }
 
         @Override
-        public void schedule(final Action1<Inner> action) {
+        public void schedule(final Action1<Recurse> action) {
             final AtomicReference<Subscription> sub = new AtomicReference<Subscription>();
 
             final AtomicReference<Subscription> sf = new AtomicReference<Subscription>();
@@ -135,7 +123,7 @@ public final class SwingScheduler extends Scheduler {
                     if (innerSubscription.isUnsubscribed()) {
                         return;
                     }
-                    action.call(_inner);
+                    action.call(Recurse.create(InnerSwingScheduler.this, action));
                     Subscription s = sf.get();
                     if (s != null) {
                         innerSubscription.remove(s);

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/subscriptions/SwingSubscriptions.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/subscriptions/SwingSubscriptions.java
@@ -17,11 +17,11 @@ package rx.subscriptions;
 
 import javax.swing.SwingUtilities;
 
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
-import rx.schedulers.SwingScheduler;
 import rx.functions.Action0;
 import rx.functions.Action1;
+import rx.schedulers.SwingScheduler;
 
 public final class SwingSubscriptions {
 
@@ -42,9 +42,9 @@ public final class SwingSubscriptions {
                 if (SwingUtilities.isEventDispatchThread()) {
                     unsubscribe.call();
                 } else {
-                    SwingScheduler.getInstance().schedule(new Action1<Inner>() {
+                    SwingScheduler.getInstance().schedule(new Action1<Recurse>() {
                         @Override
-                        public void call(Inner inner) {
+                        public void call(Recurse inner) {
                             unsubscribe.call();
                         }
                     });

--- a/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/SwingTestHelper.java
+++ b/rxjava-contrib/rxjava-swing/src/main/java/rx/swing/sources/SwingTestHelper.java
@@ -18,10 +18,10 @@ package rx.swing.sources;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import rx.Scheduler.Inner;
-import rx.schedulers.SwingScheduler;
+import rx.Scheduler.Recurse;
 import rx.functions.Action0;
 import rx.functions.Action1;
+import rx.schedulers.SwingScheduler;
 
 /* package-private */ final class SwingTestHelper { // only for test
 
@@ -36,10 +36,10 @@ import rx.functions.Action1;
     }
 
     public SwingTestHelper runInEventDispatchThread(final Action0 action) {
-        SwingScheduler.getInstance().schedule(new Action1<Inner>() {
+        SwingScheduler.getInstance().schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 try {
                     action.call();
                 } catch (Throwable e) {

--- a/rxjava-core/src/main/java/rx/Scheduler.java
+++ b/rxjava-core/src/main/java/rx/Scheduler.java
@@ -32,17 +32,19 @@ import rx.functions.Action1;
  * <p>
  * <ol>
  * <li>Java doesn't support extension methods and there are many overload methods needing default
- *     implementations.</li>
+ * implementations.</li>
  * <li>Virtual extension methods aren't available until Java8 which RxJava will not set as a minimum target for
- *     a long time.</li>
+ * a long time.</li>
  * <li>If only an interface were used Scheduler implementations would then need to extend from an
- *     AbstractScheduler pair that gives all of the functionality unless they intend on copy/pasting the
- *     functionality.</li>
+ * AbstractScheduler pair that gives all of the functionality unless they intend on copy/pasting the
+ * functionality.</li>
  * <li>Without virtual extension methods even additive changes are breaking and thus severely impede library
- *     maintenance.</li>
+ * maintenance.</li>
  * </ol>
  */
 public abstract class Scheduler {
+
+    public abstract Inner createInner();
 
     /**
      * Schedules an Action on a new Scheduler instance (typically another thread) for execution.
@@ -52,7 +54,11 @@ public abstract class Scheduler {
      * @return a subscription to be able to unsubscribe from action
      */
 
-    public abstract Subscription schedule(Action1<Scheduler.Inner> action);
+    public final Subscription schedule(Action1<Recurse> action) {
+        Inner inner = createInner();
+        inner.schedule(action);
+        return inner;
+    }
 
     /**
      * Schedules an Action on a new Scheduler instance (typically another thread) for execution at some point
@@ -66,7 +72,11 @@ public abstract class Scheduler {
      *            the time unit the delay time is given in
      * @return a subscription to be able to unsubscribe from action
      */
-    public abstract Subscription schedule(final Action1<Scheduler.Inner> action, final long delayTime, final TimeUnit unit);
+    public final Subscription schedule(final Action1<Recurse> action, final long delay, final TimeUnit unit) {
+        Inner inner = createInner();
+        inner.schedule(action, delay, unit);
+        return inner;
+    }
 
     /**
      * Schedules a cancelable action to be executed periodically. This default implementation schedules
@@ -83,98 +93,21 @@ public abstract class Scheduler {
      *            the time unit the interval above is given in
      * @return a subscription to be able to unsubscribe from action
      */
-    public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, long period, TimeUnit unit) {
+    public Subscription schedulePeriodically(final Action1<Recurse> action, long initialDelay, long period, TimeUnit unit) {
         final long periodInNanos = unit.toNanos(period);
 
-        final Action1<Scheduler.Inner> recursiveAction = new Action1<Scheduler.Inner>() {
+        final Action1<Recurse> recursiveAction = new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
-                if (!inner.isUnsubscribed()) {
+            public void call(Recurse re) {
+                if (!re.isUnsubscribed()) {
                     long startedAt = now();
-                    action.call(inner);
+                    action.call(re);
                     long timeTakenByActionInNanos = TimeUnit.MILLISECONDS.toNanos(now() - startedAt);
-                    inner.schedule(this, periodInNanos - timeTakenByActionInNanos, TimeUnit.NANOSECONDS);
+                    re.schedule(this, periodInNanos - timeTakenByActionInNanos, TimeUnit.NANOSECONDS);
                 }
             }
         };
         return schedule(recursiveAction, initialDelay, unit);
-    }
-
-    public final Subscription scheduleRecursive(final Action1<Recurse> action) {
-        return schedule(new Action1<Inner>() {
-
-            @Override
-            public void call(Inner inner) {
-                action.call(new Recurse(inner, action));
-            }
-
-        });
-    }
-
-    public static final class Recurse {
-        private final Action1<Recurse> action;
-        private final Inner inner;
-
-        private Recurse(Inner inner, Action1<Recurse> action) {
-            this.inner = inner;
-            this.action = action;
-        }
-
-        /**
-         * Schedule the current function for execution immediately.
-         */
-        public final void schedule() {
-            final Recurse self = this;
-            inner.schedule(new Action1<Inner>() {
-
-                @Override
-                public void call(Inner _inner) {
-                    action.call(self);
-                }
-
-            });
-        }
-
-        /**
-         * Schedule the current function for execution in the future.
-         */
-        public final void schedule(long delay, TimeUnit unit) {
-            final Recurse self = this;
-            inner.schedule(new Action1<Inner>() {
-
-                @Override
-                public void call(Inner _inner) {
-                    action.call(self);
-                }
-
-            }, delay, unit);
-        }
-    }
-
-    public abstract static class Inner implements Subscription {
-
-        /**
-         * Schedules an action to be executed in delayTime.
-         * 
-         * @param delayTime
-         *            time the action is to be delayed before executing
-         * @param unit
-         *            time unit of the delay time
-         */
-        public abstract void schedule(Action1<Scheduler.Inner> action, long delayTime, TimeUnit unit);
-
-        /**
-         * Schedules a cancelable action to be executed in delayTime.
-         * 
-         */
-        public abstract void schedule(Action1<Scheduler.Inner> action);
-
-        /**
-         * @return the scheduler's notion of current absolute time in milliseconds.
-         */
-        public long now() {
-            return System.currentTimeMillis();
-        }
     }
 
     /**
@@ -194,6 +127,117 @@ public abstract class Scheduler {
      */
     public long now() {
         return System.currentTimeMillis();
+    }
+
+    public static final class Recurse implements Subscription {
+        private final Action1<Recurse> action;
+        private final Inner inner;
+
+        private Recurse(Inner inner, Action1<Recurse> action) {
+            this.inner = inner;
+            this.action = action;
+        }
+
+        /**
+         * @param inner
+         *            The Inner this should schedule on.
+         * @param action
+         *            The action to invoke recursively with {@lnk #schedule()} and {@link #schedule(long, TimeUnit)}.
+         * @return new instance of Recurse
+         */
+        public static Recurse create(Inner inner, Action1<Recurse> action) {
+            return new Recurse(inner, action);
+        }
+
+        /**
+         * Schedule the current function for execution immediately.
+         */
+        public final void schedule() {
+            final Recurse self = this;
+            inner.schedule(new Action1<Recurse>() {
+
+                @Override
+                public void call(Recurse _re) {
+                    action.call(self);
+                }
+
+            });
+        }
+
+        /**
+         * Schedule the current function for execution in the future.
+         */
+        public final void schedule(long delay, TimeUnit unit) {
+            final Recurse self = this;
+            inner.schedule(new Action1<Recurse>() {
+
+                @Override
+                public void call(Recurse _re) {
+                    action.call(self);
+                }
+
+            }, delay, unit);
+        }
+
+        public final void schedule(final Action1<Recurse> action) {
+            final Recurse self = this;
+            inner.schedule(new Action1<Recurse>() {
+
+                @Override
+                public void call(Recurse _re) {
+                    action.call(self);
+                }
+
+            });
+        }
+
+        public final void schedule(final Action1<Recurse> action, final long delay, final TimeUnit unit) {
+            final Recurse self = this;
+            inner.schedule(new Action1<Recurse>() {
+
+                @Override
+                public void call(Recurse _re) {
+                    action.call(self);
+                }
+
+            }, delay, unit);
+        }
+
+        @Override
+        public final void unsubscribe() {
+            inner.unsubscribe();
+        }
+
+        @Override
+        public final boolean isUnsubscribed() {
+            return inner.isUnsubscribed();
+        }
+    }
+
+    public abstract static class Inner implements Subscription {
+
+        /**
+         * Schedules an action to be executed in delayTime.
+         * 
+         * @param delayTime
+         *            time the action is to be delayed before executing
+         * @param unit
+         *            time unit of the delay time
+         */
+        public abstract void schedule(Action1<Recurse> action, long delayTime, TimeUnit unit);
+
+        /**
+         * Schedules a cancelable action to be executed in delayTime.
+         * 
+         */
+        public abstract void schedule(Action1<Recurse> action);
+
+        /**
+         * @return the scheduler's notion of current absolute time in milliseconds.
+         */
+        public long now() {
+            return System.currentTimeMillis();
+        }
     }
 
 }

--- a/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
+++ b/rxjava-core/src/main/java/rx/operators/ChunkedOperation.java
@@ -28,6 +28,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
@@ -171,9 +172,9 @@ public class ChunkedOperation {
         @Override
         public Chunk<T, C> createChunk() {
             final Chunk<T, C> chunk = super.createChunk();
-            subscriptions.put(chunk, scheduler.schedule(new Action1<Inner>() {
+            subscriptions.put(chunk, scheduler.schedule(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     emitChunk(chunk);
                 }
             }, maxTime, unit));
@@ -253,9 +254,9 @@ public class ChunkedOperation {
         @Override
         public Chunk<T, C> createChunk() {
             final Chunk<T, C> chunk = super.createChunk();
-            subscriptions.put(chunk, scheduler.schedule(new Action1<Inner>() {
+            subscriptions.put(chunk, scheduler.schedule(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     emitChunk(chunk);
                 }
             }, time, unit));
@@ -605,18 +606,18 @@ public class ChunkedOperation {
         private final SafeObservableSubscription subscription = new SafeObservableSubscription();
 
         public TimeBasedChunkCreator(final NonOverlappingChunks<T, C> chunks, long time, TimeUnit unit, Scheduler scheduler) {
-            this.subscription.wrap(scheduler.schedulePeriodically(new Action1<Inner>() {
+            this.subscription.wrap(scheduler.schedulePeriodically(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     chunks.emitAndReplaceChunk();
                 }
             }, 0, time, unit));
         }
 
         public TimeBasedChunkCreator(final OverlappingChunks<T, C> chunks, long time, TimeUnit unit, Scheduler scheduler) {
-            this.subscription.wrap(scheduler.schedulePeriodically(new Action1<Inner>() {
+            this.subscription.wrap(scheduler.schedulePeriodically(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     chunks.createChunk();
                 }
             }, 0, time, unit));

--- a/rxjava-core/src/main/java/rx/operators/OperationDebounce.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationDebounce.java
@@ -22,7 +22,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
@@ -142,10 +142,11 @@ public final class OperationDebounce {
 
         @Override
         public void onNext(final T v) {
-            Subscription previousSubscription = lastScheduledNotification.getAndSet(scheduler.schedule(new Action1<Inner>() {
+            // TODO fix ... this is creating a new Scheduler.Inner each time, it needs to get a single Inner and reuse it
+            Subscription previousSubscription = lastScheduledNotification.getAndSet(scheduler.schedule(new Action1<Recurse>() {
 
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     observer.onNext(v);
                 }
 

--- a/rxjava-core/src/main/java/rx/operators/OperationDelay.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationDelay.java
@@ -21,7 +21,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
@@ -77,9 +77,9 @@ public final class OperationDelay {
         public Subscription onSubscribe(final Observer<? super T> t1) {
             final SerialSubscription ssub = new SerialSubscription();
 
-            ssub.set(scheduler.schedule(new Action1<Inner>() {
+            ssub.set(scheduler.schedule(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     if (!ssub.isUnsubscribed()) {
                         ssub.set(source.unsafeSubscribe(Subscribers.from(t1)));
                     }

--- a/rxjava-core/src/main/java/rx/operators/OperationInterval.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationInterval.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -68,9 +68,9 @@ public final class OperationInterval {
 
         @Override
         public Subscription onSubscribe(final Observer<? super Long> observer) {
-            final Subscription wrapped = scheduler.schedulePeriodically(new Action1<Inner>() {
+            final Subscription wrapped = scheduler.schedulePeriodically(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     observer.onNext(currentValue);
                     currentValue++;
                 }

--- a/rxjava-core/src/main/java/rx/operators/OperationSkip.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationSkip.java
@@ -22,7 +22,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
@@ -81,7 +81,7 @@ public final class OperationSkip {
          * @param <T>
          *            the observed value type
          */
-        private static final class SourceObserver<T> extends Subscriber<T> implements Action1<Inner> {
+        private static final class SourceObserver<T> extends Subscriber<T> implements Action1<Recurse> {
             final AtomicBoolean gate;
             final Observer<? super T> observer;
             final Subscription cancel;
@@ -119,7 +119,7 @@ public final class OperationSkip {
             }
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 gate.set(true);
             }
 

--- a/rxjava-core/src/main/java/rx/operators/OperationTakeTimed.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationTakeTimed.java
@@ -22,7 +22,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
@@ -212,7 +212,7 @@ public final class OperationTakeTimed {
          * @param <T>
          *            the observed value type
          */
-        private static final class SourceObserver<T> extends Subscriber<T> implements Action1<Inner> {
+        private static final class SourceObserver<T> extends Subscriber<T> implements Action1<Recurse> {
             final Observer<? super T> observer;
             final Subscription cancel;
             final AtomicInteger state = new AtomicInteger();
@@ -283,7 +283,7 @@ public final class OperationTakeTimed {
             }
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 onCompleted();
             }
 

--- a/rxjava-core/src/main/java/rx/operators/OperationTimer.java
+++ b/rxjava-core/src/main/java/rx/operators/OperationTimer.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 
@@ -50,9 +50,9 @@ public final class OperationTimer {
 
         @Override
         public Subscription onSubscribe(final Observer<? super Long> t1) {
-            return scheduler.schedule(new Action1<Inner>() {
+            return scheduler.schedule(new Action1<Recurse>() {
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     t1.onNext(0L);
                     t1.onCompleted();
                 }
@@ -79,11 +79,11 @@ public final class OperationTimer {
 
         @Override
         public Subscription onSubscribe(final Observer<? super Long> t1) {
-            return scheduler.schedulePeriodically(new Action1<Inner>() {
+            return scheduler.schedulePeriodically(new Action1<Recurse>() {
                 long count;
 
                 @Override
-                public void call(Inner inner) {
+                public void call(Recurse inner) {
                     t1.onNext(count++);
                 }
             }, initialDelay, period, unit);

--- a/rxjava-core/src/main/java/rx/operators/OperatorObserveOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorObserveOn.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Observable.Operator;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action1;
 import rx.schedulers.ImmediateScheduler;
@@ -91,29 +91,20 @@ public class OperatorObserveOn<T> implements Operator<T, T> {
         protected void schedule() {
             if (counter.getAndIncrement() == 0) {
                 if (recursiveScheduler == null) {
-                    add(scheduler.schedule(new Action1<Inner>() {
-
-                        @Override
-                        public void call(Inner inner) {
-                            recursiveScheduler = inner;
-                            pollQueue();
-                        }
-
-                    }));
-                } else {
-                    recursiveScheduler.schedule(new Action1<Inner>() {
-
-                        @Override
-                        public void call(Inner inner) {
-                            pollQueue();
-                        }
-
-                    });
+                    recursiveScheduler = scheduler.createInner();
+                    add(recursiveScheduler);
                 }
+                recursiveScheduler.schedule(new Action1<Recurse>() {
+
+                    @Override
+                    public void call(Recurse inner) {
+                        pollQueue();
+                    }
+
+                });
             }
         }
 
-        @SuppressWarnings("unchecked")
         private void pollQueue() {
             do {
                 Object v = queue.poll();

--- a/rxjava-core/src/main/java/rx/operators/OperatorObserveOnBounded.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorObserveOnBounded.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Observable.Operator;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -167,25 +167,18 @@ public class OperatorObserveOnBounded<T> implements Operator<T, T> {
                         }
 
                     }));
-                    add(scheduler.schedule(new Action1<Inner>() {
-
-                        @Override
-                        public void call(Inner inner) {
-                            recursiveScheduler = inner;
-                            pollQueue();
-                        }
-
-                    }));
-                } else {
-                    recursiveScheduler.schedule(new Action1<Inner>() {
-
-                        @Override
-                        public void call(Inner inner) {
-                            pollQueue();
-                        }
-
-                    });
+                    recursiveScheduler = scheduler.createInner();
+                    add(recursiveScheduler);
                 }
+
+                recursiveScheduler.schedule(new Action1<Recurse>() {
+
+                    @Override
+                    public void call(Recurse inner) {
+                        pollQueue();
+                    }
+
+                });
             }
         }
 

--- a/rxjava-core/src/main/java/rx/operators/OperatorRepeat.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorRepeat.java
@@ -20,6 +20,7 @@ import rx.Observable;
 import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action1;
 import rx.observers.Subscribers;
@@ -53,6 +54,7 @@ public class OperatorRepeat<T> implements Operator<T, Observable<T>> {
             child.onCompleted();
             return Subscribers.empty();
         }
+        final Inner innerScheduler = scheduler.createInner();
         return new Subscriber<Observable<T>>(child) {
 
             int executionCount = 0;
@@ -70,19 +72,17 @@ public class OperatorRepeat<T> implements Operator<T, Observable<T>> {
 
             @Override
             public void onNext(final Observable<T> t) {
-                scheduler.schedule(new Action1<Inner>() {
-
-                    final Action1<Inner> self = this;
+                innerScheduler.schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(final Inner inner) {
+                    public void call(final Recurse re) {
                         executionCount++;
                         t.unsafeSubscribe(new Subscriber<T>(child) {
 
                             @Override
                             public void onCompleted() {
                                 if (count == -1 || executionCount < count) {
-                                    inner.schedule(self);
+                                    re.schedule();
                                 } else {
                                     child.onCompleted();
                                 }

--- a/rxjava-core/src/main/java/rx/operators/OperatorSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorSubscribeOn.java
@@ -18,7 +18,7 @@ package rx.operators;
 import rx.Observable;
 import rx.Observable.Operator;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action1;
 
@@ -51,10 +51,10 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
 
             @Override
             public void onNext(final Observable<T> o) {
-                subscriber.add(scheduler.schedule(new Action1<Inner>() {
+                subscriber.add(scheduler.schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(final Inner inner) {
+                    public void call(final Recurse inner) {
                         o.unsafeSubscribe(subscriber);
                     }
                 }));

--- a/rxjava-core/src/main/java/rx/operators/OperatorTimeout.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorTimeout.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 
@@ -40,9 +40,9 @@ public final class OperatorTimeout<T> extends OperatorTimeoutBase<T> {
             public Subscription call(
                     final TimeoutSubscriber<T> timeoutSubscriber,
                     final Long seqId) {
-                return scheduler.schedule(new Action1<Inner>() {
+                return scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         timeoutSubscriber.onTimeout(seqId);
                     }
                 }, timeout, timeUnit);
@@ -53,9 +53,9 @@ public final class OperatorTimeout<T> extends OperatorTimeoutBase<T> {
             public Subscription call(
                     final TimeoutSubscriber<T> timeoutSubscriber,
                     final Long seqId, T value) {
-                return scheduler.schedule(new Action1<Inner>() {
+                return scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         timeoutSubscriber.onTimeout(seqId);
                     }
                 }, timeout, timeUnit);

--- a/rxjava-core/src/main/java/rx/operators/OperatorUnsubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorUnsubscribeOn.java
@@ -17,7 +17,7 @@ package rx.operators;
 
 import rx.Observable.Operator;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -45,10 +45,10 @@ public class OperatorUnsubscribeOn<T> implements Operator<T, T> {
             @Override
             public void call() {
                 final MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
-                mas.set(scheduler.schedule(new Action1<Inner>() {
+                mas.set(scheduler.schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(final Inner inner) {
+                    public void call(final Recurse inner) {
                         parentSubscription.unsubscribe();
                         mas.unsubscribe();
                     }

--- a/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -29,8 +29,7 @@ import rx.subscriptions.MultipleAssignmentSubscription;
 import rx.subscriptions.Subscriptions;
 
 /**
- * A {@link Scheduler} implementation that uses an {@link Executor} or {@link ScheduledExecutorService}
- * implementation.
+ * A {@link Scheduler} implementation that uses an {@link Executor} or {@link ScheduledExecutorService} implementation.
  * <p>
  * Note that if an {@link Executor} implementation is used instead of {@link ScheduledExecutorService} then a
  * system-wide Timer will be used to handle delayed events.
@@ -55,21 +54,12 @@ public class ExecutorScheduler extends Scheduler {
     }
 
     @Override
-    public Subscription schedule(Action1<Scheduler.Inner> action) {
-        InnerExecutorScheduler inner = new InnerExecutorScheduler();
-        inner.schedule(action);
-        return inner.innerSubscription;
+    public Inner createInner() {
+        return new InnerExecutorScheduler();
     }
 
     @Override
-    public Subscription schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {
-        InnerExecutorScheduler inner = new InnerExecutorScheduler();
-        inner.schedule(action, delayTime, unit);
-        return inner.innerSubscription;
-    }
-
-    @Override
-    public Subscription schedulePeriodically(final Action1<Scheduler.Inner> action, long initialDelay, long period, TimeUnit unit) {
+    public Subscription schedulePeriodically(final Action1<Recurse> action, long initialDelay, long period, TimeUnit unit) {
         if (executor instanceof ScheduledExecutorService) {
             final InnerExecutorScheduler inner = new InnerExecutorScheduler();
             ScheduledFuture<?> f = ((ScheduledExecutorService) executor).scheduleAtFixedRate(new Runnable() {
@@ -79,7 +69,7 @@ public class ExecutorScheduler extends Scheduler {
                         // don't execute if unsubscribed
                         return;
                     }
-                    action.call(inner);
+                    action.call(Recurse.create(inner, action));
                 }
             }, initialDelay, period, unit);
 
@@ -95,7 +85,7 @@ public class ExecutorScheduler extends Scheduler {
         private final MultipleAssignmentSubscription innerSubscription = new MultipleAssignmentSubscription();
 
         @Override
-        public void schedule(final Action1<Scheduler.Inner> action, long delayTime, TimeUnit unit) {
+        public void schedule(final Action1<Recurse> action, long delayTime, TimeUnit unit) {
             if (innerSubscription.isUnsubscribed()) {
                 // don't schedule, we are unsubscribed
                 return;
@@ -112,7 +102,7 @@ public class ExecutorScheduler extends Scheduler {
                             return;
                         }
                         // when the delay has passed we now do the work on the actual scheduler
-                        action.call(_inner);
+                        action.call(Recurse.create(_inner, action));
                     }
                 }, delayTime, unit);
                 // add the ScheduledFuture as a subscription so we can cancel the scheduled action if an unsubscribe happens
@@ -144,7 +134,7 @@ public class ExecutorScheduler extends Scheduler {
         }
 
         @Override
-        public void schedule(final Action1<Scheduler.Inner> action) {
+        public void schedule(final Action1<Recurse> action) {
             if (innerSubscription.isUnsubscribed()) {
                 // don't schedule, we are unsubscribed
                 return;
@@ -159,7 +149,7 @@ public class ExecutorScheduler extends Scheduler {
                         // don't execute if unsubscribed
                         return;
                     }
-                    action.call(_inner);
+                    action.call(Recurse.create(_inner, action));
                 }
             };
 

--- a/rxjava-core/src/main/java/rx/schedulers/ImmediateScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ImmediateScheduler.java
@@ -45,17 +45,8 @@ public final class ImmediateScheduler extends Scheduler {
     }
 
     @Override
-    public Subscription schedule(Action1<Scheduler.Inner> action) {
-        InnerImmediateScheduler inner = new InnerImmediateScheduler();
-        inner.schedule(action);
-        return inner.innerSubscription;
-    }
-
-    @Override
-    public Subscription schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {
-        InnerImmediateScheduler inner = new InnerImmediateScheduler();
-        inner.schedule(action, delayTime, unit);
-        return inner.innerSubscription;
+    public Inner createInner() {
+        return new InnerImmediateScheduler();
     }
 
     private class InnerImmediateScheduler extends Scheduler.Inner implements Subscription {
@@ -63,7 +54,7 @@ public final class ImmediateScheduler extends Scheduler {
         final BooleanSubscription innerSubscription = new BooleanSubscription();
 
         @Override
-        public void schedule(Action1<Scheduler.Inner> action, long delayTime, TimeUnit unit) {
+        public void schedule(Action1<Recurse> action, long delayTime, TimeUnit unit) {
             // since we are executing immediately on this thread we must cause this thread to sleep
             long execTime = now() + unit.toMillis(delayTime);
 
@@ -71,8 +62,8 @@ public final class ImmediateScheduler extends Scheduler {
         }
 
         @Override
-        public void schedule(Action1<Scheduler.Inner> action) {
-            action.call(this);
+        public void schedule(Action1<Recurse> action) {
+            action.call(Recurse.create(this, action));
         }
 
         @Override

--- a/rxjava-core/src/main/java/rx/schedulers/SleepingAction.java
+++ b/rxjava-core/src/main/java/rx/schedulers/SleepingAction.java
@@ -16,22 +16,22 @@
 package rx.schedulers;
 
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.functions.Action1;
 
-/* package */class SleepingAction implements Action1<Scheduler.Inner> {
-    private final Action1<Scheduler.Inner> underlying;
+/* package */class SleepingAction implements Action1<Recurse> {
+    private final Action1<Recurse> underlying;
     private final Scheduler scheduler;
     private final long execTime;
 
-    public SleepingAction(Action1<Scheduler.Inner> underlying, Scheduler scheduler, long execTime) {
+    public SleepingAction(Action1<Recurse> underlying, Scheduler scheduler, long execTime) {
         this.underlying = underlying;
         this.scheduler = scheduler;
         this.execTime = execTime;
     }
 
     @Override
-    public void call(Inner s) {
+    public void call(Recurse s) {
         if (s.isUnsubscribed()) {
             return;
         }

--- a/rxjava-core/src/main/java/rx/schedulers/TestScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/TestScheduler.java
@@ -21,7 +21,6 @@ import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 import rx.Scheduler;
-import rx.Subscription;
 import rx.functions.Action1;
 import rx.subscriptions.BooleanSubscription;
 
@@ -32,11 +31,11 @@ public class TestScheduler extends Scheduler {
     private static class TimedAction {
 
         private final long time;
-        private final Action1<Inner> action;
+        private final Action1<Recurse> action;
         private final Inner scheduler;
         private final long count = counter++; // for differentiating tasks at same time
 
-        private TimedAction(Inner scheduler, long time, Action1<Inner> action) {
+        private TimedAction(Inner scheduler, long time, Action1<Recurse> action) {
             this.time = time;
             this.action = action;
             this.scheduler = scheduler;
@@ -91,30 +90,15 @@ public class TestScheduler extends Scheduler {
 
             // Only execute if not unsubscribed
             if (!current.scheduler.isUnsubscribed()) {
-                current.action.call(current.scheduler);
+                current.action.call(Recurse.create(current.scheduler, current.action));
             }
         }
         time = targetTimeInNanos;
     }
 
-    public Inner createInnerScheduler() {
+    @Override
+    public Inner createInner() {
         return new InnerTestScheduler();
-    }
-
-    @Override
-    public Subscription schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {
-        Inner inner = createInnerScheduler();
-        final TimedAction timedAction = new TimedAction(inner, time + unit.toNanos(delayTime), action);
-        queue.add(timedAction);
-        return inner;
-    }
-
-    @Override
-    public Subscription schedule(Action1<Inner> action) {
-        Inner inner = createInnerScheduler();
-        final TimedAction timedAction = new TimedAction(inner, 0, action);
-        queue.add(timedAction);
-        return inner;
     }
 
     private final class InnerTestScheduler extends Inner {
@@ -132,13 +116,13 @@ public class TestScheduler extends Scheduler {
         }
 
         @Override
-        public void schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {
+        public void schedule(Action1<Recurse> action, long delayTime, TimeUnit unit) {
             final TimedAction timedAction = new TimedAction(this, time + unit.toNanos(delayTime), action);
             queue.add(timedAction);
         }
 
         @Override
-        public void schedule(Action1<Inner> action) {
+        public void schedule(Action1<Recurse> action) {
             final TimedAction timedAction = new TimedAction(this, 0, action);
             queue.add(timedAction);
         }

--- a/rxjava-core/src/main/java/rx/subjects/TestSubject.java
+++ b/rxjava-core/src/main/java/rx/subjects/TestSubject.java
@@ -23,6 +23,7 @@ import rx.Notification;
 import rx.Observer;
 import rx.Scheduler;
 import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.functions.Action1;
 import rx.schedulers.TestScheduler;
 import rx.subjects.SubjectSubscriptionManager.SubjectObserver;
@@ -96,7 +97,7 @@ public final class TestSubject<T> extends Subject<T, T> {
         super(onSubscribe);
         this.subscriptionManager = subscriptionManager;
         this.lastNotification = lastNotification;
-        this.innerScheduler = scheduler.createInnerScheduler();
+        this.innerScheduler = scheduler.createInner();
     }
 
     @Override
@@ -118,10 +119,10 @@ public final class TestSubject<T> extends Subject<T, T> {
     }
 
     public void onCompleted(long timeInMilliseconds) {
-        innerScheduler.schedule(new Action1<Inner>() {
+        innerScheduler.schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner t1) {
+            public void call(Recurse t1) {
                 _onCompleted();
             }
 
@@ -148,10 +149,10 @@ public final class TestSubject<T> extends Subject<T, T> {
     }
 
     public void onError(final Throwable e, long timeInMilliseconds) {
-        innerScheduler.schedule(new Action1<Inner>() {
+        innerScheduler.schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner t1) {
+            public void call(Recurse t1) {
                 _onError(e);
             }
 
@@ -170,10 +171,10 @@ public final class TestSubject<T> extends Subject<T, T> {
     }
 
     public void onNext(final T v, long timeInMilliseconds) {
-        innerScheduler.schedule(new Action1<Inner>() {
+        innerScheduler.schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner t1) {
+            public void call(Recurse t1) {
                 _onNext(v);
             }
 

--- a/rxjava-core/src/perf/java/rx/archive/schedulers/TestRecursionMemoryUsage.java
+++ b/rxjava-core/src/perf/java/rx/archive/schedulers/TestRecursionMemoryUsage.java
@@ -18,7 +18,7 @@ package rx.archive.schedulers;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
@@ -29,78 +29,78 @@ import rx.schedulers.Schedulers;
  */
 public class TestRecursionMemoryUsage {
 
-	public static void main(String args[]) {
-		usingFunc2(Schedulers.newThread());
-		usingAction0(Schedulers.newThread());
+    public static void main(String args[]) {
+        usingFunc2(Schedulers.newThread());
+        usingAction0(Schedulers.newThread());
 
-		usingFunc2(Schedulers.currentThread());
-		usingAction0(Schedulers.currentThread());
+        usingFunc2(Schedulers.currentThread());
+        usingAction0(Schedulers.currentThread());
 
-		usingFunc2(Schedulers.computation());
-		usingAction0(Schedulers.computation());
+        usingFunc2(Schedulers.computation());
+        usingAction0(Schedulers.computation());
 
-		System.exit(0);
-	}
+        System.exit(0);
+    }
 
-	protected static void usingFunc2(final Scheduler scheduler) {
-		System.out.println("************ usingFunc2: " + scheduler);
-		Observable.create(new OnSubscribe<Long>() {
+    protected static void usingFunc2(final Scheduler scheduler) {
+        System.out.println("************ usingFunc2: " + scheduler);
+        Observable.create(new OnSubscribe<Long>() {
 
-			@Override
-			public void call(final Subscriber<? super Long> o) {
-				o.add(scheduler.schedule(new Action1<Inner>() {
-					long i = 0;
+            @Override
+            public void call(final Subscriber<? super Long> o) {
+                o.add(scheduler.schedule(new Action1<Recurse>() {
+                    long i = 0;
 
-					@Override
-					public void call(Inner inner) {
-						i++;
-						if (i % 500000 == 0) {
-							System.out.println(i + "  Total Memory: "
-									+ Runtime.getRuntime().totalMemory()
-									+ "  Free: "
-									+ Runtime.getRuntime().freeMemory());
-							o.onNext(i);
-						}
-						if (i == 100000000L) {
-							o.onCompleted();
-							return;
-						}
+                    @Override
+                    public void call(Recurse inner) {
+                        i++;
+                        if (i % 500000 == 0) {
+                            System.out.println(i + "  Total Memory: "
+                                    + Runtime.getRuntime().totalMemory()
+                                    + "  Free: "
+                                    + Runtime.getRuntime().freeMemory());
+                            o.onNext(i);
+                        }
+                        if (i == 100000000L) {
+                            o.onCompleted();
+                            return;
+                        }
 
-						inner.schedule(this);
-					}
-				}));
-			}
-		}).toBlockingObservable().last();
-	}
+                        inner.schedule();
+                    }
+                }));
+            }
+        }).toBlockingObservable().last();
+    }
 
-	protected static void usingAction0(final Scheduler scheduler) {
-		System.out.println("************ usingAction0: " + scheduler);
-		Observable.create(new OnSubscribe<Long>() {
+    protected static void usingAction0(final Scheduler scheduler) {
+        System.out.println("************ usingAction0: " + scheduler);
+        Observable.create(new OnSubscribe<Long>() {
 
-			@Override
-			public void call(final Subscriber<? super Long> o) {
-				o.add(scheduler.schedule(new Action1<Inner>() {
+            @Override
+            public void call(final Subscriber<? super Long> o) {
+                o.add(scheduler.schedule(new Action1<Recurse>() {
 
-					private long i = 0;
+                    private long i = 0;
 
-					@Override
-					public void call(Inner inner) {
-						i++;
-						if (i % 500000 == 0) {
-							System.out.println(i + "  Total Memory: "
-									+ Runtime.getRuntime().totalMemory()
-									+ "  Free: "
-									+ Runtime.getRuntime().freeMemory());
-							o.onNext(i);
-						}
-						if (i == 100000000L) {
-							o.onCompleted();
-							return;
-						}
-						inner.schedule(this);
-					}
-				}));
-			}
-		}).toBlockingObservable().last();
-	}
+                    @Override
+                    public void call(Recurse inner) {
+                        i++;
+                        if (i % 500000 == 0) {
+                            System.out.println(i + "  Total Memory: "
+                                    + Runtime.getRuntime().totalMemory()
+                                    + "  Free: "
+                                    + Runtime.getRuntime().freeMemory());
+                            o.onNext(i);
+                        }
+                        if (i == 100000000L) {
+                            o.onCompleted();
+                            return;
+                        }
+                        inner.schedule();
+                    }
+                }));
+            }
+        }).toBlockingObservable().last();
+    }
 }

--- a/rxjava-core/src/test/java/rx/EventStream.java
+++ b/rxjava-core/src/test/java/rx/EventStream.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import rx.Observable.OnSubscribeFunc;
 import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
@@ -35,14 +36,14 @@ public class EventStream {
             @Override
             public Subscription onSubscribe(final Observer<? super Event> observer) {
                 // run on a background thread inside the OnSubscribeFunc so unsubscribe works
-                return Schedulers.newThread().schedule(new Action1<Inner>() {
+                return Schedulers.newThread().schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(Inner inner) {
-                        inner.schedule(new Action1<Inner>() {
+                    public void call(Recurse inner) {
+                        inner.schedule(new Action1<Recurse>() {
 
                             @Override
-                            public void call(Inner inner) {
+                            public void call(Recurse inner) {
                                 while (!(inner.isUnsubscribed() || Thread.currentThread().isInterrupted())) {
                                     observer.onNext(randomEvent(type, numInstances));
                                     try {

--- a/rxjava-core/src/test/java/rx/operators/OperationBufferTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationBufferTest.java
@@ -15,10 +15,13 @@
  */
 package rx.operators;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static rx.operators.OperationBuffer.*;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static rx.operators.OperationBuffer.buffer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +37,7 @@ import org.mockito.Mockito;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.functions.Func0;
@@ -347,18 +351,18 @@ public class OperationBufferTest {
     }
 
     private <T> void push(final Observer<T> observer, final T value, int delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private void complete(final Observer<?> observer, int delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onCompleted();
             }
         }, delay, TimeUnit.MILLISECONDS);

--- a/rxjava-core/src/test/java/rx/operators/OperationDebounceTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationDebounceTest.java
@@ -15,8 +15,13 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 
@@ -27,6 +32,7 @@ import org.mockito.InOrder;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.functions.Func1;
@@ -132,27 +138,27 @@ public class OperationDebounceTest {
     }
 
     private <T> void publishCompleted(final Observer<T> observer, long delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onCompleted();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Observer<T> observer, long delay, final Exception error) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onError(error);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Observer<T> observer, final long delay, final T value) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);

--- a/rxjava-core/src/test/java/rx/operators/OperationSampleTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationSampleTest.java
@@ -15,8 +15,12 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,7 +30,7 @@ import org.mockito.InOrder;
 
 import rx.Observable;
 import rx.Observer;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.schedulers.TestScheduler;
@@ -52,21 +56,21 @@ public class OperationSampleTest {
         Observable<Long> source = Observable.create(new Observable.OnSubscribeFunc<Long>() {
             @Override
             public Subscription onSubscribe(final Observer<? super Long> observer1) {
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         observer1.onNext(1L);
                     }
                 }, 1, TimeUnit.SECONDS);
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         observer1.onNext(2L);
                     }
                 }, 2, TimeUnit.SECONDS);
-                scheduler.schedule(new Action1<Inner>() {
+                scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         observer1.onCompleted();
                     }
                 }, 3, TimeUnit.SECONDS);

--- a/rxjava-core/src/test/java/rx/operators/OperationSwitchTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationSwitchTest.java
@@ -15,8 +15,13 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,7 +31,7 @@ import org.mockito.InOrder;
 
 import rx.Observable;
 import rx.Observer;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.schedulers.TestScheduler;
@@ -45,7 +50,7 @@ public class OperationSwitchTest {
     }
 
     @Test
-    public void testSwitchWhenOuterCompleteBeforeInner() {
+    public void testSwitchWhenOuterCompleteBeforeRecurse() {
         Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribeFunc<Observable<String>>() {
             @Override
             public Subscription onSubscribe(Observer<? super Observable<String>> observer) {
@@ -75,7 +80,7 @@ public class OperationSwitchTest {
     }
 
     @Test
-    public void testSwitchWhenInnerCompleteBeforeOuter() {
+    public void testSwitchWhenRecurseCompleteBeforeOuter() {
         Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribeFunc<Observable<String>>() {
             @Override
             public Subscription onSubscribe(Observer<? super Observable<String>> observer) {
@@ -352,27 +357,27 @@ public class OperationSwitchTest {
     }
 
     private <T> void publishCompleted(final Observer<T> observer, long delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onCompleted();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Observer<T> observer, long delay, final Throwable error) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onError(error);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Observer<T> observer, long delay, final T value) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);

--- a/rxjava-core/src/test/java/rx/operators/OperationThrottleFirstTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationThrottleFirstTest.java
@@ -15,8 +15,10 @@
  */
 package rx.operators;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,7 +28,7 @@ import org.mockito.InOrder;
 
 import rx.Observable;
 import rx.Observer;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.schedulers.TestScheduler;
@@ -99,27 +101,27 @@ public class OperationThrottleFirstTest {
     }
 
     private <T> void publishCompleted(final Observer<T> observer, long delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onCompleted();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Observer<T> observer, long delay, final Exception error) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onError(error);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Observer<T> observer, long delay, final T value) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);

--- a/rxjava-core/src/test/java/rx/operators/OperationWindowTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperationWindowTest.java
@@ -15,10 +15,13 @@
  */
 package rx.operators;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static rx.operators.OperationWindow.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static rx.operators.OperationWindow.window;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +32,7 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Observer;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.functions.Func0;
@@ -285,18 +288,18 @@ public class OperationWindowTest {
     }
 
     private <T> void push(final Observer<T> observer, final T value, int delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
     private void complete(final Observer<?> observer, int delay) {
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 observer.onCompleted();
             }
         }, delay, TimeUnit.MILLISECONDS);

--- a/rxjava-core/src/test/java/rx/operators/OperatorAmbTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorAmbTest.java
@@ -30,7 +30,7 @@ import org.mockito.InOrder;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.functions.Action1;
 import rx.schedulers.TestScheduler;
@@ -55,17 +55,17 @@ public class OperatorAmbTest {
                 subscriber.add(parentSubscription);
                 long delay = interval;
                 for (final String value : values) {
-                    parentSubscription.add(scheduler.schedule(new Action1<Inner>() {
+                    parentSubscription.add(scheduler.schedule(new Action1<Recurse>() {
                         @Override
-                        public void call(Inner inner) {
+                        public void call(Recurse inner) {
                             subscriber.onNext(value);
                         }
                     }, delay, TimeUnit.MILLISECONDS));
                     delay += interval;
                 }
-                parentSubscription.add(scheduler.schedule(new Action1<Inner>() {
+                parentSubscription.add(scheduler.schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         if (e == null) {
                             subscriber.onCompleted();
                         } else {

--- a/rxjava-core/src/test/java/rx/operators/OperatorMergeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMergeTest.java
@@ -42,7 +42,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
@@ -485,10 +485,10 @@ public class OperatorMergeTest {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {
-                Schedulers.newThread().schedule(new Action1<Inner>() {
+                Schedulers.newThread().schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         for (int i = 0; i < 10000; i++) {
                             s.onNext(1);
                         }
@@ -519,10 +519,10 @@ public class OperatorMergeTest {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {
-                Schedulers.newThread().schedule(new Action1<Inner>() {
+                Schedulers.newThread().schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         for (int i = 0; i < 100; i++) {
                             s.onNext(1);
                             try {
@@ -558,10 +558,10 @@ public class OperatorMergeTest {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {
-                Schedulers.newThread().schedule(new Action1<Inner>() {
+                Schedulers.newThread().schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         for (int i = 0; i < 10000; i++) {
                             s.onNext(1);
                         }

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -15,7 +15,10 @@
  */
 package rx.schedulers;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +31,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
@@ -98,16 +101,16 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch unsubscribeLatch = new CountDownLatch(1);
         final AtomicInteger counter = new AtomicInteger();
-        Subscription s = getScheduler().schedule(new Action1<Inner>() {
+        Subscription s = getScheduler().schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(final Inner inner) {
-                inner.schedule(new Action1<Inner>() {
+            public void call(final Recurse inner) {
+                inner.schedule(new Action1<Recurse>() {
 
                     int i = 0;
 
                     @Override
-                    public void call(Inner s) {
+                    public void call(Recurse s) {
                         System.out.println("Run: " + i++);
                         if (i == 10) {
                             latch.countDown();
@@ -141,16 +144,16 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
     public void testUnsubscribeRecursiveScheduleFromInside() throws InterruptedException {
         final CountDownLatch unsubscribeLatch = new CountDownLatch(1);
         final AtomicInteger counter = new AtomicInteger();
-        getScheduler().schedule(new Action1<Inner>() {
+        getScheduler().schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner inner) {
-                inner.schedule(new Action1<Inner>() {
+            public void call(Recurse inner) {
+                inner.schedule(new Action1<Recurse>() {
 
                     int i = 0;
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         System.out.println("Run: " + i++);
                         if (i == 10) {
                             inner.unsubscribe();
@@ -174,16 +177,16 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch unsubscribeLatch = new CountDownLatch(1);
         final AtomicInteger counter = new AtomicInteger();
-        Subscription s = getScheduler().schedule(new Action1<Inner>() {
+        Subscription s = getScheduler().schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(final Inner innerScheduler) {
-                innerScheduler.schedule(new Action1<Inner>() {
+            public void call(final Recurse innerScheduler) {
+                innerScheduler.schedule(new Action1<Recurse>() {
 
                     long i = 1L;
 
                     @Override
-                    public void call(Inner s) {
+                    public void call(Recurse s) {
                         if (i++ == 10) {
                             latch.countDown();
                             try {
@@ -214,12 +217,12 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
     @Test
     public void recursionFromOuterActionAndUnsubscribeInside() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        getScheduler().schedule(new Action1<Inner>() {
+        getScheduler().schedule(new Action1<Recurse>() {
 
             int i = 0;
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 i++;
                 if (i % 100000 == 0) {
                     System.out.println(i + "  Total Memory: " + Runtime.getRuntime().totalMemory() + "  Free: " + Runtime.getRuntime().freeMemory());
@@ -238,12 +241,12 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
     @Test
     public void testRecursion() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        getScheduler().schedule(new Action1<Inner>() {
+        getScheduler().schedule(new Action1<Recurse>() {
 
             private long i = 0;
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 i++;
                 if (i % 100000 == 0) {
                     System.out.println(i + "  Total Memory: " + Runtime.getRuntime().totalMemory() + "  Free: " + Runtime.getRuntime().freeMemory());
@@ -269,9 +272,9 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
             @Override
             public Subscription onSubscribe(final Observer<? super Integer> observer) {
 
-                final Subscription s = getScheduler().schedule(new Action1<Inner>() {
+                final Subscription s = getScheduler().schedule(new Action1<Recurse>() {
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         observer.onNext(42);
                         latch.countDown();
 

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
@@ -15,9 +15,15 @@
  */
 package rx.schedulers;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +41,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
@@ -67,26 +73,26 @@ public abstract class AbstractSchedulerTests {
         final Action0 thirdStepStart = mock(Action0.class);
         final Action0 thirdStepEnd = mock(Action0.class);
 
-        final Action1<Inner> firstAction = new Action1<Inner>() {
+        final Action1<Recurse> firstAction = new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 firstStepStart.call();
                 firstStepEnd.call();
                 latch.countDown();
             }
         };
-        final Action1<Inner> secondAction = new Action1<Inner>() {
+        final Action1<Recurse> secondAction = new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 secondStepStart.call();
                 inner.schedule(firstAction);
                 secondStepEnd.call();
 
             }
         };
-        final Action1<Inner> thirdAction = new Action1<Inner>() {
+        final Action1<Recurse> thirdAction = new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 thirdStepStart.call();
                 inner.schedule(secondAction);
                 thirdStepEnd.call();
@@ -149,8 +155,8 @@ public abstract class AbstractSchedulerTests {
         final Scheduler scheduler = getScheduler();
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final Action1<Inner> first = mock(Action1.class);
-        final Action1<Inner> second = mock(Action1.class);
+        final Action1<Recurse> first = mock(Action1.class);
+        final Action1<Recurse> second = mock(Action1.class);
 
         // make it wait until both the first and second are called
         doAnswer(new Answer() {
@@ -163,7 +169,7 @@ public abstract class AbstractSchedulerTests {
                     latch.countDown();
                 }
             }
-        }).when(first).call(any(Inner.class));
+        }).when(first).call(any(Recurse.class));
         doAnswer(new Answer() {
 
             @Override
@@ -174,15 +180,15 @@ public abstract class AbstractSchedulerTests {
                     latch.countDown();
                 }
             }
-        }).when(second).call(any(Inner.class));
+        }).when(second).call(any(Recurse.class));
 
         scheduler.schedule(first);
         scheduler.schedule(second);
 
         latch.await();
 
-        verify(first, times(1)).call(any(Inner.class));
-        verify(second, times(1)).call(any(Inner.class));
+        verify(first, times(1)).call(any(Recurse.class));
+        verify(second, times(1)).call(any(Recurse.class));
 
     }
 
@@ -191,18 +197,18 @@ public abstract class AbstractSchedulerTests {
         Scheduler scheduler = getScheduler();
 
         final CountDownLatch latch = new CountDownLatch(1);
-        final Action1<Inner> first = mock(Action1.class);
-        final Action1<Inner> second = mock(Action1.class);
+        final Action1<Recurse> first = mock(Action1.class);
+        final Action1<Recurse> second = mock(Action1.class);
 
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 inner.schedule(first, 30, TimeUnit.MILLISECONDS);
                 inner.schedule(second, 10, TimeUnit.MILLISECONDS);
-                inner.schedule(new Action1<Inner>() {
+                inner.schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         latch.countDown();
                     }
                 }, 40, TimeUnit.MILLISECONDS);
@@ -212,8 +218,8 @@ public abstract class AbstractSchedulerTests {
         latch.await();
         InOrder inOrder = inOrder(first, second);
 
-        inOrder.verify(second, times(1)).call(any(Inner.class));
-        inOrder.verify(first, times(1)).call(any(Inner.class));
+        inOrder.verify(second, times(1)).call(any(Recurse.class));
+        inOrder.verify(first, times(1)).call(any(Recurse.class));
 
     }
 
@@ -222,22 +228,22 @@ public abstract class AbstractSchedulerTests {
         Scheduler scheduler = getScheduler();
 
         final CountDownLatch latch = new CountDownLatch(1);
-        final Action1<Inner> first = mock(Action1.class);
-        final Action1<Inner> second = mock(Action1.class);
-        final Action1<Inner> third = mock(Action1.class);
-        final Action1<Inner> fourth = mock(Action1.class);
+        final Action1<Recurse> first = mock(Action1.class);
+        final Action1<Recurse> second = mock(Action1.class);
+        final Action1<Recurse> third = mock(Action1.class);
+        final Action1<Recurse> fourth = mock(Action1.class);
 
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 inner.schedule(first);
                 inner.schedule(second, 300, TimeUnit.MILLISECONDS);
                 inner.schedule(third, 100, TimeUnit.MILLISECONDS);
                 inner.schedule(fourth);
-                inner.schedule(new Action1<Inner>() {
+                inner.schedule(new Action1<Recurse>() {
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         latch.countDown();
                     }
                 }, 400, TimeUnit.MILLISECONDS);
@@ -247,10 +253,10 @@ public abstract class AbstractSchedulerTests {
         latch.await();
         InOrder inOrder = inOrder(first, second, third, fourth);
 
-        inOrder.verify(first, times(1)).call(any(Inner.class));
-        inOrder.verify(fourth, times(1)).call(any(Inner.class));
-        inOrder.verify(third, times(1)).call(any(Inner.class));
-        inOrder.verify(second, times(1)).call(any(Inner.class));
+        inOrder.verify(first, times(1)).call(any(Recurse.class));
+        inOrder.verify(fourth, times(1)).call(any(Recurse.class));
+        inOrder.verify(third, times(1)).call(any(Recurse.class));
+        inOrder.verify(second, times(1)).call(any(Recurse.class));
     }
 
     @Test
@@ -258,10 +264,10 @@ public abstract class AbstractSchedulerTests {
         final Scheduler scheduler = getScheduler();
         final AtomicInteger i = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 if (i.incrementAndGet() < 100) {
                     inner.schedule(this);
                 } else {
@@ -280,12 +286,12 @@ public abstract class AbstractSchedulerTests {
         final AtomicInteger i = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        scheduler.schedule(new Action1<Inner>() {
+        scheduler.schedule(new Action1<Recurse>() {
 
             int state = 0;
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 i.set(state);
                 if (state++ < 100) {
                     inner.schedule(this, 1, TimeUnit.MILLISECONDS);
@@ -305,11 +311,11 @@ public abstract class AbstractSchedulerTests {
         Observable<Integer> obs = Observable.create(new OnSubscribeFunc<Integer>() {
             @Override
             public Subscription onSubscribe(final Observer<? super Integer> observer) {
-                return getScheduler().schedule(new Action1<Inner>() {
+                return getScheduler().schedule(new Action1<Recurse>() {
                     int i = 0;
 
                     @Override
-                    public void call(Inner inner) {
+                    public void call(Recurse inner) {
                         if (i > 42) {
                             observer.onCompleted();
                             return;

--- a/rxjava-core/src/test/java/rx/schedulers/ExecutorSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/ExecutorSchedulerTests.java
@@ -15,7 +15,9 @@
  */
 package rx.schedulers;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
@@ -24,7 +26,7 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Scheduler;
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.functions.Action1;
 import rx.functions.Func1;
 
@@ -43,13 +45,13 @@ public class ExecutorSchedulerTests extends AbstractSchedulerConcurrencyTests {
         final CountDownLatch latch = new CountDownLatch(1);
         final HashMap<String, Integer> map = new HashMap<String, Integer>();
         
-        Schedulers.computation().schedule(new Action1<Inner>() {
+        Schedulers.computation().schedule(new Action1<Recurse>() {
 
             private HashMap<String, Integer> statefulMap = map;
             int nonThreadSafeCounter = 0;
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 Integer i = statefulMap.get("a");
                 if (i == null) {
                     i = 1;

--- a/rxjava-core/src/test/java/rx/schedulers/TestSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/TestSchedulerTest.java
@@ -15,9 +15,12 @@
  */
 package rx.schedulers;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,7 +29,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-import rx.Scheduler.Inner;
+import rx.Scheduler.Recurse;
 import rx.Subscription;
 import rx.functions.Action1;
 import rx.functions.Func1;
@@ -40,9 +43,9 @@ public class TestSchedulerTest {
         final Func1<Long, Void> calledOp = mock(Func1.class);
 
         final TestScheduler scheduler = new TestScheduler();
-        Subscription subscription = scheduler.schedulePeriodically(new Action1<Inner>() {
+        Subscription subscription = scheduler.schedulePeriodically(new Action1<Recurse>() {
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 System.out.println(scheduler.now());
                 calledOp.call(scheduler.now());
             }
@@ -79,10 +82,10 @@ public class TestSchedulerTest {
 
         final AtomicInteger counter = new AtomicInteger(0);
 
-        Subscription subscription = s.schedule(new Action1<Inner>() {
+        Subscription subscription = s.schedule(new Action1<Recurse>() {
 
             @Override
-            public void call(Inner inner) {
+            public void call(Recurse inner) {
                 counter.incrementAndGet();
                 System.out.println("counter: " + counter.get());
                 inner.schedule(this);

--- a/rxjava-core/src/test/java/rx/test/OperatorTester.java
+++ b/rxjava-core/src/test/java/rx/test/OperatorTester.java
@@ -18,7 +18,6 @@ package rx.test;
 import java.util.concurrent.TimeUnit;
 
 import rx.Scheduler;
-import rx.Subscription;
 import rx.functions.Action1;
 
 /**
@@ -56,13 +55,38 @@ public class OperatorTester {
         }
 
         @Override
-        public Subscription schedule(Action1<Inner> action) {
-            return underlying.schedule(action);
+        public Inner createInner() {
+            return new InnerScheduler(underlying.createInner());
         }
 
-        @Override
-        public Subscription schedule(Action1<Inner> action, long delayTime, TimeUnit unit) {
-            return underlying.schedule(action, delayTime, unit);
+        public static class InnerScheduler extends Scheduler.Inner {
+
+            private final Inner actualInner;
+
+            public InnerScheduler(Inner inner) {
+                this.actualInner = inner;
+            }
+
+            @Override
+            public void schedule(Action1<Recurse> action) {
+                actualInner.schedule(action);
+            }
+
+            @Override
+            public void schedule(Action1<Recurse> action, long delayTime, TimeUnit unit) {
+                actualInner.schedule(action, delayTime, unit);
+            }
+
+            @Override
+            public void unsubscribe() {
+                actualInner.unsubscribe();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return actualInner.isUnsubscribed();
+            }
+
         }
 
     }


### PR DESCRIPTION
API changes as per https://github.com/Netflix/RxJava/issues/997

Usage looks like this:

``` java
import java.util.concurrent.TimeUnit;

import rx.Scheduler.Inner;
import rx.Scheduler.Recurse;
import rx.functions.Action1;
import rx.schedulers.Schedulers;

public class Test {

    public static void main(String args[]) {

        Schedulers.newThread().schedule(new Action1<Recurse>() {

            @Override
            public void call(Recurse inner) {
                System.out.println("do stuff");
                // recurse
                inner.schedule(this);
            }

        });

        Schedulers.newThread().schedule(recurse -> {
            System.out.println("do stuff");
            recurse.schedule();
        });

        Schedulers.newThread().schedule(recurse -> {
            System.out.println("do stuff");
            recurse.schedule(1000, TimeUnit.MILLISECONDS);
        });

        Schedulers.newThread().schedule(recurse -> {
            recurse.schedule(re -> {
                System.out.println("do more stuff");
            });
        });

        Inner inner = Schedulers.newThread().createInner();
        inner.schedule(re -> {
            System.out.println("do stuff");
            re.schedule(r -> {
                System.out.println("do more stuff");
            });
        });

    }
}
```

Code outline:

![screen shot 2014-04-02 at 11 08 31 pm](https://cloud.githubusercontent.com/assets/813492/2600101/6c680404-baf6-11e3-916e-c41a817bc328.png)
