### PR TITLE
Upgrade Gradle wrapper for Android samples to Gradle 1.11

### DIFF
--- a/rxjava-contrib/rxjava-android-samples/gradle/wrapper/gradle-wrapper.properties
+++ b/rxjava-contrib/rxjava-android-samples/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 12 12:09:46 CET 2014
+#Sat Apr 05 11:18:06 CEST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip


### PR DESCRIPTION
Android Studio 0.5.4 refuses to build with 1.10.
