### PR TITLE
isolate subscriber used for retries, cleanup tests

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperatorRetry.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorRetry.java
@@ -82,7 +82,7 @@ public class OperatorRetry<T> implements Operator<T, Observable<T>> {
                         final Action1<Inner> _self = this;
                         attempts.incrementAndGet();
 
-                        Subscriber<T> subscriber = new Subscriber<T>(child) {
+                        Subscriber<T> subscriber = new Subscriber<T>() {
 
                             @Override
                             public void onCompleted() {


### PR DESCRIPTION
potential fix for #1024

there is an outstanding question (see commit comments) about whether its appropriate for the operator to use `unsafeSubscribe` given that it does not completely isolate the `Subscriber` from a badly behaved `Observable`.
