### PR TITLE
Benchmarking: Add JMH benchmark for ReplaySubject.

### DIFF
--- a/rxjava-core/src/perf/java/rx/jmh/Baseline.java
+++ b/rxjava-core/src/perf/java/rx/jmh/Baseline.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.jmh;
 
 import org.openjdk.jmh.annotations.GenerateMicroBenchmark;

--- a/rxjava-core/src/perf/java/rx/operators/OperatorMapPerf.java
+++ b/rxjava-core/src/perf/java/rx/operators/OperatorMapPerf.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.operators;
 
 import java.util.concurrent.CountDownLatch;

--- a/rxjava-core/src/perf/java/rx/operators/OperatorSerializePerf.java
+++ b/rxjava-core/src/perf/java/rx/operators/OperatorSerializePerf.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.operators;
 
 import java.util.concurrent.CountDownLatch;

--- a/rxjava-core/src/perf/java/rx/subjects/ReplaySubjectPerf.java
+++ b/rxjava-core/src/perf/java/rx/subjects/ReplaySubjectPerf.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.subjects;
+
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.logic.BlackHole;
+import rx.Observer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Benchmarks the {@link ReplaySubject}.
+ */
+public class ReplaySubjectPerf {
+
+    @State(Scope.Thread)
+    public static class Input {
+        @Param({ "1", "512", "1024", "1048576" })
+        public int nextRuns;
+    }
+
+    @GenerateMicroBenchmark
+    public void subscribeBeforeEvents(final Input input, final BlackHole bh) throws Exception {
+        ReplaySubject<Object> subject = ReplaySubject.create();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicLong sum = new AtomicLong();
+
+        subject.subscribe(new Observer<Object>() {
+            @Override
+            public void onCompleted() {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onNext(Object o) {
+                sum.incrementAndGet();
+            }
+        });
+        for (int i = 0; i < input.nextRuns; i++) {
+            subject.onNext("Response");
+        }
+        subject.onCompleted();
+        latch.await();
+        bh.consume(sum);
+    }
+
+    @GenerateMicroBenchmark
+    public void subscribeAfterEvents(final Input input, final BlackHole bh) throws Exception {
+        ReplaySubject<Object> subject = ReplaySubject.create();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicLong sum = new AtomicLong();
+
+        for (int i = 0; i < input.nextRuns; i++) {
+            subject.onNext("Response");
+        }
+        subject.onCompleted();
+
+        subject.subscribe(new Observer<Object>() {
+            @Override
+            public void onCompleted() {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onNext(Object o) {
+                sum.incrementAndGet();
+            }
+        });
+        latch.await();
+        bh.consume(sum);
+    }
+
+}


### PR DESCRIPTION
Adds some benches for the replay subject.

I.E.

```
Benchmark                                     (nextRuns)   Mode   Samples         Mean   Mean error    Units
r.s.ReplaySubjectPerf.subscribeAfterEvents             1  thrpt         5  1898239.827    57634.047    ops/s
r.s.ReplaySubjectPerf.subscribeAfterEvents          1024  thrpt         5    35680.927      470.929    ops/s
r.s.ReplaySubjectPerf.subscribeAfterEvents       1048576  thrpt         5       32.427        1.462    ops/s
r.s.ReplaySubjectPerf.subscribeBeforeEvents            1  thrpt         5  1427820.733    19194.452    ops/s
r.s.ReplaySubjectPerf.subscribeBeforeEvents         1024  thrpt         5    36835.800      264.748    ops/s
r.s.ReplaySubjectPerf.subscribeBeforeEvents      1048576  thrpt         5       35.520        1.145    ops/s
```
