### PR TITLE
Fix NPE in SubjectSubscriptionManager

### DIFF
--- a/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -94,7 +94,7 @@ import rx.subscriptions.Subscriptions;
                         }));
                         if (subscription.isUnsubscribed()) {
                             addedObserver = false;
-                            break;
+                            return;
                         }
                         // on subscribe add it to the map of outbound observers to notify
                         newState = current.addObserver(subscription, observer);


### PR DESCRIPTION
If unsubscribed it should just return, not continue forward. If it does, the `newState` is null and it throws an NPE. 
