### PR TITLE
replaced FRP with RP in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RxJava: Functional Reactive Programming on the JVM
+# RxJava: Reactive Programming on the JVM
 
 This library is a Java implementation of <a href="https://rx.codeplex.com">Rx Observables</a>.
 


### PR DESCRIPTION
Mentioning "Functional Reactive Programming" causes confusion and misconception.
I think it's better to simply stick with "Reactive Programming".
