### PR TITLE
rxjava-android: parameterize OperatorViewClick by concrete view type

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/observables/ViewObservable.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/observables/ViewObservable.java
@@ -26,7 +26,7 @@ import android.widget.EditText;
 
 public class ViewObservable {
 
-    public static Observable<View> clicks(final View view, final boolean emitInitialValue) {
+    public static <T extends View> Observable<T> clicks(final T view, final boolean emitInitialValue) {
         return Observable.create(new OperatorViewClick(view, emitInitialValue));
     }
 

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorViewClick.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/operators/OperatorViewClick.java
@@ -28,17 +28,17 @@ import rx.android.subscriptions.AndroidSubscriptions;
 import rx.functions.Action0;
 import android.view.View;
 
-public final class OperatorViewClick implements Observable.OnSubscribe<View> {
+public final class OperatorViewClick<T extends View> implements Observable.OnSubscribe<T> {
     private final boolean emitInitialValue;
-    private final View view;
+    private final T view;
 
-    public OperatorViewClick(final View view, final boolean emitInitialValue) {
+    public OperatorViewClick(final T view, final boolean emitInitialValue) {
         this.emitInitialValue = emitInitialValue;
         this.view = view;
     }
 
     @Override
-    public void call(final Subscriber<? super View> observer) {
+    public void call(final Subscriber<? super T> observer) {
         Assertions.assertUiThread();
         final CompositeOnClickListener composite = CachedListeners.getFromViewOrCreate(view);
 


### PR DESCRIPTION
Parameterize OperatorViewClick observable to actual View type.
So actual view with it native type can be used.

So instead of 

```
Observable<View> imageClicks = ViewObservable.clicks(imageView, false);
        //...
        imageClicks.subscribe(new Action1<View>() {
            @Override
            public void call(View view) {
                ImageView imageView = (ImageView) view;
                imageView.setImageBitmap(bitmap);
            }
        });
```

you can use

```
        Observable<ImageView> imageClicks = ViewObservable.clicks(imageView, false);
        //...
        imageClicks.subscribe(new Action1<ImageView>() {
            @Override
            public void call(ImageView view) {
                view.setImageBitmap(bitmap);
            }
        });
```
