### PR TITLE
CompositeSubscription fix

### DIFF
--- a/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -72,7 +72,7 @@ public final class CompositeSubscription implements Subscription {
             for (Subscription _s : subscriptions) {
                 if (!_s.equals(s)) {
                     // was not in this composite
-                    if (idx == subscriptions.length) {
+                    if (idx == newSubscriptions.length) {
                         return this;
                     }
                     newSubscriptions[idx] = _s;

--- a/rxjava-core/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
+++ b/rxjava-core/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
@@ -324,4 +324,17 @@ public class CompositeSubscriptionTest {
         // we should have only unsubscribed once
         assertEquals(1, counter.get());
     }
+    @Test
+    public void testTryRemoveIfNotIn() {
+        CompositeSubscription csub = new CompositeSubscription();
+        
+        CompositeSubscription csub1 = new CompositeSubscription();
+        CompositeSubscription csub2 = new CompositeSubscription();
+        
+        csub.add(csub1);
+        csub.remove(csub1);
+        csub.add(csub2);
+        
+        csub.remove(csub1); // try removing agian
+    }
 }


### PR DESCRIPTION
A bug in the remove() method caused ArrayIndexOutOfBoundsException if the composite is not empty and trying to remove a subscription that is not in the composite at all.
