### PR TITLE
rxjava-android Poposal: Call action immediately in HandlerThreadScheduler if thread is the same

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -25,7 +25,7 @@ import android.os.Looper;
 public class AndroidSchedulers {
 
     private static final Scheduler MAIN_THREAD_SCHEDULER =
-            new HandlerThreadScheduler(new Handler(Looper.getMainLooper()));
+            new HandlerThreadScheduler(new Handler(Looper.getMainLooper()), true);
 
     private AndroidSchedulers(){
 
@@ -38,6 +38,18 @@ public class AndroidSchedulers {
      */
     public static Scheduler handlerThread(final Handler handler) {
         return new HandlerThreadScheduler(handler);
+    }
+
+    /**
+     * {@link Scheduler} which uses the provided {@link Handler} to execute an action
+     * @param handler The handler that will be used when executing the action
+     * @param immediate
+     *      if true, immediate actions scheduled from the same Thread will be called directly
+     *      without posting to {@link Handler}
+     * @return A handler based scheduler
+     */
+    public static Scheduler handlerThread(final Handler handler, final boolean immediate) {
+        return new HandlerThreadScheduler(handler, immediate);
     }
 
     /**

--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/HandlerThreadScheduler.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/HandlerThreadScheduler.java
@@ -31,29 +31,46 @@ import android.os.Handler;
 public class HandlerThreadScheduler extends Scheduler {
 
     private final Handler handler;
+    private final boolean immediate;
 
     /**
      * Constructs a {@link HandlerThreadScheduler} using the given {@link Handler}
+     * @param handler
+     *            {@link Handler} to use when scheduling actions
+     * @param immediate
+     *            if true, immediate actions scheduled from the same Thread will be called directly
+     *            without posting to {@link Handler}
+     */
+    public HandlerThreadScheduler(Handler handler, boolean immediate) {
+        this.handler = handler;
+        this.immediate = immediate;
+    }
+
+    /**
+     * Constructs a {@link HandlerThreadScheduler} using the given {@link Handler} and
+     * {@link Handler}
      * 
      * @param handler
      *            {@link Handler} to use when scheduling actions
      */
     public HandlerThreadScheduler(Handler handler) {
-        this.handler = handler;
+        this(handler, false);
     }
 
     @Override
     public Worker createWorker() {
-        return new InnerHandlerThreadScheduler(handler);
+        return new InnerHandlerThreadScheduler(handler, immediate);
     }
     
     private static class InnerHandlerThreadScheduler extends Worker {
 
         private final Handler handler;
+        private final boolean immediate;
         private BooleanSubscription innerSubscription = new BooleanSubscription();
 
-        public InnerHandlerThreadScheduler(Handler handler) {
+        public InnerHandlerThreadScheduler(Handler handler, boolean immediate) {
             this.handler = handler;
+            this.immediate = immediate;
         }
 
         @Override
@@ -91,7 +108,7 @@ public class HandlerThreadScheduler extends Scheduler {
 
         @Override
         public Subscription schedule(final Action0 action) {
-            if (handler.getLooper().getThread() == Thread.currentThread()) {
+            if (immediate && handler.getLooper().getThread() == Thread.currentThread()) {
                 action.call();
                 return Subscriptions.empty();
             } else {

--- a/rxjava-contrib/rxjava-android/src/test/java/rx/android/schedulers/HandlerThreadSchedulerTest.java
+++ b/rxjava-contrib/rxjava-android/src/test/java/rx/android/schedulers/HandlerThreadSchedulerTest.java
@@ -29,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import rx.Observable;
 import rx.Scheduler;
 import rx.Scheduler.Worker;
 import rx.functions.Action0;
@@ -49,7 +50,7 @@ public class HandlerThreadSchedulerTest {
         @SuppressWarnings("unchecked")
         final Action0 action = mock(Action0.class);
 
-        Scheduler scheduler = new HandlerThreadScheduler(handler);
+        Scheduler scheduler = new HandlerThreadScheduler(handler, true);
         Worker inner = scheduler.createWorker();
         inner.schedule(action);
 
@@ -64,9 +65,6 @@ public class HandlerThreadSchedulerTest {
     @Test
     public void shouldScheduleDelayedActionOnHandlerThread() {
         final Handler handler = mock(Handler.class);
-        final Looper looper = mock(Looper.class);
-        when(handler.getLooper()).thenReturn(looper);
-        when(looper.getThread()).thenReturn(Thread.currentThread());
         @SuppressWarnings("unchecked")
         final Action0 action = mock(Action0.class);
 


### PR DESCRIPTION
By avoiding unnecessary Runnable creation, and posting it to handler we can decrease overhead when scheduling is made from the same thread.

Current Activity.runOnUIThread is implemented in the same way:

``` java
    public final void runOnUiThread(Runnable action) {
        if (Thread.currentThread() != mUiThread) {
            mHandler.post(action);
        } else {
            action.run();
        }
    }
```
