### PR TITLE
OperatorSequenceEqual

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -63,7 +63,6 @@ import rx.operators.OperationOnExceptionResumeNextViaObservable;
 import rx.operators.OperationParallelMerge;
 import rx.operators.OperationReplay;
 import rx.operators.OperationSample;
-import rx.operators.OperationSequenceEqual;
 import rx.operators.OperationSkip;
 import rx.operators.OperationSkipUntil;
 import rx.operators.OperationSwitch;
@@ -113,6 +112,7 @@ import rx.operators.OperatorPivot;
 import rx.operators.OperatorRepeat;
 import rx.operators.OperatorRetry;
 import rx.operators.OperatorScan;
+import rx.operators.OperatorSequenceEqual;
 import rx.operators.OperatorSerialize;
 import rx.operators.OperatorSingle;
 import rx.operators.OperatorSkip;
@@ -2476,7 +2476,7 @@ public class Observable<T> {
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#wiki-sequenceequal">RxJava Wiki: sequenceEqual()</a>
      */
     public final static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> first, Observable<? extends T> second, Func2<? super T, ? super T, Boolean> equality) {
-        return OperationSequenceEqual.sequenceEqual(first, second, equality);
+        return OperatorSequenceEqual.sequenceEqual(first, second, equality);
     }
 
     /**

--- a/rxjava-core/src/test/java/rx/operators/OperatorSequenceEqualTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorSequenceEqualTest.java
@@ -27,7 +27,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.functions.Func2;
 
-public class OperationSequenceEqualTests {
+public class OperatorSequenceEqualTest {
 
     @Test
     public void test1() {


### PR DESCRIPTION
Operator SequenceEqual
#1060

Lightened the operator, but note that NotificationLite escaping an operator may cause undesired effects in other operators relying on NotificationLite as well.
