### PR TITLE
Fixes to the operators.

### DIFF
--- a/rxjava-core/src/main/java/rx/observers/Subscribers.java
+++ b/rxjava-core/src/main/java/rx/observers/Subscribers.java
@@ -7,29 +7,9 @@ import rx.functions.Action0;
 import rx.functions.Action1;
 
 public class Subscribers {
-
-    private static final Subscriber<Object> EMPTY = new Subscriber<Object>() {
-
-        @Override
-        public final void onCompleted() {
-            // do nothing
-        }
-
-        @Override
-        public final void onError(Throwable e) {
-            throw new OnErrorNotImplementedException(e);
-        }
-
-        @Override
-        public final void onNext(Object args) {
-            // do nothing
-        }
-
-    };
-
     @SuppressWarnings("unchecked")
     public static <T> Subscriber<T> empty() {
-        return (Subscriber<T>) EMPTY;
+        return from(Observers.empty());
     }
 
     public static <T> Subscriber<T> from(final Observer<? super T> o) {

--- a/rxjava-core/src/main/java/rx/operators/OperatorRefCount.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorRefCount.java
@@ -15,6 +15,10 @@
  */
 package rx.operators;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.Subscription;
@@ -31,32 +35,175 @@ public final class OperatorRefCount<T> implements OnSubscribe<T> {
     final ConnectableObservable<? extends T> source;
     final Object guard;
     /** Guarded by guard. */
-    int count;
+    int index;
     /** Guarded by guard. */
+    boolean emitting;
+    /** Guarded by guard. If true, indicates a connection request, false indicates a disconnect request. */
+    List<Token> queue;
+    /** Manipulated while in the serialized section. */
+    int count;
+    /** Manipulated while in the serialized section. */
     Subscription connection;
+    /** Manipulated while in the serialized section. */
+    final Map<Token, Object> connectionStatus;
+    /** Occupied indicator. */
+    private static final Object OCCUPIED = new Object();
     public OperatorRefCount(ConnectableObservable<? extends T> source) {
         this.source = source;
         this.guard = new Object();
+        this.connectionStatus = new WeakHashMap<Token, Object>();
     }
 
     @Override
     public void call(Subscriber<? super T> t1) {
+        int id;
+        synchronized (guard) {
+            id = ++index;
+        }
+        final Token t = new Token(id);
         t1.add(Subscriptions.create(new Action0() {
             @Override
             public void call() {
-                synchronized (guard) {
-                    if (--count == 0) {
-                        connection.unsubscribe();
-                        connection = null;
-                    }
-                }
+                disconnect(t);
             }
         }));
         source.unsafeSubscribe(t1);
+        connect(t);
+    }
+    private void connect(Token id) {
+        List<Token> localQueue;
         synchronized (guard) {
+            if (emitting) {
+                if (queue == null) {
+                    queue = new ArrayList<Token>();
+                }
+                queue.add(id);
+                return;
+            }
+            
+            localQueue = queue;
+            queue = null;
+            emitting = true;
+        }
+        boolean once = true;
+        do {
+            drain(localQueue);
+            if (once) {
+                once = false;
+                doConnect(id);
+            }
+            synchronized (guard) {
+                localQueue = queue;
+                queue = null;
+                if (localQueue == null) {
+                    emitting = false;
+                    return;
+                }
+            }
+        } while (true);
+    }
+    private void disconnect(Token id) {
+        List<Token> localQueue;
+        synchronized (guard) {
+            if (emitting) {
+                if (queue == null) {
+                    queue = new ArrayList<Token>();
+                }
+                queue.add(id.toDisconnect()); // negative value indicates disconnect
+                return;
+            }
+            
+            localQueue = queue;
+            queue = null;
+            emitting = true;
+        }
+        boolean once = true;
+        do {
+            drain(localQueue);
+            if (once) {
+                once = false;
+                doDisconnect(id);
+            }
+            synchronized (guard) {
+                localQueue = queue;
+                queue = null;
+                if (localQueue == null) {
+                    emitting = false;
+                    return;
+                }
+            }
+        } while (true);
+    }
+    private void drain(List<Token> localQueue) {
+        if (localQueue == null) {
+            return;
+        }
+        int n = localQueue.size();
+        for (int i = 0; i < n; i++) {
+            Token id = localQueue.get(i);
+            if (id.isDisconnect()) {
+                doDisconnect(id);
+            } else {
+                doConnect(id);
+            }
+        }
+    }
+    private void doConnect(Token id) {
+        // this method is called only once per id
+        // if add succeeds, id was not yet disconnected
+        if (connectionStatus.put(id, OCCUPIED) == null) {
             if (count++ == 0) {
                 connection = source.connect();
             }
+        } else {
+            // connection exists due to disconnect, just remove
+            connectionStatus.remove(id);
+        }
+    }
+    private void doDisconnect(Token id) {
+        // this method is called only once per id
+        // if remove succeeds, id was connected
+        if (connectionStatus.remove(id) != null) {
+            if (--count == 0) {
+                connection.unsubscribe();
+                connection = null;
+            }
+        } else {
+            // mark id as if connected
+            connectionStatus.put(id, OCCUPIED);
+        }
+    }
+    /** Token that represens a connection request or a disconnection request. */
+    private static final class Token {
+        final int id;
+        public Token(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (obj.getClass() != getClass()) {
+                return false;
+            }
+            int other = ((Token)obj).id;
+            return id == other || -id == other;
+        }
+
+        @Override
+        public int hashCode() {
+            return id < 0 ? -id : id;
+        }
+        public boolean isDisconnect() {
+            return id < 0;
+        }
+        public Token toDisconnect() {
+            if (id < 0) {
+                return this;
+            }
+            return new Token(-id);
         }
     }
 }

--- a/rxjava-core/src/main/java/rx/operators/OperatorSampleWithTime.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorSampleWithTime.java
@@ -80,6 +80,7 @@ public final class OperatorSampleWithTime<T> implements Operator<T, T> {
         @Override
         public void onCompleted() {
             subscriber.onCompleted();
+            unsubscribe();
         }
 
         @Override


### PR DESCRIPTION
Fixes for issue #1136
- `OperatorMulticast` is straightforward from concurrency perspective. The only consideration is that if the current subscription gets unsubscribed before the `connect` reaches the `unsafeSubscribe`, it really depends on the source what it will do with an unsubscribed client. It is possible to put extra effort to make sure a newly established connection won't get unsubscribed before it is actually connected or if it gets unsubscribed immediately, no subscription is attempted at all.
- `OperatorSampleWithTime`: didn't want to push too many PRs so I just included it here. There was a missing unsubscribe in the `onCompleted()` that makes sure the worker is stopped.
- `Subscribers.empty()` was implemented by returning the same Subscriber to everyone, which Subscriber is stateful so if someone unsubscribes it, it will appear everywhere as unsubscribed and can have unwanted effects. There is no such problem with `Observers.empty()` as it is stateless. The change just uses `Subscribers.from()` to wrap `Observers.empty()` and every caller gets its own independent instance.
- `OperatorRefCount` was a bit more tricky. Since it has a connection counter, one has to serialize subscriptions with unsubscriptions. However, it is possible a subscription gets unsubscribed before code reaches the connect check which may disrupt the connection counter. The solution is to keep track of the unsubscriptions that happen before the connection attempts and not change the counter in case of out-of-order behavior. The final aim was to avoid leaking the connection statuses if the `unsafeSubscribe` throws concurrently with a client unsubscribing by using weak tokens (integers wouldn't have worked as the first 0-127 are cached in the JVM and would never GC).
