### PR TITLE
Update 'contains' signature to 'contains(Object)'

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -3213,7 +3213,7 @@ public class Observable<T> {
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Conditional-and-Boolean-Operators#wiki-contains">RxJava Wiki: contains()</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh228965.aspx">MSDN: Observable.Contains</a>
      */
-    public final Observable<Boolean> contains(final T element) {
+    public final Observable<Boolean> contains(final Object element) {
         return exists(new Func1<T, Boolean>() {
             public final Boolean call(T t1) {
                 return element == null ? t1 == null : element.equals(t1);


### PR DESCRIPTION
The original `contains` signature can not support the following codes:

``` java
    public void test() {
        ArrayList<String> l = new ArrayList<String>();
        l.add("test");
        Observable<ArrayList<String>> o = Observable.<ArrayList<String>>from(l);
        o.contains(Arrays.asList("test"));
    }
```

This PR changes the signature from `contains(T)` to `contains(Object)`. It's also consistent with `equals(Object)`.

This change should not break the old codes.
