### PR TITLE
Scheduler correctness improvements.

### DIFF
--- a/rxjava-core/src/main/java/rx/schedulers/EventLoopsScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/EventLoopsScheduler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.schedulers;
 
 import java.util.concurrent.ThreadFactory;
@@ -7,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import rx.Scheduler;
 import rx.Subscription;
 import rx.functions.Action0;
-import rx.schedulers.NewThreadScheduler.NewThreadWorker.Remover;
 import rx.schedulers.NewThreadScheduler.NewThreadWorker.ScheduledAction;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;

--- a/rxjava-core/src/main/java/rx/schedulers/NewThreadScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/NewThreadScheduler.java
@@ -69,11 +69,7 @@ public class NewThreadScheduler extends Scheduler {
 
         @Override
         public Subscription schedule(final Action0 action) {
-            return schedule(action, null);
-        }
-
-        /* package */Subscription schedule(final Action0 action, final OnActionComplete onComplete) {
-            return scheduleActual(action, 0, null);
+            return schedule(action, 0, null);
         }
 
         @Override
@@ -98,7 +94,7 @@ public class NewThreadScheduler extends Scheduler {
         }
         
         /** Remove a child subscription from a composite when unsubscribing. */
-        public static final class Remover implements Subscription {
+        private static final class Remover implements Subscription {
             final Subscription s;
             final CompositeSubscription parent;
             final AtomicBoolean once;
@@ -185,11 +181,4 @@ public class NewThreadScheduler extends Scheduler {
         }
 
     }
-
-    /* package */static interface OnActionComplete {
-
-        public void complete(Subscription s);
-
-    }
-
 }


### PR DESCRIPTION
Second round on the scheduler correctness issue.

Sure it looks more heavy as `ScheduledAction` now has its own inner `CompositeSubscription` and a shared reference to the parent `innerSubscription`.

I've tried to benchmark it with `SchedulerPerformanceTests` but that test is flawed:
- Multiple threads pound on the same long sum value, so naturally additions get lost.
- The LongObserver gets unsubscribed after the first loop so `from` will not actually call `onNext` but `isUnsubscribed` a lot.
- Does not wait for the computations to finish and basically measures how fast 5M tasks can be added to the NewThreadScheduler's innerSubscription.

The flawed test gives ~ 11M ops/sec on my machine. If I fix the test and run against the master, 5M takes extremely long to finish due to the inherent slowness of add/remove in CompositeSubscription if large. On my 4 core hyperthread enabled machine, I get 50k-150k ops/second for baseline with a 100k loop.

The proposed changes run with the flawed test gives ~10.8M ops/sec. With the test fixed and with the proposed changes, I get ~1.2M ops/sec.
