### PR TITLE
Rxscala improvement

### DIFF
--- a/language-adaptors/rxjava-scala/src/examples/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/language-adaptors/rxjava-scala/src/examples/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -780,8 +780,9 @@ class RxScalaDemo extends JUnitSuite {
   }
 
   @Test def startWithExample1(): Unit = {
-    val o = List(2, 3).toObservable + 1
-    assertEquals(List(1, 2, 3), o.toBlockingObservable.toList)
+    val o1 = List(3, 4).toObservable
+    val o2 = 1 :: 2 :: o1
+    assertEquals(List(1, 2, 3, 4), o2.toBlockingObservable.toList)
   }
 
   @Test def startWithExample2(): Unit = {

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
@@ -247,7 +247,7 @@ trait Observable[+T]
    * @param elem the item to emit
    * @return an Observable that emits the specified item before it begins to emit items emitted by the source Observable
    */
-  def +[U >: T](elem: U): Observable[U] = {
+  def ::[U >: T](elem: U): Observable[U] = {
     val thisJava = this.asJavaObservable.asInstanceOf[rx.Observable[U]]
     toScalaObservable(thisJava.startWith(elem))
   }

--- a/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/CompletenessTest.scala
+++ b/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/CompletenessTest.scala
@@ -167,7 +167,7 @@ class CompletenessTest extends JUnitSuite {
       "zip(Iterable[_ <: Observable[_]], FuncN[_ <: R])" -> "[use `zip` in companion object and `map`]"
   ) ++ List.iterate("T", 9)(s => s + ", T").map(
       // all 9 overloads of startWith:
-      "startWith(" + _ + ")" -> "[unnecessary because we can just use `+` instead]"
+      "startWith(" + _ + ")" -> "[unnecessary because we can just use `::` instead]"
   ).toMap ++ List.iterate("Observable[_ <: T]", 9)(s => s + ", Observable[_ <: T]").map(
       // concat 2-9
       "concat(" + _ + ")" -> "[unnecessary because we can use `++` instead or `Observable(o1, o2, ...).concat`]"


### PR DESCRIPTION
Add `dropUntil`, `contains`, `repeat`, `doOnTerminate`, `startWith`, `publish` variants to RxScala. #1151, #1153.

/cc @headinthebox @samuelgruetter
