### PR TITLE
Fixed synchronous ConnectableObservable.connect problem

### DIFF
--- a/rxjava-core/src/main/java/rx/observables/ConnectableObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/ConnectableObservable.java
@@ -18,6 +18,7 @@ package rx.observables;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.functions.Action1;
 import rx.operators.OperatorRefCount;
 
 /**
@@ -44,10 +45,28 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
     /**
      * Call a ConnectableObservable's connect() method to instruct it to begin emitting the
      * items from its underlying {@link Observable} to its {@link Subscriber}s.
+     * <p>To disconnect from a synchronous source, use the {@link #connect(rx.functions.Action1)}
+     * method.
      * @return the subscription representing the connection
      */
-    public abstract Subscription connect();
-
+    public final Subscription connect() {
+        final Subscription[] out = new Subscription[1];
+        connect(new Action1<Subscription>() {
+            @Override
+            public void call(Subscription t1) {
+                out[0] = t1;
+            }
+        });
+        return out[0];
+    }
+    /**
+     * Call a ConnectableObservable's connect() method to instruct it to begin emitting the
+     * items from its underlying {@link Observable} to its {@link Subscriber}s.
+     * @param connection the action that receives the connection subscription
+     * before the subscription to source happens allowing the caller
+     * to synchronously disconnect a synchronous source.
+     */
+    public abstract void connect(Action1<? super Subscription> connection);
     /**
      * Returns an observable sequence that stays connected to the source as long
      * as there is at least one subscription to the observable sequence.

--- a/rxjava-core/src/main/java/rx/operators/OperatorMulticastSelector.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorMulticastSelector.java
@@ -18,12 +18,13 @@ package rx.operators;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.observables.ConnectableObservable;
 import rx.observers.SafeSubscriber;
 import rx.subjects.Subject;
-import rx.subscriptions.CompositeSubscription;
 
 /**
  * Returns an observable sequence that contains the elements of a sequence
@@ -63,14 +64,16 @@ public final class OperatorMulticastSelector<TInput, TIntermediate, TResult> imp
             return;
         }
         
-        CompositeSubscription csub = new CompositeSubscription();
-        child.add(csub);
-        
-        SafeSubscriber<TResult> s = new SafeSubscriber<TResult>(child);
+        final SafeSubscriber<TResult> s = new SafeSubscriber<TResult>(child);
         
         observable.unsafeSubscribe(s);
         
-        csub.add(connectable.connect());
+        connectable.connect(new Action1<Subscription>() {
+            @Override
+            public void call(Subscription t1) {
+                s.add(t1);
+            }
+        });
     }
     
 }


### PR DESCRIPTION
ConnectableObservable.connect returns a Subscription and thus cannot be unsubscribed synchronously, similar how take didn't work before the Subscriber changes. This PR modifies the `ConnectableObservable` and its current implementation `OperatorMulticast` to extract the connection Subscription token before it is connected to the source. Cancelling this extracted token makes sure the synchronous connection is unsubscribed.

(The Rx.NET version of the test case seemingly doesn't exhibit the problem. I suspect it is the interplay of `IDisposable`s.)
