### PR TITLE
NotificationLite.accept performance improvements

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/NotificationLite.java
+++ b/rxjava-core/src/main/java/rx/operators/NotificationLite.java
@@ -111,17 +111,22 @@ public final class NotificationLite<T> {
      * @throws NullPointerException
      *             if the {@link Observer} is null.
      */
+    @SuppressWarnings("unchecked")
     public void accept(Observer<? super T> o, Object n) {
-        switch (kind(n)) {
-        case OnNext:
-            o.onNext(getValue(n));
-            break;
-        case OnCompleted:
+        if (n == ON_COMPLETED_SENTINEL) {
             o.onCompleted();
-            break;
-        case OnError:
-            o.onError(getError(n));
-            break;
+        } else
+        if (n == ON_NEXT_NULL_SENTINEL) {
+            o.onNext(null);
+        } else
+        if (n != null) {
+            if (n.getClass() == OnErrorSentinel.class) {
+                o.onError(((OnErrorSentinel)n).e);
+            } else {
+                o.onNext((T)n);
+            }
+        } else {
+            throw new IllegalArgumentException("The lite notification can not be null");
         }
     }
 


### PR DESCRIPTION
This is a proposal for speeding up the `accept()` method (i.e., reducing its latency).

Benchmark comparison:

direct onNext: 488 MOps/s
master accept: 378 MOps/s
this accept: 477 MOps/s

(i7 4770K, JDK 1.8u5 x64)
