### PR TITLE
Scheduler fixes and related improvements

### DIFF
--- a/rxjava-core/src/main/java/rx/Scheduler.java
+++ b/rxjava-core/src/main/java/rx/Scheduler.java
@@ -16,9 +16,11 @@
 package rx;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import rx.functions.Action0;
 import rx.schedulers.Schedulers;
+import rx.subscriptions.Subscriptions;
 
 /**
  * Represents an object that schedules units of work.
@@ -101,18 +103,23 @@ public abstract class Scheduler {
             final long periodInNanos = unit.toNanos(period);
             final long startInNanos = TimeUnit.MILLISECONDS.toNanos(now()) + unit.toNanos(initialDelay);
 
+            final StampedSubscription stamp = new StampedSubscription();
+            
             final Action0 recursiveAction = new Action0() {
                 long count = 0;
                 @Override
                 public void call() {
-                    if (!isUnsubscribed()) {
+                    if (!stamp.isUnsubscribed()) {
                         action.call();
                         long nextTick = startInNanos + (++count * periodInNanos);
-                        schedule(this, nextTick - TimeUnit.MILLISECONDS.toNanos(now()), TimeUnit.NANOSECONDS);
+                        Subscription s = schedule(this, nextTick - TimeUnit.MILLISECONDS.toNanos(now()), TimeUnit.NANOSECONDS);
+                        stamp.setNext(s);
                     }
                 }
             };
-            return schedule(recursiveAction, initialDelay, unit);
+            Subscription s = schedule(recursiveAction, initialDelay, unit);
+            stamp.setFirst(s);
+            return stamp;
         }
 
         /**
@@ -121,8 +128,101 @@ public abstract class Scheduler {
         public long now() {
             return System.currentTimeMillis();
         }
-    }
+        /** 
+         * Contains a subscription and prevents overwriting a subsequent subscription by the first subscription.
+         * This is used by the schedulePeriodic to capture the first schedule subscription and make
+         * sure it does not replace a newer subscription in case the scheduled action completes before the
+         * outer would set the first reference. This implies that calling setNext should happen sequentially
+         * in respect to each other.
+         */
+        static final class StampedSubscription implements Subscription {
+            static final class State {
+                final boolean unsubscribed;
+                final boolean subsequent;
+                final Subscription subscription;
 
+                public State(boolean unsubscribed, boolean subsequent, Subscription subscription) {
+                    this.unsubscribed = unsubscribed;
+                    this.subsequent = subsequent;
+                    this.subscription = subscription;
+                }
+                public State unsubscribe() {
+                    return new State(true, subsequent, subscription);
+                }
+                public State setNext(Subscription s) {
+                    return new State(unsubscribed, true, s);
+                }
+            }
+            final AtomicReference<State> state = new AtomicReference<State>(new State(false, false, Subscriptions.empty()));
+
+            @Override
+            public void unsubscribe() {
+                do {
+                    State s = state.get();
+                    if (s.unsubscribed) {
+                        return;
+                    }
+                    State s2 = s.unsubscribe();
+                    if (state.compareAndSet(s, s2)) {
+                        s2.subscription.unsubscribe();
+                        return;
+                    }
+                } while (true);
+                
+            }
+            /**
+             * Tries to set the first subscription and giving up
+             * if a newer subscription was already set.
+             * @param s the first subscription to set
+             */
+            public void setFirst(Subscription s) {
+                do {
+                    State oldState = state.get();
+                    if (oldState.unsubscribed) {
+                        s.unsubscribe();
+                        return;
+                    }
+                    if (oldState.subsequent) {
+                        return;
+                    }
+                    State newState = oldState.setNext(s);
+                    if (state.compareAndSet(oldState, newState)) {
+                        return;
+                    }
+                } while (true);
+            }
+            /**
+             * Sets a new subscription.
+             * Make sure this is called sequentially.
+             * @param s the next subscription to set
+             */
+            public void setNext(Subscription s) {
+                do {
+                    State oldState = state.get();
+                    if (oldState.unsubscribed) {
+                        s.unsubscribe();
+                        return;
+                    }
+                    State newState = oldState.setNext(s);
+                    if (state.compareAndSet(oldState, newState)) {
+                        return;
+                    }
+                } while (true);
+            }
+            /**
+             * @return the current subscription
+             */
+            public Subscription get() {
+                return state.get().subscription;
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return state.get().unsubscribed;
+            }
+            
+        }
+    }
     /**
      * Parallelism available to a Scheduler.
      * <p>

--- a/rxjava-core/src/main/java/rx/schedulers/NewThreadScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/NewThreadScheduler.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Scheduler;
@@ -32,7 +32,7 @@ import rx.subscriptions.Subscriptions;
 /**
  * Schedules work on a new thread.
  */
-public class NewThreadScheduler extends Scheduler {
+/* package */final class NewThreadScheduler extends Scheduler {
 
     private final static NewThreadScheduler INSTANCE = new NewThreadScheduler();
     private final static AtomicLong count = new AtomicLong();
@@ -60,8 +60,8 @@ public class NewThreadScheduler extends Scheduler {
     }
 
     /* package */static class NewThreadWorker extends Scheduler.Worker implements Subscription {
-        private final CompositeSubscription innerSubscription = new CompositeSubscription();
         private final ScheduledExecutorService executor;
+        private volatile boolean unsubscribed;
 
         /* package */NewThreadWorker(ThreadFactory threadFactory) {
             executor = Executors.newScheduledThreadPool(1, threadFactory);
@@ -74,14 +74,14 @@ public class NewThreadScheduler extends Scheduler {
 
         @Override
         public Subscription schedule(final Action0 action, long delayTime, TimeUnit unit) {
-            if (innerSubscription.isUnsubscribed()) {
+            if (unsubscribed) {
                 return Subscriptions.empty();
             }
             return scheduleActual(action, delayTime, unit);
         }
 
         /* package */ScheduledAction scheduleActual(final Action0 action, long delayTime, TimeUnit unit) {
-            ScheduledAction run = new ScheduledAction(action, innerSubscription);
+            ScheduledAction run = new ScheduledAction(action);
             Future<?> f;
             if (delayTime <= 0) {
                 f = executor.submit(run);
@@ -92,27 +92,27 @@ public class NewThreadScheduler extends Scheduler {
             
             return run;
         }
-        
         /** Remove a child subscription from a composite when unsubscribing. */
         private static final class Remover implements Subscription {
             final Subscription s;
             final CompositeSubscription parent;
-            final AtomicBoolean once;
+            volatile int unsubscribed;
+            private static final AtomicIntegerFieldUpdater<Remover> UNSUBSCRIBED_UPDATER =
+                    AtomicIntegerFieldUpdater.newUpdater(Remover.class, "unsubscribed");
             
             public Remover(Subscription s, CompositeSubscription parent) {
                 this.s = s;
                 this.parent = parent;
-                this.once = new AtomicBoolean();
             }
             
             @Override
             public boolean isUnsubscribed() {
-                return s.isUnsubscribed();
+                return unsubscribed == 1;
             }
             
             @Override
             public void unsubscribe() {
-                if (once.compareAndSet(false, true)) {
+                if (UNSUBSCRIBED_UPDATER.compareAndSet(this, 0, 1)) {
                     parent.remove(s);
                 }
             }
@@ -125,14 +125,13 @@ public class NewThreadScheduler extends Scheduler {
         public static final class ScheduledAction implements Runnable, Subscription {
             final CompositeSubscription cancel;
             final Action0 action;
-            final CompositeSubscription parent;
-            final AtomicBoolean once;
+            volatile int unsubscribed;
+            private static final AtomicIntegerFieldUpdater<ScheduledAction> UNSUBSCRIBED_UPDATER =
+                    AtomicIntegerFieldUpdater.newUpdater(ScheduledAction.class, "unsubscribed");
 
-            public ScheduledAction(Action0 action, CompositeSubscription parent) {
+            public ScheduledAction(Action0 action) {
                 this.action = action;
-                this.parent = parent;
                 this.cancel = new CompositeSubscription();
-                this.once = new AtomicBoolean();
             }
 
             @Override
@@ -146,14 +145,13 @@ public class NewThreadScheduler extends Scheduler {
 
             @Override
             public boolean isUnsubscribed() {
-                return cancel.isUnsubscribed();
+                return unsubscribed == 1;
             }
             
             @Override
             public void unsubscribe() {
-                if (once.compareAndSet(false, true)) {
+                if (UNSUBSCRIBED_UPDATER.compareAndSet(this, 0, 1)) {
                     cancel.unsubscribe();
-                    parent.remove(this);
                 }
             }
             public void add(Subscription s) {
@@ -165,19 +163,19 @@ public class NewThreadScheduler extends Scheduler {
              * @param parent 
              */
             public void addParent(CompositeSubscription parent) {
-                cancel.add(new Remover(this, parent));
+                add(new Remover(this, parent));
             } 
         }
 
         @Override
         public void unsubscribe() {
-            executor.shutdown();
-            innerSubscription.unsubscribe();
+            unsubscribed = true;
+            executor.shutdownNow();
         }
 
         @Override
         public boolean isUnsubscribed() {
-            return innerSubscription.isUnsubscribed();
+            return unsubscribed;
         }
 
     }

--- a/rxjava-core/src/main/java/rx/schedulers/TestScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/TestScheduler.java
@@ -26,7 +26,7 @@ import rx.functions.Action0;
 import rx.subscriptions.BooleanSubscription;
 import rx.subscriptions.Subscriptions;
 
-public class TestScheduler extends Scheduler {
+public final class TestScheduler extends Scheduler {
     private final Queue<TimedAction> queue = new PriorityQueue<TimedAction>(11, new CompareActionsByTime());
     private static long counter = 0;
 

--- a/rxjava-core/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -28,7 +28,7 @@ import rx.subscriptions.Subscriptions;
 /**
  * Schedules work on the current thread but does not execute immediately. Work is put in a queue and executed after the current unit of work is completed.
  */
-public class TrampolineScheduler extends Scheduler {
+public final class TrampolineScheduler extends Scheduler {
     private static final TrampolineScheduler INSTANCE = new TrampolineScheduler();
 
     /* package */static TrampolineScheduler instance() {

--- a/rxjava-core/src/main/java/rx/subscriptions/SubscriptionQueue.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/SubscriptionQueue.java
@@ -1,0 +1,151 @@
+ /**
+  * Copyright 2014 Netflix, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  * use this file except in compliance with the License. You may obtain a copy of
+  * the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  * License for the specific language governing permissions and limitations under
+  * the License.
+  */
+package rx.subscriptions;
+
+import rx.Subscription;
+
+/**
+ * Array-based queue that grows as neccessary, allows identity-based
+ * dequeueing and the contents can be unsubscribed at once.
+ * <p>Enqueued and dequeued subscriptions must not be {@code null}.
+ * <p>Dequeueing is done based on object identity {@code ==} c
+ */
+public final class SubscriptionQueue implements Subscription {
+    static final int INITIAL_CAPACITY = 8;
+    Subscription[] array = new Subscription[INITIAL_CAPACITY];
+    volatile boolean isUnsubscribed;
+    int head;
+    int tail;
+    int size;
+    /**
+     * Enqueue a subscription.
+     * @param s the subscription to enqueue, mustn't be {@code null}
+     */
+    public void add(Subscription s) {
+        synchronized (this) {
+            if (!isUnsubscribed) {
+                Subscription[] a = array;
+                int n = a.length;
+                int p = head;
+                int t = tail;
+                int r = n - p;
+                a[t] = s;
+                tail = (t + 1) & (n - 1);
+                size++;
+                if (head == tail) {
+                    Subscription[] a2 = new Subscription[n << 1];
+                    System.arraycopy(a, p, a2, 0, r);
+                    System.arraycopy(a, 0, a2, r, p);
+                    array = a2;
+                    head = 0;
+                    tail = n;
+                }
+                return;
+            }
+        }
+        s.unsubscribe();
+    }
+    /**
+     * Dequeue a subscription. If the subscription is
+     * not in this queue, nothing happens.
+     * <p>Does not unsubscribe the subscription.
+     * @param s the subscription, mustn't be null
+     */
+    public void remove(Subscription s) {
+        synchronized (this) {
+            if (!isUnsubscribed) {
+                Subscription[] a = array;
+                int h = head;
+                int k = a.length - 1;
+                if (a[h] == s) {
+                    a[h] = null;
+                    size--;
+                    head = (h + 1) & k;
+                } else {
+                    int i = h;
+                    int t = tail;
+                    while (i != t && a[i] == null) {
+                        i = (i + 1) & k;
+                        h = i;
+                    }
+                    while (i != t) {
+                        if (a[i] == s) {
+                            a[i] = null;
+                            size--;
+                            if (i == h) {
+                                h = (h + 1) & k;
+                            }
+                            break;
+                        }
+                        i = (i + 1) & k;
+                    }
+                    head = h;
+                }
+            }
+        }
+    }
+    @Override
+    public boolean isUnsubscribed() {
+        return isUnsubscribed;
+    }
+    @Override
+    public void unsubscribe() {
+        Subscription[] a;
+        synchronized (this) {
+            if (isUnsubscribed) {
+                return;
+            }
+            isUnsubscribed = true;
+            a = array;
+            array = null;
+            size = 0;
+            head = 0;
+            tail = 0;
+        }
+        CompositeSubscription.unsubscribeFromAll(a);
+    }
+    /**
+     * Creates a subscription which dequeues the given
+     * subscription from this queue when the unsubscribe is called on it.
+     * @param s the subscription to queue, mustn't be null
+     * @return the subscription to perform the dequeueing
+     */
+    public Subscription createDequeuer(Subscription s) {
+        return new Dequeuer(s, this);
+    }
+    /**
+     * Dequeues a subscription from a queue when the unsubscribe is called.
+     */
+    private static final class Dequeuer implements Subscription {
+        final Subscription s;
+        final SubscriptionQueue sq;
+        
+        public Dequeuer(Subscription s, SubscriptionQueue sq) {
+            this.s = s;
+            this.sq = sq;
+        }
+        
+        @Override
+        public boolean isUnsubscribed() {
+            return s.isUnsubscribed();
+        }
+        
+        @Override
+        public void unsubscribe() {
+            sq.remove(s);
+        }
+    }
+}


### PR DESCRIPTION
A newer set of scheduler improvements.
- Fixed `schedulePeriodic` to properly capture the Subscription of the repeated schedule calls to allow unsubscribing the periodic task without the need to unsubscribe the whole worker.
- Fixed `NewThreadScheduler` to call `shutdownNow` to correctly cancel all pending tasks.
- Removed `innerSubscription` from `NewThreadScheduler` because it was unnecessary and didn't even work.
- Took `CompositeSubscription` from #1145 to improve on the add/removal time of timed tasks with a help of a `HashSet` and atomic field updaters.
- Added `SubscriptionQueue` that works like an ringbuffer and can add/remove non-delayed tasks faster than `CompositeSubscription`.
- Reduced memory footprint of `CompositeSubscription` and `ScheduledAction`.
- Modified `EventLoopScheduler` to track delayed and non-delayed task Subscriptions separately.
- Added a few `final` modifiers.
