### PR TITLE
initial rev of two experimental event loop schedulers

### DIFF
--- a/rxjava-core/src/main/java/rx/schedulers/BalancingEventLoopScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/BalancingEventLoopScheduler.java
@@ -1,0 +1,326 @@
+package rx.schedulers;
+
+import rx.Observable;
+import rx.Observer;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.Subscriptions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class BalancingEventLoopScheduler extends Scheduler {
+
+    private final AtomicLong qNum = new AtomicLong(0);
+
+    @Override
+    public Worker createWorker() {
+        WorkerQueue workerQueue = new WorkerQueue(qNum.getAndIncrement());
+        CoreThreadWorkers.INSTANCE.assignCoreThread(workerQueue);
+        return workerQueue;
+    }
+
+    // ToDo Remove this
+    public int getNumRebalances() {
+        return CoreThreadWorkers.INSTANCE.getNumRebalances();
+    }
+
+    private static class CoreThreadWorkers {
+        private final CoreThreadWorker[] CORE_THREAD_WORKERS;
+        private final static int NUM_CORES = Runtime.getRuntime().availableProcessors();
+        static final CoreThreadWorkers INSTANCE = new CoreThreadWorkers();
+        private int n=1;
+        private long lastRebalancedAt=System.currentTimeMillis();
+        private long rebalanceInterval=100; // ToDo what's a good number?
+        private int numRebalances=0;
+
+        CoreThreadWorkers() {
+            CORE_THREAD_WORKERS = new CoreThreadWorker[NUM_CORES];
+            for(int c=0; c<NUM_CORES; c++) {
+                CORE_THREAD_WORKERS[c] = new CoreThreadWorker(c, c==0);
+                CORE_THREAD_WORKERS[c].setDaemon(true);
+                CORE_THREAD_WORKERS[c].start();
+            }
+        }
+
+        void assignCoreThread(WorkerQueue queue) {
+            // ToDo figure out the lightest loaded worker instead of n++
+            CoreThreadWorker worker = CORE_THREAD_WORKERS[n++ % CORE_THREAD_WORKERS.length];
+            worker.assignQueue(queue);
+        }
+
+        private boolean shouldRebalancePair(HotQueue from, HotQueue to) {
+            if((from.totalLoad-from.qLoad) >= (to.totalLoad+from.qLoad))
+                return true;
+            return false;
+        }
+
+        int getNumRebalances() {
+            return numRebalances;
+        }
+
+        void rebalanceQs() {
+            if((lastRebalancedAt+rebalanceInterval)>System.currentTimeMillis())
+                return;
+            lastRebalancedAt=System.currentTimeMillis();
+            List<HotQueue> hotQueues = new ArrayList<HotQueue>();
+            boolean needRebalncing=false;
+            for(int c=0; c<CORE_THREAD_WORKERS.length; c++) {
+                HotQueue queue = CORE_THREAD_WORKERS[c].getHotQueue();
+                if(queue==null)
+                    queue = new HotQueue(c, null, 0, 0);
+                else if(queue.qLoad>0)
+                    needRebalncing=true;
+                hotQueues.add(queue);
+            }
+            if(needRebalncing) {
+                Collections.sort(hotQueues, new Comparator<HotQueue>() {
+                    @Override
+                    public int compare(HotQueue o1, HotQueue o2) {
+                        if(o1.queue==null || o1.totalLoad==0)
+                            return -1;
+                        if(o2.queue==null || o2.totalLoad==0)
+                            return 1;
+                        if(o1.qLoad == 0)
+                            return -1;
+                        if(o2.qLoad == 0)
+                            return 1;
+                        return Long.compare(o1.totalLoad, o2.totalLoad);
+                    }
+                });
+                boolean allDone=false;
+                for(int h=hotQueues.size()-1; h>0 && !allDone; h--) {
+                    if(hotQueues.get(h).qLoad == 0)
+                        allDone = true;
+                    else {
+                        for(int b=0; b<h; b++) {
+                            if(shouldRebalancePair(hotQueues.get(h), hotQueues.get(b))) {
+                                hotQueues.get(b).totalLoad += hotQueues.get(h).qLoad;
+                                CORE_THREAD_WORKERS[hotQueues.get(h).workerIndex].transferQueue(hotQueues.get(h).queue,
+                                        CORE_THREAD_WORKERS[hotQueues.get(b).workerIndex]);
+                                numRebalances++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static class HotQueue {
+        final int workerIndex;
+        WorkerQueue queue;
+        long qLoad;
+        long totalLoad;
+        private HotQueue(int workerIndex, WorkerQueue queue, long qLoad, long totalLoad) {
+            this.workerIndex = workerIndex;
+            this.queue = queue;
+            this.qLoad = qLoad;
+            this.totalLoad = totalLoad;
+        }
+    }
+
+    private static class QueueTransferRequest {
+        private WorkerQueue queue;
+        private CoreThreadWorker worker;
+        private QueueTransferRequest(WorkerQueue queue, CoreThreadWorker worker) {
+            this.queue = queue;
+            this.worker = worker;
+        }
+    }
+
+    private static class CoreThreadWorker extends Thread {
+        private final int myIndex;
+        private final List<WorkerQueue> workerQueues = new ArrayList<WorkerQueue>();
+        private final int WORK_BUF_SIZE=10;
+        private final List<Action0> workBuffer = new ArrayList<Action0>(WORK_BUF_SIZE);
+        private final BlockingQueue<QueueTransferRequest> transferRequests = new LinkedBlockingQueue<QueueTransferRequest>();
+        private volatile HotQueue hotQueue;
+        private final boolean rebalancer;
+
+        CoreThreadWorker(int myIndex, boolean rebalancer) {
+            this.myIndex = myIndex;
+            this.rebalancer = rebalancer;
+        }
+
+        private HotQueue getHotQueue() {
+            return hotQueue;
+        }
+
+        @Override
+        public void run() {
+            while(true) {
+                trasnferRequests();
+                Iterator<WorkerQueue> iterator = workerQueues.iterator();
+                long ttlLoad=0;
+                long now=0;
+                WorkerQueue hq=null;
+                long hqLoad=0;
+                boolean hasMoreThanOneQ=false;
+                while(iterator.hasNext()) {
+                    WorkerQueue wQ = iterator.next();
+                    if(wQ.isUnsubscribed()) {
+                        iterator.remove();
+                    }
+                    else {
+                        workBuffer.clear();
+                        int w = (wQ.theQueue.peek() == null)? 0 : wQ.theQueue.drainTo(workBuffer, WORK_BUF_SIZE);
+                        if(w > 0) {
+                            now = System.currentTimeMillis();
+                            for(int a=0; a<w; a++) {
+                                try {
+                                    workBuffer.get(a).call();
+                                }
+                                catch (Exception e) {} // protect against spurious exception
+                            }
+                            long latestLoad = System.currentTimeMillis()-now;
+                            ttlLoad += latestLoad;
+                            if(!hasMoreThanOneQ && iterator.hasNext())
+                                hasMoreThanOneQ=true;
+                            if(hasMoreThanOneQ && (hq == null || latestLoad>hqLoad)) {
+                                hq = wQ;
+                                hqLoad = latestLoad;
+                            }
+                        }
+                    }
+                }
+                if(ttlLoad>0) {
+                    hotQueue = new HotQueue(myIndex, hq, hqLoad, ttlLoad);
+                }
+                else {
+                    hotQueue = null;
+                    // didn't do any work, sleep some ??
+                    //Thread.yield();
+                    synchronized (this) {
+                        try{this.wait(0, 50);} catch (InterruptedException ie) {}
+                    }
+                }
+                if(rebalancer)
+                    CoreThreadWorkers.INSTANCE.rebalanceQs();
+            }
+        }
+
+        private void trasnferRequests() {
+            if(transferRequests.peek() != null) {
+                List<QueueTransferRequest> xferRequests = new ArrayList<QueueTransferRequest>(CoreThreadWorkers.NUM_CORES);
+                int x = transferRequests.drainTo(xferRequests, CoreThreadWorkers.NUM_CORES);
+                for(int transferred=0; transferred<x; transferred++) {
+                    QueueTransferRequest qtr = xferRequests.get(transferred);
+                    if(qtr.worker == null) { // Xfering in
+                        workerQueues.add(qtr.queue);
+                    }
+                    else {
+                        workerQueues.remove(qtr.queue);
+                        qtr.worker.assignQueue(qtr.queue);
+                    }
+                }
+            }
+        }
+
+        void assignQueue(WorkerQueue queue) {
+            transferRequests.add(new QueueTransferRequest(queue, null));
+        }
+
+        void transferQueue(WorkerQueue queue, CoreThreadWorker worker) {
+            transferRequests.add(new QueueTransferRequest(queue, worker));
+        }
+    }
+
+    private static class WorkerQueue extends Scheduler.Worker {
+        private final long myId;
+        private final BlockingQueue<Action0> theQueue = new LinkedBlockingQueue<Action0>();
+        private final CompositeSubscription innerSubscription = new CompositeSubscription();
+        private volatile CoreThreadWorker worker=null;
+
+        WorkerQueue(long myId) {
+            this.myId = myId;
+        }
+
+        void setWorker(CoreThreadWorker worker) {
+            this.worker = worker;
+        }
+
+        @Override
+        public Subscription schedule(final Action0 action) {
+            if(innerSubscription.isUnsubscribed())
+                return Subscriptions.empty();
+            theQueue.offer(new Action0() {
+                @Override
+                public void call() {
+                    try{action.call();} catch (Exception e) {}//protect against spurious exception from action
+                }
+            });
+            if(innerSubscription.isUnsubscribed()) {
+                theQueue.clear();
+                return Subscriptions.empty();
+            }
+            if(worker != null) {
+                synchronized (worker) {
+                    worker.notify();
+                }
+            }
+            return Subscriptions.create(new Action0() {
+                @Override
+                public void call() {
+                    theQueue.remove(action);
+                }
+            });
+        }
+
+        @Override
+        public Subscription schedule(final Action0 action, long delayTime, TimeUnit unit) {
+            final AtomicReference<Subscription> sf = new AtomicReference<Subscription>();
+            // we use the system scheduler since it doesn't make sense to launch a new Thread and then sleep
+            // we will instead schedule the event then launch the thread after the delay has passed
+            ScheduledFuture<?> f = GenericScheduledExecutorService.getInstance().schedule(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        if (innerSubscription.isUnsubscribed()) {
+                            return;
+                        }
+                        // now that the delay is past schedule the work to be done for real on the UI thread
+                        schedule(action);
+                    } finally {
+                        // remove the subscription now that we're completed
+                        Subscription s = sf.get();
+                        if (s != null) {
+                            innerSubscription.remove(s);
+                        }
+                    }
+                }
+            }, delayTime, unit);
+            Subscription s = Subscriptions.from(f);
+            sf.set(s);
+            innerSubscription.add(s);
+            return s;
+        }
+
+        @Override
+        public void unsubscribe() {
+            innerSubscription.unsubscribe();
+            theQueue.clear();
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return innerSubscription.isUnsubscribed();
+        }
+    }
+
+}

--- a/rxjava-core/src/main/java/rx/schedulers/ReroutingEventLoopScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/ReroutingEventLoopScheduler.java
@@ -1,0 +1,390 @@
+package rx.schedulers;
+
+import rx.Scheduler;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.subscriptions.CompositeSubscription;
+import rx.subscriptions.Subscriptions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ReroutingEventLoopScheduler extends Scheduler {
+    @Override
+    public Worker createWorker() {
+        return WorkerQueues.INSTANCE.createWorkerQueue();
+    }
+
+    // ToDo REMOVE THIS
+    public void printStats() {
+        for(CoreThreadWorker worker: CoreThreadWorkers.INSTANCE.CORE_THREAD_WORKERS) {
+            System.out.printf("%d: avgLatency=%10.2f  count=%d\n", worker.myIndex, worker.latencyCounts.getAverage(), worker.getCount());
+        }
+    }
+
+    protected static class CoreThreadWorkers {
+        final AtomicLong counter = new AtomicLong();
+        protected final CoreThreadWorker[] CORE_THREAD_WORKERS;
+        protected final static int NUM_CORES = Runtime.getRuntime().availableProcessors();
+        protected static final CoreThreadWorkers INSTANCE = new CoreThreadWorkers();
+        private int n=1;
+        private double[] latencies = new double[NUM_CORES];
+        private AtomicBoolean canReroute = new AtomicBoolean(true);
+        private int rerouter=-1;
+        private long lastReroutingAt=0;
+        private final long ReroutingDelayIntervalMillis = 100;
+
+        private CoreThreadWorkers() {
+            CORE_THREAD_WORKERS = new CoreThreadWorker[NUM_CORES];
+            for(int i=0; i<NUM_CORES; i++) {
+                CORE_THREAD_WORKERS[i] = new CoreThreadWorker(i);
+            }
+        }
+
+        private CoreThreadWorker getNextWorker() {
+            return getNextWorkerToRouteTo();
+        }
+
+        protected CoreThreadWorker getNextWorkerToRouteTo() {
+            return CORE_THREAD_WORKERS[(int)(counter.getAndIncrement() % NUM_CORES)];
+        }
+
+        protected int getRerouteDestination(int from, double[] latencyValues) {
+            return -1;
+        }
+
+        int shouldRerouteTo(int theWorker) {
+            if(!canReroute.compareAndSet(true, false))
+                return -1;
+            if(rerouter >= 0)
+                return -1;
+            if(lastReroutingAt > (System.currentTimeMillis()-ReroutingDelayIntervalMillis))
+                return -1;
+            try {
+                for(int i=0; i<NUM_CORES; i++) {
+                    latencies[i] = CORE_THREAD_WORKERS[i].latencyCounts.getAverage();
+                }
+                int dest = getRerouteDestination(theWorker, latencies);
+                if(dest>=0)
+                    rerouter = theWorker;
+                return dest;
+            }
+            finally {
+                canReroute.set(true);
+            }
+        }
+
+        void endReroutring(int theWorker) {
+            if(rerouter == theWorker) {
+                lastReroutingAt = System.currentTimeMillis();
+                rerouter = -1;
+            }
+        }
+
+    }
+
+    protected static class WorkerQueueToReRoute {
+        long qIndex;
+
+    }
+
+    private static class AverageOfN {
+        private final int MAX_LATENCY_COUNTS=10;
+        private List<Long> list = new ArrayList<Long>(MAX_LATENCY_COUNTS+1);
+        private long sum=0;
+        void add(long val) {
+            list.add(val);
+            if(list.size()>=MAX_LATENCY_COUNTS) {
+                long v = list.remove(0);
+                sum -= v;
+            }
+            sum += val;
+        }
+        double getAverage() {
+            if(list.isEmpty())
+                return 0.0;
+            return sum/list.size();
+        }
+    }
+
+    protected static class CoreThreadWorker {
+        private final int myIndex;
+        private final ScheduledExecutorService executor;
+        private volatile int counter = 0;
+        private AverageOfN latencyCounts = new AverageOfN();
+        //private List<Long> latencyCounts = new ArrayList<Long>(MAX_LATENCY_COUNTS+1);
+        private Map<Long, AverageOfN> queueCounts = new HashMap<Long, AverageOfN>();
+        private long latencyEvalInterval=100; // ToDo what's a good number?
+        private static final double EPS=0.25;
+
+        CoreThreadWorker(final int index) {
+            this.myIndex = index;
+            executor = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r, "RxScheduledExecutorPool-" + index);
+                    t.setDaemon(true);
+                    return t;
+                }
+            });
+            latencyEvalWrapper();
+        }
+
+        private void latencyEvalWrapper() {
+            executor.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    scheduleLatencyEval(System.currentTimeMillis());
+                }
+            }, latencyEvalInterval, TimeUnit.MILLISECONDS);
+        }
+
+        private void endRerouting() {
+            CoreThreadWorkers.INSTANCE.endReroutring(myIndex);
+        }
+
+        private void scheduleLatencyEval(final long start) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    latencyCounts.add(System.currentTimeMillis() - start);
+                    if(queueCounts.size()>1) {
+                        int q=0;
+                        long maxQ=-1;
+                        double max=0.0;
+                        for(Map.Entry<Long, AverageOfN> entry: queueCounts.entrySet()) {
+                            if(entry.getValue().getAverage()>EPS) {
+                                q++;
+                                if(entry.getValue().getAverage()>max) {
+                                    max = entry.getValue().getAverage();
+                                    maxQ = entry.getKey();
+                                }
+                            }
+                        }
+                        if(q>1) {
+                            int dest = CoreThreadWorkers.INSTANCE.shouldRerouteTo(myIndex);
+                            if(dest>=0) {
+                                if(dest==myIndex)
+                                    endRerouting();
+                                else {
+                                    // reroute maxQ
+                                    final long reroutedQ = maxQ;
+                                    WorkerQueues.INSTANCE.getWorkerQueue(reroutedQ).rerouteTo(dest, new Action0() {
+                                        @Override
+                                        public void call() {
+                                            queueCounts.remove(reroutedQ);
+                                            endRerouting();
+                                        }
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    latencyEvalWrapper();
+                }
+            });
+        }
+
+        long getCount() {
+            return counter;
+        }
+
+        Future submit(final long workerQNum, final Runnable runnable) {
+            return executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    counter++;
+                    if(queueCounts.get(workerQNum) == null) {
+                        queueCounts.put(workerQNum, new AverageOfN());
+                    }
+                    queueCounts.get(workerQNum).add(1L);
+                    runnable.run();
+                }
+            });
+        }
+
+        Future schedule(final long workerQNum, final Runnable runnable, long delayTime, TimeUnit unit) {
+            return executor.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    counter++;
+                    if(queueCounts.get(workerQNum) == null) {
+                        queueCounts.put(workerQNum, new AverageOfN());
+                    }
+                    queueCounts.get(workerQNum).add(1L);
+                    runnable.run();
+                }}, delayTime, unit);
+        }
+
+        void remove(final long workerQNum) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    queueCounts.remove(workerQNum);
+                }
+            });
+        }
+    }
+
+    private static class WorkerQueues {
+        static final WorkerQueues INSTANCE = new WorkerQueues();
+        private final ConcurrentMap<Long, WorkerQueue> workerQMap;
+        final AtomicLong queueCounter;
+
+        private WorkerQueues() {
+            workerQMap = new ConcurrentHashMap<Long, WorkerQueue>();
+            queueCounter = new AtomicLong();
+        }
+
+        WorkerQueue createWorkerQueue() {
+            long idx = queueCounter.getAndIncrement();
+            WorkerQueue workerQueue = new WorkerQueue(idx, CoreThreadWorkers.INSTANCE.getNextWorker());
+            workerQMap.put(idx, workerQueue);
+            return workerQueue;
+        }
+
+        WorkerQueue getWorkerQueue(long idx) {
+            return workerQMap.get(idx);
+        }
+
+        void removeWorker(long idx) {
+            workerQMap.remove(idx);
+        }
+    }
+
+    // ToDo: confirm that Worker.schedule(...) methods are called sequentially
+    private static class WorkerQueue extends Scheduler.Worker {
+        private final long myIndex;
+        private volatile CoreThreadWorker worker;
+        private final CompositeSubscription innerSubscription = new CompositeSubscription();
+        private volatile CoreThreadWorker transferDest=null;
+        private volatile Action0 onTransferComplete=null;
+        private boolean transferInitiated=false;
+        private final List<Action0> transferQueue = new LinkedList<Action0>();
+        private final AtomicBoolean transferCompletionReady = new AtomicBoolean(false);
+
+        WorkerQueue(long myIndex, CoreThreadWorker worker) {
+            this.myIndex = myIndex;
+            this.worker = worker;
+        }
+
+        void rerouteTo(int dest, Action0 onComplete) {
+            onTransferComplete = onComplete;
+            transferInitiated = false;
+            transferDest = CoreThreadWorkers.INSTANCE.CORE_THREAD_WORKERS[dest];
+        }
+
+        private void setupReroute() {
+            if(transferInitiated)
+                return;
+            transferInitiated = true;
+            transferQueue.clear();
+            transferCompletionReady.set(false);
+            worker.submit(myIndex, new Runnable() {
+                @Override
+                public void run() {
+                    transferCompletionReady.set(true);
+                }
+            });
+        }
+
+        private void markRerouteComplete() {
+            worker = transferDest;
+            transferDest = null;
+        }
+
+        private boolean rerouteIfNeeded(final Action0 action) {
+            if(transferDest == null)
+                return false;
+            setupReroute();
+            if(transferCompletionReady.get()) {
+                // finish the reroute
+                // ToDo subscriptions need to be managed correctly!!!
+//                for(Action0 a: transferQueue) {
+//                    transferDest.submit(myIndex, a);
+//                }
+                markRerouteComplete();
+                onTransferComplete.call();
+            }
+            else
+                transferQueue.add(action);
+            return true;
+        }
+
+        @Override
+        public Subscription schedule(final Action0 action) {
+//            if(rerouteIfNeeded(action))
+//                return SomeUsefulSubscription;
+            final AtomicReference<Subscription> sf = new AtomicReference<Subscription>();
+            Subscription s = Subscriptions.from(worker.submit(myIndex, new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if(innerSubscription.isUnsubscribed())
+                            return;
+                        action.call();
+                    }
+                    finally {
+                        Subscription s = sf.get();
+                        if (s != null) {
+                            innerSubscription.remove(s);
+                        }
+                    }
+                }
+            }));
+            sf.set(s);
+            innerSubscription.add(s);
+            return s;
+        }
+
+        @Override
+        public Subscription schedule(final Action0 action, long delayTime, TimeUnit unit) {
+//            if(rerouteIfNeeded(action)) // need to handle delayed action
+//                return SomeUsefulSubscription;
+            final AtomicReference<Subscription> sf = new AtomicReference<Subscription>();
+            Subscription s = Subscriptions.from(worker.schedule(myIndex, new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if (innerSubscription.isUnsubscribed())
+                            return;
+                        action.call();
+                    } finally {
+                        Subscription s = sf.get();
+                        if (s != null) {
+                            innerSubscription.remove(s);
+                        }
+                    }
+                }
+            }, delayTime, unit));
+            sf.set(s);
+            innerSubscription.add(s);
+            return s;
+        }
+
+        @Override
+        public void unsubscribe() {
+            innerSubscription.unsubscribe();
+            WorkerQueues.INSTANCE.removeWorker(myIndex);
+            worker.remove(myIndex);
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return innerSubscription.isUnsubscribed();
+        }
+    }
+}

--- a/rxjava-core/src/perf/java/rx/schedulers/MultipleObserversOnOneBusyObservable.java
+++ b/rxjava-core/src/perf/java/rx/schedulers/MultipleObserversOnOneBusyObservable.java
@@ -1,0 +1,78 @@
+package rx.schedulers;
+
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.logic.BlackHole;
+import rx.Observable;
+import rx.Observer;
+import rx.Scheduler;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+public class MultipleObserversOnOneBusyObservable {
+
+    @GenerateMicroBenchmark
+    public void runAll(final Input input) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(input.numObservers);
+        Observable<Integer> smallObservable = Observable.from(Arrays.asList(1, 2, 3, 4, 5));
+        Observable<Integer> bigObservable = Observable.from(input.numbers);
+        for(int o=0; o<input.numObservers; o++) {
+            final int foo = o;
+            Observable<Integer> theObservable = smallObservable;
+            if(((o+1) % 4) != 0) {
+                theObservable = bigObservable;
+            }
+            theObservable
+                    .observeOn(input.schedulers[input.schedulerIndex])
+                    .subscribe(new Observer<Integer>() {
+                        @Override
+                        public void onCompleted() {
+                            latch.countDown();
+                        }
+
+                        @Override
+                        public void onError(Throwable e) {
+                            throw new RuntimeException(e);
+                        }
+
+                        @Override
+                        public void onNext(Integer integer) {
+                            input.blackHole.consume(integer*integer);
+                        }
+                    });
+        }
+        latch.await();
+    }
+
+    @State(Scope.Benchmark)
+    public static class Input {
+        private static final int NUM_INTEGERS=5000;
+        private final int NUM_CORES = Runtime.getRuntime().availableProcessors();
+        private int numObservers;
+        private Scheduler[] schedulers;
+        private List<Integer> numbers;
+        private BlackHole blackHole = new BlackHole();
+
+        @Param({ "0", "1", "2" })
+        public int schedulerIndex;
+
+        @Setup
+        public void setup() {
+            schedulers = new Scheduler[]{new EventLoopsScheduler(), new BalancingEventLoopScheduler(),
+                    new ReroutingEventLoopScheduler()};
+            numObservers = (int)(NUM_CORES * 10);
+            numbers = new ArrayList<Integer>(NUM_INTEGERS);
+            for(int n=0; n<NUM_INTEGERS; n++)
+                numbers.add((int)(Math.random()*1000.0));
+        }
+
+    }
+
+}


### PR DESCRIPTION
I created two new variations of EventLoopsScheduler - BalancingEventLoopScheduler and ReroutingEventLoopScheduler. These are currently experimental since they are not fully implemented for performance, but are fully functional. There are a couple of known problems and still evolving solutions. However, the ideas are concrete enough to garner discussion and feedback. The objective of rebalancing workload when there is non-trivial disparity in loads across cores is constrained by costs to both maintain state as well as to run rebalancing algorithms. Especially while maintaining the contracts of event concurrency, etc. and minimizing synchronization for gathering state and rebalancing.
I also created a new JMH benchmark, MultipleObserversOnOneBusyObservable.java (pardon the naming), to help compare these two new variants with the existing scheduler.

Here's a description of the benchmark and the two new schedulers.

JMH Benchmark MultipleObserversOnOneBusyObservable.java

<pre>
setup Input
    theArray = Array of N numbers
    Array of schedulers (schedlrIndex)
        0: EventLoopsScheduler
        1: BalancingEventLoopScheduler
        2: ReroutingEventLoopScheduler
    numObservers = NUM_CORES * 10
    @GenerateMicroBenchmark
    runAll(input)
        for(i = 1 .. input.numObservers)
        if(i%4 == 0)
            theO = Observable.from(1,2,3,4,5)
        else
            theO = Observable.from(input.theArray)
        theO.observeOn(input.scheduler[schedlrIndex]).subscribe(... input.blackhHole.consume(number)...)
</pre>


Benchmark run  on Ubuntu desktop: Intel Xeon W3550 @ 3.7 GHz, 8-Cores, 40GB memory.

```
gradlew benchmarks '-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 10 -r 1 .*MultipleObserversOnOneBusyObservable.*'
```

Results:

<pre>
N=50

Benchmark                                         (schedulerIndex)   Mode   Samples         Mean   Mean error    Units
r.s.MultipleObserversOnOneBusyObservable.runAll                  0  thrpt        10     3460.543       50.047   ops/s
r.s.MultipleObserversOnOneBusyObservable.runAll                  1  thrpt        10      430.402        1.783    ops/s
r.s.MultipleObserversOnOneBusyObservable.runAll                  2  thrpt        10     3200.517      140.199   ops/s


N=500

Benchmark                                         (schedulerIndex)   Mode   Samples         Mean   Mean error    Units
r.s.MultipleObserversOnOneBusyObservable.runAll                  0  thrpt        10      345.918        8.889   ops/s
r.s.MultipleObserversOnOneBusyObservable.runAll                  1  thrpt        10      366.105       11.945    ops/s
r.s.MultipleObserversOnOneBusyObservable.runAll                  2  thrpt        10      361.587       10.627   ops/s


N=5000

Benchmark                                         (schedulerIndex)   Mode   Samples         Mean   Mean error    Units
r.s.MultipleObserversOnOneBusyObservable.runAll                  0  thrpt        10       36.383        1.698    ops/s
r.s.MultipleObserversOnOneBusyObservable.runAll                  1  thrpt        10       88.317        4.917    ops/s
r.s.MultipleObserversOnOneBusyObservable.runAll                  2  thrpt        10       37.533        0.951   ops/s
</pre>


Note that the workload in this benchmark isn't such that there's a much rebalancing, if any, to do. However, we need to make sure that the variants do not degrade performance in that case. 

Some observations:

<ul>
  <li>BalancingEventLoopScheduler does poorly for small N, but does pretty well beyond a threshold.</li>
  <li>RebalancingEventLoopScheduler
    <ul>
        <li>added logic to evaluate and maintain state (1. avgLatency per core, 2. hot queue per core) and still is able to do as good as the old EventLoopsScheduler. That is, there's near zero cost to maintaining that state.</li>
<li>Even if rebalancing proves costly and we evolve an algorithm later, the result so far itself might be a good improvement over the current one if we just "pause" the hot Q and randomly pick another core. </li>
    </ul></li>
</ul>


Below, I point out the problem area for each of the new schedulers. Ideas/feedback welcome.

<h2>BalancingEventLoopScheduler</h2>

<pre>
N worker threads are created, 1 per core
Each of N worker threads are assigned 0 or more worker queues to process
One of the worker threads is assigned as the RebalancerThread for load balancing
Scheduler.createWorker()  creates a queue and assigns to one of the worker threads
WorkerThread.run():
    act on Q transfers (transferring queue in, or out)
    grab updated list of Qs
    totalLoad=0
    for(Q q: theQlist)
        q.drainTo(workList)
        now = currentTime
        for(Action a: workList)
        a.call()
        load = currentTime - now
        totalLoad += load
        maintain hotQueue: name and load; that has the highest load
    update current worker thread's hot queue 
    if I am the RebalancerThread, call rebalanceQs()
    if(totalLoad == 0)
        did no work, sleep a bit to prevent busy cpu   **PROBLEM**
        would be nice to have a multi-queue poll() here to be called on all our Qs
        this sleep kills performance when work comes in relatively slowly
rebalanceQs()
    if did rebalance recently, return
    get HotQueues from each core thread workers
    if none of them had a hot q, return
    sort in increasing order, hot Qs based on core thread worker's totalLoad and the qLoad
    for loadedWorker: from end of sorted hot Q list
        for availableWorker: from beginning of sorted hotQ list until loadedWorker
            if(shouldRebalancePair(loadedWorker, availableWorker), then
                move the hotQ from loadedWorker to availableWorker
                That is, WorkerThread[loadedWorker].transferQueue(theHotQ, WorkerThread[availableWorker])
shouldRebalancePair(loadedWorker, availableWorker)
    if( (loadedWorker.totalLoad - loadedWorker.hotQLoad) >= (availableWorker.totalLoad + loadedWorker.hotQLoad) )
        return true
    return false
</pre>


<h2>ReroutingEventLoopsScheduler</h2>

<pre>
N worker threads are created, 1 per core
Each of N worker threads has a single thread executor (ScheduledThreadPoolExecutor)
Scheduler.createWorker() creates a WorkerQueue and assigns to one of the worker threads (could possibly make it pick the least loaded one; that info is available based on the details below)
WorkerQueue.schedule() calls workerThread.schedule() on the currently assigned workerThread
WorkerThread routinely schedules a house keeping action, latencyEval,  into its schedulerService to note time it takes for it to get executed (this measures latency)
WorkerThread.schedule(callerQId, action)
    wrap each runnable with 
        increment counter to track #items
        increment per queue counter to track per queueId throughput (queueCounts)
    executor.schedule(wrapped runnable)
WorkerThread essentially maintains two numbers: avgLatency and throughput (overall + perWorker)
WorkerThread.latencyEval
    note latency (currentTime - latencyEvalLaunchTime)
    if(queueCounts.size > 1)
        maxQ = queue from queueCounts with max number, where number > EPS (threshold)
        destination = shouldReroute(myWorkerIndex)
        if(desination >= 0)
            WorkerQueue[maxQ].rerouteTo(destination)
shouldReroute(sourceWorker)
    ensure nobody else is rerouting right now or just did
    get avgLatencies for all workers (as many as #Cores)
    pick a worker with that can take sourceWorker's load based on latencies (currently always return -1, effectively actual load balancing is turned off)
    return picked worker 
WorkerQueue.schedule(action)
    if am being rerouted
        initialize reroute
            put an ending marker action into current worker that notifies us of the last action handled
            we can use the new worker only after the last one sent to previous one completes
        if (ending marker indicated)
            switch worker to the new one
            move all actions in transfer queue to new worker
        else
            park action into a transfer queue
            Don't yet know how to manage subscriptions when parking actions  **PROBLEM**
            It is functional though since actual rebalancing isn't happening.
            Perhaps, don't park actions, just pause until ending marker comes through. Subscriptions are managed just like before then. The caller is then blocked until rebalancing finishes. Which make be OK?
    else
        worker.schedule(action)
</pre>
