### PR TITLE
OperatorToObservableList: use LinkedList to buffer the sequence’s items

### DIFF
--- a/rxjava-core/src/main/java/rx/operators/OperatorToObservableList.java
+++ b/rxjava-core/src/main/java/rx/operators/OperatorToObservableList.java
@@ -15,11 +15,12 @@
  */
 package rx.operators;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import rx.Observable.Operator;
 import rx.Subscriber;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Returns an Observable that emits a single item, a list composed of all the items emitted by the
@@ -41,7 +42,7 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
     public Subscriber<? super T> call(final Subscriber<? super List<T>> o) {
         return new Subscriber<T>(o) {
 
-            final List<T> list = new ArrayList<T>();
+            final List<T> list = new LinkedList<T>();
 
             @Override
             public void onCompleted() {


### PR DESCRIPTION
LinkedList has guaranteed constant insertion time when appending to the end of the list, whereas ArrayList takes O(1) amortized, since a reallocation might be necessary to insert further items. Since no capacity was specified for the buffer, on Hotspot this would cause the array to reallocate after the first 10 insertions, on Android even after the first insertion (since Android’s ArrayList uses a default capacity of zero.)

Since the buffer is copied to an ArrayList before emission, subscriber performance when working with the list should remain unaffected.

Sorry for the import noise, that's IntelliJ reformatting them every time I look at the file.

Refs #1141
