### PR TITLE
Exposing PublishSubject

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/subjects/PublishSubject.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/subjects/PublishSubject.scala
@@ -17,7 +17,7 @@ package rx.lang.scala.subjects
 
 import rx.lang.scala.Subject
 
-private [scala] object PublishSubject {
+object PublishSubject {
   def apply[T](): PublishSubject[T] =  new PublishSubject[T](rx.subjects.PublishSubject.create[T]())
 }
 


### PR DESCRIPTION
All other subjects (Async, Behavior, Replay) have non-private companion objects.
