### PR TITLE
Remove Ambiguous Subscribe Overloads with Scheduler

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
@@ -122,17 +122,6 @@ trait Observable[+T]
    * $subscribeObserverMain
    *
    * @param observer $subscribeObserverParamObserver
-   * @param scheduler $subscribeObserverParamScheduler
-   * @return $subscribeAllReturn
-   */
-  def subscribe(observer: Observer[T], scheduler: Scheduler): Subscription = {
-    asJavaObservable.subscribe(observer.asJavaObserver, scheduler)
-  }
-
-  /**
-   * $subscribeObserverMain
-   *
-   * @param observer $subscribeObserverParamObserver
    * @return $subscribeAllReturn
    */
   def subscribe(observer: Observer[T]): Subscription = {
@@ -146,19 +135,6 @@ trait Observable[+T]
    * @return $subscribeAllReturn
    */
   def apply(observer: Observer[T]): Subscription = subscribe(observer)
-
-  /**
-   * $subscribeSubscriberMain
-   *
-   * @param subscriber $subscribeSubscriberParamObserver
-   * @param scheduler $subscribeSubscriberParamScheduler
-   * @return $subscribeAllReturn
-   */
-  def subscribe(subscriber: Subscriber[T], scheduler: Scheduler): Subscription = {
-    // Add the casting to avoid compile error "ambiguous reference to overloaded definition"
-    val thisJava = asJavaObservable.asInstanceOf[rx.Observable[T]]
-    thisJava.subscribe(subscriber.asJavaSubscriber, scheduler)
-  }
 
   /**
    * $subscribeSubscriberMain
@@ -218,48 +194,6 @@ trait Observable[+T]
       scalaFunction1ProducingUnitToAction1(onError), 
       scalaFunction0ProducingUnitToAction0(onCompleted)
     )
-  }
-
-  /**
-   * $subscribeCallbacksMainWithNotifications
-   *
-   * @param onNext $subscribeCallbacksParamOnNext
-   * @param onError $subscribeCallbacksParamOnError
-   * @param onCompleted $subscribeCallbacksParamOnComplete
-   * @param scheduler $subscribeCallbacksParamScheduler
-   * @return $subscribeAllReturn
-   */
-  def subscribe(onNext: T => Unit, onError: Throwable => Unit, onCompleted: () => Unit, scheduler: Scheduler): Subscription = {
-    asJavaObservable.subscribe(scalaFunction1ProducingUnitToAction1(onNext),
-      scalaFunction1ProducingUnitToAction1(onError),
-      scalaFunction0ProducingUnitToAction0(onCompleted),
-      scheduler)
-  }
-
-  /**
-   * $subscribeCallbacksMainWithNotifications
-   *
-   * @param onNext $subscribeCallbacksParamOnNext
-   * @param onError $subscribeCallbacksParamOnError
-   * @param scheduler $subscribeCallbacksParamScheduler
-   * @return $subscribeAllReturn
-   */
-  def subscribe(onNext: T => Unit, onError: Throwable => Unit, scheduler: Scheduler): Subscription = {
-    asJavaObservable.subscribe(
-      scalaFunction1ProducingUnitToAction1(onNext),
-      scalaFunction1ProducingUnitToAction1(onError),
-      scheduler)
-  }
-
-  /**
-   * $subscribeCallbacksMainNoNotifications
-   *
-   * @param onNext $subscribeCallbacksParamOnNext
-   * @param scheduler $subscribeCallbacksParamScheduler
-   * @return $subscribeAllReturn
-   */
-  def subscribe(onNext: T => Unit, scheduler: Scheduler): Subscription = {
-    asJavaObservable.subscribe(scalaFunction1ProducingUnitToAction1(onNext), scheduler)
   }
 
   /**

--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -6027,76 +6027,6 @@ public class Observable<T> {
     }
 
     /**
-     * An {@link Observer} must call an Observable's {@code subscribe} method in order to receive items and
-     * notifications from the Observable.
-     * 
-     * @param onNext
-     *            FIXME FIXME FIXME
-     * @param onError
-     *            FIXME FIXME FIXME
-     * @param onComplete
-     *            FIXME FIXME FIXME
-     * @param scheduler
-     *            FIXME FIXME FIXME
-     * @return a {@link Subscription} reference with which the {@link Observer} can stop receiving items before
-     *         the Observable has finished sending them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable#wiki-onnext-oncompleted-and-onerror">RxJava Wiki: onNext, onCompleted, and onError</a>
-     */
-    public final Subscription subscribe(final Action1<? super T> onNext, final Action1<Throwable> onError, final Action0 onComplete, Scheduler scheduler) {
-        return subscribeOn(scheduler).subscribe(onNext, onError, onComplete);
-    }
-
-    /**
-     * An {@link Observer} must call an Observable's {@code subscribe} method in order to receive items and
-     * notifications from the Observable.
-     * 
-     * @param onNext
-     *            FIXME FIXME FIXME
-     * @param onError
-     *            FIXME FIXME FIXME
-     * @param scheduler
-     *            FIXME FIXME FIXME
-     * @return a {@link Subscription} reference with which the {@link Observer} can stop receiving items before
-     *         the Observable has finished sending them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable#wiki-onnext-oncompleted-and-onerror">RxJava Wiki: onNext, onCompleted, and onError</a>
-     */
-    public final Subscription subscribe(final Action1<? super T> onNext, final Action1<Throwable> onError, Scheduler scheduler) {
-        return subscribeOn(scheduler).subscribe(onNext, onError);
-    }
-
-    /**
-     * An {@link Observer} must call an Observable's {@code subscribe} method in order to receive items and
-     * notifications from the Observable.
-     * 
-     * @param onNext
-     *            FIXME FIXME FIXME
-     * @param scheduler
-     *            FIXME FIXME FIXME
-     * @return a {@link Subscription} reference with which the {@link Observer} can stop receiving items before
-     *         the Observable has finished sending them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable#wiki-onnext-oncompleted-and-onerror">RxJava Wiki: onNext, onCompleted, and onError</a>
-     */
-    public final Subscription subscribe(final Action1<? super T> onNext, Scheduler scheduler) {
-        return subscribeOn(scheduler).subscribe(onNext);
-    }
-
-    /**
-     * An {@link Observer} must subscribe to an Observable in order to receive items and notifications from the
-     * Observable.
-     *
-     * @param observer
-     *            FIXME FIXME FIXME
-     * @param scheduler
-     *            FIXME FIXME FIXME
-     * @return a {@link Subscription} reference with which the {@link Observer} can stop receiving items before
-     *         the Observable has finished sending them
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable#wiki-onnext-oncompleted-and-onerror">RxJava Wiki: onNext, onCompleted, and onError</a>
-     */
-    public final Subscription subscribe(final Observer<? super T> observer, Scheduler scheduler) {
-        return subscribeOn(scheduler).subscribe(observer);
-    }
-
-    /**
      * An {@link Observer} must subscribe to an Observable in order to receive items and notifications from the
      * Observable.
      *
@@ -6239,38 +6169,6 @@ public class Observable<T> {
             }
             return Subscriptions.empty();
         }
-    }
-
-    /**
-     * A {@link Subscriber} must call an Observable's {@code subscribe} method in order to receive items and
-     * notifications from the Observable.
-     * <p>
-     * A typical implementation of {@code subscribe} does the following:
-     * <ol>
-     * <li>It stores a reference to the Subscriber in a collection object, such as a {@code List<T>} object.</li>
-     * <li>It returns a reference to the {@link Subscription} interface. This enables Observers to unsubscribe,
-     * that is, to stop receiving items and notifications before the Observable stops sending them, which also
-     * invokes the Observer's {@link Observer#onCompleted onCompleted} method.</li>
-     * </ol><p>
-     * An {@code Observable<T>} instance is responsible for accepting all subscriptions and notifying all
-     * Subscribers. Unless the documentation for a particular {@code Observable<T>} implementation indicates
-     * otherwise, Subscribers should make no assumptions about the order in which multiple Subscribers will
-     * receive their notifications.
-     * <p>
-     * For more information see the
-     * <a href="https://github.com/Netflix/RxJava/wiki/Observable">RxJava Wiki</a>
-     * 
-     * @param observer
-     *            the {@link Subscriber}
-     * @param scheduler
-     *            the {@link Scheduler} on which Subscribers subscribe to the Observable
-     * @return a {@link Subscription} reference with which Subscribers that are {@link Observer}s can
-     *         unsubscribe from the Observable
-     * @throws IllegalArgumentException
-     *             if an argument to {@code subscribe()} is {@code null}
-     */
-    public final Subscription subscribe(Subscriber<? super T> observer, Scheduler scheduler) {
-        return subscribeOn(scheduler).subscribe(observer);
     }
 
     /**

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -371,7 +371,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(5);
         final CountDownLatch first = new CountDownLatch(1);
 
-        o1.subscribe(new Action1<Integer>() {
+        o1.subscribeOn(scheduler).subscribe(new Action1<Integer>() {
 
             @Override
             public void call(Integer t) {
@@ -388,7 +388,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                 count.incrementAndGet();
                 latch.countDown();
             }
-        }, scheduler);
+        });
 
         // assert we are async
         assertEquals(0, count.get());


### PR DESCRIPTION
- Fixes https://github.com/Netflix/RxJava/issues/1116
- These should never have been added, the subscribeOn operator already provides this functionality
