### PR TITLE
Deprecate toBlockingObservable in favor of toBlocking

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -6949,7 +6949,10 @@ public class Observable<T> {
      * 
      * @return a {@code BlockingObservable} version of this Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Blocking-Observable-Operators">RxJava Wiki: Blocking Observable Observers</a>
+     * 
+     * @deprecated Use {@link #toBlocking()} instead.
      */
+    @Deprecated
     public final BlockingObservable<T> toBlockingObservable() {
         return BlockingObservable.from(this);
     }
@@ -6957,13 +6960,11 @@ public class Observable<T> {
     /**
      * Converts an Observable into a {@link BlockingObservable} (an Observable with blocking operators).
      *
-     * This method is an alias for {@link #toBlockingObservable()}.
-     *
      * @return a {@code BlockingObservable} version of this Observable
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Blocking-Observable-Operators">RxJava Wiki: Blocking Observable Observers</a>
      */
     public final BlockingObservable<T> toBlocking() {
-        return toBlockingObservable();
+        return BlockingObservable.from(this);
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
@@ -35,7 +35,7 @@ import rx.operators.BlockingOperatorToIterator;
  * An extension of {@link Observable} that provides blocking operators.
  * <p>
  * You construct a <code>BlockingObservable</code> from an
- * <code>Observable</code> with {@link #from(Observable)} or {@link Observable#toBlockingObservable()} <p>
+ * <code>Observable</code> with {@link #from(Observable)} or {@link Observable#toBlocking()} <p>
  * The documentation for this interface makes use of a form of marble diagram
  * that has been modified to illustrate blocking operators. The following legend
  * explains these marble diagrams:

--- a/rxjava-core/src/perf/java/rx/archive/schedulers/TestRecursionMemoryUsage.java
+++ b/rxjava-core/src/perf/java/rx/archive/schedulers/TestRecursionMemoryUsage.java
@@ -66,6 +66,6 @@ public class TestRecursionMemoryUsage {
                     }
                 });
             }
-        }).toBlockingObservable().last();
+        }).toBlocking().last();
     }
 }

--- a/rxjava-core/src/test/java/rx/CombineLatestTests.java
+++ b/rxjava-core/src/test/java/rx/CombineLatestTests.java
@@ -36,11 +36,11 @@ public class CombineLatestTests {
         Observable<HorrorMovie> horrors = Observable.from(new HorrorMovie());
         Observable<CoolRating> ratings = Observable.from(new CoolRating());
 
-        Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine).toBlockingObservable().forEach(action);
-        Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine).toBlockingObservable().forEach(action);
-        Observable.<Media, Rating, ExtendedResult> combineLatest(horrors, ratings, combine).toBlockingObservable().forEach(extendedAction);
-        Observable.<Media, Rating, Result> combineLatest(horrors, ratings, combine).toBlockingObservable().forEach(action);
-        Observable.<Media, Rating, ExtendedResult> combineLatest(horrors, ratings, combine).toBlockingObservable().forEach(action);
+        Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine).toBlocking().forEach(action);
+        Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine).toBlocking().forEach(action);
+        Observable.<Media, Rating, ExtendedResult> combineLatest(horrors, ratings, combine).toBlocking().forEach(extendedAction);
+        Observable.<Media, Rating, Result> combineLatest(horrors, ratings, combine).toBlocking().forEach(action);
+        Observable.<Media, Rating, ExtendedResult> combineLatest(horrors, ratings, combine).toBlocking().forEach(action);
 
         Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine);
     }

--- a/rxjava-core/src/test/java/rx/ConcatTests.java
+++ b/rxjava-core/src/test/java/rx/ConcatTests.java
@@ -35,7 +35,7 @@ public class ConcatTests {
         Observable<String> o1 = Observable.from("one", "two");
         Observable<String> o2 = Observable.from("three", "four");
 
-        List<String> values = Observable.concat(o1, o2).toList().toBlockingObservable().single();
+        List<String> values = Observable.concat(o1, o2).toList().toBlocking().single();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -51,7 +51,7 @@ public class ConcatTests {
 
         Observable<Observable<String>> os = Observable.from(o1, o2, o3);
 
-        List<String> values = Observable.concat(os).toList().toBlockingObservable().single();
+        List<String> values = Observable.concat(os).toList().toBlocking().single();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -68,7 +68,7 @@ public class ConcatTests {
         @SuppressWarnings("unchecked")
         Iterable<Observable<String>> is = Arrays.asList(o1, o2, o3);
 
-        List<String> values = Observable.concat(Observable.from(is)).toList().toBlockingObservable().single();
+        List<String> values = Observable.concat(Observable.from(is)).toList().toBlocking().single();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -83,7 +83,7 @@ public class ConcatTests {
 
         Observable<Observable<Media>> os = Observable.from(o1, o2);
 
-        List<Media> values = Observable.concat(os).toList().toBlockingObservable().single();
+        List<Media> values = Observable.concat(os).toList().toBlocking().single();
         
         assertEquals(4, values.size());
     }
@@ -95,7 +95,7 @@ public class ConcatTests {
 
         Observable<Observable<Media>> os = Observable.from(o1, o2);
 
-        List<Media> values = Observable.concat(os).toList().toBlockingObservable().single();
+        List<Media> values = Observable.concat(os).toList().toBlocking().single();
 
         assertEquals(5, values.size());
     }
@@ -105,7 +105,7 @@ public class ConcatTests {
         Observable<Movie> o1 = Observable.from(new HorrorMovie(), new Movie());
         Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.concat(o1, o2).toList().toBlockingObservable().single();
+        List<Media> values = Observable.concat(o1, o2).toList().toBlocking().single();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
@@ -129,7 +129,7 @@ public class ConcatTests {
 
         Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.concat(o1, o2).toList().toBlockingObservable().single();
+        List<Media> values = Observable.concat(o1, o2).toList().toBlocking().single();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);

--- a/rxjava-core/src/test/java/rx/GroupByTests.java
+++ b/rxjava-core/src/test/java/rx/GroupByTests.java
@@ -38,7 +38,7 @@ public class GroupByTests {
                     }
 
                 }).take(1)
-                .toBlockingObservable().forEach(new Action1<GroupedObservable<String, Event>>() {
+                .toBlocking().forEach(new Action1<GroupedObservable<String, Event>>() {
 
                     @Override
                     public void call(GroupedObservable<String, Event> g) {
@@ -79,7 +79,7 @@ public class GroupByTests {
 
                 })
                 .take(20)
-                .toBlockingObservable().forEach(new Action1<String>() {
+                .toBlocking().forEach(new Action1<String>() {
 
                     @Override
                     public void call(String v) {

--- a/rxjava-core/src/test/java/rx/MergeTests.java
+++ b/rxjava-core/src/test/java/rx/MergeTests.java
@@ -46,7 +46,7 @@ public class MergeTests {
 
         Observable<Observable<Media>> os = Observable.from(o1, o2);
 
-        List<Media> values = Observable.merge(os).toList().toBlockingObservable().single();
+        List<Media> values = Observable.merge(os).toList().toBlocking().single();
         
         assertEquals(4, values.size());
     }
@@ -58,7 +58,7 @@ public class MergeTests {
 
         Observable<Observable<Media>> os = Observable.from(o1, o2);
 
-        List<Media> values = Observable.merge(os).toList().toBlockingObservable().single();
+        List<Media> values = Observable.merge(os).toList().toBlocking().single();
 
         assertEquals(5, values.size());
     }
@@ -68,7 +68,7 @@ public class MergeTests {
         Observable<Movie> o1 = Observable.from(new HorrorMovie(), new Movie());
         Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.merge(o1, o2).toList().toBlockingObservable().single();
+        List<Media> values = Observable.merge(o1, o2).toList().toBlocking().single();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
@@ -92,7 +92,7 @@ public class MergeTests {
 
         Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.merge(o1, o2).toList().toBlockingObservable().single();
+        List<Media> values = Observable.merge(o1, o2).toList().toBlocking().single();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);

--- a/rxjava-core/src/test/java/rx/ObservableDoOnTest.java
+++ b/rxjava-core/src/test/java/rx/ObservableDoOnTest.java
@@ -39,7 +39,7 @@ public class ObservableDoOnTest {
             public void call(String v) {
                 r.set(v);
             }
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
 
         assertEquals("one", output);
         assertEquals("one", r.get());
@@ -56,7 +56,7 @@ public class ObservableDoOnTest {
                 public void call(Throwable v) {
                     r.set(v);
                 }
-            }).toBlockingObservable().single();
+            }).toBlocking().single();
             fail("expected exception, not a return value");
         } catch (Throwable e) {
             t = e;
@@ -75,7 +75,7 @@ public class ObservableDoOnTest {
             public void call() {
                 r.set(true);
             }
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
 
         assertEquals("one", output);
         assertTrue(r.get());

--- a/rxjava-core/src/test/java/rx/ObservableTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableTests.java
@@ -74,9 +74,9 @@ public class ObservableTests {
     @Test
     public void fromArray() {
         String[] items = new String[] { "one", "two", "three" };
-        assertEquals(new Integer(3), Observable.from(items).count().toBlockingObservable().single());
-        assertEquals("two", Observable.from(items).skip(1).take(1).toBlockingObservable().single());
-        assertEquals("three", Observable.from(items).takeLast(1).toBlockingObservable().single());
+        assertEquals(new Integer(3), Observable.from(items).count().toBlocking().single());
+        assertEquals("two", Observable.from(items).skip(1).take(1).toBlocking().single());
+        assertEquals("three", Observable.from(items).takeLast(1).toBlocking().single());
     }
 
     @Test
@@ -86,26 +86,26 @@ public class ObservableTests {
         items.add("two");
         items.add("three");
 
-        assertEquals(new Integer(3), Observable.from(items).count().toBlockingObservable().single());
-        assertEquals("two", Observable.from(items).skip(1).take(1).toBlockingObservable().single());
-        assertEquals("three", Observable.from(items).takeLast(1).toBlockingObservable().single());
+        assertEquals(new Integer(3), Observable.from(items).count().toBlocking().single());
+        assertEquals("two", Observable.from(items).skip(1).take(1).toBlocking().single());
+        assertEquals("three", Observable.from(items).takeLast(1).toBlocking().single());
     }
 
     @Test
     public void fromArityArgs3() {
         Observable<String> items = Observable.from("one", "two", "three");
 
-        assertEquals(new Integer(3), items.count().toBlockingObservable().single());
-        assertEquals("two", items.skip(1).take(1).toBlockingObservable().single());
-        assertEquals("three", items.takeLast(1).toBlockingObservable().single());
+        assertEquals(new Integer(3), items.count().toBlocking().single());
+        assertEquals("two", items.skip(1).take(1).toBlocking().single());
+        assertEquals("three", items.takeLast(1).toBlocking().single());
     }
 
     @Test
     public void fromArityArgs1() {
         Observable<String> items = Observable.from("one");
 
-        assertEquals(new Integer(1), items.count().toBlockingObservable().single());
-        assertEquals("one", items.takeLast(1).toBlockingObservable().single());
+        assertEquals(new Integer(1), items.count().toBlocking().single());
+        assertEquals("one", items.takeLast(1).toBlocking().single());
     }
 
     @Test
@@ -253,7 +253,7 @@ public class ObservableTests {
                 return t1 + t2;
             }
 
-        }).toBlockingObservable().forEach(new Action1<Integer>() {
+        }).toBlocking().forEach(new Action1<Integer>() {
 
             @Override
             public void call(Integer t1) {
@@ -279,7 +279,7 @@ public class ObservableTests {
                 return t1 + t2;
             }
 
-        }).toBlockingObservable().last();
+        }).toBlocking().last();
 
         assertEquals(1, value);
     }
@@ -970,7 +970,7 @@ public class ObservableTests {
             public void call(List<Integer> list, Integer v) {
                 list.add(v);
             }
-        }).toBlockingObservable().last();
+        }).toBlocking().last();
 
         assertEquals(3, list.size());
         assertEquals(1, list.get(0).intValue());
@@ -989,7 +989,7 @@ public class ObservableTests {
                 }
                 sb.append(v);
             }
-        }).toBlockingObservable().last().toString();
+        }).toBlocking().last().toString();
 
         assertEquals("1-2-3", value);
     }

--- a/rxjava-core/src/test/java/rx/ObservableWindowTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableWindowTests.java
@@ -37,7 +37,7 @@ public class ObservableWindowTests {
             public Observable<List<Integer>> call(Observable<Integer> xs) {
                 return xs.toList();
             }
-        })).toBlockingObservable().forEach(new Action1<List<Integer>>() {
+        })).toBlocking().forEach(new Action1<List<Integer>>() {
 
             @Override
             public void call(List<Integer> xs) {

--- a/rxjava-core/src/test/java/rx/ReduceTests.java
+++ b/rxjava-core/src/test/java/rx/ReduceTests.java
@@ -34,7 +34,7 @@ public class ReduceTests {
             public Integer call(Integer t1, Integer t2) {
                 return t1 + t2;
             }
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
 
         assertEquals(6, value);
     }

--- a/rxjava-core/src/test/java/rx/ScanTests.java
+++ b/rxjava-core/src/test/java/rx/ScanTests.java
@@ -40,7 +40,7 @@ public class ScanTests {
 
                 })
                 .take(10)
-                .toBlockingObservable().forEach(new Action1<Map<String, String>>() {
+                .toBlocking().forEach(new Action1<Map<String, String>>() {
 
                     @Override
                     public void call(Map<String, String> v) {

--- a/rxjava-core/src/test/java/rx/StartWithTests.java
+++ b/rxjava-core/src/test/java/rx/StartWithTests.java
@@ -26,7 +26,7 @@ public class StartWithTests {
 
     @Test
     public void startWith1() {
-        List<String> values = Observable.from("one", "two").startWith("zero").toList().toBlockingObservable().single();
+        List<String> values = Observable.from("one", "two").startWith("zero").toList().toBlocking().single();
 
         assertEquals("zero", values.get(0));
         assertEquals("two", values.get(2));
@@ -37,7 +37,7 @@ public class StartWithTests {
         List<String> li = new ArrayList<String>();
         li.add("alpha");
         li.add("beta");
-        List<String> values = Observable.from("one", "two").startWith(li).toList().toBlockingObservable().single();
+        List<String> values = Observable.from("one", "two").startWith(li).toList().toBlocking().single();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));
@@ -50,7 +50,7 @@ public class StartWithTests {
         List<String> li = new ArrayList<String>();
         li.add("alpha");
         li.add("beta");
-        List<String> values = Observable.from("one", "two").startWith(Observable.from(li)).toList().toBlockingObservable().single();
+        List<String> values = Observable.from("one", "two").startWith(Observable.from(li)).toList().toBlocking().single();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));

--- a/rxjava-core/src/test/java/rx/ZipTests.java
+++ b/rxjava-core/src/test/java/rx/ZipTests.java
@@ -69,7 +69,7 @@ public class ZipTests {
                     }
                 })
                 .take(10)
-                .toBlockingObservable().forEach(new Action1<Map<String, String>>() {
+                .toBlocking().forEach(new Action1<Map<String, String>>() {
 
                     @Override
                     public void call(Map<String, String> v) {
@@ -89,11 +89,11 @@ public class ZipTests {
         Observable<HorrorMovie> horrors = Observable.from(new HorrorMovie());
         Observable<CoolRating> ratings = Observable.from(new CoolRating());
 
-        Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine).toBlockingObservable().forEach(action);
-        Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine).toBlockingObservable().forEach(action);
-        Observable.<Media, Rating, ExtendedResult> zip(horrors, ratings, combine).toBlockingObservable().forEach(extendedAction);
-        Observable.<Media, Rating, Result> zip(horrors, ratings, combine).toBlockingObservable().forEach(action);
-        Observable.<Media, Rating, ExtendedResult> zip(horrors, ratings, combine).toBlockingObservable().forEach(action);
+        Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine).toBlocking().forEach(action);
+        Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine).toBlocking().forEach(action);
+        Observable.<Media, Rating, ExtendedResult> zip(horrors, ratings, combine).toBlocking().forEach(extendedAction);
+        Observable.<Media, Rating, Result> zip(horrors, ratings, combine).toBlocking().forEach(action);
+        Observable.<Media, Rating, ExtendedResult> zip(horrors, ratings, combine).toBlocking().forEach(action);
 
         Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine);
     }
@@ -120,7 +120,7 @@ public class ZipTests {
             }
         });
 
-        assertSame(invoked, result.toBlockingObservable().last());
+        assertSame(invoked, result.toBlocking().last());
     }
 
     Func2<Media, Rating, ExtendedResult> combine = new Func2<Media, Rating, ExtendedResult>() {

--- a/rxjava-core/src/test/java/rx/operators/BlockingOperatorLatestTest.java
+++ b/rxjava-core/src/test/java/rx/operators/BlockingOperatorLatestTest.java
@@ -33,7 +33,7 @@ public class BlockingOperatorLatestTest {
     public void testSimple() {
         TestScheduler scheduler = new TestScheduler();
 
-        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlockingObservable();
+        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlocking();
 
         Iterable<Long> iter = source.latest();
 
@@ -57,7 +57,7 @@ public class BlockingOperatorLatestTest {
     public void testSameSourceMultipleIterators() {
         TestScheduler scheduler = new TestScheduler();
 
-        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlockingObservable();
+        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlocking();
 
         Iterable<Long> iter = source.latest();
 
@@ -81,7 +81,7 @@ public class BlockingOperatorLatestTest {
 
     @Test(timeout = 1000, expected = NoSuchElementException.class)
     public void testEmpty() {
-        BlockingObservable<Long> source = Observable.<Long> empty().toBlockingObservable();
+        BlockingObservable<Long> source = Observable.<Long> empty().toBlocking();
 
         Iterable<Long> iter = source.latest();
 
@@ -96,7 +96,7 @@ public class BlockingOperatorLatestTest {
     public void testSimpleJustNext() {
         TestScheduler scheduler = new TestScheduler();
 
-        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlockingObservable();
+        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlocking();
 
         Iterable<Long> iter = source.latest();
 
@@ -115,7 +115,7 @@ public class BlockingOperatorLatestTest {
     public void testHasNextThrows() {
         TestScheduler scheduler = new TestScheduler();
 
-        BlockingObservable<Long> source = Observable.<Long> error(new RuntimeException("Forced failure!"), scheduler).toBlockingObservable();
+        BlockingObservable<Long> source = Observable.<Long> error(new RuntimeException("Forced failure!"), scheduler).toBlocking();
 
         Iterable<Long> iter = source.latest();
 
@@ -130,7 +130,7 @@ public class BlockingOperatorLatestTest {
     public void testNextThrows() {
         TestScheduler scheduler = new TestScheduler();
 
-        BlockingObservable<Long> source = Observable.<Long> error(new RuntimeException("Forced failure!"), scheduler).toBlockingObservable();
+        BlockingObservable<Long> source = Observable.<Long> error(new RuntimeException("Forced failure!"), scheduler).toBlocking();
 
         Iterable<Long> iter = source.latest();
         Iterator<Long> it = iter.iterator();
@@ -143,7 +143,7 @@ public class BlockingOperatorLatestTest {
     @Test(timeout = 1000)
     public void testFasterSource() {
         PublishSubject<Integer> source = PublishSubject.create();
-        BlockingObservable<Integer> blocker = source.toBlockingObservable();
+        BlockingObservable<Integer> blocker = source.toBlocking();
 
         Iterable<Integer> iter = blocker.latest();
         Iterator<Integer> it = iter.iterator();

--- a/rxjava-core/src/test/java/rx/operators/BlockingOperatorMostRecentTest.java
+++ b/rxjava-core/src/test/java/rx/operators/BlockingOperatorMostRecentTest.java
@@ -79,7 +79,7 @@ public class BlockingOperatorMostRecentTest {
     @Test(timeout = 1000)
     public void testSingleSourceManyIterators() {
         TestScheduler scheduler = new TestScheduler();
-        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlockingObservable();
+        BlockingObservable<Long> source = Observable.interval(1, TimeUnit.SECONDS, scheduler).take(10).toBlocking();
 
         Iterable<Long> iter = source.mostRecent(-1L);
 

--- a/rxjava-core/src/test/java/rx/operators/BlockingOperatorNextTest.java
+++ b/rxjava-core/src/test/java/rx/operators/BlockingOperatorNextTest.java
@@ -295,7 +295,7 @@ public class BlockingOperatorNextTest {
     @Test /* (timeout = 8000) */
     public void testSingleSourceManyIterators() throws InterruptedException {
         PublishSubject<Long> ps = PublishSubject.create();
-        BlockingObservable<Long> source = ps.take(10).toBlockingObservable();
+        BlockingObservable<Long> source = ps.take(10).toBlocking();
 
         Iterable<Long> iter = source.next();
 

--- a/rxjava-core/src/test/java/rx/operators/OperatorElementAtTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorElementAtTest.java
@@ -27,7 +27,7 @@ public class OperatorElementAtTest {
 
     @Test
     public void testElementAt() {
-        assertEquals(2, Observable.from(Arrays.asList(1, 2)).elementAt(1).toBlockingObservable().single()
+        assertEquals(2, Observable.from(Arrays.asList(1, 2)).elementAt(1).toBlocking().single()
                 .intValue());
     }
 
@@ -38,18 +38,18 @@ public class OperatorElementAtTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testElementAtWithIndexOutOfBounds() {
-        Observable.from(Arrays.asList(1, 2)).elementAt(2).toBlockingObservable().single();
+        Observable.from(Arrays.asList(1, 2)).elementAt(2).toBlocking().single();
     }
 
     @Test
     public void testElementAtOrDefault() {
-        assertEquals(2, Observable.from(Arrays.asList(1, 2)).elementAtOrDefault(1, 0).toBlockingObservable()
+        assertEquals(2, Observable.from(Arrays.asList(1, 2)).elementAtOrDefault(1, 0).toBlocking()
                 .single().intValue());
     }
 
     @Test
     public void testElementAtOrDefaultWithIndexOutOfBounds() {
-        assertEquals(0, Observable.from(Arrays.asList(1, 2)).elementAtOrDefault(2, 0).toBlockingObservable()
+        assertEquals(0, Observable.from(Arrays.asList(1, 2)).elementAtOrDefault(2, 0).toBlocking()
                 .single().intValue());
     }
 

--- a/rxjava-core/src/test/java/rx/operators/OperatorGroupByTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorGroupByTest.java
@@ -137,7 +137,7 @@ public class OperatorGroupByTest {
 
         final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<K, Collection<V>>();
 
-        observable.toBlockingObservable().forEach(new Action1<GroupedObservable<K, V>>() {
+        observable.toBlocking().forEach(new Action1<GroupedObservable<K, V>>() {
 
             @Override
             public void call(final GroupedObservable<K, V> o) {
@@ -640,7 +640,7 @@ public class OperatorGroupByTest {
                 }
             }
 
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String s) {
@@ -732,7 +732,7 @@ public class OperatorGroupByTest {
                 System.err.println("outer notification => " + t1);
             }
 
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String s) {
@@ -809,7 +809,7 @@ public class OperatorGroupByTest {
                 }
             }
 
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String s) {
@@ -865,7 +865,7 @@ public class OperatorGroupByTest {
                 System.out.println("notification => " + t1);
             }
 
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String s) {
@@ -913,7 +913,7 @@ public class OperatorGroupByTest {
                 });
             }
 
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String s) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorLastTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorLastTest.java
@@ -35,20 +35,20 @@ public class OperatorLastTest {
     @Test
     public void testLastWithElements() {
         Observable<Integer> last = Observable.from(1, 2, 3).last();
-        assertEquals(3, last.toBlockingObservable().single().intValue());
+        assertEquals(3, last.toBlocking().single().intValue());
     }
 
     @Test(expected = NoSuchElementException.class)
     public void testLastWithNoElements() {
         Observable<?> last = Observable.empty().last();
-        last.toBlockingObservable().single();
+        last.toBlocking().single();
     }
 
     @Test
     public void testLastMultiSubscribe() {
         Observable<Integer> last = Observable.from(1, 2, 3).last();
-        assertEquals(3, last.toBlockingObservable().single().intValue());
-        assertEquals(3, last.toBlockingObservable().single().intValue());
+        assertEquals(3, last.toBlocking().single().intValue());
+        assertEquals(3, last.toBlocking().single().intValue());
     }
 
     @Test

--- a/rxjava-core/src/test/java/rx/operators/OperatorMapTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMapTest.java
@@ -193,7 +193,7 @@ public class OperatorMapTest {
                     public Integer call(Integer arg0) {
                         throw new IllegalArgumentException("any error");
                     }
-                }).toBlockingObservable().single();
+                }).toBlocking().single();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -210,7 +210,7 @@ public class OperatorMapTest {
                 });
 
         // block for response, expecting exception thrown
-        m.toBlockingObservable().last();
+        m.toBlocking().last();
     }
 
     /**
@@ -225,7 +225,7 @@ public class OperatorMapTest {
                 return i;
             }
 
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
     }
 
     /**
@@ -240,7 +240,7 @@ public class OperatorMapTest {
                 return i;
             }
 
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
     }
 
     /**
@@ -256,7 +256,7 @@ public class OperatorMapTest {
                 return i / 0;
             }
 
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
     }
 
     @Test(expected = OnErrorNotImplementedException.class)

--- a/rxjava-core/src/test/java/rx/operators/OperatorMaterializeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMaterializeTest.java
@@ -89,8 +89,8 @@ public class OperatorMaterializeTest {
 
         Observable<Notification<String>> m = Observable.create(o).materialize();
 
-        assertEquals(3, m.toList().toBlockingObservable().toFuture().get().size());
-        assertEquals(3, m.toList().toBlockingObservable().toFuture().get().size());
+        assertEquals(3, m.toList().toBlocking().toFuture().get().size());
+        assertEquals(3, m.toList().toBlocking().toFuture().get().size());
     }
 
     private static class TestObserver extends Subscriber<Notification<String>> {

--- a/rxjava-core/src/test/java/rx/operators/OperatorMergeMaxConcurrentTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMergeMaxConcurrentTest.java
@@ -53,7 +53,7 @@ public class OperatorMergeMaxConcurrentTest {
             os.add(Observable.from("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
 
             List<String> expected = Arrays.asList("one", "two", "three", "four", "five", "one", "two", "three", "four", "five", "one", "two", "three", "four", "five");
-            Iterator<String> iter = Observable.merge(os, 1).toBlockingObservable().toIterable().iterator();
+            Iterator<String> iter = Observable.merge(os, 1).toBlocking().toIterable().iterator();
             List<String> actual = new ArrayList<String>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
@@ -78,7 +78,7 @@ public class OperatorMergeMaxConcurrentTest {
                 os.add(Observable.create(sco));
             }
 
-            Iterator<String> iter = Observable.merge(os, maxConcurrent).toBlockingObservable().toIterable().iterator();
+            Iterator<String> iter = Observable.merge(os, maxConcurrent).toBlocking().toIterable().iterator();
             List<String> actual = new ArrayList<String>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
@@ -134,7 +134,7 @@ public class OperatorMergeMaxConcurrentTest {
         for (int i = 0; i < n; i++) {
             sourceList.add(Observable.just(i));
         }
-        Iterator<Integer> it = Observable.merge(Observable.from(sourceList), 1).toBlockingObservable().getIterator();
+        Iterator<Integer> it = Observable.merge(Observable.from(sourceList), 1).toBlocking().getIterator();
         int j = 0;
         while (it.hasNext()) {
             assertEquals((Integer)j, it.next());
@@ -149,7 +149,7 @@ public class OperatorMergeMaxConcurrentTest {
         for (int i = 0; i < n; i++) {
             sourceList.add(Observable.just(i));
         }
-        Iterator<Integer> it = Observable.merge(Observable.from(sourceList), 1).take(n / 2).toBlockingObservable().getIterator();
+        Iterator<Integer> it = Observable.merge(Observable.from(sourceList), 1).take(n / 2).toBlocking().getIterator();
         int j = 0;
         while (it.hasNext()) {
             assertEquals((Integer)j, it.next());

--- a/rxjava-core/src/test/java/rx/operators/OperatorMergeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorMergeTest.java
@@ -159,7 +159,7 @@ public class OperatorMergeTest {
         });
 
         final AtomicInteger count = new AtomicInteger();
-        Observable.merge(source).take(6).toBlockingObservable().forEach(new Action1<Long>() {
+        Observable.merge(source).take(6).toBlocking().forEach(new Action1<Long>() {
 
             @Override
             public void call(Long v) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorObserveOnTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorObserveOnTest.java
@@ -235,7 +235,7 @@ public class OperatorObserveOnTest {
             }
 
         }).observeOn(Schedulers.newThread())
-                .toBlockingObservable().forEach(new Action1<Integer>() {
+                .toBlocking().forEach(new Action1<Integer>() {
 
                     @Override
                     public void call(Integer t1) {
@@ -262,7 +262,7 @@ public class OperatorObserveOnTest {
             }
 
         }).observeOn(Schedulers.computation())
-                .toBlockingObservable().forEach(new Action1<Integer>() {
+                .toBlocking().forEach(new Action1<Integer>() {
 
                     @Override
                     public void call(Integer t1) {
@@ -302,7 +302,7 @@ public class OperatorObserveOnTest {
             }
 
         }).observeOn(Schedulers.computation())
-                .toBlockingObservable().forEach(new Action1<Integer>() {
+                .toBlocking().forEach(new Action1<Integer>() {
 
                     @Override
                     public void call(Integer t1) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorParallelMergeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorParallelMergeTest.java
@@ -44,9 +44,9 @@ public class OperatorParallelMergeTest {
         Observable<Observable<String>> twoStreams = Observable.parallelMerge(fourStreams, 2);
         Observable<Observable<String>> threeStreams = Observable.parallelMerge(fourStreams, 3);
 
-        List<? super Observable<String>> fourList = fourStreams.toList().toBlockingObservable().last();
-        List<? super Observable<String>> threeList = threeStreams.toList().toBlockingObservable().last();
-        List<? super Observable<String>> twoList = twoStreams.toList().toBlockingObservable().last();
+        List<? super Observable<String>> fourList = fourStreams.toList().toBlocking().last();
+        List<? super Observable<String>> threeList = threeStreams.toList().toBlocking().last();
+        List<? super Observable<String>> twoList = twoStreams.toList().toBlocking().last();
 
         System.out.println("two list: " + twoList);
         System.out.println("three list: " + threeList);
@@ -71,7 +71,7 @@ public class OperatorParallelMergeTest {
                         return o.observeOn(Schedulers.newThread());
                     }
                 })
-                .toBlockingObservable().forEach(new Action1<String>() {
+                .toBlocking().forEach(new Action1<String>() {
 
                     @Override
                     public void call(String o) {
@@ -90,7 +90,7 @@ public class OperatorParallelMergeTest {
         // now we parallelMerge into 3 streams and observeOn for each
         // we expect 3 threads in the output
         Observable.merge(Observable.parallelMerge(getStreams(), 3, Schedulers.newThread()))
-                .toBlockingObservable().forEach(new Action1<String>() {
+                .toBlocking().forEach(new Action1<String>() {
 
                     @Override
                     public void call(String o) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorParallelTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorParallelTest.java
@@ -60,7 +60,7 @@ public class OperatorParallelTest {
                         });
                     }
                 })
-                .toBlockingObservable().forEach(new Action1<Integer[]>() {
+                .toBlocking().forEach(new Action1<Integer[]>() {
 
                     @Override
                     public void call(Integer[] v) {
@@ -94,7 +94,7 @@ public class OperatorParallelTest {
 
                         });
                     }
-                }).toBlockingObservable().forEach(new Action1<String>() {
+                }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String v) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorRepeatTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorRepeatTest.java
@@ -48,7 +48,7 @@ public class OperatorRepeatTest {
                 o.onNext(count.incrementAndGet());
                 o.onCompleted();
             }
-        }).repeat(Schedulers.computation()).take(NUM).toBlockingObservable().last();
+        }).repeat(Schedulers.computation()).take(NUM).toBlocking().last();
 
         assertEquals(NUM, value);
     }
@@ -56,13 +56,13 @@ public class OperatorRepeatTest {
     @Test(timeout = 2000)
     public void testRepeatTake() {
         Observable<Integer> xs = Observable.from(1, 2);
-        Object[] ys = xs.repeat(Schedulers.newThread()).take(4).toList().toBlockingObservable().last().toArray();
+        Object[] ys = xs.repeat(Schedulers.newThread()).take(4).toList().toBlocking().last().toArray();
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
     }
 
     @Test(timeout = 20000)
     public void testNoStackOverFlow() {
-        Observable.from(1).repeat(Schedulers.newThread()).take(100000).toBlockingObservable().last();
+        Observable.from(1).repeat(Schedulers.newThread()).take(100000).toBlocking().last();
     }
 
     @Test
@@ -92,7 +92,7 @@ public class OperatorRepeatTest {
                 return t1;
             }
 
-        }).take(4).toList().toBlockingObservable().last().toArray();
+        }).take(4).toList().toBlocking().last().toArray();
 
         assertEquals(2, counter.get());
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);

--- a/rxjava-core/src/test/java/rx/operators/OperatorTakeTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorTakeTest.java
@@ -83,7 +83,7 @@ public class OperatorTakeTest {
             public Integer call(Integer t1) {
                 throw new IllegalArgumentException("some error");
             }
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
     }
 
     @Test
@@ -237,7 +237,7 @@ public class OperatorTakeTest {
                 }
             }
 
-        }).take(100).take(1).toBlockingObservable().forEach(new Action1<Integer>() {
+        }).take(100).take(1).toBlocking().forEach(new Action1<Integer>() {
 
             @Override
             public void call(Integer t1) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorTakeWhileTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorTakeWhileTest.java
@@ -121,7 +121,7 @@ public class OperatorTakeWhileTest {
             public Boolean call(String s) {
                 return false;
             }
-        }).toBlockingObservable().lastOrDefault("");
+        }).toBlocking().lastOrDefault("");
     }
 
     @Test

--- a/rxjava-core/src/test/java/rx/operators/OperatorUsingTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorUsingTest.java
@@ -152,7 +152,7 @@ public class OperatorUsingTest {
             }
         };
 
-        Observable.using(resourceFactory, observableFactory).toBlockingObservable().last();
+        Observable.using(resourceFactory, observableFactory).toBlocking().last();
     }
 
     @Test
@@ -173,7 +173,7 @@ public class OperatorUsingTest {
         };
 
         try {
-            Observable.using(resourceFactory, observableFactory).toBlockingObservable().last();
+            Observable.using(resourceFactory, observableFactory).toBlocking().last();
             fail("Should throw a TestException when the observableFactory throws it");
         } catch (TestException e) {
             // Make sure that unsubscribe is called so that users can close
@@ -205,7 +205,7 @@ public class OperatorUsingTest {
         };
 
         try {
-            Observable.using(resourceFactory, observableFactory).toBlockingObservable().last();
+            Observable.using(resourceFactory, observableFactory).toBlocking().last();
             fail("Should throw a TestException when the observableFactory throws it");
         } catch (TestException e) {
             // Make sure that unsubscribe is called so that users can close

--- a/rxjava-core/src/test/java/rx/operators/OperatorWindowTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorWindowTest.java
@@ -62,7 +62,7 @@ public class OperatorWindowTest {
                 return xs.toList();
             }
         }))
-                .toBlockingObservable()
+                .toBlocking()
                 .forEach(new Action1<List<T>>() {
                     @Override
                     public void call(List<T> xs) {

--- a/rxjava-core/src/test/java/rx/operators/OperatorZipTest.java
+++ b/rxjava-core/src/test/java/rx/operators/OperatorZipTest.java
@@ -1036,7 +1036,7 @@ public class OperatorZipTest {
             }
         });
 
-        o.toBlockingObservable().last();
+        o.toBlocking().last();
     }
 
     Observable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
@@ -130,7 +130,7 @@ public abstract class AbstractSchedulerTests {
 
         });
 
-        List<String> strings = m.toList().toBlockingObservable().last();
+        List<String> strings = m.toList().toBlocking().last();
 
         assertEquals(4, strings.size());
         // because flatMap does a merge there is no guarantee of order
@@ -333,7 +333,7 @@ public abstract class AbstractSchedulerTests {
         });
 
         final AtomicInteger lastValue = new AtomicInteger();
-        obs.toBlockingObservable().forEach(new Action1<Integer>() {
+        obs.toBlocking().forEach(new Action1<Integer>() {
 
             @Override
             public void call(Integer v) {

--- a/rxjava-core/src/test/java/rx/schedulers/ComputationSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/ComputationSchedulerTests.java
@@ -102,7 +102,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             }
         });
 
-        o.subscribeOn(Schedulers.computation()).toBlockingObservable().forEach(new Action1<String>() {
+        o.subscribeOn(Schedulers.computation()).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t) {
@@ -129,7 +129,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             }
         });
 
-        o.toBlockingObservable().forEach(new Action1<String>() {
+        o.toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t) {

--- a/rxjava-core/src/test/java/rx/schedulers/ImmediateSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/ImmediateSchedulerTest.java
@@ -68,7 +68,7 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTests {
             }
         });
 
-        o.toBlockingObservable().forEach(new Action1<String>() {
+        o.toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t) {
@@ -93,7 +93,7 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTests {
             }
         });
 
-        o.toBlockingObservable().forEach(new Action1<String>() {
+        o.toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t) {

--- a/rxjava-core/src/test/java/rx/schedulers/NewThreadSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/NewThreadSchedulerTest.java
@@ -49,7 +49,7 @@ public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
             }
         });
 
-        o.subscribeOn(Schedulers.io()).toBlockingObservable().forEach(new Action1<String>() {
+        o.subscribeOn(Schedulers.io()).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t) {

--- a/rxjava-core/src/test/java/rx/schedulers/TrampolineSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/TrampolineSchedulerTest.java
@@ -47,7 +47,7 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
             }
         });
 
-        o.toBlockingObservable().forEach(new Action1<String>() {
+        o.toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t) {

--- a/rxjava-core/src/test/java/rx/subjects/AsyncSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/AsyncSubjectTest.java
@@ -274,7 +274,7 @@ public class AsyncSubjectTest {
         public void run() {
             try {
                 // a timeout exception will happen if we don't get a terminal state 
-                String v = subject.timeout(2000, TimeUnit.MILLISECONDS).toBlockingObservable().single();
+                String v = subject.timeout(2000, TimeUnit.MILLISECONDS).toBlocking().single();
                 value.set(v);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/rxjava-core/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
@@ -71,7 +71,7 @@ public class ReplaySubjectConcurrencyTest {
         });
         source.start();
 
-        long v = replay.toBlockingObservable().last();
+        long v = replay.toBlocking().last();
         assertEquals(10000, v);
 
         // it's been played through once so now it will all be replays
@@ -198,7 +198,7 @@ public class ReplaySubjectConcurrencyTest {
 
                 @Override
                 public void run() {
-                    List<Long> values = replay.toList().toBlockingObservable().last();
+                    List<Long> values = replay.toList().toBlocking().last();
                     listOfListsOfValues.add(values);
                     System.out.println("Finished thread: " + count);
                 }
@@ -330,7 +330,7 @@ public class ReplaySubjectConcurrencyTest {
         public void run() {
             try {
                 // a timeout exception will happen if we don't get a terminal state 
-                String v = subject.timeout(2000, TimeUnit.MILLISECONDS).toBlockingObservable().single();
+                String v = subject.timeout(2000, TimeUnit.MILLISECONDS).toBlocking().single();
                 value.set(v);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/rxjava-core/src/test/java/rx/util/AssertObservable.java
+++ b/rxjava-core/src/test/java/rx/util/AssertObservable.java
@@ -48,7 +48,7 @@ public class AssertObservable {
      *            Observable with actual values
      */
     public static <T> void assertObservableEqualsBlocking(String message, Observable<T> expected, Observable<T> actual) {
-        assertObservableEquals(expected, actual).toBlockingObservable().lastOrDefault(null);
+        assertObservableEquals(expected, actual).toBlocking().lastOrDefault(null);
     }
 
     /**


### PR DESCRIPTION
As per discussion at https://github.com/Netflix/RxJava/pull/1224#issuecomment-43658284

This will better match `toParallel` and is shorter to use while still being clear as to what is happening.
