### PR TITLE
Lock-free, MPSC-queue based, fast-path serializing Observer.

### DIFF
--- a/rxjava-core/src/main/java/rx/observers/MpscPaddedQueue.java
+++ b/rxjava-core/src/main/java/rx/observers/MpscPaddedQueue.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package rx.observers;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * A multiple-producer single consumer queue implementation with padded reference
+ * to tail to avoid cache-line thrashing.
+ * Based on Netty's <a href='https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/internal/MpscLinkedQueue.java'>MpscQueue implementation</a> but using AtomicReferenceFieldUpdater
+ * instead of Unsafe.
+ * @param <E> the element type
+ */
+public final class MpscPaddedQueue<E> extends AtomicReference<MpscPaddedQueue.Node<E>> {
+    @SuppressWarnings(value = "rawtypes")
+    static final AtomicReferenceFieldUpdater<PaddedNode, Node> TAIL_UPDATER = AtomicReferenceFieldUpdater.newUpdater(PaddedNode.class, Node.class, "tail");
+    /** */
+    private static final long serialVersionUID = 1L;
+    /** The padded tail reference. */
+    final PaddedNode<E> tail;
+    /**
+     * Initializes the empty queue.
+     */
+    public MpscPaddedQueue() {
+        Node<E> first = new Node<E>(null);
+        tail = new PaddedNode<E>();
+        tail.tail = first;
+        set(first);
+    }
+    /**
+     * Offer a new value.
+     * @param v the value to offer
+     */
+    public void offer(E v) {
+        Node<E> n = new Node<E>(v);
+        getAndSet(n).set(n);
+    }
+
+    /**
+     * @return Poll a value from the head of the queue or return null if the queue is empty.
+     */
+    public E poll() {
+        Node<E> n = peekNode();
+        if (n == null) {
+            return null;
+        }
+        E v = n.value;
+        n.value = null; // do not retain this value as the node still stays in the queue
+        TAIL_UPDATER.lazySet(tail, n);
+        return v;
+    }
+    /**
+     * Check if there is a node available without changing anything.
+     */
+    private Node<E> peekNode() {
+        for (;;) {
+            @SuppressWarnings(value = "unchecked")
+            Node<E> t = TAIL_UPDATER.get(tail);
+            Node<E> n = t.get();
+            if (n != null || get() == t) {
+                return n;
+            }
+        }
+    }
+    /**
+     * Clears the queue.
+     */
+    public void clear() {
+        for (;;) {
+            if (poll() == null) {
+                break;
+            }
+        }
+    }
+    /** Class that contains a Node reference padded around to fit a typical cache line. */
+    static final class PaddedNode<E> {
+        /** Padding, public to prevent optimizing it away. */
+        public int p1;
+        volatile Node<E> tail;
+        /** Padding, public to prevent optimizing it away. */
+        public long p2;
+        /** Padding, public to prevent optimizing it away. */
+        public long p3;
+        /** Padding, public to prevent optimizing it away. */
+        public long p4;
+        /** Padding, public to prevent optimizing it away. */
+        public long p5;
+        /** Padding, public to prevent optimizing it away. */
+        public long p6;
+    }
+    /**
+     * Regular node with value and reference to the next node.
+     */
+    static final class Node<E> {
+
+        E value;
+        @SuppressWarnings(value = "rawtypes")
+        static final AtomicReferenceFieldUpdater<Node, Node> TAIL_UPDATER = AtomicReferenceFieldUpdater.newUpdater(Node.class, Node.class, "tail");
+        volatile Node<E> tail;
+
+        public Node(E value) {
+            this.value = value;
+        }
+
+        public void set(Node<E> newTail) {
+            TAIL_UPDATER.lazySet(this, newTail);
+        }
+
+        @SuppressWarnings(value = "unchecked")
+        public Node<E> get() {
+            return TAIL_UPDATER.get(this);
+        }
+    }
+    
+}

--- a/rxjava-core/src/main/java/rx/observers/PaddedAtomicInteger.java
+++ b/rxjava-core/src/main/java/rx/observers/PaddedAtomicInteger.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package rx.observers;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An AtomicInteger with extra fields to pad it out to fit a typical cache line.
+ */
+public final class PaddedAtomicInteger extends AtomicInteger {
+    private static final long serialVersionUID = 1L;
+    /** Padding, public to prevent optimizing it away. */
+    public int p1;
+    /** Padding, public to prevent optimizing it away. */
+    public int p2;
+    /** Padding, public to prevent optimizing it away. */
+    public int p3;
+    /** Padding, public to prevent optimizing it away. */
+    public int p4;
+    /** Padding, public to prevent optimizing it away. */
+    public int p5;
+    /** Padding, public to prevent optimizing it away. */
+    public int p6;
+    /** Padding, public to prevent optimizing it away. */
+    public int p7;
+    /** Padding, public to prevent optimizing it away. */
+    public int p8;
+    /** Padding, public to prevent optimizing it away. */
+    public int p9;
+    /** Padding, public to prevent optimizing it away. */
+    public int p10;
+    /** Padding, public to prevent optimizing it away. */
+    public int p11;
+    /** Padding, public to prevent optimizing it away. */
+    public int p12;
+    /** Padding, public to prevent optimizing it away. */
+    public int p13;
+    /** @return prevents optimizing away the fields, most likely. */
+    public int noopt() {
+        return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + p10 + p11 + p12 + p13;
+    }
+    
+}

--- a/rxjava-core/src/main/java/rx/operators/NotificationLite.java
+++ b/rxjava-core/src/main/java/rx/operators/NotificationLite.java
@@ -129,6 +129,39 @@ public final class NotificationLite<T> {
             throw new IllegalArgumentException("The lite notification can not be null");
         }
     }
+    /**
+     * Unwraps the lite notification and calls the appropriate method on the {@link Observer}.
+     * 
+     * @param o
+     *            the {@link Observer} to call onNext, onCompleted or onError.
+     * @param n
+     * @return true if the n was a termination event
+     * @throws IllegalArgumentException
+     *             if the notification is null.
+     * @throws NullPointerException
+     *             if the {@link Observer} is null.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean accept2(Observer<? super T> o, Object n) {
+        if (n == ON_COMPLETED_SENTINEL) {
+            o.onCompleted();
+            return true;
+        } else
+        if (n == ON_NEXT_NULL_SENTINEL) {
+            o.onNext(null);
+            return false;
+        } else
+        if (n != null) {
+            if (n.getClass() == OnErrorSentinel.class) {
+                o.onError(((OnErrorSentinel)n).e);
+                return true;
+            }
+            o.onNext((T)n);
+            return false;
+        } else {
+            throw new IllegalArgumentException("The lite notification can not be null");
+        }
+    }
 
     public boolean isCompleted(Object n) {
         return n == ON_COMPLETED_SENTINEL;


### PR DESCRIPTION
I've rewritten the `SerializedObserver` to improve performance. It is now lock-free, uses a multiple-producer-single-consumer queue based on Netty's implementation and employs a fast-path logic for single-threaded write-through.

Benchmarked by measuring how fast 500k integers can get through it, if running 1-8 producers at the same time. For a single threaded case, master gives about 18 MOps/s, this implementation gives ~36 MOps/s (would be ~16 MOps/s on the slow path). For producers > 2, master gives ~5.5 MOps/s and this gives ~11.5 MOps/s. For 2 producers, aka 1 producer - 1 consumer, master gives ~4.5 MOps and this gives ~8.5 MOps/s.

The two new class, `PaddedAtomicInteger` and `MpscPaddedQueue` will come in handy with other lock-free structures such as Schedulers, etc. We may consider adding back the `rx.util` or some other sub-package to store these helper classes: they don't need to be part of the public API but can be left `public` to enable cross-package access internally.

Things I learned during the implementation:
- It is worth padding the wip counter to fit a cache line so the constant cache thrashing won't affect the parent class' other fields, most likely.
- Using FieldUpdaters saves space but `sun.misc.Unsafe` can add 8-10% more throughput. To avoid platform issues, I stayed with the FieldUpdaters.
- Using `getAndIncrement` and `decrementAndGet` are intrinsified in Java 8 and are compiled to a single x86 instruction, which generally outperforms any CAS loop. Same is true for the `getAndSet`.
- Padding out the `tail` in the `MpscPaddedQueue` again helps separate producers trashing on the tail and a consumer reading the head. Without it, the throughput would decrease by about ~1.5 MOps/s
- By adding the fast-path logic, the single-threaded throughput increases by a factor of 2 since it avoids an unnecessary enqueue and dequeue and all associated volatile writes. However, if taking the fast-path fails, it incurs extra cost on the slow path for everyone else because of the +1 failed CAS at the start. To fix this case, I've introduced a flag that enables and disables fast-path. To disable the fast path, the active fast path checks if it was able to change wip to zero. If not, it means there was concurrent access and continues on the emission loop path, but disables the fast-path then on. It is basically a detector for concurrent use. Since such concurrent use may be transient, the loop counts how many elements it had to emit, an if it was only 1 or 2, it reenables the fast-path. This limit is the result of trying several values with the benchmark above.
- The fast-path logic has its weak spot in 2 producer case compared to a plain MPSC queue running in SPSC mode; the latter gives about ~11 MOps/s which is better than this implementation's ~8.5 MOps/s. In contrast, the single-treaded use for the plain MPSC is only ~16 MOps/s. Both implementations perform the same if producers > 2. Therefore, I decided it is more worth having an implementation that is weak for 2 producers but otherwise is as good or outperforms the alternatives. Note that if one knows the number of producers up front, one can create a more specialized implementation, but this is not the case with RxJava operators. This may affect `merge` and co which serialize multiple sources. Note however, that if the source speed isn't that high as in the benchmark, this implementation still provide less latency than the alternatives because the fast-path would be most likely open if the source emission is interleaved.
