### PR TITLE
Android HandlerThreadScheduler fix (closes #1241)

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/HandlerThreadScheduler.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/HandlerThreadScheduler.java
@@ -68,6 +68,10 @@ public class HandlerThreadScheduler extends Scheduler {
 
         @Override
         public Subscription schedule(final Action0 action, long delayTime, TimeUnit unit) {
+            if (innerSubscription.isUnsubscribed()) {
+                // don't schedule, we are unsubscribed
+                return Subscriptions.empty();
+            }
             final Runnable runnable = new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
Some events are not delivered due to race condition around the check to `innerSubscription.isUnsubscribed()` in the posted runnable. It's currently possible for the Handler thread to be delayed enough that innerSubscription becomes unsubscribed, and causing the action not to run.

After cross-checking the code with `NewThreadScheduler`, it seems that the expected behavior is to continue to run the action even if the inner/parent subscription is unsubscribed, and only stop when the outer subscription is unsubscribed (which is already happening with `handler.removeCallbacks(runnable)`).

This fixes #1241.
