### PR TITLE
Observable.from(T) using Observable.just(T)

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -1084,10 +1084,8 @@ public class Observable<T> {
      * @return an Observable that emits the item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#wiki-from">RxJava Wiki: from()</a>
      */
-    // suppress unchecked because we are using varargs inside the method
-    @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1) {
-        return from(Arrays.asList(t1));
+        return just(t1);
     }
 
     /**


### PR DESCRIPTION
For code like `Observable.from(1)` Improve performance from ~3.9m to 4.5+m ops/second

Before;

```
r.u.PerfTransforms.flatMapTransformsUsingFrom        1  thrpt         5  3923845.687    46657.660    ops/s
r.u.PerfTransforms.flatMapTransformsUsingFrom     1024  thrpt         5     8924.953     1983.161    ops/s

r.u.PerfTransforms.flatMapTransformsUsingFrom        1  thrpt         5  3623228.857   490894.492    ops/s
r.u.PerfTransforms.flatMapTransformsUsingFrom     1024  thrpt         5     9176.330      923.929    ops/s
```

After:

```
Benchmark                                       (size)   Mode   Samples         Mean   Mean error    Units
r.u.PerfTransforms.flatMapTransformsUsingFrom        1  thrpt         5  4052364.587   100971.234    ops/s
r.u.PerfTransforms.flatMapTransformsUsingFrom     1024  thrpt         5    11682.783      496.656    ops/s

Benchmark                                       (size)   Mode   Samples         Mean   Mean error    Units
r.u.PerfTransforms.flatMapTransformsUsingFrom        1  thrpt         5  4700583.987    77742.037    ops/s
r.u.PerfTransforms.flatMapTransformsUsingFrom     1024  thrpt         5    12588.803       58.935    ops/s
```

Using this test:

```
../gradlew benchmarks '-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 5 -prof GC .*PerfTransforms.flatMapTransformsUsingFrom*'
```
