### PR TITLE
Fixed testConcurrentOnNextFailsValidation

### DIFF
--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
@@ -453,8 +453,8 @@ public abstract class AbstractSchedulerTests {
 
         @Override
         public void onError(Throwable e) {
-            completed.countDown();
             error.set(e);
+            completed.countDown();
         }
 
         @Override


### PR DESCRIPTION
The two instructions need to be swapped to make sure woken-up awaiters see the error reliably.
