### PR TITLE
utility function for creating observables for closeable resources

### DIFF
--- a/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
+++ b/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
@@ -37,6 +37,7 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.util.Arrays;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -55,7 +56,7 @@ public class StringObservable {
         return from(i, 8 * 1024);
     }
     
-    private static class CloseableResource<S extends AutoCloseable> implements Subscription {
+    private static class CloseableResource<S extends Closeable> implements Subscription {
         private final AtomicBoolean unsubscribed = new AtomicBoolean();
         private S closable;
 
@@ -86,8 +87,8 @@ public class StringObservable {
      *
      * @param <R>
      */
-    public static interface UnsafeFunc0<R> {
-        public R call() throws Throwable;
+    public static interface UnsafeFunc0<R> extends Callable<R> {
+        public R call() throws Exception;
     }
 
     /**
@@ -103,7 +104,7 @@ public class StringObservable {
      *            Converts the {@link Closeable} resource into a {@link Observable} with {@link #from(InputStream)} or {@link #from(Reader)}
      * @return
      */
-    public static <R, S extends AutoCloseable> Observable<R> using(final UnsafeFunc0<S> resourceFactory,
+    public static <R, S extends Closeable> Observable<R> using(final UnsafeFunc0<S> resourceFactory,
             final Func1<S, Observable<R>> observableFactory) {
         return Observable.using(new Func0<CloseableResource<S>>() {
             @Override

--- a/rxjava-contrib/rxjava-string/src/test/java/rx/observables/StringObservableTest.java
+++ b/rxjava-contrib/rxjava-string/src/test/java/rx/observables/StringObservableTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.MalformedInputException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StringObservableTest {
@@ -303,7 +304,7 @@ public class StringObservableTest {
 
         using(new UnsafeFunc0<Reader>() {
             @Override
-            public Reader call() throws Throwable {
+            public Reader call() throws Exception {
                 return reader;
             }
         }, new Func1<Reader, Observable<String>>() {
@@ -338,7 +339,7 @@ public class StringObservableTest {
 
         using(new UnsafeFunc0<Reader>() {
             @Override
-            public Reader call() throws Throwable {
+            public Reader call() throws Exception {
                 return reader;
             }
         }, new Func1<Reader, Observable<String>>() {
@@ -362,7 +363,7 @@ public class StringObservableTest {
 
         using(new UnsafeFunc0<Reader>() {
             @Override
-            public Reader call() throws Throwable {
+            public Reader call() throws Exception {
                 return reader;
             }
         }, new Func1<Reader, Observable<String>>() {


### PR DESCRIPTION
#1199 the answer to the issue was nagging at me when I tried to recommend it recently.  I think @zsxwing's solution was ok but would fail if there were repeated subscriptions to the observable returned.  I created a utility function on StringObservable to make it easier to use `using()` for objects that implement the `AutoCloseable` interface.

PS. I made a breaking change to arguments of `join(Observable<Object>)` to `join(Observable<String>)` and added a `Observable<String> toString(Observable<Object>)` to make up for it.

PPS. I made a `UnsafeFunc0<R>` scoped to this class but I would like to have `UnsafeFunc<N>` in the rx.functions packages and have `Func<N>` extends `UnsafeFunc<N>`.   Makes it clear to the compiler that we don't expect the code the user's are giving us to always work. This also helps the users because they don't have to always fill their closures with try catch blocks

```
() -> new FileReader(file)
```

vs.

```
() -> {
    try {
        return new FileReader(file);
    } catch (Exception e) {
        throw new RuntimeException(e);
    }
}
```
