### PR TITLE
Ensure StringObservable.from() does not perform unnecessary read 

### DIFF
--- a/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
+++ b/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
@@ -71,11 +71,11 @@ public class StringObservable {
                 try {
                     if (o.isUnsubscribed())
                         return;
-                    int n = 0;
-                    n = i.read(buffer);
+                    int n = i.read(buffer);
                     while (n != -1 && !o.isUnsubscribed()) {
                         o.onNext(Arrays.copyOf(buffer, n));
-                        n = i.read(buffer);
+                        if (!o.isUnsubscribed())
+                            n = i.read(buffer);
                     }
                 } catch (IOException e) {
                     o.onError(e);


### PR DESCRIPTION
An extra check is useful to check for unsubscription because as is even `StringObservable.from(InputStream).first()` performs two reads and the second read may block. 

Added another check just before the `InputStream.read()` and simplified the initialization of `n`.
