### PR TITLE
Fix and Update JMH Perf Tests

### DIFF
--- a/rxjava-core/src/perf/java/rx/jmh/InputWithIncrementingInteger.java
+++ b/rxjava-core/src/perf/java/rx/jmh/InputWithIncrementingInteger.java
@@ -15,8 +15,6 @@
  */
 package rx.jmh;
 
-import java.util.concurrent.CountDownLatch;
-
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -27,6 +25,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Subscriber;
+import rx.observers.TestSubscriber;
 
 /**
  * Exposes an Observable and Observer that increments n Integers and consumes them in a Blackhole.
@@ -37,12 +36,11 @@ public class InputWithIncrementingInteger {
     public int size;
 
     public Observable<Integer> observable;
-    public Observer<Integer> observer;
-
-    private CountDownLatch latch;
+    private BlackHole bh;
 
     @Setup
     public void setup(final BlackHole bh) {
+        this.bh = bh;
         observable = Observable.create(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> o) {
@@ -54,13 +52,12 @@ public class InputWithIncrementingInteger {
                 o.onCompleted();
             }
         });
+    }
 
-        latch = new CountDownLatch(1);
-
-        observer = new Observer<Integer>() {
+    public TestSubscriber<Integer> newSubscriber() {
+        return new TestSubscriber<Integer>(new Observer<Integer>() {
             @Override
             public void onCompleted() {
-                latch.countDown();
             }
 
             @Override
@@ -72,11 +69,6 @@ public class InputWithIncrementingInteger {
             public void onNext(Integer value) {
                 bh.consume(value);
             }
-        };
-
-    }
-
-    public void awaitCompletion() throws InterruptedException {
-        latch.await();
+        });
     }
 }

--- a/rxjava-core/src/perf/java/rx/operators/OperatorMapPerf.java
+++ b/rxjava-core/src/perf/java/rx/operators/OperatorMapPerf.java
@@ -20,13 +20,15 @@ import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
 import rx.Observable.Operator;
 import rx.functions.Func1;
 import rx.jmh.InputWithIncrementingInteger;
+import rx.observers.TestSubscriber;
 
 public class OperatorMapPerf {
 
     @GenerateMicroBenchmark
     public void mapIdentityFunction(InputWithIncrementingInteger input) throws InterruptedException {
-        input.observable.lift(MAP_OPERATOR).subscribe(input.observer);
-        input.awaitCompletion();
+        TestSubscriber<Integer> ts = input.newSubscriber();
+        input.observable.lift(MAP_OPERATOR).subscribe(ts);
+        ts.awaitTerminalEvent();
     }
 
     private static final Func1<Integer, Integer> IDENTITY_FUNCTION = new Func1<Integer, Integer>() {

--- a/rxjava-core/src/perf/java/rx/schedulers/ComputationSchedulerPerf.java
+++ b/rxjava-core/src/perf/java/rx/schedulers/ComputationSchedulerPerf.java
@@ -18,18 +18,21 @@ package rx.schedulers;
 import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
 
 import rx.jmh.InputWithIncrementingInteger;
+import rx.observers.TestSubscriber;
 
 public class ComputationSchedulerPerf {
 
     @GenerateMicroBenchmark
     public void subscribeOn(InputWithIncrementingInteger input) throws InterruptedException {
-        input.observable.subscribeOn(Schedulers.computation()).subscribe(input.observer);
-        input.awaitCompletion();
+        TestSubscriber<Integer> ts = input.newSubscriber();
+        input.observable.subscribeOn(Schedulers.computation()).subscribe(ts);
+        ts.awaitTerminalEvent();
     }
 
     @GenerateMicroBenchmark
     public void observeOn(InputWithIncrementingInteger input) throws InterruptedException {
-        input.observable.observeOn(Schedulers.computation()).subscribe(input.observer);
-        input.awaitCompletion();
+        TestSubscriber<Integer> ts = input.newSubscriber();
+        input.observable.observeOn(Schedulers.computation()).subscribe(ts);
+        ts.awaitTerminalEvent();
     }
 }


### PR DESCRIPTION
- The tests were wrong and re-using a single Subscriber instance which meant they weren't really testing much.
- Same with the CountDownLatch which meant they weren't waiting if async.
- Added several SerializePerf and PerfTransform tests
