### PR TITLE
Remove Bad Perf Test

### DIFF
--- a/rxjava-core/src/perf/java/rx/usecases/PerfTransforms.java
+++ b/rxjava-core/src/perf/java/rx/usecases/PerfTransforms.java
@@ -90,17 +90,4 @@ public class PerfTransforms {
         input.awaitCompletion();
     }
 
-    @GenerateMicroBenchmark
-    public void flatMapAsyncNested(final UseCaseInput input) throws InterruptedException {
-        input.observable.flatMap(new Func1<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> call(Integer i) {
-                return input.observable.subscribeOn(Schedulers.computation());
-            }
-
-        }).subscribe(input.observer);
-        input.awaitCompletion();
-    }
-
 }


### PR DESCRIPTION
- this just stresses scheduling and at this throughput creates massive garbage and tests the wrong thing
