### PR TITLE
Hide ChainedSubscription/SubscriptionList from Public API

### DIFF
--- a/rxjava-core/src/main/java/rx/Subscriber.java
+++ b/rxjava-core/src/main/java/rx/Subscriber.java
@@ -15,7 +15,7 @@
  */
 package rx;
 
-import rx.subscriptions.ChainedSubscription;
+import rx.internal.util.SubscriptionList;
 import rx.subscriptions.CompositeSubscription;
 
 /**
@@ -32,27 +32,20 @@ import rx.subscriptions.CompositeSubscription;
  */
 public abstract class Subscriber<T> implements Observer<T>, Subscription {
 
-    private final ChainedSubscription cs;
+    private final SubscriptionList cs;
 
-    protected Subscriber(ChainedSubscription cs) {
-        if (cs == null) {
-            throw new IllegalArgumentException("The CompositeSubscription can not be null");
-        }
-        this.cs = cs;
-    }
-    
     @Deprecated
     protected Subscriber(CompositeSubscription cs) {
-        this(new ChainedSubscription());
+        this.cs = new SubscriptionList();
         add(cs);
     }
 
     protected Subscriber() {
-        this(new ChainedSubscription());
+        this.cs = new SubscriptionList();
     }
 
     protected Subscriber(Subscriber<?> op) {
-        this(op.cs);
+        this.cs = op.cs;
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -26,7 +26,6 @@ import rx.exceptions.OnErrorThrowable;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.observables.GroupedObservable;
-import rx.subscriptions.ChainedSubscription;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -55,7 +54,7 @@ public final class OperatorGroupBy<K, T> implements Operator<GroupedObservable<K
         public GroupBySubscriber(Func1<? super T, ? extends K> keySelector, Subscriber<? super GroupedObservable<K, T>> child) {
             // a new CompositeSubscription to decouple the subscription as the inner subscriptions need a separate lifecycle
             // and will unsubscribe on this parent if they are all unsubscribed
-            super(new ChainedSubscription());
+            super();
             this.keySelector = keySelector;
             this.child = child;
         }

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorUnsubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorUnsubscribeOn.java
@@ -19,7 +19,6 @@ import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Subscriber;
 import rx.functions.Action0;
-import rx.subscriptions.ChainedSubscription;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -36,25 +35,7 @@ public class OperatorUnsubscribeOn<T> implements Operator<T, T> {
 
     @Override
     public Subscriber<? super T> call(final Subscriber<? super T> subscriber) {
-        final ChainedSubscription parentSubscription = new ChainedSubscription();
-        subscriber.add(Subscriptions.create(new Action0() {
-
-            @Override
-            public void call() {
-                final Scheduler.Worker inner = scheduler.createWorker();
-                inner.schedule(new Action0() {
-
-                    @Override
-                    public void call() {
-                        parentSubscription.unsubscribe();
-                        inner.unsubscribe();
-                    }
-                });
-            }
-
-        }));
-
-        return new Subscriber<T>(parentSubscription) {
+        final Subscriber<T> parent = new Subscriber<T>() {
 
             @Override
             public void onCompleted() {
@@ -72,5 +53,26 @@ public class OperatorUnsubscribeOn<T> implements Operator<T, T> {
             }
 
         };
+        
+        subscriber.add(Subscriptions.create(new Action0() {
+
+            @Override
+            public void call() {
+                final Scheduler.Worker inner = scheduler.createWorker();
+                inner.schedule(new Action0() {
+
+                    @Override
+                    public void call() {
+                        parent.unsubscribe();
+                        inner.unsubscribe();
+                    }
+                });
+            }
+
+        }));
+        
+        return parent;
+
+
     }
 }

--- a/rxjava-core/src/main/java/rx/internal/util/SubscriptionList.java
+++ b/rxjava-core/src/main/java/rx/internal/util/SubscriptionList.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.subscriptions;
+package rx.internal.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,15 +29,15 @@ import rx.exceptions.CompositeException;
  * 
  * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.disposables.compositedisposable(v=vs.103).aspx">Rx.Net equivalent CompositeDisposable</a>
  */
-public final class ChainedSubscription implements Subscription {
+public final class SubscriptionList implements Subscription {
 
     private List<Subscription> subscriptions;
     private boolean unsubscribed = false;
 
-    public ChainedSubscription() {
+    public SubscriptionList() {
     }
 
-    public ChainedSubscription(final Subscription... subscriptions) {
+    public SubscriptionList(final Subscription... subscriptions) {
         this.subscriptions = new LinkedList<Subscription>(Arrays.asList(subscriptions));
     }
 
@@ -47,8 +47,8 @@ public final class ChainedSubscription implements Subscription {
     }
 
     /**
-     * Adds a new {@link Subscription} to this {@code ChainedSubscription} if the {@code ChainedSubscription} is
-     * not yet unsubscribed. If the {@code ChainedSubscription} <em>is</em> unsubscribed, {@code add} will
+     * Adds a new {@link Subscription} to this {@code SubscriptionList} if the {@code SubscriptionList} is
+     * not yet unsubscribed. If the {@code SubscriptionList} <em>is</em> unsubscribed, {@code add} will
      * indicate this by explicitly unsubscribing the new {@code Subscription} as well.
      *
      * @param s

--- a/rxjava-core/src/test/java/rx/internal/util/SubscriptionListTest.java
+++ b/rxjava-core/src/test/java/rx/internal/util/SubscriptionListTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.subscriptions;
+package rx.internal.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,13 +29,14 @@ import org.junit.Test;
 
 import rx.Subscription;
 import rx.exceptions.CompositeException;
+import rx.internal.util.SubscriptionList;
 
-public class ChainedSubscriptionTest {
+public class SubscriptionListTest {
 
     @Test
     public void testSuccess() {
         final AtomicInteger counter = new AtomicInteger();
-        ChainedSubscription s = new ChainedSubscription();
+        SubscriptionList s = new SubscriptionList();
         s.add(new Subscription() {
 
             @Override
@@ -70,7 +71,7 @@ public class ChainedSubscriptionTest {
     @Test(timeout = 1000)
     public void shouldUnsubscribeAll() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        final ChainedSubscription s = new ChainedSubscription();
+        final SubscriptionList s = new SubscriptionList();
 
         final int count = 10;
         final CountDownLatch start = new CountDownLatch(1);
@@ -117,7 +118,7 @@ public class ChainedSubscriptionTest {
     @Test
     public void testException() {
         final AtomicInteger counter = new AtomicInteger();
-        ChainedSubscription s = new ChainedSubscription();
+        SubscriptionList s = new SubscriptionList();
         s.add(new Subscription() {
 
             @Override
@@ -159,7 +160,7 @@ public class ChainedSubscriptionTest {
     @Test
     public void testCompositeException() {
         final AtomicInteger counter = new AtomicInteger();
-        ChainedSubscription s = new ChainedSubscription();
+        SubscriptionList s = new SubscriptionList();
         s.add(new Subscription() {
 
             @Override
@@ -215,7 +216,7 @@ public class ChainedSubscriptionTest {
     @Test
     public void testUnsubscribeIdempotence() {
         final AtomicInteger counter = new AtomicInteger();
-        ChainedSubscription s = new ChainedSubscription();
+        SubscriptionList s = new SubscriptionList();
         s.add(new Subscription() {
 
             @Override
@@ -241,7 +242,7 @@ public class ChainedSubscriptionTest {
     public void testUnsubscribeIdempotenceConcurrently()
             throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        final ChainedSubscription s = new ChainedSubscription();
+        final SubscriptionList s = new SubscriptionList();
 
         final int count = 10;
         final CountDownLatch start = new CountDownLatch(1);


### PR DESCRIPTION
Instead of adding this type to the public API, it hides it as an internal implementation detail and does not expose it via the `Subscriber` constructor.

If we want to expose it later we can figure out a proper name and do so.

This also changes operator implementations to not inject a `SubscriptionList` but instead just create the `Subscriber` and use it directly.
