### PR TITLE
TrampolineScheduler & Unsubscribe

### DIFF
--- a/rxjava-core/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/rxjava-core/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -83,9 +83,6 @@ public final class TrampolineScheduler extends Scheduler {
 
             if (exec) {
                 while (!queue.isEmpty()) {
-                    if (innerSubscription.isUnsubscribed()) {
-                        return Subscriptions.empty();
-                    }
                     queue.poll().action.call();
                 }
 
@@ -108,7 +105,6 @@ public final class TrampolineScheduler extends Scheduler {
 
         @Override
         public void unsubscribe() {
-            QUEUE.set(null); // this assumes we are calling unsubscribe from the same thread
             innerSubscription.unsubscribe();
         }
 


### PR DESCRIPTION
Unsubscribing should prevent new additions to a Worker, but not prevent already scheduled work, and definitely not affect other Workers using the same thread (by modifying the ThreadLocal as it was doing).

See the unit test for details of how unsubscribing 1 Worker could prevent work from being done on a completely separate Worker.
