### PR TITLE
Adding an unzip operator to split 1 observable into N observables.

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -3053,6 +3053,31 @@ public class Observable<T> {
         return just(new Observable<?>[] { o1, o2, o3, o4, o5, o6, o7, o8, o9 }).lift(new OperatorZip<R>(zipFunction));
     }
 
+    public final <T1, T2, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func2<Observable<T1>, Observable<T2>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2);
+    }
+    public final <T1, T2, T3, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func3<Observable<T1>, Observable<T2>, Observable<T3>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3);
+    }
+    public final <T1, T2, T3, T4, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func1<T, T1> select4, Func4<Observable<T1>, Observable<T2>, Observable<T3>, Observable<T4>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3, select4);
+    }
+    public final <T1, T2, T3, T4, T5, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func1<T, T1> select4, Func1<T, T1> select5, Func5<Observable<T1>, Observable<T2>, Observable<T3>, Observable<T4>, Observable<T5>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3, select4, select5);
+    }
+    public final <T1, T2, T3, T4, T5, T6, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func1<T, T1> select4, Func1<T, T1> select5, Func1<T, T1> select6, Func6<Observable<T1>, Observable<T2>, Observable<T3>, Observable<T4>, Observable<T5>, Observable<T6>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3, select4, select5, select6);
+    }
+    public final <T1, T2, T3, T4, T5, T6, T7, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func1<T, T1> select4, Func1<T, T1> select5, Func1<T, T1> select6, Func1<T, T1> select7, Func7<Observable<T1>, Observable<T2>, Observable<T3>, Observable<T4>, Observable<T5>, Observable<T6>, Observable<T7>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3, select4, select5, select6, select7);
+    }
+    public final <T1, T2, T3, T4, T5, T6, T7, T8, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func1<T, T1> select4, Func1<T, T1> select5, Func1<T, T1> select6, Func1<T, T1> select7, Func1<T, T1> select8, Func8<Observable<T1>, Observable<T2>, Observable<T3>, Observable<T4>, Observable<T5>, Observable<T6>, Observable<T7>, Observable<T8>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3, select4, select5, select6, select7, select8);
+    }
+    public final <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> R unzip(Func1<T, T1> select1, Func1<T, T1> select2, Func1<T, T1> select3, Func1<T, T1> select4, Func1<T, T1> select5, Func1<T, T1> select6, Func1<T, T1> select7, Func1<T, T1> select8, Func1<T, T1> select9, Func9<Observable<T1>, Observable<T2>, Observable<T3>, Observable<T4>, Observable<T5>, Observable<T6>, Observable<T7>, Observable<T8>, Observable<T9>, R> unzipFunc) {
+        return OperatorUnzip.unzip(this, Functions.fromFunc(unzipFunc), select1, select2, select3, select4, select5, select6, select7, select8, select9);
+    }
+    
     /**
      * Returns an Observable that emits a Boolean that indicates whether all of the items emitted by the source
      * Observable satisfy a condition.

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorUnzip.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorUnzip.java
@@ -1,0 +1,46 @@
+package rx.internal.operators;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import rx.Observable;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action1;
+import rx.functions.Func1;
+import rx.functions.FuncN;
+import rx.observables.ConnectableObservable;
+import rx.observers.SafeSubscriber;
+
+public class OperatorUnzip<T, R> {
+    public static <T, R> R unzip(Observable<T> source, FuncN<R> unzipFunc, final Func1<T, ?>... selectFuncs) {
+        final Object[] observables = new Observable[selectFuncs.length];
+
+        final ConnectableObservable<T> connectable = source.publish();
+
+        final AtomicInteger subscribeCount = new AtomicInteger(0);
+
+        for (int i = 0; i < selectFuncs.length; i++) {
+            final Func1<T, ?> selectFunc = selectFuncs[i];
+            observables[i] = Observable.create(new OnSubscribe<Object>() {
+                @Override
+                public void call(Subscriber<? super Object> child) {
+                    final SafeSubscriber<Object> s = new SafeSubscriber<Object>(child);
+
+                    connectable.map(selectFunc).unsafeSubscribe(s);
+
+                    if (subscribeCount.incrementAndGet() == selectFuncs.length) {
+                        connectable.connect(new Action1<Subscription>() {
+                            @Override
+                            public void call(Subscription t1) {
+                                s.add(t1);
+                            }
+                        });
+                    }
+                }
+            });
+        }
+
+        return unzipFunc.call(observables);
+    }
+}

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorUnzipTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorUnzipTest.java
@@ -1,0 +1,67 @@
+package rx.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.functions.Func0;
+import rx.functions.Func1;
+import rx.functions.FuncN;
+import rx.observers.TestSubscriber;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class OperatorUnzipTest {
+
+    @Test
+    public void test() {
+        class Tuple<A, B> {
+            A a;
+            B b;
+
+            public Tuple(A a, B b) {
+                this.a = a;
+                this.b = b;
+            }
+        }
+
+        final AtomicInteger start = new AtomicInteger(1);
+        Observable<Tuple<String, Integer>> source = Observable.defer(new Func0<Observable<Tuple<String, Integer>>>() {
+            @Override
+            public Observable<Tuple<String, Integer>> call() {
+                return Observable.from(new Tuple<String, Integer>("a", start.getAndIncrement()),
+                        new Tuple<String, Integer>("b", start.getAndIncrement()));
+            }
+        });
+
+        Tuple<Observable<String>, Observable<Integer>> out = OperatorUnzip.unzip(source,
+                new FuncN<Tuple<Observable<String>, Observable<Integer>>>() {
+                    @Override
+                    public Tuple<Observable<String>, Observable<Integer>> call(Object... args) {
+                        return new Tuple<Observable<String>, Observable<Integer>>((Observable<String>) args[0],
+                                (Observable<Integer>) args[1]);
+                    }
+                }, new Func1<Tuple<String, Integer>, String>() {
+                    @Override
+                    public String call(Tuple<String, Integer> t1) {
+                        return t1.a;
+                    }
+                }, new Func1<Tuple<String, Integer>, Integer>() {
+                    @Override
+                    public Integer call(Tuple<String, Integer> t1) {
+                        return t1.b;
+                    }
+                });
+
+        TestSubscriber<String> sub0 = new TestSubscriber<String>();
+        out.a.subscribe(sub0);
+        TestSubscriber<Integer> sub1 = new TestSubscriber<Integer>();
+        out.b.subscribe(sub1);
+
+        assertEquals(Arrays.asList("a", "b"), sub0.getOnNextEvents());
+        assertEquals(Arrays.asList(1, 2), sub1.getOnNextEvents());
+    }
+}


### PR DESCRIPTION
This isn't ready for merging but should work for #1317.  It's a naive implementation that bases the N observables off of ReplaySubject of the source.
