### PR TITLE
Make Future receive NoSuchElementException when the BlockingObservable is empty

### DIFF
--- a/rxjava-core/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
@@ -52,7 +52,7 @@ public class BlockingOperatorToFuture {
         final AtomicReference<T> value = new AtomicReference<T>();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
-        final Subscription s = that.subscribe(new Subscriber<T>() {
+        final Subscription s = that.single().subscribe(new Subscriber<T>() {
 
             @Override
             public void onCompleted() {
@@ -67,11 +67,8 @@ public class BlockingOperatorToFuture {
 
             @Override
             public void onNext(T v) {
-                if (!value.compareAndSet(null, v)) {
-                    // this means we received more than one value and must fail as a Future can handle only a single value
-                    error.compareAndSet(null, new IllegalStateException("Observable.toFuture() only supports sequences with a single value. Use .toList().toFuture() if multiple values are expected."));
-                    finished.countDown();
-                }
+                // "single" guarantees there is only one "onNext"
+                value.set(v);
             }
         });
 

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSingle.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSingle.java
@@ -56,6 +56,7 @@ public final class OperatorSingle<T> implements Operator<T, T> {
                 if (isNonEmpty) {
                     hasTooManyElements = true;
                     subscriber.onError(new IllegalArgumentException("Sequence contains too many elements"));
+                    unsubscribe();
                 } else {
                     this.value = value;
                     isNonEmpty = true;

--- a/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
+++ b/rxjava-core/src/main/java/rx/observables/BlockingObservable.java
@@ -405,9 +405,11 @@ public class BlockingObservable<T> {
     /**
      * Returns a {@link Future} representing the single value emitted by this {@code BlockingObservable}.
      * <p>
-     * {@code toFuture} throws an exception if the {@code BlockingObservable} emits more than one item. If the
-     * {@code BlockingObservable} may emit more than item, use
-     * {@link Observable#toList toList()}{@code .toFuture()}.
+     * If {@link BlockingObservable} emits more than one item, {@link java.util.concurrent.Future} will receive an
+     * {@link java.lang.IllegalArgumentException}. If {@link BlockingObservable} is empty, {@link java.util.concurrent.Future}
+     * will receive an {@link java.util.NoSuchElementException}.
+     * <p>
+     * If the {@code BlockingObservable} may emit more than one item, use {@code Observable.toList().toBlocking().toFuture()}.
      * <p>
      * <img width="640" height="395" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/B.toFuture.png">
      * 


### PR DESCRIPTION
Now `Future.get` will return `null` if there is a single `null` in the BlockingObservable, or it is empty. People cannot distinguish between these two cases.

This PR has 2 breaking changes:
- Throw an `NoSuchElementException` rather than returning `null` when the BlockingObservable is empty.
- Change the exception from `IllegalStateException` to `IllegalArgumentException` when the BlockingObservable emits more than one items. This is because I used `single` directly.
