### PR TITLE
RxScala: Simplify doOnCompleted/Terminate, finallyDo callback usage

### DIFF
--- a/language-adaptors/rxjava-scala/src/examples/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/language-adaptors/rxjava-scala/src/examples/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -751,22 +751,31 @@ class RxScalaDemo extends JUnitSuite {
     obs.toBlockingObservable.toIterable.last
   }
 
+  @Test def doOnCompletedExample(): Unit = {
+    val o = List("red", "green", "blue").toObservable.doOnCompleted { println("onCompleted") }
+    o.subscribe(v => println(v), e => e.printStackTrace)
+    // red
+    // green
+    // blue
+    // onCompleted
+  }
+
   @Test def doOnTerminateExample(): Unit = {
-    val o = List("red", "green", "blue").toObservable.doOnTerminate(() => println("terminate"))
+    val o = List("red", "green", "blue").toObservable.doOnTerminate { println("terminate") }
     o.subscribe(v => println(v), e => e.printStackTrace, () => println("onCompleted"))
     // red
     // green
-    // blud
+    // blue
     // terminate
     // onCompleted
   }
 
   @Test def finallyDoExample(): Unit = {
-    val o = List("red", "green", "blue").toObservable.finallyDo(() => println("finally"))
+    val o = List("red", "green", "blue").toObservable.finallyDo { println("finally") }
     o.subscribe(v => println(v), e => e.printStackTrace, () => println("onCompleted"))
     // red
     // green
-    // blud
+    // blue
     // onCompleted
     // finally
   }

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
@@ -879,8 +879,8 @@ trait Observable[+T]
    *            an function to be invoked when the source Observable finishes
    * @return an Observable that emits the same items as the source Observable, then invokes the function
    */
-  def finallyDo(action: () => Unit): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.finallyDo(action))
+  def finallyDo(action: => Unit): Observable[T] = {
+    toScalaObservable[T](asJavaObservable.finallyDo(() => action))
   }
 
   /**
@@ -3406,8 +3406,8 @@ trait Observable[+T]
    *                    `onCompleted`
    * @return the source Observable with the side-effecting behavior applied
    */
-  def doOnCompleted(onCompleted: () => Unit): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.doOnCompleted(onCompleted))
+  def doOnCompleted(onCompleted: => Unit): Observable[T] = {
+    toScalaObservable[T](asJavaObservable.doOnCompleted(() => onCompleted))
   }
 
   /**
@@ -3461,8 +3461,8 @@ trait Observable[+T]
    * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#wiki-doonterminate">RxJava Wiki: doOnTerminate()</a>
    * @see <a href="http://msdn.microsoft.com/en-us/library/hh229804.aspx">MSDN: Observable.Do</a>
    */
-  def doOnTerminate(onTerminate: () => Unit): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.doOnTerminate(onTerminate))
+  def doOnTerminate(onTerminate: => Unit): Observable[T] = {
+    toScalaObservable[T](asJavaObservable.doOnTerminate(() => onTerminate))
   }
 
   /**


### PR DESCRIPTION
As mentioned in #1342
