### PR TITLE
Don't add the subscriber to the manager if it unsubscribed during the on...

### DIFF
--- a/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/rxjava-core/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -57,8 +57,10 @@ import rx.subscriptions.Subscriptions;
         SubjectObserver<T> bo = new SubjectObserver<T>(child);
         addUnsubscriber(child, bo);
         onStart.call(bo);
-        if (add(bo) && child.isUnsubscribed()) {
-            remove(bo);
+        if (!child.isUnsubscribed()) {
+            if (add(bo) && child.isUnsubscribed()) {
+                remove(bo);
+            }
         }
     }
     /** Registers the unsubscribe action for the given subscriber. */


### PR DESCRIPTION
...Start call

This may happen, for example, when subscribing to a ReplaySubject containing some elements and taking fewer elements than available. In the original, the logic opened a small window where the SubjectSubscriber could get an onNext event even if the actual Subscriber was already unsubscribed at that point.
