### PR TITLE
DebugHook got miswired before

### DIFF
--- a/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugNotification.java
+++ b/rxjava-contrib/rxjava-debug/src/main/java/rx/plugins/DebugNotification.java
@@ -37,7 +37,7 @@ public class DebugNotification<T> {
             o = ds.getActual();
         }
         if (sourceFunc instanceof DebugHook.DebugOnSubscribe) {
-            sourceFunc = (OnSubscribe<T>) ((SafeSubscriber<T>) sourceFunc).getActual();
+            sourceFunc = ((DebugHook.DebugOnSubscribe) sourceFunc).getActual();
         }
         return new DebugNotification<T>(o, from, Kind.Subscribe, null, null, to, source, sourceFunc);
     }


### PR DESCRIPTION
This was throwing ClassCastExceptions when used.  Now it works
