### PR TITLE
Utility Class for Accessing Unsafe

### DIFF
--- a/rxjava-core/src/main/java/rx/internal/util/UnsafeAccess.java
+++ b/rxjava-core/src/main/java/rx/internal/util/UnsafeAccess.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.util;
+
+import java.lang.reflect.Field;
+
+import sun.misc.Unsafe;
+
+public class UnsafeAccess {
+    public static final Unsafe UNSAFE;
+    static {
+        try {
+            /*
+             * This mechanism for getting UNSAFE originally from:
+             * 
+             * Original License: https://github.com/JCTools/JCTools/blob/master/LICENSE
+             * Original location: https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/util/UnsafeAccess.java
+             */
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            UNSAFE = (Unsafe) field.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /*
+     * Methods below are utilities to offer functionality on top of Unsafe. Several of these already exist in Java7/8 but we must support Java 6.
+     */
+
+    public static int incrementAndGetInt(Object obj, long offset) {
+        for (;;) {
+            int current = UNSAFE.getIntVolatile(obj, offset);
+            int next = current + 1;
+            if (UNSAFE.compareAndSwapInt(obj, offset, current, next))
+                return current + 1;
+        }
+    }
+    
+    public static int getAndIncrementInt(Object obj, long offset) {
+        for (;;) {
+            int current = UNSAFE.getIntVolatile(obj, offset);
+            int next = current + 1;
+            if (UNSAFE.compareAndSwapInt(obj, offset, current, next))
+                return current;
+        }
+    }
+    
+    public static int decrementAndGetInt(Object obj, long offset) {
+        for (;;) {
+            int current = UNSAFE.getIntVolatile(obj, offset);
+            int next = current - 1;
+            if (UNSAFE.compareAndSwapInt(obj, offset, current, next))
+                return current - 1;
+        }
+    }
+    
+    public static int getAndDecrementInt(Object obj, long offset) {
+        for (;;) {
+            int current = UNSAFE.getIntVolatile(obj, offset);
+            int next = current - 1;
+            if (UNSAFE.compareAndSwapInt(obj, offset, current, next))
+                return current;
+        }
+    }
+
+    public static int getAndAddInt(Object obj, long offset, int n) {
+        for (;;) {
+            int current = UNSAFE.getIntVolatile(obj, offset);
+            int next = current + n;
+            if (UNSAFE.compareAndSwapInt(obj, offset, current, next))
+                return current;
+        }
+    }
+
+    public static int getAndSetInt(Object obj, long offset, int newValue) {
+        for (;;) {
+            int current = UNSAFE.getIntVolatile(obj, offset);
+            if (UNSAFE.compareAndSwapInt(obj, offset, current, newValue))
+                return current;
+        }
+    }
+
+    public static boolean compareAndSwapInt(Object obj, long offset, int expected, int newValue) {
+        return UNSAFE.compareAndSwapInt(obj, offset, expected, newValue);
+    }
+}


### PR DESCRIPTION
While working on code for v0.20 I have come across reasons for using sun.misc.Unsafe (such as #1372).

This provides a common way for getting access to `sun.misc.Unsafe` as well as utility methods for commonly needed APIs (that exist in Java 8, but not Java 6).

I need someone to help me confirm whether this works on Android, and if not how we can make this be aware of what platform it is running on, as per https://github.com/Netflix/RxJava/issues/1372#issuecomment-46717293
