### PR TITLE
BugFix: Pivot Concurrency

### DIFF
--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorPivotTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorPivotTest.java
@@ -13,23 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package rx.internal.operators;
 
 import java.util.Random;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
+import rx.Scheduler;
 import rx.Subscriber;
 import rx.functions.Func1;
 import rx.observables.GroupedObservable;
@@ -38,10 +41,12 @@ import rx.schedulers.Schedulers;
 
 public class OperatorPivotTest {
 
-    @Test
+    @Test(timeout=10000)
     public void testPivotEvenAndOdd() throws InterruptedException {
-        Observable<GroupedObservable<Boolean, Integer>> o1 = Observable.range(1, 10).groupBy(modKeySelector).subscribeOn(Schedulers.newThread());
-        Observable<GroupedObservable<Boolean, Integer>> o2 = Observable.range(11, 10).groupBy(modKeySelector).subscribeOn(Schedulers.newThread());
+        for(int i=0; i<1000; i++) {
+            System.out.println("------------------------------------------ testPivotEvenAndOdd -------------------------------------------");
+        Observable<GroupedObservable<Boolean, Integer>> o1 = Observable.range(1, 10).groupBy(modKeySelector).subscribeOn(Schedulers.computation());
+        Observable<GroupedObservable<Boolean, Integer>> o2 = Observable.range(11, 10).groupBy(modKeySelector).subscribeOn(Schedulers.computation());
         Observable<GroupedObservable<String, GroupedObservable<Boolean, Integer>>> groups = Observable.from(GroupedObservable.from("o1", o1), GroupedObservable.from("o2", o2));
         Observable<GroupedObservable<Boolean, GroupedObservable<String, Integer>>> pivoted = Observable.pivot(groups);
 
@@ -53,10 +58,12 @@ public class OperatorPivotTest {
 
             @Override
             public Observable<String> call(final GroupedObservable<Boolean, GroupedObservable<String, Integer>> outerGroup) {
+                System.out.println("Outer Group: " + outerGroup.getKey());
                 return outerGroup.flatMap(new Func1<GroupedObservable<String, Integer>, Observable<String>>() {
 
                     @Override
                     public Observable<String> call(final GroupedObservable<String, Integer> innerGroup) {
+                        System.out.println("Inner Group: " + innerGroup.getKey());
                         return innerGroup.map(new Func1<Integer, String>() {
 
                             @Override
@@ -94,14 +101,16 @@ public class OperatorPivotTest {
 
         });
 
-        if (!latch.await(800, TimeUnit.MILLISECONDS)) {
+        if (!latch.await(20000000, TimeUnit.MILLISECONDS)) {
             System.out.println("xxxxxxxxxxxxxxxxxx> TIMED OUT <xxxxxxxxxxxxxxxxxxxx");
             System.out.println("Received count: " + count.get());
             fail("Timed Out");
         }
 
         System.out.println("Received count: " + count.get());
+        // TODO sometimes this test fails and gets 15 instead of 20 so there is a bug somewhere
         assertEquals(20, count.get());
+        }
     }
 
     /**
@@ -112,7 +121,7 @@ public class OperatorPivotTest {
      * It's NOT easy to understand though, and easy to end up with far more data consumed than expected, because pivot by definition
      * is inverting the data so we can not unsubscribe from the parent until all children are done since the top key becomes the leaf once pivoted.
      */
-    @Test
+    @Test(timeout=10000)
     public void testUnsubscribeFromGroups() throws InterruptedException {
         AtomicInteger counter1 = new AtomicInteger();
         AtomicInteger counter2 = new AtomicInteger();
@@ -221,7 +230,7 @@ public class OperatorPivotTest {
      * 
      * Then a subsequent step can merge them if desired and add serialization, such as merge(even.o1, even.o2) to become a serialized "even"
      */
-    @Test
+    @Test(timeout=10000)
     public void testConcurrencyAndSerialization() throws InterruptedException {
         final AtomicInteger maxOuterConcurrency = new AtomicInteger();
         final AtomicInteger maxGroupConcurrency = new AtomicInteger();


### PR DESCRIPTION
It wasn't serializing the `onNext`.
