### PR TITLE
Explore SubscriptionList/Subscriber & Synchronization

### DIFF
--- a/rxjava-core/src/main/java/rx/internal/util/SubscriptionList.java
+++ b/rxjava-core/src/main/java/rx/internal/util/SubscriptionList.java
@@ -52,23 +52,16 @@ public final class SubscriptionList implements Subscription {
      * indicate this by explicitly unsubscribing the new {@code Subscription} as well.
      *
      * @param s
-     *          the {@link Subscription} to add
+     *            the {@link Subscription} to add
      */
     public void add(final Subscription s) {
-        Subscription unsubscribe = null;
-        synchronized (this) {
-            if (unsubscribed) {
-                unsubscribe = s;
-            } else {
-                if (subscriptions == null) {
-                    subscriptions = new LinkedList<Subscription>();
-                }
-                subscriptions.add(s);
+        if (unsubscribed) {
+            s.unsubscribe();
+        } else {
+            if (subscriptions == null) {
+                subscriptions = new LinkedList<Subscription>();
             }
-        }
-        if (unsubscribe != null) {
-            // call after leaving the synchronized block so we're not holding a lock while executing this
-            unsubscribe.unsubscribe();
+            subscriptions.add(s);
         }
     }
 
@@ -78,14 +71,13 @@ public final class SubscriptionList implements Subscription {
      */
     @Override
     public void unsubscribe() {
-        synchronized (this) {
-            if (unsubscribed) {
-                return;
-            }
-            unsubscribed = true;
+        if (unsubscribed) {
+            return;
         }
+        unsubscribed = true;
         // we will only get here once
         unsubscribeFromAll(subscriptions);
+        subscriptions = null;
     }
 
     private static void unsubscribeFromAll(Collection<Subscription> subscriptions) {

--- a/rxjava-core/src/main/java/rx/internal/util/SynchronizedSubscription.java
+++ b/rxjava-core/src/main/java/rx/internal/util/SynchronizedSubscription.java
@@ -1,0 +1,23 @@
+package rx.internal.util;
+
+import rx.Subscription;
+
+public class SynchronizedSubscription implements Subscription {
+
+    private final Subscription s;
+
+    public SynchronizedSubscription(Subscription s) {
+        this.s = s;
+    }
+
+    @Override
+    public synchronized void unsubscribe() {
+        s.unsubscribe();
+    }
+
+    @Override
+    public synchronized boolean isUnsubscribed() {
+        return s.isUnsubscribed();
+    }
+
+}


### PR DESCRIPTION
This is an exploratory pull request related to https://github.com/Netflix/RxJava/issues/1383 that removes SubscriptionList synchronization and synchronizes ObserveOn.unsubscribe.

The performance impact on rapid subscribe/unsubscribe (such as an `Observable` with 1 item) is significant (31m -> 47m ops/second).

What I don't know however is if this is completely safe. Some unit tests did indeed fail when I removed the synchronization from `SubscriptionList` until I modified `observeOn` – so that's good. Then the unit tests all passed again when I made `observeOn` handle the synchronization. I have to think however that there are use cases I'm not covering with unit tests. 

I'd appreciate other peoples thoughts on this.

```
BEFORE

Benchmark                               (size)   Mode   Samples         Mean   Mean error    Units
r.PerfBaseline.observableConsumption         1  thrpt         5 31167007.424  2027918.084    ops/s
r.PerfBaseline.observableConsumption      1000  thrpt         5   227387.447    32738.021    ops/s
r.PerfBaseline.observableConsumption   1000000  thrpt         5      245.632       13.743    ops/s

AFTER

Benchmark                               (size)   Mode   Samples         Mean   Mean error    Units
r.PerfBaseline.observableConsumption         1  thrpt         5 47142418.802  5341223.740    ops/s
r.PerfBaseline.observableConsumption      1000  thrpt         5   220175.324    35936.506    ops/s
r.PerfBaseline.observableConsumption   1000000  thrpt         5      221.077       44.437    ops/s
```

BEFORE

```
Benchmark                                         (size)   Mode   Samples         Mean   Mean error    Units
r.o.OperatorObserveOnPerf.observeOnComputation         1  thrpt         5    86331.092     5181.739    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation      1000  thrpt         5     8787.634      316.166    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation   1000000  thrpt         5        8.590        4.527    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate           1  thrpt         5 13074710.596   217808.611    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate        1000  thrpt         5   188868.055     5448.065    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate     1000000  thrpt         5      185.372        4.190    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread           1  thrpt         5    13848.943     2601.271    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread        1000  thrpt         5     6867.300      172.123    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread     1000000  thrpt         5       10.100        1.925    ops/s

AFTER

Benchmark                                         (size)   Mode   Samples         Mean   Mean error    Units
r.o.OperatorObserveOnPerf.observeOnComputation         1  thrpt         5    69120.389    16422.228    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation      1000  thrpt         5    12261.472      267.137    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation   1000000  thrpt         5       15.466        0.269    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate           1  thrpt         5 13200910.511   418278.691    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate        1000  thrpt         5   179868.400     6465.965    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate     1000000  thrpt         5      184.210        2.299    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread           1  thrpt         5    12880.951     2183.905    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread        1000  thrpt         5     9164.764      385.580    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread     1000000  thrpt         5       17.249        1.173    ops/s
```
