### PR TITLE
add Observable.sort() instance methods

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -7981,6 +7981,52 @@ public class Observable<T> {
     public final Observable<List<T>> toSortedList(Func2<? super T, ? super T, Integer> sortFunction) {
         return lift(new OperatorToObservableSortedList<T>(sortFunction));
     }
+    
+    /**
+     * Returns an Observable that emits the items emitted by the source Observable in a
+     * sorted order. Each item emitted by the Observable must implement {@link Comparable} with respect to all
+     * other items in the sequence.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toSortedList.png">
+     * <p>
+     * {@code sort} does not operate by default on a particular {@link Scheduler}.
+     * 
+     * @throws ClassCastException
+     *             if any item emitted by the Observable does not implement {@link Comparable} with respect to
+     *             all other items emitted by the Observable
+     * @return an Observable that emits the items emitted by the source Observable in
+     *         sorted order
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#sort">RxJava Wiki: sort()</a>
+     */
+    public final Observable<T> sort() {
+        return toSortedList().flatMap(new Func1<List<T>,Observable<T>>() {
+            @Override
+            public Observable<T> call(List<T> list) {
+                return from(list);
+            }});
+    }
+    
+    /**
+     * Returns an Observable that emits the items emitted by the source Observable in a
+     * sorted order based on a specified comparison function.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toSortedList.f.png">
+     * <p>
+     * {@code sort} does not operate by default on a particular {@link Scheduler}.
+     * 
+     * @param sortFunction
+     *            a function that compares two items emitted by the source Observable and returns an Integer
+     *            that indicates their sort order
+     * @return an Observable that emits the items emitted by the source Observable in sorted order
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Mathematical-and-Aggregate-Operators#sort">RxJava Wiki: sort()</a>
+     */
+    public final Observable<T> sort(Func2<? super T, ? super T, Integer> sortFunction) {
+        return toSortedList(sortFunction).flatMap(new Func1<List<T>,Observable<T>>() {
+            @Override
+            public Observable<T> call(List<T> list) {
+                return from(list);
+            }});
+    }
 
     /**
      * Modifies the source Observable so that subscribers will unsubscribe from it on a specified

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
@@ -33,11 +33,45 @@ import rx.internal.operators.OperatorToObservableSortedList;
 
 public class OperatorToObservableSortedListTest {
 
+    
+    private static final Func2<Integer, Integer, Integer> SORT_FUNCTION = new Func2<Integer, Integer, Integer>() {
+
+        @Override
+        public Integer call(Integer t1, Integer t2) {
+            return t2 - t1;
+        }
+    };
+    
+    
     @Test
     public void testSortedList() {
         Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
         Observable<List<Integer>> observable = w.lift(new OperatorToObservableSortedList<Integer>());
+        verifySortedList(observable);
+    }
 
+    @Test
+    public void testSortedListWithCustomFunction() {
+        Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.lift(new OperatorToObservableSortedList<Integer>(SORT_FUNCTION));
+        verifySortedListWithCustomFunction(observable);
+    }
+    
+    @Test
+    public void testSort() {
+        Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.sort().toList();
+        verifySortedList(observable);
+    }
+    
+    @Test
+    public void testSortWithCustomFunction() {
+        Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.sort(SORT_FUNCTION).toList();
+        verifySortedListWithCustomFunction(observable);
+    }
+    
+    private void verifySortedList(Observable<List<Integer>> observable) {
         @SuppressWarnings("unchecked")
         Observer<List<Integer>> observer = mock(Observer.class);
         observable.subscribe(observer);
@@ -46,18 +80,7 @@ public class OperatorToObservableSortedListTest {
         verify(observer, times(1)).onCompleted();
     }
 
-    @Test
-    public void testSortedListWithCustomFunction() {
-        Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
-        Observable<List<Integer>> observable = w.lift(new OperatorToObservableSortedList<Integer>(new Func2<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer call(Integer t1, Integer t2) {
-                return t2 - t1;
-            }
-
-        }));
-
+    private void verifySortedListWithCustomFunction(Observable<List<Integer>> observable) {
         @SuppressWarnings("unchecked")
         Observer<List<Integer>> observer = mock(Observer.class);
         observable.subscribe(observer);
@@ -65,4 +88,6 @@ public class OperatorToObservableSortedListTest {
         verify(observer, Mockito.never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
+    
+    
 }


### PR DESCRIPTION
Added two `Observable.sort` instance methods that are equivalent to 

``` java
Observable.toSortedList().flatMap(x -> Observable.from(x))
```

I guess you might ask well why don't people just code that. I think it adds the following:
- a more natural reading api method
- doesn't interrupt the observable flow with buffered type `Observable<List<T>>`
- less mess for those people coding without lambdas
