### PR TITLE
Zip with backpressure support

### DIFF
--- a/rxjava-core/src/main/java/rx/Subscriber.java
+++ b/rxjava-core/src/main/java/rx/Subscriber.java
@@ -79,6 +79,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
      * 
      * @return {@code true} if this Subscriber has unsubscribed from its subscriptions, {@code false} otherwise
      */
+    @Override
     public final boolean isUnsubscribed() {
         return cs.isUnsubscribed();
     }
@@ -108,9 +109,10 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
 
     public final void setProducer(Producer producer) {
         producer = onSetProducer(producer);
-        int toRequest = requested;
+        int toRequest;
         boolean setProducer = false;
         synchronized (this) {
+            toRequest = requested;
             p = producer;
             if (op != null) {
                 // middle operator ... we pass thru unless a request has been made


### PR DESCRIPTION
If I understand the backpressure correctly, zip with backpressure is relatively simple: if the client requests N items, it is forwarded to all sources because they would need to produce N events each in order to get N events zipped. Since N may vary, bounded buffering may not be feasible. 

In addition, I'm not sure what type of typical backpressure tests should be written so I only included a simple one.

I've also fixed the unsynchronized read of `requested` in `Subscriber.setProducer`.
