### PR TITLE
Concurrency Fixes for RxRingBuffer & Merge

### DIFF
--- a/rxjava-core/src/main/java/rx/Subscriber.java
+++ b/rxjava-core/src/main/java/rx/Subscriber.java
@@ -108,9 +108,10 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
 
     public final void setProducer(Producer producer) {
         producer = onSetProducer(producer);
-        int toRequest = requested;
+        int toRequest;
         boolean setProducer = false;
         synchronized (this) {
+            toRequest = requested;
             p = producer;
             if (op != null) {
                 // middle operator ... we pass thru unless a request has been made

--- a/rxjava-core/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/rxjava-core/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -25,6 +25,10 @@ import rx.internal.util.unsafe.SpmcArrayQueue;
 import rx.internal.util.unsafe.SpscArrayQueue;
 import rx.internal.util.unsafe.UnsafeAccess;
 
+/**
+ * This assumes Spsc or Spmc usage. This means only a single producer calling the on* methods. This is the Rx contract of an Observer.
+ * Concurrent invocations of on* methods will not be thread-safe.
+ */
 public class RxRingBuffer implements Subscription {
 
     public static RxRingBuffer getSpscInstance() {
@@ -70,6 +74,29 @@ public class RxRingBuffer implements Subscription {
      * Benchmark                                        Mode   Samples        Score  Score error    Units
      * r.i.RxRingBufferPerf.ringBufferAddRemove1       thrpt         5 23951121.098  1982380.330    ops/s
      * r.i.RxRingBufferPerf.ringBufferAddRemove1000    thrpt         5     1142.351       33.592    ops/s
+     * 
+     * With SynchronizedQueue (synchronized LinkedList)
+     * 
+     * r.i.RxRingBufferPerf.createUseAndDestroy1       thrpt         5 33231667.136   685757.510    ops/s
+     * r.i.RxRingBufferPerf.createUseAndDestroy1000    thrpt         5    74623.614     5493.766    ops/s
+     * r.i.RxRingBufferPerf.ringBufferAddRemove1       thrpt         5 22907359.257   707026.632    ops/s
+     * r.i.RxRingBufferPerf.ringBufferAddRemove1000    thrpt         5    22222.410      320.829    ops/s
+     * 
+     * With ArrayBlockingQueue
+     * 
+     * Benchmark                                            Mode   Samples        Score  Score error    Units
+     * r.i.RxRingBufferPerf.createUseAndDestroy1       thrpt         5  2389804.664    68990.804    ops/s
+     * r.i.RxRingBufferPerf.createUseAndDestroy1000    thrpt         5    27384.274     1411.789    ops/s
+     * r.i.RxRingBufferPerf.ringBufferAddRemove1       thrpt         5 26497037.559    91176.247    ops/s
+     * r.i.RxRingBufferPerf.ringBufferAddRemove1000    thrpt         5    17985.144      237.771    ops/s
+     * 
+     * With ArrayBlockingQueue and Object Pool
+     * 
+     * Benchmark                                            Mode   Samples        Score  Score error    Units
+     * r.i.RxRingBufferPerf.createUseAndDestroy1       thrpt         5 12465685.522   399070.770    ops/s
+     * r.i.RxRingBufferPerf.createUseAndDestroy1000    thrpt         5    27701.294      395.217    ops/s
+     * r.i.RxRingBufferPerf.ringBufferAddRemove1       thrpt         5 26399625.086   695639.436    ops/s
+     * r.i.RxRingBufferPerf.ringBufferAddRemove1000    thrpt         5    17985.427      253.190    ops/s
      * 
      * With SpscArrayQueue (single consumer, so failing 1 unit test)
      *  - requires access to Unsafe
@@ -130,7 +157,15 @@ public class RxRingBuffer implements Subscription {
     private final int size;
     private final ObjectPool<Queue<Object>> pool;
 
-    private volatile Object terminalState;
+    /**
+     * We store the terminal state separately so it doesn't count against the size.
+     * We don't just +1 the size since some of the queues require sizes that are a power of 2.
+     * This is a subjective thing ... wanting to keep the size (ie 1024) the actual number of onNext
+     * that can be sent rather than something like 1023 onNext + 1 terminal event. It also simplifies
+     * checking that we have received only 1 terminal event, as we don't need to peek at the last item
+     * or retain a boolean flag.
+     */
+    public volatile Object terminalState;
 
     public static final int SIZE = 1024;
 
@@ -233,7 +268,22 @@ public class RxRingBuffer implements Subscription {
         }
         Object o;
         o = queue.poll();
-        if (o == null && terminalState != null) {
+        /*
+         * benjchristensen July 10 2014 => The check for 'queue.size() == 0' came from a very rare concurrency bug where poll()
+         * is invoked, then an "onNext + onCompleted/onError" arrives before hitting the if check below. In that case,
+         * "o == null" and there is a terminal state, but now "queue.size() > 0" and we should NOT return the terminalState.
+         * 
+         * The queue.size() check is a double-check that works to handle this, without needing to synchronize poll with on*
+         * or needing to enqueue terminalState.
+         * 
+         * This did make me consider eliminating the 'terminalState' ref and enqueuing it ... but then that requires
+         * a +1 of the size, or -1 of how many onNext can be sent. See comment on 'terminalState' above for why it
+         * is currently the way it is.
+         * 
+         * This performs fine as long as we don't use a queue implementation where the size() impl has to scan the whole list,
+         * such as ConcurrentLinkedQueue.
+         */
+        if (o == null && terminalState != null && queue.size() == 0) {
             o = terminalState;
             // once emitted we clear so a poll loop will finish
             terminalState = null;


### PR DESCRIPTION
Possible fix for #1420

I was unable to exactly reproduce the issue, but was able to create a possibly related one. This fixes it.
It also simplifies the logic and code somewhat, at a possible small performance cost for these:

```
r.o.OperatorMergePerf.merge1SyncStreamOfN            1000  thrpt         5    59407.716     2073.945    ops/s
r.o.OperatorMergePerf.merge1SyncStreamOfN         1000000  thrpt         5       66.557        2.693    ops/s
r.o.OperatorMergePerf.mergeNSyncStreamsOfN           1000  thrpt         5       59.293        5.046    ops/s
```
