### PR TITLE
Changed producer interface to work with long instead of int

### DIFF
--- a/rxjava-core/src/main/java/rx/Producer.java
+++ b/rxjava-core/src/main/java/rx/Producer.java
@@ -17,6 +17,6 @@ package rx;
 
 public interface Producer {
 
-    public void request(int n);
+    public void request(long n);
 
 }

--- a/rxjava-core/src/main/java/rx/Subscriber.java
+++ b/rxjava-core/src/main/java/rx/Subscriber.java
@@ -38,7 +38,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
     /* protected by `this` */
     private Producer p;
     /* protected by `this` */
-    private int requested = Integer.MIN_VALUE; // default to not set
+    private long requested = Long.MIN_VALUE; // default to not set
 
     @Deprecated
     protected Subscriber(CompositeSubscription cs) {
@@ -87,7 +87,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
         // do nothing by default
     }
     
-    public final void request(int n) {
+    public final void request(long n) {
         Producer shouldRequest = null;
         synchronized (this) {
             if (p != null) {
@@ -108,14 +108,14 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
 
     public final void setProducer(Producer producer) {
         producer = onSetProducer(producer);
-        int toRequest;
+        long toRequest;
         boolean setProducer = false;
         synchronized (this) {
             toRequest = requested;
             p = producer;
             if (op != null) {
                 // middle operator ... we pass thru unless a request has been made
-                if (toRequest == Integer.MIN_VALUE) {
+                if (toRequest == Long.MIN_VALUE) {
                     // we pass-thru to the next producer as nothing has been requested
                     setProducer = true;
                 }
@@ -127,7 +127,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
             op.setProducer(p);
         } else {
             // we execute the request with whatever has been requested (or -1)
-            if (toRequest == Integer.MIN_VALUE) {
+            if (toRequest == Long.MIN_VALUE) {
                 p.request(-1);
             } else {
                 p.request(toRequest);

--- a/rxjava-core/src/main/java/rx/internal/operators/OnSubscribeRange.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OnSubscribeRange.java
@@ -15,7 +15,7 @@
  */
 package rx.internal.operators;
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import rx.Observable.OnSubscribe;
 import rx.Producer;
@@ -43,9 +43,9 @@ public final class OnSubscribeRange implements OnSubscribe<Integer> {
         private final Subscriber<? super Integer> o;
         @SuppressWarnings("unused")
         // accessed by REQUESTED_UPDATER
-        private volatile int requested;
-        private static final AtomicIntegerFieldUpdater<RangeProducer> REQUESTED_UPDATER = AtomicIntegerFieldUpdater.newUpdater(RangeProducer.class, "requested");
-        private int index;
+        private volatile long requested;
+        private static final AtomicLongFieldUpdater<RangeProducer> REQUESTED_UPDATER = AtomicLongFieldUpdater.newUpdater(RangeProducer.class, "requested");
+        private long index;
         private final int end;
 
         private RangeProducer(Subscriber<? super Integer> o, int start, int end) {
@@ -55,36 +55,36 @@ public final class OnSubscribeRange implements OnSubscribe<Integer> {
         }
 
         @Override
-        public void request(int n) {
+        public void request(long n) {
             if (n < 0) {
                 // fast-path without backpressure
-                for (int i = index; i <= end; i++) {
+                for (long i = index; i <= end; i++) {
                     if (o.isUnsubscribed()) {
                         return;
                     }
-                    o.onNext(i);
+                    o.onNext((int) i);
                 }
                 o.onCompleted();
             } else if (n > 0) {
                 // backpressure is requested
-                int _c = REQUESTED_UPDATER.getAndAdd(this, n);
+                long _c = REQUESTED_UPDATER.getAndAdd(this, n);
                 if (_c == 0) {
                     while (true) {
                         /*
                          * This complicated logic is done to avoid touching the volatile `index` and `requested` values
                          * during the loop itself. If they are touched during the loop the performance is impacted significantly.
                          */
-                        int r = requested;
-                        int idx = index;
-                        int numLeft = end - idx + 1;
-                        int e = Math.min(numLeft, r);
+                        long r = requested;
+                        long idx = index;
+                        long numLeft = end - idx + 1;
+                        long e = Math.min(numLeft, r);
                         boolean completeOnFinish = numLeft <= r;
-                        int stopAt = e + idx;
-                        for (int i = idx; i < stopAt; i++) {
+                        long stopAt = e + idx;
+                        for (long i = idx; i < stopAt; i++) {
                             if (o.isUnsubscribed()) {
                                 return;
                             }
-                            o.onNext(i);
+                            o.onNext((int) i);
                         }
                         index = stopAt;
                         

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -386,7 +386,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
         static final AtomicLongFieldUpdater<MergeProducer> REQUESTED = AtomicLongFieldUpdater.newUpdater(MergeProducer.class, "requested");
 
         @Override
-        public void request(int n) {
+        public void request(long n) {
             if (n < 0) {
                 requested = -1;
             } else {

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -90,7 +90,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
             child.setProducer(new Producer() {
 
                 @Override
-                public void request(int n) {
+                public void request(long n) {
                     REQUESTED.getAndAdd(ObserveOnSubscriber.this, n);
                     schedule();
                 }

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
@@ -15,7 +15,7 @@
  */
 package rx.internal.operators;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Observable.Operator;
 import rx.Producer;
@@ -25,12 +25,12 @@ public class OperatorOnBackpressureDrop<T> implements Operator<T, T> {
 
     @Override
     public Subscriber<? super T> call(final Subscriber<? super T> child) {
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
 
         child.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 requested.getAndAdd(n);
             }
 

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSkip.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSkip.java
@@ -66,7 +66,7 @@ public final class OperatorSkip<T> implements Observable.Operator<T, T> {
                 return new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         // add the skip num to the requested amount, since we'll skip everything and then emit to the buffer downstream
                         if (n > 0) {
                             producer.request(n + (toSkip - skipped));

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
@@ -81,7 +81,7 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
                                 return new Producer() {
 
                                     @Override
-                                    public void request(final int n) {
+                                    public void request(final long n) {
                                         if (Thread.currentThread() == t) {
                                             // don't schedule if we're already on the thread (primarily for first setProducer call)
                                             // see unit test 'testSetProducerSynchronousRequest' for more context on this

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorTake.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorTake.java
@@ -78,8 +78,8 @@ public final class OperatorTake<T> implements Operator<T, T> {
                 return new Producer() {
 
                     @Override
-                    public void request(int n) {
-                        int c = limit - count;
+                    public void request(long n) {
+                        long c = limit - count;
                         if (n < c) {
                             producer.request(n);
                         } else {
@@ -113,7 +113,7 @@ public final class OperatorTake<T> implements Operator<T, T> {
         child.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 if (n < 0) {
                     // request up the limit that has been set, no point in asking for more, even if synchronous
                     parent.request(limit);

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorTakeLast.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorTakeLast.java
@@ -17,7 +17,7 @@ package rx.internal.operators;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import rx.Observable.Operator;
 import rx.Producer;
@@ -96,9 +96,9 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
             this.subscriber = subscriber;
         }
 
-        private volatile int requested = 0;
+        private volatile long requested = 0;
         @SuppressWarnings("rawtypes")
-        private static final AtomicIntegerFieldUpdater<QueueProducer> REQUESTED_UPDATER = AtomicIntegerFieldUpdater.newUpdater(QueueProducer.class, "requested");
+        private static final AtomicLongFieldUpdater<QueueProducer> REQUESTED_UPDATER = AtomicLongFieldUpdater.newUpdater(QueueProducer.class, "requested");
 
         void startEmitting() {
             if (!emittingStarted) {
@@ -108,8 +108,8 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
         }
 
         @Override
-        public void request(int n) {
-            int _c = 0;
+        public void request(long n) {
+            long _c = 0;
             if (n < 0) {
                 requested = -1;
             } else {
@@ -122,7 +122,7 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
             emit(_c);
         }
 
-        void emit(int previousRequested) {
+        void emit(long previousRequested) {
             if (requested < 0) {
                 // fast-path without backpressure
                 try {
@@ -142,7 +142,7 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
                          * This complicated logic is done to avoid touching the volatile `requested` value
                          * during the loop itself. If it is touched during the loop the performance is impacted significantly.
                          */
-                        int numToEmit = requested;
+                        long numToEmit = requested;
                         int emitted = 0;
                         Object o;
                         while (--numToEmit >= 0 && (o = deque.poll()) != null) {

--- a/rxjava-core/src/test/java/rx/BackpressureTests.java
+++ b/rxjava-core/src/test/java/rx/BackpressureTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -452,7 +453,7 @@ public class BackpressureTests {
     private static Observable<Integer> incrementingIntegers(final AtomicInteger counter, final ConcurrentLinkedQueue<Thread> threadsSeen) {
         return Observable.create(new OnSubscribe<Integer>() {
 
-            final AtomicInteger requested = new AtomicInteger();
+            final AtomicLong requested = new AtomicLong();
 
             @Override
             public void call(final Subscriber<? super Integer> s) {
@@ -460,7 +461,7 @@ public class BackpressureTests {
                     int i = 0;
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         if (n == 0) {
                             // nothing to do
                             return;
@@ -468,7 +469,7 @@ public class BackpressureTests {
                         if (threadsSeen != null) {
                             threadsSeen.offer(Thread.currentThread());
                         }
-                        int _c = requested.getAndAdd(n);
+                        long _c = requested.getAndAdd(n);
                         if (_c == 0) {
                             while (!s.isUnsubscribed()) {
                                 s.onNext(i++);

--- a/rxjava-core/src/test/java/rx/SubscriberTest.java
+++ b/rxjava-core/src/test/java/rx/SubscriberTest.java
@@ -18,6 +18,7 @@ package rx;
 import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -36,11 +37,11 @@ public class SubscriberTest {
     public void testRequestFromFinalSubscribeWithRequestValue() {
         Subscriber<String> s = new TestSubscriber<String>();
         s.request(10);
-        final AtomicInteger r = new AtomicInteger();
+        final AtomicLong r = new AtomicLong();
         s.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 r.set(n);
             }
 
@@ -54,11 +55,11 @@ public class SubscriberTest {
     @Test
     public void testRequestFromFinalSubscribeWithoutRequestValue() {
         Subscriber<String> s = new TestSubscriber<String>();
-        final AtomicInteger r = new AtomicInteger();
+        final AtomicLong r = new AtomicLong();
         s.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 r.set(n);
             }
 
@@ -97,13 +98,13 @@ public class SubscriberTest {
         s.request(10);
         Subscriber<? super String> ns = o.call(s);
 
-        final AtomicInteger r = new AtomicInteger();
+        final AtomicLong r = new AtomicLong();
         // set set the producer at the top of the chain (ns) and it should flow through the operator to the (s) subscriber
         // and then it should request up with the value set on the final Subscriber (s)
         ns.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 r.set(n);
             }
 
@@ -142,13 +143,13 @@ public class SubscriberTest {
         s.request(10);
         Subscriber<? super String> ns = o.call(s);
 
-        final AtomicInteger r = new AtomicInteger();
+        final AtomicLong r = new AtomicLong();
         // set set the producer at the top of the chain (ns) and it should flow through the operator to the (s) subscriber
         // and then it should request up with the value set on the final Subscriber (s)
         ns.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 r.set(n);
             }
 
@@ -160,7 +161,7 @@ public class SubscriberTest {
     @Test
     public void testRequestFromDecoupledOperatorThatRequestsN() {
         Subscriber<String> s = new TestSubscriber<String>();
-        final AtomicInteger innerR = new AtomicInteger();
+        final AtomicLong innerR = new AtomicLong();
         Operator<String, String> o = new Operator<String, String>() {
 
             @Override
@@ -169,7 +170,7 @@ public class SubscriberTest {
                 child.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         innerR.set(n);
                     }
 
@@ -202,13 +203,13 @@ public class SubscriberTest {
         s.request(10);
         Subscriber<? super String> ns = o.call(s);
 
-        final AtomicInteger r = new AtomicInteger();
+        final AtomicLong r = new AtomicLong();
         // set set the producer at the top of the chain (ns) and it should flow through the operator to the (s) subscriber
         // and then it should request up with the value set on the final Subscriber (s)
         ns.setProducer(new Producer() {
 
             @Override
-            public void request(int n) {
+            public void request(long n) {
                 r.set(n);
             }
 
@@ -221,7 +222,7 @@ public class SubscriberTest {
     public void testRequestToObservable() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
             @Override
@@ -229,7 +230,7 @@ public class SubscriberTest {
                 s.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested.set(n);
                     }
 
@@ -244,7 +245,7 @@ public class SubscriberTest {
     public void testRequestThroughMap() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
             @Override
@@ -252,7 +253,7 @@ public class SubscriberTest {
                 s.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested.set(n);
                     }
 
@@ -274,7 +275,7 @@ public class SubscriberTest {
     public void testRequestThroughTakeThatReducesRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
             @Override
@@ -282,7 +283,7 @@ public class SubscriberTest {
                 s.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested.set(n);
                     }
 
@@ -297,7 +298,7 @@ public class SubscriberTest {
     public void testRequestThroughTakeWhereRequestIsSmallerThanTake() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
             @Override
@@ -305,7 +306,7 @@ public class SubscriberTest {
                 s.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested.set(n);
                     }
 
@@ -318,8 +319,8 @@ public class SubscriberTest {
 
     @Test
     public void testSetProducerFromOperator() {
-        final AtomicInteger requested1 = new AtomicInteger();
-        final AtomicInteger requested2 = new AtomicInteger();
+        final AtomicLong requested1 = new AtomicLong();
+        final AtomicLong requested2 = new AtomicLong();
         final AtomicReference<Producer> producer1 = new AtomicReference<Producer>();
         final AtomicReference<Producer> producer2 = new AtomicReference<Producer>();
         final AtomicReference<Producer> gotProducer = new AtomicReference<Producer>();
@@ -331,7 +332,7 @@ public class SubscriberTest {
                     int index = 0;
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested1.set(n);
                         System.out.println("onSubscribe => requested: " + n);
                         for (int i = 0; i < n; i++) {
@@ -352,7 +353,7 @@ public class SubscriberTest {
                 Producer p2 = new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         System.out.println("lift => requested: " + n);
                         requested2.set(n);
                     }
@@ -424,8 +425,8 @@ public class SubscriberTest {
 
     @Test
     public void testSetProducerFromOperatorWithUnsafeSubscribe() {
-        final AtomicInteger requested1 = new AtomicInteger();
-        final AtomicInteger requested2 = new AtomicInteger();
+        final AtomicLong requested1 = new AtomicLong();
+        final AtomicLong requested2 = new AtomicLong();
         final AtomicReference<Producer> producer1 = new AtomicReference<Producer>();
         final AtomicReference<Producer> producer2 = new AtomicReference<Producer>();
         final AtomicReference<Producer> gotProducer = new AtomicReference<Producer>();
@@ -437,7 +438,7 @@ public class SubscriberTest {
                     int index = 0;
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested1.set(n);
                         System.out.println("onSubscribe => requested: " + n);
                         for (int i = 0; i < n; i++) {
@@ -458,7 +459,7 @@ public class SubscriberTest {
                 Producer p2 = new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         System.out.println("lift => requested: " + n);
                         requested2.set(n);
                     }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 
@@ -226,11 +227,11 @@ public class OperatorSubscribeOnTest {
 
             @Override
             public Subscriber<? super Integer> call(final Subscriber<? super Integer> child) {
-                final AtomicInteger requested = new AtomicInteger();
+                final AtomicLong requested = new AtomicLong();
                 child.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         if (!requested.compareAndSet(0, n)) {
                             child.onError(new RuntimeException("Expected to receive request before onNext but didn't"));
                         }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeTest.java
@@ -321,7 +321,7 @@ public class OperatorTakeTest {
     public void testProducerRequestThroughTake() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
             @Override
@@ -329,7 +329,7 @@ public class OperatorTakeTest {
                 s.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested.set(n);
                     }
 
@@ -344,7 +344,7 @@ public class OperatorTakeTest {
     public void testProducerRequestThroughTakeIsModified() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
-        final AtomicInteger requested = new AtomicInteger();
+        final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
             @Override
@@ -352,7 +352,7 @@ public class OperatorTakeTest {
                 s.setProducer(new Producer() {
 
                     @Override
-                    public void request(int n) {
+                    public void request(long n) {
                         requested.set(n);
                     }
 

--- a/rxjava-core/src/test/java/rx/internal/util/RxRingBufferSpmcTest.java
+++ b/rxjava-core/src/test/java/rx/internal/util/RxRingBufferSpmcTest.java
@@ -57,7 +57,7 @@ public class RxRingBufferSpmcTest extends RxRingBufferBase {
             AtomicInteger c = new AtomicInteger();
 
             @Override
-            public void request(final int n) {
+            public void request(final long n) {
                 System.out.println("request[" + c.incrementAndGet() + "]: " + n + "  Thread: " + Thread.currentThread());
                 w1.schedule(new Action0() {
 

--- a/rxjava-core/src/test/java/rx/internal/util/RxRingBufferWithoutUnsafeTest.java
+++ b/rxjava-core/src/test/java/rx/internal/util/RxRingBufferWithoutUnsafeTest.java
@@ -57,7 +57,7 @@ public class RxRingBufferWithoutUnsafeTest extends RxRingBufferBase {
             AtomicInteger c = new AtomicInteger();
 
             @Override
-            public void request(final int n) {
+            public void request(final long n) {
                 System.out.println("request[" + c.incrementAndGet() + "]: " + n + "  Thread: " + Thread.currentThread());
                 w1.schedule(new Action0() {
 


### PR DESCRIPTION
Changing `int` to `long` in `Producer` implementations. 
