### PR TITLE
CompositeException fix for Android

### DIFF
--- a/rxjava-core/src/main/java/rx/exceptions/CompositeException.java
+++ b/rxjava-core/src/main/java/rx/exceptions/CompositeException.java
@@ -38,9 +38,9 @@ public final class CompositeException extends RuntimeException {
     public CompositeException(String messagePrefix, Collection<Throwable> errors) {
         List<Throwable> _exceptions = new ArrayList<Throwable>();
         CompositeExceptionCausalChain _cause = new CompositeExceptionCausalChain();
-        int count = 0;
+        int count = errors.size();
+        errors = removeDuplicatedCauses(errors);
         for (Throwable e : errors) {
-            count++;
             attachCallingThreadStack(_cause, e);
             _exceptions.add(e);
         }
@@ -71,6 +71,29 @@ public final class CompositeException extends RuntimeException {
     @Override
     public synchronized Throwable getCause() {
         return cause;
+    }
+
+    private Collection<Throwable> removeDuplicatedCauses(Collection<Throwable> errors) {
+        Set<Throwable> duplicated = new HashSet<Throwable>();
+        for (Throwable cause : errors) {
+            for (Throwable error : errors) {
+                if(cause == error || duplicated.contains(error)) {
+                    continue;
+                }
+                while (error.getCause() != null) {
+                    error = error.getCause();
+                    if (error == cause) {
+                        duplicated.add(cause);
+                        break;
+                    }
+                }
+            }
+        }
+        if (!duplicated.isEmpty()) {
+            errors = new ArrayList<Throwable>(errors);
+            errors.removeAll(duplicated);
+        }
+        return errors;
     }
 
     @SuppressWarnings("unused")

--- a/rxjava-core/src/test/java/rx/exceptions/CompositeExceptionTest.java
+++ b/rxjava-core/src/test/java/rx/exceptions/CompositeExceptionTest.java
@@ -54,6 +54,16 @@ public class CompositeExceptionTest {
     }
 
     @Test(timeout = 1000)
+    public void testOneIsCauseOfAnother() {
+        Throwable rootCause = new Throwable("RootCause");
+        Throwable throwable = new Throwable("1", rootCause);
+        CompositeException ce = new CompositeException("One is the cause of another",
+                Arrays.asList(rootCause, throwable));
+
+        assertEquals(1, ce.getExceptions().size());
+    }
+
+    @Test(timeout = 1000)
     public void testAttachCallingThreadStackParentThenChild() {
         CompositeException.attachCallingThreadStack(ex1, ex2);
         assertEquals("Ex2", ex1.getCause().getMessage());


### PR DESCRIPTION
Fixes #1405
- revert changes from f4ae92aa
- remove duplicated causes in stack trace chain
