### PR TITLE
Don't use postdelayed if already on right looper

### DIFF
--- a/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/HandlerThreadScheduler.java
+++ b/rxjava-contrib/rxjava-android/src/main/java/rx/android/schedulers/HandlerThreadScheduler.java
@@ -17,6 +17,7 @@ package rx.android.schedulers;
 
 import java.util.concurrent.TimeUnit;
 
+import android.os.Looper;
 import rx.Scheduler;
 import rx.Subscription;
 import rx.functions.Action0;
@@ -79,7 +80,11 @@ public class HandlerThreadScheduler extends Scheduler {
             scheduledAction.addParent(compositeSubscription);
             compositeSubscription.add(scheduledAction);
 
-            handler.postDelayed(scheduledAction, unit.toMillis(delayTime));
+            if (Looper.myLooper() == handler.getLooper() && delayTime == 0L) {
+                scheduledAction.run();
+            } else {
+                handler.postDelayed(scheduledAction, unit.toMillis(delayTime));
+            }
 
             return scheduledAction;
         }


### PR DESCRIPTION
There is no need to do postDelayed if we are on the right looper already and no delay needed.

Fix is required because for some UI scenarios postDelayed latency is not acceptable. 

I don't know how to write test for this case. Let me know if have an idea and I will add it.

@loganj @akarnokd @benjchristensen
