### PR TITLE
Allow us to make custom Scheduler

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Scheduler.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Scheduler.scala
@@ -26,7 +26,7 @@ import rx.lang.scala.JavaConversions._
  */
 trait Scheduler {
 
-  private [scala] val asJavaScheduler: rx.Scheduler
+  protected def asJavaScheduler: rx.Scheduler
 
   /**
    * Parallelism available to a Scheduler.


### PR DESCRIPTION
If someone wants to extend `Scheduler` he needs to override `asJavaScheduler`, but it's very tedious due to the `private [scala] val` declaration. In RxJava it's pretty easy to make custom Scheduler. In my opinion RxScala shouldn't prevent people doing so.
