### PR TITLE
Infinite request with Long.MAX_VALUE instead of -1

### DIFF
--- a/rxjava-core/src/main/java/rx/Subscriber.java
+++ b/rxjava-core/src/main/java/rx/Subscriber.java
@@ -126,9 +126,9 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
         if (setProducer) {
             op.setProducer(p);
         } else {
-            // we execute the request with whatever has been requested (or -1)
+            // we execute the request with whatever has been requested (or Long.MAX_VALUE)
             if (toRequest == Long.MIN_VALUE) {
-                p.request(-1);
+                p.request(Long.MAX_VALUE);
             } else {
                 p.request(toRequest);
             }

--- a/rxjava-core/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -62,7 +62,7 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
 
         @Override
         public void request(long n) {
-            if (n < 0) {
+            if (n == Long.MAX_VALUE) {
                 // fast-path without backpressure
                 while (it.hasNext()) {
                     if (o.isUnsubscribed()) {
@@ -71,7 +71,7 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
                     o.onNext(it.next());
                 }
                 o.onCompleted();
-            } else {
+            } else if(n > 0) {
                 // backpressure is requested
                 long _c = REQUESTED_UPDATER.getAndAdd(this, n);
                 if (_c == 0) {

--- a/rxjava-core/src/main/java/rx/internal/operators/OnSubscribeRange.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OnSubscribeRange.java
@@ -56,7 +56,7 @@ public final class OnSubscribeRange implements OnSubscribe<Integer> {
 
         @Override
         public void request(long n) {
-            if (n < 0) {
+            if (n == Long.MAX_VALUE) {
                 // fast-path without backpressure
                 for (long i = index; i <= end; i++) {
                     if (o.isUnsubscribed()) {

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -391,8 +391,8 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
 
         @Override
         public void request(long n) {
-            if (n < 0) {
-                requested = -1;
+            if (n == Long.MAX_VALUE) {
+                requested = Long.MAX_VALUE;
             } else {
                 REQUESTED.getAndAdd(this, n);
                 ms.drainQueuesIfNeeded();

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSkip.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSkip.java
@@ -67,17 +67,17 @@ public final class OperatorSkip<T> implements Observable.Operator<T, T> {
 
                     @Override
                     public void request(long n) {
-                        // add the skip num to the requested amount, since we'll skip everything and then emit to the buffer downstream
-                        if (n > 0) {
-                            producer.request(n + (toSkip - skipped));
-                        } else {
+                        if (n == Long.MAX_VALUE) {
                             // infinite so leave it alone
                             producer.request(n);
+                        } else if (n > 0) {
+                            // add the skip num to the requested amount, since we'll skip everything and then emit to the buffer downstream
+                            producer.request(n + (toSkip - skipped));
                         }
                     }
                 };
             }
-            
+
         };
     }
 }

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorTakeLast.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorTakeLast.java
@@ -52,7 +52,7 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
             @Override
             public void onStart() {
                 // we do this to break the chain of the child subscriber being passed through
-                request(-1);
+                request(Long.MAX_VALUE);
             }
 
             @Override
@@ -109,8 +109,8 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
         @Override
         public void request(long n) {
             long _c = 0;
-            if (n < 0) {
-                requested = -1;
+            if (n == Long.MAX_VALUE) {
+                requested = Long.MAX_VALUE;
             } else {
                 _c = REQUESTED_UPDATER.getAndAdd(this, n);
             }

--- a/rxjava-core/src/test/java/rx/SubscriberTest.java
+++ b/rxjava-core/src/test/java/rx/SubscriberTest.java
@@ -64,7 +64,7 @@ public class SubscriberTest {
             }
 
         });
-        assertEquals(-1, r.get());
+        assertEquals(Long.MAX_VALUE, r.get());
     }
 
     @Test
@@ -154,8 +154,8 @@ public class SubscriberTest {
             }
 
         });
-        // this will be -1 because it is decoupled and nothing requsted on the Operator subscriber
-        assertEquals(-1, r.get());
+        // this will be Long.MAX_VALUE because it is decoupled and nothing requsted on the Operator subscriber
+        assertEquals(Long.MAX_VALUE, r.get());
     }
 
     @Test

--- a/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -143,7 +143,7 @@ public class OnSubscribeFromIterableTest {
         OnSubscribeFromIterable<Integer> o = new OnSubscribeFromIterable<Integer>(Arrays.asList(1, 2, 3, 4, 5));
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
-        ts.request(-1); // infinite
+        ts.request(Long.MAX_VALUE); // infinite
         o.call(ts);
         ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
         ts.assertTerminalEvent();

--- a/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -126,7 +126,7 @@ public class OnSubscribeRangeTest {
         OnSubscribeRange o = new OnSubscribeRange(1, list.size());
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
-        ts.request(-1); // infinite
+        ts.request(Long.MAX_VALUE); // infinite
         o.call(ts);
         ts.assertReceivedOnNext(list);
         ts.assertTerminalEvent();


### PR DESCRIPTION
Migrating to this after discussions at https://github.com/reactive-streams/reactive-streams/issues/62
