### PR TITLE
Removing onStart and onSetProducer from rx.Subscriber...

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -159,7 +159,6 @@ public class Observable<T> {
                 try {
                     Subscriber<? super T> st = hook.onLift(lift).call(o);
                     // new Subscriber created and being subscribed with so 'onStart' it
-                    st.onStart();
                     onSubscribe.call(st);
                 } catch (Throwable e) {
                     // localized capture of errors rather than it skipping all operators 
@@ -6852,8 +6851,6 @@ public class Observable<T> {
      */
     public final Subscription unsafeSubscribe(Subscriber<? super T> subscriber) {
         try {
-            // new Subscriber so onStart it
-            subscriber.onStart();
             // allow the hook to intercept and/or decorate
             hook.onSubscribeStart(this, onSubscribe).call(subscriber);
             return hook.onSubscribeReturn(subscriber);
@@ -6925,9 +6922,6 @@ public class Observable<T> {
              * so I won't mention that in the exception
              */
         }
-        
-        // new Subscriber so onStart it
-        subscriber.onStart();
         
         /*
          * See https://github.com/Netflix/RxJava/issues/216 for discussion on "Guideline 6.4: Protect calls

--- a/rxjava-core/src/main/java/rx/Subscriber.java
+++ b/rxjava-core/src/main/java/rx/Subscriber.java
@@ -38,7 +38,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
     /* protected by `this` */
     private Producer p;
     /* protected by `this` */
-    private long requested = Long.MIN_VALUE; // default to not set
+    private Long requested = null; // default to null
 
     @Deprecated
     protected Subscriber(CompositeSubscription cs) {
@@ -84,17 +84,6 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
     }
 
     /**
-     * This method is invoked when the Subscriber and Observable have been connected but the Observable has
-     * not yet begun to emit items or send notifications to the Subscriber. Override this method to add any
-     * useful initialization to your subscription, for instance to initiate backpressure.
-     *
-     * @since 0.20
-     */
-    public void onStart() {
-        // do nothing by default
-    }
-    
-    /**
      * Request a certain maximum number of emitted items from the Observable this Subscriber is subscribed to.
      * This is a way of requesting backpressure. To disable backpressure, pass {@code Long.MAX_VALUE} to this
      * method.
@@ -120,33 +109,22 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
 
     /**
      * @warn javadoc description missing
-     * @return
-     * @since 0.20
-     */
-    protected Producer onSetProducer(Producer producer) {
-        return producer;
-    }
-
-    /**
-     * @warn javadoc description missing
      * @warn param producer not described
      * @param producer
      * @since 0.20
      */
-    public final void setProducer(Producer producer) {
-        producer = onSetProducer(producer);
-        long toRequest;
+    public void setProducer(Producer producer) {
+        Long toRequest;
         boolean setProducer = false;
         synchronized (this) {
             toRequest = requested;
             p = producer;
             if (op != null) {
                 // middle operator ... we pass thru unless a request has been made
-                if (toRequest == Long.MIN_VALUE) {
+                if (toRequest == null) {
                     // we pass-thru to the next producer as nothing has been requested
                     setProducer = true;
                 }
-
             }
         }
         // do after releasing lock
@@ -154,7 +132,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
             op.setProducer(p);
         } else {
             // we execute the request with whatever has been requested (or Long.MAX_VALUE)
-            if (toRequest == Long.MIN_VALUE) {
+            if (toRequest == null) {
                 p.request(Long.MAX_VALUE);
             } else {
                 p.request(toRequest);

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -84,10 +84,6 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             // decoupled the subscription chain because we need to decouple and control backpressure
             actual.add(this);
             actual.setProducer(mergeProducer);
-        }
-
-        @Override
-        public void onStart() {
             // we request backpressure so we can handle long-running Observables that are enqueueing, such as flatMap use cases
             // we decouple the Producer chain while keeping the Subscription chain together (perf benefit) via super(actual)
             request(RxRingBuffer.SIZE);

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -99,12 +99,6 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
             add(scheduledUnsubscribe);
             child.add(recursiveScheduler);
             child.add(this);
-            
-        }
-        
-        @Override
-        public void onStart() {
-            // signal that this is an async operator capable of receiving this many
             request(RxRingBuffer.SIZE);
         }
 

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSkip.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSkip.java
@@ -62,9 +62,8 @@ public final class OperatorSkip<T> implements Observable.Operator<T, T> {
             }
 
             @Override
-            protected Producer onSetProducer(final Producer producer) {
-                return new Producer() {
-
+            public void setProducer(final Producer producer) {
+                child.setProducer(new Producer() {
                     @Override
                     public void request(long n) {
                         if (n == Long.MAX_VALUE) {
@@ -75,7 +74,7 @@ public final class OperatorSkip<T> implements Observable.Operator<T, T> {
                             producer.request(n + (toSkip - skipped));
                         }
                     }
-                };
+                });
             }
 
         };

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
@@ -77,9 +77,8 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
                             }
 
                             @Override
-                            protected Producer onSetProducer(final Producer producer) {
-                                return new Producer() {
-
+                            public void setProducer(final Producer producer) {
+                                subscriber.setProducer(new Producer() {
                                     @Override
                                     public void request(final long n) {
                                         if (Thread.currentThread() == t) {
@@ -97,7 +96,7 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
                                         }
                                     }
 
-                                };
+                                });
                             }
 
                         });

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorTake.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorTake.java
@@ -74,9 +74,8 @@ public final class OperatorTake<T> implements Operator<T, T> {
              * We want to adjust the requested values based on the `take` count.
              */
             @Override
-            protected Producer onSetProducer(final Producer producer) {
-                return new Producer() {
-
+            public void setProducer(final Producer producer) {
+                child.setProducer(new Producer() {
                     @Override
                     public void request(long n) {
                         long c = limit - count;
@@ -86,7 +85,7 @@ public final class OperatorTake<T> implements Operator<T, T> {
                             producer.request(c);
                         }
                     }
-                };
+                });
             }
 
         };

--- a/rxjava-core/src/perf/java/rx/operators/OperatorRangePerf.java
+++ b/rxjava-core/src/perf/java/rx/operators/OperatorRangePerf.java
@@ -40,13 +40,7 @@ public class OperatorRangePerf {
         }
 
         public Subscriber<Integer> newSubscriber() {
-            return new Subscriber<Integer>() {
-
-                @Override
-                public void onStart() {
-                    request(size);
-                }
-                
+            final Subscriber<Integer> subscriber = new Subscriber<Integer>() {
                 @Override
                 public void onCompleted() {
 
@@ -63,6 +57,8 @@ public class OperatorRangePerf {
                 }
 
             };
+            subscriber.request(size);
+            return subscriber;
         }
 
     }

--- a/rxjava-core/src/test/java/rx/BackpressureTests.java
+++ b/rxjava-core/src/test/java/rx/BackpressureTests.java
@@ -306,13 +306,7 @@ public class BackpressureTests {
         final AtomicInteger totalReceived = new AtomicInteger();
         final AtomicInteger batches = new AtomicInteger();
         final AtomicInteger received = new AtomicInteger();
-        incrementingIntegers(c).subscribe(new Subscriber<Integer>() {
-
-            @Override
-            public void onStart() {
-                request(100);
-            }
-            
+        final Subscriber<Integer> subscriber = new Subscriber<Integer>() {
             @Override
             public void onCompleted() {
 
@@ -337,7 +331,9 @@ public class BackpressureTests {
                 }
             }
 
-        });
+        };
+        subscriber.request(100);
+        incrementingIntegers(c).subscribe(subscriber);
 
         System.out.println("testUserSubscriberUsingRequestSync => Received: " + totalReceived.get() + "  Emitted: " + c.get() + " Request Batches: " + batches.get());
         assertEquals(2000, c.get());
@@ -352,14 +348,7 @@ public class BackpressureTests {
         final AtomicInteger received = new AtomicInteger();
         final AtomicInteger batches = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
-        incrementingIntegers(c).subscribeOn(Schedulers.newThread()).subscribe(new Subscriber<Integer>() {
-
-            @Override
-            public void onStart() {
-                request(100);
-            }
-            
-            
+        final Subscriber<Integer> subscriber = new Subscriber<Integer>() {
             @Override
             public void onCompleted() {
                 latch.countDown();
@@ -385,7 +374,9 @@ public class BackpressureTests {
                 }
             }
 
-        });
+        };
+        subscriber.request(100);
+        incrementingIntegers(c).subscribeOn(Schedulers.newThread()).subscribe(subscriber);
 
         latch.await();
         System.out.println("testUserSubscriberUsingRequestAsync => Received: " + totalReceived.get() + "  Emitted: " + c.get() + " Request Batches: " + batches.get());


### PR DESCRIPTION
...because they are unnecessary and it can't be undone once it is released.  The `rx.Subscriber` is part of the public API and these methods aren't really needed for the Rx to work.
