### PR TITLE
New test case for takeWhile that currently fails

### DIFF
--- a/rxjava-core/src/test/java/rx/ObservableTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableTests.java
@@ -1027,4 +1027,29 @@ public class ObservableTests {
         });
         o.subscribe();
     }
+
+    @Test
+    public void testTakeWhileToList() {
+        int[] nums = {1, 2, 3};
+        final AtomicInteger count = new AtomicInteger();
+        for(final int n: nums) {
+            Observable
+                    .from(Boolean.TRUE, Boolean.FALSE)
+                    .takeWhile(new Func1<Boolean, Boolean>() {
+                        @Override
+                        public Boolean call(Boolean value) {
+                            return value;
+                        }
+                    })
+                    .toList()
+                    .doOnNext(new Action1<List<Boolean>>() {
+                        @Override
+                        public void call(List<Boolean> booleans) {
+                            count.incrementAndGet();
+                        }
+                    })
+                    .subscribe();
+        }
+        assertEquals(nums.length, count.get());
+    }
 }


### PR DESCRIPTION
Created a test case to verify the failing case of takeWhile() followed by toList() as mentioned in <a href="https://github.com/Netflix/RxJava/issues/1451">Issue 1451</a>.
