### PR TITLE
Merge Bug: Missing Emissions

### DIFF
--- a/rxjava-core/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import rx.Notification;
 import rx.Observable;
@@ -89,7 +90,13 @@ public class BlockingOperatorToIterator {
 
             private Notification<? extends T> take() {
                 try {
-                    return notifications.take();
+                    Notification<? extends T> n = notifications.poll(10000, TimeUnit.MILLISECONDS);
+                    if(n == null) {
+                        System.err.println("Timed out waiting for value. File a bug at github.com/Netflix/RxJava");
+                        throw new RuntimeException("Timed out waiting for value. File a bug at github.com/Netflix/RxJava");
+                    } else {
+                        return n;
+                    }
                 } catch (InterruptedException e) {
                     throw Exceptions.propagate(e);
                 }

--- a/rxjava-core/src/main/java/rx/internal/util/SubscriptionIndexedRingBuffer.java
+++ b/rxjava-core/src/main/java/rx/internal/util/SubscriptionIndexedRingBuffer.java
@@ -57,7 +57,8 @@ public final class SubscriptionIndexedRingBuffer<T extends Subscription> impleme
      * 
      * @return int index that can be used to remove a Subscription
      */
-    public int add(final T s) {
+    public synchronized int add(final T s) {
+        // TODO figure out how to remove synchronized here. See https://github.com/Netflix/RxJava/issues/1420
         if (unsubscribed == 1 || subscriptions == null) {
             s.unsubscribe();
             return -1;
@@ -116,13 +117,14 @@ public final class SubscriptionIndexedRingBuffer<T extends Subscription> impleme
     public int forEach(Func1<T, Boolean> action) {
         return forEach(action, 0);
     }
-    
+
     /**
      * 
      * @param action
      * @return int of last index seen if forEach exited early
      */
-    public int forEach(Func1<T, Boolean> action, int startIndex) {
+    public synchronized int forEach(Func1<T, Boolean> action, int startIndex) {
+        // TODO figure out how to remove synchronized here. See https://github.com/Netflix/RxJava/issues/1420
         if (unsubscribed == 1 || subscriptions == null) {
             return 0;
         }


### PR DESCRIPTION
Notes and temporary fix using `synchronized` to achieve correctness until a proper solution can be found.

This code does not exhibit the issue when I do production testing. Without the two `synchronized` methods I get errors in prod that I've temporarily added to `BlockingOperatorToIterator` until this is fixed so it's visible.

```
/apps/tomcat/logs$ tail -f catalina.out |grep "Timed out waiting for value"
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
Timed out waiting for value. File a bug at github.com/Netflix/RxJava
```
