### PR TITLE
retrytest.iterativeBackoff

### DIFF
--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -100,6 +100,7 @@ public class OperatorRetryTest {
             }
         }).subscribe(ts);
         ts.awaitTerminalEvent();
+        ts.assertNoErrors();
 
         InOrder inOrder = inOrder(consumer);
         inOrder.verify(consumer, never()).onError(any(Throwable.class));


### PR DESCRIPTION
Unable to replicate failure of this test ... but adding assertNoErrors so we can see an exception if it happens again.
