### PR TITLE
Fixing a bug and a potential for other concurrency issues.

### DIFF
--- a/rxjava-core/src/test/java/rx/internal/operators/BlockingOperatorMostRecentTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/BlockingOperatorMostRecentTest.java
@@ -34,6 +34,10 @@ import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
 public class BlockingOperatorMostRecentTest {
+    @Test
+    public void testMostRecentNull() {
+        assertEquals(null, Observable.<Void>never().toBlocking().mostRecent(null).iterator().next());
+    }
 
     @Test
     public void testMostRecent() {


### PR DESCRIPTION
Fix for #1542.

the root cause of the issue was this line of code where it was casting the notification list object to T.

```
        private T getRecentValue() {
            return (T)value;
        }
```

While I was in there I noticed that is was a race condition between calling `hasNext()` and `next()` on the `Iterator`.
