### PR TITLE
Compose/Transform Covariance

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -192,14 +192,14 @@ public class Observable<T> {
      * @param transformer
      * @return
      */
-    public <R> Observable<R> compose(Transformer<T, R> transformer) {
+    public <R> Observable<? extends R> compose(Transformer<? super T, ? extends R> transformer) {
         return transformer.call(this);
     }
     
     /**
      * Transformer function for `compose`
      */
-    public static interface Transformer<T, R> extends Func1<Observable<T>, Observable<R>> {
+    public static interface Transformer<T, R> extends Func1<Observable<? extends T>, Observable<? extends R>> {
         // cover for generics insanity
     }
     

--- a/rxjava-core/src/test/java/rx/CovarianceTest.java
+++ b/rxjava-core/src/test/java/rx/CovarianceTest.java
@@ -65,7 +65,7 @@ public class CovarianceTest {
         movie.compose(new Transformer<Movie, Movie>() {
 
             @Override
-            public Observable<Movie> call(Observable<Movie> t1) {
+            public Observable<? extends Movie> call(Observable<? extends Movie> t1) {
                 return Observable.from(new Movie());
             }
             
@@ -76,12 +76,10 @@ public class CovarianceTest {
     public void testCovarianceOfCompose2() {
         Observable<Movie> movie = Observable.<Movie> from(new HorrorMovie());
         movie.compose(new Transformer<Movie, Movie>() {
-
             @Override
-            public Observable<Movie> call(Observable<Movie> t1) {
+            public Observable<? extends Movie> call(Observable<? extends Movie> t1) {
                 return Observable.from(new HorrorMovie());
             }
-            
         });
     }
     

--- a/rxjava-core/src/test/java/rx/ObservableTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableTests.java
@@ -1108,9 +1108,9 @@ public class ObservableTests {
         Observable.from(1, 2, 3).compose(new Transformer<Integer, String>() {
 
             @Override
-            public Observable<String> call(Observable<Integer> t1) {
+            public Observable<? extends String> call(Observable<? extends Integer> t1) {
                 return t1.map(new Func1<Integer, String>() {
-
+                    
                     @Override
                     public String call(Integer t1) {
                         return String.valueOf(t1);


### PR DESCRIPTION
Failing test while exploring generic variance for https://github.com/Netflix/RxJava/issues/1416

Code like this makes these generics work:

``` java
    @Test
    public void testCovarianceOfCompose() {
        Observable<HorrorMovie> movie = Observable.<HorrorMovie> from(new HorrorMovie());
        movie.compose(new Transformer<Movie, Movie>() {

            @Override
            public Observable<? extends Movie> call(Observable<? super Movie> t1) {
                return Observable.from(new Movie());
            }

        });
    }

    @Test
    public void testCovarianceOfCompose2() {
        Observable<Movie> movie = Observable.<Movie> from(new HorrorMovie());
        movie.compose(new Transformer<Movie, Movie>() {

            @Override
            public Observable<? extends Movie> call(Observable<? super Movie> t1) {
                return Observable.from(new HorrorMovie());
            }

        });
    }
```

however, I couldn't get the `compose`/`Transformer` types to correctly work.

Anyone else want to help figure out generics for this?

See https://github.com/Netflix/RxJava/blob/master/rxjava-core/src/main/java/rx/Observable.java#L195
