### PR TITLE
from(T) -> just(T)

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -821,7 +821,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2) {
-        return concat(from(t1, t2));
+        return concat(just(t1, t2));
     }
 
     /**
@@ -846,7 +846,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3) {
-        return concat(from(t1, t2, t3));
+        return concat(just(t1, t2, t3));
     }
 
     /**
@@ -873,7 +873,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4) {
-        return concat(from(t1, t2, t3, t4));
+        return concat(just(t1, t2, t3, t4));
     }
 
     /**
@@ -902,7 +902,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5) {
-        return concat(from(t1, t2, t3, t4, t5));
+        return concat(just(t1, t2, t3, t4, t5));
     }
 
     /**
@@ -933,7 +933,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6) {
-        return concat(from(t1, t2, t3, t4, t5, t6));
+        return concat(just(t1, t2, t3, t4, t5, t6));
     }
 
     /**
@@ -966,7 +966,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7) {
-        return concat(from(t1, t2, t3, t4, t5, t6, t7));
+        return concat(just(t1, t2, t3, t4, t5, t6, t7));
     }
 
     /**
@@ -1001,7 +1001,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8) {
-        return concat(from(t1, t2, t3, t4, t5, t6, t7, t8));
+        return concat(just(t1, t2, t3, t4, t5, t6, t7, t8));
     }
 
     /**
@@ -1038,7 +1038,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.concat.aspx">MSDN: Observable.Concat</a>
      */
     public final static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8, Observable<? extends T> t9) {
-        return concat(from(t1, t2, t3, t4, t5, t6, t7, t8, t9));
+        return concat(just(t1, t2, t3, t4, t5, t6, t7, t8, t9));
     }
 
     /**
@@ -1246,6 +1246,7 @@ public class Observable<T> {
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
      */
     public final static <T> Observable<T> from(Future<? extends T> future, Scheduler scheduler) {
+        // TODO in a future revision the Scheduler will become important because we'll start polling instead of blocking on the Future
         return create(OnSubscribeToObservableFuture.toObservableFuture(future)).subscribeOn(scheduler);
     }
 
@@ -1292,7 +1293,9 @@ public class Observable<T> {
      *         Scheduler
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212140.aspx">MSDN: Observable.ToObservable</a>
+     * @deprecated Use subscribeOn to Schedule the work
      */
+    @Deprecated
     public final static <T> Observable<T> from(Iterable<? extends T> iterable, Scheduler scheduler) {
         return from(iterable).subscribeOn(scheduler);
     }
@@ -1312,7 +1315,9 @@ public class Observable<T> {
      *            the type of the item
      * @return an Observable that emits the item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use just or item instead
      */
+    @Deprecated
     public final static <T> Observable<T> from(T t1) {
         return just(t1);
     }
@@ -1334,7 +1339,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2) {
@@ -1360,7 +1367,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3) {
@@ -1388,7 +1397,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4) {
@@ -1418,7 +1429,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4, T t5) {
@@ -1450,7 +1463,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4, T t5, T t6) {
@@ -1484,7 +1499,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4, T t5, T t6, T t7) {
@@ -1520,7 +1537,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8) {
@@ -1558,7 +1577,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8, T t9) {
@@ -1598,7 +1619,9 @@ public class Observable<T> {
      *            the type of these items
      * @return an Observable that emits each item
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     * @deprecated Use items instead
      */
+    @Deprecated
     // suppress unchecked because we are using varargs inside the method
     @SuppressWarnings("unchecked")
     public final static <T> Observable<T> from(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8, T t9, T t10) {
@@ -1622,8 +1645,8 @@ public class Observable<T> {
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212140.aspx">MSDN: Observable.ToObservable</a>
      */
-    public final static <T> Observable<T> from(T... t1) {
-        return from(Arrays.asList(t1));
+    public final static <T> Observable<T> from(T[] array) {
+        return from(Arrays.asList(array));
     }
 
     /**
@@ -1644,7 +1667,9 @@ public class Observable<T> {
      * @return an Observable that emits each item in the source Array
      * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh212140.aspx">MSDN: Observable.ToObservable</a>
+     * @deprecated Use subscribeOn to Schedule the work
      */
+    @Deprecated
     public final static <T> Observable<T> from(T[] items, Scheduler scheduler) {
         return from(Arrays.asList(items), scheduler);
     }
@@ -1721,30 +1746,295 @@ public class Observable<T> {
     public final static <T> Observable<T> just(final T value) {
         return ScalarSynchronousObservable.create(value);
     }
-
+    
     /**
-     * Returns an Observable that emits a single item and then completes, on a specified Scheduler.
+     * Converts two items into an Observable that emits those items.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/just.s.png" alt="">
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param value
-     *            the item to emit
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
      * @param <T>
-     *            the type of that item
-     * @param scheduler
-     *            the Scheduler to emit the single item on
-     * @return an Observable that emits {@code value} as a single item and then completes, on a specified
-     *         Scheduler
-     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#just">RxJava wiki: just</a>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
      */
-    public final static <T> Observable<T> just(T value, Scheduler scheduler) {
-        return just(value).subscribeOn(scheduler);
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2) {
+        return from(Arrays.asList(t1, t2));
     }
 
+    /**
+     * Converts three items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3) {
+        return from(Arrays.asList(t1, t2, t3));
+    }
+
+    /**
+     * Converts four items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4) {
+        return from(Arrays.asList(t1, t2, t3, t4));
+    }
+
+    /**
+     * Converts five items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param t5
+     *            fifth item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4, T t5) {
+        return from(Arrays.asList(t1, t2, t3, t4, t5));
+    }
+
+    /**
+     * Converts six items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param t5
+     *            fifth item
+     * @param t6
+     *            sixth item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4, T t5, T t6) {
+        return from(Arrays.asList(t1, t2, t3, t4, t5, t6));
+    }
+
+    /**
+     * Converts seven items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param t5
+     *            fifth item
+     * @param t6
+     *            sixth item
+     * @param t7
+     *            seventh item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4, T t5, T t6, T t7) {
+        return from(Arrays.asList(t1, t2, t3, t4, t5, t6, t7));
+    }
+
+    /**
+     * Converts eight items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param t5
+     *            fifth item
+     * @param t6
+     *            sixth item
+     * @param t7
+     *            seventh item
+     * @param t8
+     *            eighth item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8) {
+        return from(Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8));
+    }
+
+    /**
+     * Converts nine items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param t5
+     *            fifth item
+     * @param t6
+     *            sixth item
+     * @param t7
+     *            seventh item
+     * @param t8
+     *            eighth item
+     * @param t9
+     *            ninth item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8, T t9) {
+        return from(Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8, t9));
+    }
+
+    /**
+     * Converts ten items into an Observable that emits those items.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/from.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param t1
+     *            first item
+     * @param t2
+     *            second item
+     * @param t3
+     *            third item
+     * @param t4
+     *            fourth item
+     * @param t5
+     *            fifth item
+     * @param t6
+     *            sixth item
+     * @param t7
+     *            seventh item
+     * @param t8
+     *            eighth item
+     * @param t9
+     *            ninth item
+     * @param t10
+     *            tenth item
+     * @param <T>
+     *            the type of these items
+     * @return an Observable that emits each item
+     * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#from">RxJava wiki: from</a>
+     */
+    // suppress unchecked because we are using varargs inside the method
+    @SuppressWarnings("unchecked")
+    public final static <T> Observable<T> just(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8, T t9, T t10) {
+        return from(Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10));
+    }
+    
     /**
      * Flattens an Iterable of Observables into one Observable, without any transformation.
      * <p>
@@ -2265,7 +2555,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2) {
-        return mergeDelayError(from(t1, t2));
+        return mergeDelayError(just(t1, t2));
     }
 
     /**
@@ -2298,7 +2588,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3) {
-        return mergeDelayError(from(t1, t2, t3));
+        return mergeDelayError(just(t1, t2, t3));
     }
 
     /**
@@ -2333,7 +2623,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4) {
-        return mergeDelayError(from(t1, t2, t3, t4));
+        return mergeDelayError(just(t1, t2, t3, t4));
     }
 
     /**
@@ -2370,7 +2660,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5) {
-        return mergeDelayError(from(t1, t2, t3, t4, t5));
+        return mergeDelayError(just(t1, t2, t3, t4, t5));
     }
 
     /**
@@ -2409,7 +2699,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6) {
-        return mergeDelayError(from(t1, t2, t3, t4, t5, t6));
+        return mergeDelayError(just(t1, t2, t3, t4, t5, t6));
     }
 
     /**
@@ -2451,7 +2741,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7) {
-        return mergeDelayError(from(t1, t2, t3, t4, t5, t6, t7));
+        return mergeDelayError(just(t1, t2, t3, t4, t5, t6, t7));
     }
 
     /**
@@ -2495,7 +2785,7 @@ public class Observable<T> {
      */
     // suppress because the types are checked by the method signature before using a vararg
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8) {
-        return mergeDelayError(from(t1, t2, t3, t4, t5, t6, t7, t8));
+        return mergeDelayError(just(t1, t2, t3, t4, t5, t6, t7, t8));
     }
 
     /**
@@ -2540,7 +2830,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/hh229099.aspx">MSDN: Observable.Merge</a>
      */
     public final static <T> Observable<T> mergeDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8, Observable<? extends T> t9) {
-        return mergeDelayError(from(t1, t2, t3, t4, t5, t6, t7, t8, t9));
+        return mergeDelayError(just(t1, t2, t3, t4, t5, t6, t7, t8, t9));
     }
 
     /**
@@ -7694,7 +7984,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1) {
-        return concat(Observable.<T> from(t1), this);
+        return concat(just(t1), this);
     }
 
     /**
@@ -7717,7 +8007,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2) {
-        return concat(Observable.<T> from(t1, t2), this);
+        return concat(just(t1, t2), this);
     }
 
     /**
@@ -7742,7 +8032,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3) {
-        return concat(Observable.<T> from(t1, t2, t3), this);
+        return concat(just(t1, t2, t3), this);
     }
 
     /**
@@ -7769,7 +8059,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3, T t4) {
-        return concat(Observable.<T> from(t1, t2, t3, t4), this);
+        return concat(just(t1, t2, t3, t4), this);
     }
 
     /**
@@ -7798,7 +8088,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3, T t4, T t5) {
-        return concat(Observable.<T> from(t1, t2, t3, t4, t5), this);
+        return concat(just(t1, t2, t3, t4, t5), this);
     }
 
     /**
@@ -7829,7 +8119,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3, T t4, T t5, T t6) {
-        return concat(Observable.<T> from(t1, t2, t3, t4, t5, t6), this);
+        return concat(just(t1, t2, t3, t4, t5, t6), this);
     }
 
     /**
@@ -7862,7 +8152,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3, T t4, T t5, T t6, T t7) {
-        return concat(Observable.<T> from(t1, t2, t3, t4, t5, t6, t7), this);
+        return concat(just(t1, t2, t3, t4, t5, t6, t7), this);
     }
 
     /**
@@ -7897,7 +8187,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8) {
-        return concat(Observable.<T> from(t1, t2, t3, t4, t5, t6, t7, t8), this);
+        return concat(just(t1, t2, t3, t4, t5, t6, t7, t8), this);
     }
 
     /**
@@ -7934,7 +8224,7 @@ public class Observable<T> {
      * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.startwith.aspx">MSDN: Observable.StartWith</a>
      */
     public final Observable<T> startWith(T t1, T t2, T t3, T t4, T t5, T t6, T t7, T t8, T t9) {
-        return concat(Observable.<T> from(t1, t2, t3, t4, t5, t6, t7, t8, t9), this);
+        return concat(just(t1, t2, t3, t4, t5, t6, t7, t8, t9), this);
     }
 
     /**

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorSequenceEqual.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorSequenceEqual.java
@@ -16,7 +16,7 @@
 package rx.internal.operators;
 
 import static rx.Observable.concat;
-import static rx.Observable.from;
+import static rx.Observable.just;
 import static rx.Observable.zip;
 import rx.Observable;
 import rx.functions.Func1;
@@ -43,7 +43,7 @@ public final class OperatorSequenceEqual {
                         return t1;
                     }
 
-                }), from(LOCAL_ONCOMPLETED));
+                }), just(LOCAL_ONCOMPLETED));
     }
 
     /**

--- a/rxjava-core/src/test/java/rx/CombineLatestTests.java
+++ b/rxjava-core/src/test/java/rx/CombineLatestTests.java
@@ -33,8 +33,8 @@ public class CombineLatestTests {
      */
     @Test
     public void testCovarianceOfCombineLatest() {
-        Observable<HorrorMovie> horrors = Observable.from(new HorrorMovie());
-        Observable<CoolRating> ratings = Observable.from(new CoolRating());
+        Observable<HorrorMovie> horrors = Observable.just(new HorrorMovie());
+        Observable<CoolRating> ratings = Observable.just(new CoolRating());
 
         Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine).toBlocking().forEach(action);
         Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine).toBlocking().forEach(action);

--- a/rxjava-core/src/test/java/rx/ConcatTests.java
+++ b/rxjava-core/src/test/java/rx/ConcatTests.java
@@ -31,8 +31,8 @@ public class ConcatTests {
 
     @Test
     public void testConcatSimple() {
-        Observable<String> o1 = Observable.from("one", "two");
-        Observable<String> o2 = Observable.from("three", "four");
+        Observable<String> o1 = Observable.just("one", "two");
+        Observable<String> o2 = Observable.just("three", "four");
 
         List<String> values = Observable.concat(o1, o2).toList().toBlocking().single();
 
@@ -44,11 +44,11 @@ public class ConcatTests {
 
     @Test
     public void testConcatWithObservableOfObservable() {
-        Observable<String> o1 = Observable.from("one", "two");
-        Observable<String> o2 = Observable.from("three", "four");
-        Observable<String> o3 = Observable.from("five", "six");
+        Observable<String> o1 = Observable.just("one", "two");
+        Observable<String> o2 = Observable.just("three", "four");
+        Observable<String> o3 = Observable.just("five", "six");
 
-        Observable<Observable<String>> os = Observable.from(o1, o2, o3);
+        Observable<Observable<String>> os = Observable.just(o1, o2, o3);
 
         List<String> values = Observable.concat(os).toList().toBlocking().single();
 
@@ -62,9 +62,9 @@ public class ConcatTests {
 
     @Test
     public void testConcatWithIterableOfObservable() {
-        Observable<String> o1 = Observable.from("one", "two");
-        Observable<String> o2 = Observable.from("three", "four");
-        Observable<String> o3 = Observable.from("five", "six");
+        Observable<String> o1 = Observable.just("one", "two");
+        Observable<String> o2 = Observable.just("three", "four");
+        Observable<String> o3 = Observable.just("five", "six");
 
         @SuppressWarnings("unchecked")
         Iterable<Observable<String>> is = Arrays.asList(o1, o2, o3);
@@ -86,10 +86,10 @@ public class ConcatTests {
     	Media media = new Media();
     	HorrorMovie horrorMovie2 = new HorrorMovie();
     	
-        Observable<Media> o1 = Observable.<Media> from(horrorMovie1, movie);
-        Observable<Media> o2 = Observable.from(media, horrorMovie2);
+        Observable<Media> o1 = Observable.<Media> just(horrorMovie1, movie);
+        Observable<Media> o2 = Observable.just(media, horrorMovie2);
 
-        Observable<Observable<Media>> os = Observable.from(o1, o2);
+        Observable<Observable<Media>> os = Observable.just(o1, o2);
 
         List<Media> values = Observable.concat(os).toList().toBlocking().single();
         
@@ -108,10 +108,10 @@ public class ConcatTests {
     	Media media2 = new Media();
     	HorrorMovie horrorMovie2 = new HorrorMovie();
     	
-        Observable<Media> o1 = Observable.from(horrorMovie1, movie, media1);
-        Observable<Media> o2 = Observable.from(media2, horrorMovie2);
+        Observable<Media> o1 = Observable.just(horrorMovie1, movie, media1);
+        Observable<Media> o2 = Observable.just(media2, horrorMovie2);
 
-        Observable<Observable<Media>> os = Observable.from(o1, o2);
+        Observable<Observable<Media>> os = Observable.just(o1, o2);
 
         List<Media> values = Observable.concat(os).toList().toBlocking().single();
 
@@ -130,8 +130,8 @@ public class ConcatTests {
     	Media media = new Media();
     	HorrorMovie horrorMovie2 = new HorrorMovie();
     	
-        Observable<Movie> o1 = Observable.from(horrorMovie1, movie);
-        Observable<Media> o2 = Observable.from(media, horrorMovie2);
+        Observable<Movie> o1 = Observable.just(horrorMovie1, movie);
+        Observable<Media> o2 = Observable.just(media, horrorMovie2);
 
         List<Media> values = Observable.concat(o1, o2).toList().toBlocking().single();
 
@@ -160,7 +160,7 @@ public class ConcatTests {
             }
         });
 
-        Observable<Media> o2 = Observable.from(media, horrorMovie2);
+        Observable<Media> o2 = Observable.just(media, horrorMovie2);
 
         List<Media> values = Observable.concat(o1, o2).toList().toBlocking().single();
 

--- a/rxjava-core/src/test/java/rx/CovarianceTest.java
+++ b/rxjava-core/src/test/java/rx/CovarianceTest.java
@@ -33,7 +33,7 @@ public class CovarianceTest {
      */
     @Test
     public void testCovarianceOfFrom() {
-        Observable.<Movie> from(new HorrorMovie());
+        Observable.<Movie> just(new HorrorMovie());
         Observable.<Movie> from(new ArrayList<HorrorMovie>());
         // Observable.<HorrorMovie>from(new Movie()); // may not compile
     }
@@ -49,11 +49,11 @@ public class CovarianceTest {
         };
 
         // this one would work without the covariance generics
-        Observable<Media> o = Observable.from(new Movie(), new TVSeason(), new Album());
+        Observable<Media> o = Observable.just(new Movie(), new TVSeason(), new Album());
         o.toSortedList(SORT_FUNCTION);
 
         // this one would NOT work without the covariance generics
-        Observable<Movie> o2 = Observable.from(new Movie(), new ActionMovie(), new HorrorMovie());
+        Observable<Movie> o2 = Observable.just(new Movie(), new ActionMovie(), new HorrorMovie());
         o2.toSortedList(SORT_FUNCTION);
     }
 

--- a/rxjava-core/src/test/java/rx/MergeTests.java
+++ b/rxjava-core/src/test/java/rx/MergeTests.java
@@ -34,17 +34,17 @@ public class MergeTests {
      */
     @Test
     public void testCovarianceOfMerge() {
-        Observable<HorrorMovie> horrors = Observable.from(new HorrorMovie());
+        Observable<HorrorMovie> horrors = Observable.just(new HorrorMovie());
         Observable<Observable<HorrorMovie>> metaHorrors = Observable.just(horrors);
         Observable.<Media> merge(metaHorrors);
     }
 
     @Test
     public void testMergeCovariance() {
-        Observable<Media> o1 = Observable.<Media> from(new HorrorMovie(), new Movie());
-        Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
+        Observable<Media> o1 = Observable.<Media> just(new HorrorMovie(), new Movie());
+        Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
-        Observable<Observable<Media>> os = Observable.from(o1, o2);
+        Observable<Observable<Media>> os = Observable.just(o1, o2);
 
         List<Media> values = Observable.merge(os).toList().toBlocking().single();
         
@@ -53,10 +53,10 @@ public class MergeTests {
 
     @Test
     public void testMergeCovariance2() {
-        Observable<Media> o1 = Observable.from(new HorrorMovie(), new Movie(), new Media());
-        Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
+        Observable<Media> o1 = Observable.just(new HorrorMovie(), new Movie(), new Media());
+        Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
-        Observable<Observable<Media>> os = Observable.from(o1, o2);
+        Observable<Observable<Media>> os = Observable.just(o1, o2);
 
         List<Media> values = Observable.merge(os).toList().toBlocking().single();
 
@@ -65,8 +65,8 @@ public class MergeTests {
 
     @Test
     public void testMergeCovariance3() {
-        Observable<Movie> o1 = Observable.from(new HorrorMovie(), new Movie());
-        Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
+        Observable<Movie> o1 = Observable.just(new HorrorMovie(), new Movie());
+        Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
         List<Media> values = Observable.merge(o1, o2).toList().toBlocking().single();
 
@@ -90,7 +90,7 @@ public class MergeTests {
             }
         });
 
-        Observable<Media> o2 = Observable.from(new Media(), new HorrorMovie());
+        Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
         List<Media> values = Observable.merge(o1, o2).toList().toBlocking().single();
 

--- a/rxjava-core/src/test/java/rx/ObservableDoOnTest.java
+++ b/rxjava-core/src/test/java/rx/ObservableDoOnTest.java
@@ -33,7 +33,7 @@ public class ObservableDoOnTest {
     @Test
     public void testDoOnEach() {
         final AtomicReference<String> r = new AtomicReference<String>();
-        String output = Observable.from("one").doOnNext(new Action1<String>() {
+        String output = Observable.just("one").doOnNext(new Action1<String>() {
 
             @Override
             public void call(String v) {
@@ -69,7 +69,7 @@ public class ObservableDoOnTest {
     @Test
     public void testDoOnCompleted() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Observable.from("one").doOnCompleted(new Action0() {
+        String output = Observable.just("one").doOnCompleted(new Action0() {
 
             @Override
             public void call() {

--- a/rxjava-core/src/test/java/rx/ObservableTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableTests.java
@@ -96,7 +96,7 @@ public class ObservableTests {
 
     @Test
     public void fromArityArgs3() {
-        Observable<String> items = Observable.from("one", "two", "three");
+        Observable<String> items = Observable.just("one", "two", "three");
 
         assertEquals(new Integer(3), items.count().toBlocking().single());
         assertEquals("two", items.skip(1).take(1).toBlocking().single());
@@ -105,7 +105,7 @@ public class ObservableTests {
 
     @Test
     public void fromArityArgs1() {
-        Observable<String> items = Observable.from("one");
+        Observable<String> items = Observable.just("one");
 
         assertEquals(new Integer(1), items.count().toBlocking().single());
         assertEquals("one", items.takeLast(1).toBlocking().single());
@@ -138,7 +138,7 @@ public class ObservableTests {
 
     @Test
     public void testCountAFewItems() {
-        Observable<String> observable = Observable.from("a", "b", "c", "d");
+        Observable<String> observable = Observable.just("a", "b", "c", "d");
         observable.count().subscribe(w);
         // we should be called only once
         verify(w, times(1)).onNext(anyInt());
@@ -173,7 +173,7 @@ public class ObservableTests {
     }
 
     public void testTakeFirstWithPredicateOfSome() {
-        Observable<Integer> observable = Observable.from(1, 3, 5, 4, 6, 3);
+        Observable<Integer> observable = Observable.just(1, 3, 5, 4, 6, 3);
         observable.takeFirst(IS_EVEN).subscribe(w);
         verify(w, times(1)).onNext(anyInt());
         verify(w).onNext(4);
@@ -183,7 +183,7 @@ public class ObservableTests {
 
     @Test
     public void testTakeFirstWithPredicateOfNoneMatchingThePredicate() {
-        Observable<Integer> observable = Observable.from(1, 3, 5, 7, 9, 7, 5, 3, 1);
+        Observable<Integer> observable = Observable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
         observable.takeFirst(IS_EVEN).subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w, times(1)).onCompleted();
@@ -192,7 +192,7 @@ public class ObservableTests {
 
     @Test
     public void testTakeFirstOfSome() {
-        Observable<Integer> observable = Observable.from(1, 2, 3);
+        Observable<Integer> observable = Observable.just(1, 2, 3);
         observable.take(1).subscribe(w);
         verify(w, times(1)).onNext(anyInt());
         verify(w).onNext(1);
@@ -220,7 +220,7 @@ public class ObservableTests {
 
     @Test
     public void testFirstWithPredicateOfNoneMatchingThePredicate() {
-        Observable<Integer> observable = Observable.from(1, 3, 5, 7, 9, 7, 5, 3, 1);
+        Observable<Integer> observable = Observable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
         observable.first(IS_EVEN).subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w, never()).onCompleted();
@@ -229,7 +229,7 @@ public class ObservableTests {
 
     @Test
     public void testReduce() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4);
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4);
         observable.reduce(new Func2<Integer, Integer, Integer>() {
 
             @Override
@@ -289,7 +289,7 @@ public class ObservableTests {
 
     @Test
     public void testReduceWithInitialValue() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4);
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4);
         observable.reduce(50, new Func2<Integer, Integer, Integer>() {
 
             @Override
@@ -820,7 +820,7 @@ public class ObservableTests {
     public void testTakeWithErrorInObserver() {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        Observable.from("1", "2", "three", "4").take(3).subscribe(new Subscriber<String>() {
+        Observable.just("1", "2", "three", "4").take(3).subscribe(new Subscriber<String>() {
 
             @Override
             public void onCompleted() {
@@ -852,7 +852,7 @@ public class ObservableTests {
 
     @Test
     public void testOfType() {
-        Observable<String> observable = Observable.from(1, "abc", false, 2L).ofType(String.class);
+        Observable<String> observable = Observable.just(1, "abc", false, 2L).ofType(String.class);
 
         @SuppressWarnings("unchecked")
         Observer<Object> observer = mock(Observer.class);
@@ -874,7 +874,7 @@ public class ObservableTests {
         l2.add(2);
 
         @SuppressWarnings("rawtypes")
-        Observable<List> observable = Observable.<Object> from(l1, l2, "123").ofType(List.class);
+        Observable<List> observable = Observable.<Object> just(l1, l2, "123").ofType(List.class);
 
         @SuppressWarnings("unchecked")
         Observer<Object> observer = mock(Observer.class);
@@ -889,7 +889,7 @@ public class ObservableTests {
 
     @Test
     public void testContains() {
-        Observable<Boolean> observable = Observable.from("a", "b", null).contains("b");
+        Observable<Boolean> observable = Observable.just("a", "b", null).contains("b");
 
         @SuppressWarnings("unchecked")
         Observer<Object> observer = mock(Observer.class);
@@ -903,7 +903,7 @@ public class ObservableTests {
 
     @Test
     public void testContainsWithInexistence() {
-        Observable<Boolean> observable = Observable.from("a", "b", null).contains("c");
+        Observable<Boolean> observable = Observable.just("a", "b", null).contains("c");
 
         @SuppressWarnings("unchecked")
         Observer<Object> observer = mock(Observer.class);
@@ -917,7 +917,7 @@ public class ObservableTests {
 
     @Test
     public void testContainsWithNull() {
-        Observable<Boolean> observable = Observable.from("a", "b", null).contains(null);
+        Observable<Boolean> observable = Observable.just("a", "b", null).contains(null);
 
         @SuppressWarnings("unchecked")
         Observer<Object> observer = mock(Observer.class);
@@ -945,7 +945,7 @@ public class ObservableTests {
 
     @Test
     public void testIgnoreElements() {
-        Observable<Integer> observable = Observable.from(1, 2, 3).ignoreElements();
+        Observable<Integer> observable = Observable.just(1, 2, 3).ignoreElements();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = mock(Observer.class);
@@ -956,27 +956,27 @@ public class ObservableTests {
     }
 
     @Test
-    public void testFromWithScheduler() {
-        TestScheduler scheduler = new TestScheduler();
-        Observable<Integer> observable = Observable.from(Arrays.asList(1, 2), scheduler);
-
-        @SuppressWarnings("unchecked")
-        Observer<Integer> observer = mock(Observer.class);
-        observable.subscribe(observer);
-
-        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
-
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onCompleted();
-        inOrder.verifyNoMoreInteractions();
-    }
+            public void testJustWithScheduler() {
+                TestScheduler scheduler = new TestScheduler();
+                Observable<Integer> observable = Observable.from(Arrays.asList(1, 2), scheduler);
+        
+                @SuppressWarnings("unchecked")
+                Observer<Integer> observer = mock(Observer.class);
+                observable.subscribe(observer);
+        
+                scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        
+                InOrder inOrder = inOrder(observer);
+                inOrder.verify(observer, times(1)).onNext(1);
+                inOrder.verify(observer, times(1)).onNext(2);
+                inOrder.verify(observer, times(1)).onCompleted();
+                inOrder.verifyNoMoreInteractions();
+            }
 
     @Test
     public void testStartWithWithScheduler() {
         TestScheduler scheduler = new TestScheduler();
-        Observable<Integer> observable = Observable.from(3, 4).startWith(Arrays.asList(1, 2), scheduler);
+        Observable<Integer> observable = Observable.just(3, 4).startWith(Arrays.asList(1, 2), scheduler);
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = mock(Observer.class);
@@ -1015,7 +1015,7 @@ public class ObservableTests {
 
     @Test
     public void testCollectToList() {
-        List<Integer> list = Observable.from(1, 2, 3).collect(new ArrayList<Integer>(), new Action2<List<Integer>, Integer>() {
+        List<Integer> list = Observable.just(1, 2, 3).collect(new ArrayList<Integer>(), new Action2<List<Integer>, Integer>() {
 
             @Override
             public void call(List<Integer> list, Integer v) {
@@ -1031,7 +1031,7 @@ public class ObservableTests {
 
     @Test
     public void testCollectToString() {
-        String value = Observable.from(1, 2, 3).collect(new StringBuilder(), new Action2<StringBuilder, Integer>() {
+        String value = Observable.just(1, 2, 3).collect(new StringBuilder(), new Action2<StringBuilder, Integer>() {
 
             @Override
             public void call(StringBuilder sb, Integer v) {
@@ -1068,7 +1068,7 @@ public class ObservableTests {
 
     @Test(expected = OnErrorNotImplementedException.class)
     public void testSubscribeWithoutOnError() {
-        Observable<String> o = Observable.from("a", "b").flatMap(new Func1<String, Observable<String>>() {
+        Observable<String> o = Observable.just("a", "b").flatMap(new Func1<String, Observable<String>>() {
             @Override
             public Observable<String> call(String s) {
                 return Observable.error(new Exception("test"));
@@ -1083,7 +1083,7 @@ public class ObservableTests {
         final AtomicInteger count = new AtomicInteger();
         for(final int n: nums) {
             Observable
-                    .from(Boolean.TRUE, Boolean.FALSE)
+                    .just(Boolean.TRUE, Boolean.FALSE)
                     .takeWhile(new Func1<Boolean, Boolean>() {
                         @Override
                         public Boolean call(Boolean value) {
@@ -1105,7 +1105,7 @@ public class ObservableTests {
     @Test
     public void testCompose() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.from(1, 2, 3).compose(new Transformer<Integer, String>() {
+        Observable.just(1, 2, 3).compose(new Transformer<Integer, String>() {
 
             @Override
             public Observable<String> call(Observable<Integer> t1) {

--- a/rxjava-core/src/test/java/rx/ObservableWindowTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableWindowTests.java
@@ -32,7 +32,7 @@ public class ObservableWindowTests {
     public void testWindow() {
         final ArrayList<List<Integer>> lists = new ArrayList<List<Integer>>();
 
-        Observable.concat(Observable.from(1, 2, 3, 4, 5, 6).window(3).map(new Func1<Observable<Integer>, Observable<List<Integer>>>() {
+        Observable.concat(Observable.just(1, 2, 3, 4, 5, 6).window(3).map(new Func1<Observable<Integer>, Observable<List<Integer>>>() {
             @Override
             public Observable<List<Integer>> call(Observable<Integer> xs) {
                 return xs.toList();

--- a/rxjava-core/src/test/java/rx/ReduceTests.java
+++ b/rxjava-core/src/test/java/rx/ReduceTests.java
@@ -27,7 +27,7 @@ public class ReduceTests {
 
     @Test
     public void reduceInts() {
-        Observable<Integer> o = Observable.from(1, 2, 3);
+        Observable<Integer> o = Observable.just(1, 2, 3);
         int value = o.reduce(new Func2<Integer, Integer, Integer>() {
 
             @Override
@@ -42,7 +42,7 @@ public class ReduceTests {
     @SuppressWarnings("unused")
     @Test
     public void reduceWithObjects() {
-        Observable<Movie> horrorMovies = Observable.<Movie> from(new HorrorMovie());
+        Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
 
         Func2<Movie, Movie, Movie> chooseSecondMovie =
                 new Func2<Movie, Movie, Movie>() {
@@ -64,7 +64,7 @@ public class ReduceTests {
     @SuppressWarnings("unused")
     @Test
     public void reduceWithCovariantObjects() {
-        Observable<Movie> horrorMovies = Observable.<Movie> from(new HorrorMovie());
+        Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
 
         Func2<Movie, Movie, Movie> chooseSecondMovie =
                 new Func2<Movie, Movie, Movie>() {
@@ -84,7 +84,7 @@ public class ReduceTests {
     @Test
     public void reduceCovariance() {
         // must type it to <Movie>
-        Observable<Movie> horrorMovies = Observable.<Movie> from(new HorrorMovie());
+        Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
         libraryFunctionActingOnMovieObservables(horrorMovies);
     }
 

--- a/rxjava-core/src/test/java/rx/StartWithTests.java
+++ b/rxjava-core/src/test/java/rx/StartWithTests.java
@@ -26,7 +26,7 @@ public class StartWithTests {
 
     @Test
     public void startWith1() {
-        List<String> values = Observable.from("one", "two").startWith("zero").toList().toBlocking().single();
+        List<String> values = Observable.just("one", "two").startWith("zero").toList().toBlocking().single();
 
         assertEquals("zero", values.get(0));
         assertEquals("two", values.get(2));
@@ -37,7 +37,7 @@ public class StartWithTests {
         List<String> li = new ArrayList<String>();
         li.add("alpha");
         li.add("beta");
-        List<String> values = Observable.from("one", "two").startWith(li).toList().toBlocking().single();
+        List<String> values = Observable.just("one", "two").startWith(li).toList().toBlocking().single();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));
@@ -50,7 +50,7 @@ public class StartWithTests {
         List<String> li = new ArrayList<String>();
         li.add("alpha");
         li.add("beta");
-        List<String> values = Observable.from("one", "two").startWith(Observable.from(li)).toList().toBlocking().single();
+        List<String> values = Observable.just("one", "two").startWith(Observable.from(li)).toList().toBlocking().single();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));

--- a/rxjava-core/src/test/java/rx/SubscriberTest.java
+++ b/rxjava-core/src/test/java/rx/SubscriberTest.java
@@ -320,7 +320,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartCalledOnceViaSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Observable.from(1, 2, 3, 4).take(2).subscribe(new Subscriber<Integer>() {
+        Observable.just(1, 2, 3, 4).take(2).subscribe(new Subscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -352,7 +352,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartCalledOnceViaUnsafeSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Observable.from(1, 2, 3, 4).take(2).unsafeSubscribe(new Subscriber<Integer>() {
+        Observable.just(1, 2, 3, 4).take(2).unsafeSubscribe(new Subscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -384,7 +384,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartCalledOnceViaLift() {
         final AtomicInteger c = new AtomicInteger();
-        Observable.from(1, 2, 3, 4).lift(new Operator<Integer, Integer>() {
+        Observable.just(1, 2, 3, 4).lift(new Operator<Integer, Integer>() {
 
             @Override
             public Subscriber<? super Integer> call(final Subscriber<? super Integer> child) {

--- a/rxjava-core/src/test/java/rx/ZipTests.java
+++ b/rxjava-core/src/test/java/rx/ZipTests.java
@@ -86,8 +86,8 @@ public class ZipTests {
      */
     @Test
     public void testCovarianceOfZip() {
-        Observable<HorrorMovie> horrors = Observable.from(new HorrorMovie());
-        Observable<CoolRating> ratings = Observable.from(new CoolRating());
+        Observable<HorrorMovie> horrors = Observable.just(new HorrorMovie());
+        Observable<CoolRating> ratings = Observable.just(new CoolRating());
 
         Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine).toBlocking().forEach(action);
         Observable.<Movie, CoolRating, Result> zip(horrors, ratings, combine).toBlocking().forEach(action);

--- a/rxjava-core/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/rxjava-core/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -29,7 +29,7 @@ public class ExceptionsTest {
 
     @Test(expected = OnErrorNotImplementedException.class)
     public void testOnErrorNotImplementedIsThrown() {
-        Observable.from(1, 2, 3).subscribe(new Action1<Integer>() {
+        Observable.just(1, 2, 3).subscribe(new Action1<Integer>() {
 
             @Override
             public void call(Integer t1) {
@@ -117,7 +117,7 @@ public class ExceptionsTest {
 
     @Test(expected = ThreadDeath.class)
     public void testThreadDeathIsThrown() {
-        Observable.from(1).subscribe(new Observer<Integer>() {
+        Observable.just(1).subscribe(new Observer<Integer>() {
 
             @Override
             public void onCompleted() {

--- a/rxjava-core/src/test/java/rx/exceptions/OnNextValueTest.java
+++ b/rxjava-core/src/test/java/rx/exceptions/OnNextValueTest.java
@@ -80,7 +80,7 @@ public final class OnNextValueTest {
     public void addOnNextValueExceptionAdded() throws Exception {
         Observer<BadToString> observer = new BadToStringObserver();
 
-        Observable.from(new BadToString(false))
+        Observable.just(new BadToString(false))
                 .map(new Func1<BadToString, BadToString>() {
                     @Override
                     public BadToString call(BadToString badToString) {
@@ -94,7 +94,7 @@ public final class OnNextValueTest {
     public void addOnNextValueExceptionNotAddedWithBadString() throws Exception {
         Observer<BadToString> observer = new BadToStringObserver();
 
-        Observable.from(new BadToString(true))
+        Observable.just(new BadToString(true))
                 .map(new Func1<BadToString, BadToString>() {
                     @Override
                     public BadToString call(BadToString badToString) {

--- a/rxjava-core/src/test/java/rx/internal/operators/BlockingOperatorToFutureTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/BlockingOperatorToFutureTest.java
@@ -38,14 +38,14 @@ public class BlockingOperatorToFutureTest {
 
     @Test
     public void testToFuture() throws InterruptedException, ExecutionException {
-        Observable<String> obs = Observable.from("one");
+        Observable<String> obs = Observable.just("one");
         Future<String> f = toFuture(obs);
         assertEquals("one", f.get());
     }
 
     @Test
     public void testToFutureList() throws InterruptedException, ExecutionException {
-        Observable<String> obs = Observable.from("one", "two", "three");
+        Observable<String> obs = Observable.just("one", "two", "three");
         Future<List<String>> f = toFuture(obs.toList());
         assertEquals("one", f.get().get(0));
         assertEquals("two", f.get().get(1));
@@ -54,7 +54,7 @@ public class BlockingOperatorToFutureTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testExceptionWithMoreThanOneElement() throws Throwable {
-        Observable<String> obs = Observable.from("one", "two");
+        Observable<String> obs = Observable.just("one", "two");
         Future<String> f = toFuture(obs);
         try {
             // we expect an exception since there are more than 1 element
@@ -127,7 +127,7 @@ public class BlockingOperatorToFutureTest {
 
     @Test
     public void testGetWithASingleNullItem() throws Exception {
-        Observable<String> obs = Observable.from((String)null);
+        Observable<String> obs = Observable.just((String)null);
         Future<String> f = obs.toBlocking().toFuture();
         assertEquals(null, f.get());
     }

--- a/rxjava-core/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
@@ -31,7 +31,7 @@ public class BlockingOperatorToIteratorTest {
 
     @Test
     public void testToIterator() {
-        Observable<String> obs = Observable.from("one", "two", "three");
+        Observable<String> obs = Observable.just("one", "two", "three");
 
         Iterator<String> it = toIterator(obs);
 

--- a/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeCacheTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeCacheTest.java
@@ -96,7 +96,7 @@ public class OnSubscribeCacheTest {
     }
 
     private void testWithCustomSubjectAndRepeat(Subject<Integer, Integer> subject, Integer... expected) {
-        Observable<Integer> source0 = Observable.from(1, 2, 3)
+        Observable<Integer> source0 = Observable.just(1, 2, 3)
                 .subscribeOn(Schedulers.io())
                 .flatMap(new Func1<Integer, Observable<Integer>>() {
                     @Override

--- a/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -198,7 +198,7 @@ public class OnSubscribeCombineLatestTest {
         /* define a Observer to receive aggregated events */
         Observer<String> observer = mock(Observer.class);
 
-        Observable<String> w = Observable.combineLatest(Observable.from("one", "two"), Observable.from(2, 3, 4), combineLatestFunction);
+        Observable<String> w = Observable.combineLatest(Observable.just("one", "two"), Observable.just(2, 3, 4), combineLatestFunction);
         w.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));
@@ -217,7 +217,7 @@ public class OnSubscribeCombineLatestTest {
         /* define a Observer to receive aggregated events */
         Observer<String> observer = mock(Observer.class);
 
-        Observable<String> w = Observable.combineLatest(Observable.from("one", "two"), Observable.from(2), Observable.from(new int[] { 4, 5, 6 }), combineLatestFunction);
+        Observable<String> w = Observable.combineLatest(Observable.just("one", "two"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }), combineLatestFunction);
         w.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));
@@ -234,7 +234,7 @@ public class OnSubscribeCombineLatestTest {
         /* define a Observer to receive aggregated events */
         Observer<String> observer = mock(Observer.class);
 
-        Observable<String> w = Observable.combineLatest(Observable.from("one"), Observable.from(2), Observable.from(new int[] { 4, 5, 6 }, new int[] { 7, 8 }), combineLatestFunction);
+        Observable<String> w = Observable.combineLatest(Observable.just("one"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }, new int[] { 7, 8 }), combineLatestFunction);
         w.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));
@@ -510,7 +510,7 @@ public class OnSubscribeCombineLatestTest {
             List<Observable<Integer>> sources = new ArrayList<Observable<Integer>>();
             List<Object> values = new ArrayList<Object>();
             for (int j = 0; j < i; j++) {
-                sources.add(Observable.just(j, Schedulers.io()));
+                sources.add(Observable.just(j).subscribeOn(Schedulers.io()));
                 values.add(j);
             }
             

--- a/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeDeferTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeDeferTest.java
@@ -38,8 +38,8 @@ public class OnSubscribeDeferTest {
 
         Func0<Observable<String>> factory = mock(Func0.class);
 
-        Observable<String> firstObservable = Observable.from("one", "two");
-        Observable<String> secondObservable = Observable.from("three", "four");
+        Observable<String> firstObservable = Observable.just("one", "two");
+        Observable<String> secondObservable = Observable.just("three", "four");
         when(factory.call()).thenReturn(firstObservable, secondObservable);
 
         Observable<String> deferred = Observable.defer(factory);

--- a/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeDelayTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OnSubscribeDelayTest.java
@@ -201,7 +201,7 @@ public class OnSubscribeDelayTest {
 
     @Test
     public void testDelaySubscription() {
-        Observable<Integer> result = Observable.from(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
+        Observable<Integer> result = Observable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
@@ -224,7 +224,7 @@ public class OnSubscribeDelayTest {
 
     @Test
     public void testDelaySubscriptionCancelBeforeTime() {
-        Observable<Integer> result = Observable.from(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
+        Observable<Integer> result = Observable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorAllTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorAllTest.java
@@ -33,7 +33,7 @@ public class OperatorAllTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testAll() {
-        Observable<String> obs = Observable.from("one", "two", "six");
+        Observable<String> obs = Observable.just("one", "two", "six");
 
         Observer<Boolean> observer = mock(Observer.class);
         obs.all(new Func1<String, Boolean>() {
@@ -51,7 +51,7 @@ public class OperatorAllTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testNotAll() {
-        Observable<String> obs = Observable.from("one", "two", "three", "six");
+        Observable<String> obs = Observable.just("one", "two", "three", "six");
 
         Observer<Boolean> observer = mock(Observer.class);
         obs.all(new Func1<String, Boolean>() {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorAnyTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorAnyTest.java
@@ -34,7 +34,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testAnyWithTwoItems() {
-        Observable<Integer> w = Observable.from(1, 2);
+        Observable<Integer> w = Observable.just(1, 2);
         Observable<Boolean> observable = w.exists(Functions.alwaysTrue());
 
         @SuppressWarnings("unchecked")
@@ -48,7 +48,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testIsEmptyWithTwoItems() {
-        Observable<Integer> w = Observable.from(1, 2);
+        Observable<Integer> w = Observable.just(1, 2);
         Observable<Boolean> observable = w.isEmpty();
 
         @SuppressWarnings("unchecked")
@@ -62,7 +62,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testAnyWithOneItem() {
-        Observable<Integer> w = Observable.from(1);
+        Observable<Integer> w = Observable.just(1);
         Observable<Boolean> observable = w.exists(Functions.alwaysTrue());
 
         @SuppressWarnings("unchecked")
@@ -76,7 +76,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testIsEmptyWithOneItem() {
-        Observable<Integer> w = Observable.from(1);
+        Observable<Integer> w = Observable.just(1);
         Observable<Boolean> observable = w.isEmpty();
 
         @SuppressWarnings("unchecked")
@@ -118,7 +118,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testAnyWithPredicate1() {
-        Observable<Integer> w = Observable.from(1, 2, 3);
+        Observable<Integer> w = Observable.just(1, 2, 3);
         Observable<Boolean> observable = w.exists(
                 new Func1<Integer, Boolean>() {
 
@@ -139,7 +139,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testExists1() {
-        Observable<Integer> w = Observable.from(1, 2, 3);
+        Observable<Integer> w = Observable.just(1, 2, 3);
         Observable<Boolean> observable = w.exists(
                 new Func1<Integer, Boolean>() {
 
@@ -160,7 +160,7 @@ public class OperatorAnyTest {
 
     @Test
     public void testAnyWithPredicate2() {
-        Observable<Integer> w = Observable.from(1, 2, 3);
+        Observable<Integer> w = Observable.just(1, 2, 3);
         Observable<Boolean> observable = w.exists(
                 new Func1<Integer, Boolean>() {
 

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorBufferTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorBufferTest.java
@@ -315,7 +315,7 @@ public class OperatorBufferTest {
     public void testLongTimeAction() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         LongTimeAction action = new LongTimeAction(latch);
-        Observable.from(1).buffer(10, TimeUnit.MILLISECONDS, 10)
+        Observable.just(1).buffer(10, TimeUnit.MILLISECONDS, 10)
                 .subscribe(action);
         latch.await();
         assertFalse(action.fail);
@@ -526,7 +526,7 @@ public class OperatorBufferTest {
     }
     @Test(timeout = 2000)
     public void bufferWithSizeTake1() {
-        Observable<Integer> source = Observable.from(1).repeat();
+        Observable<Integer> source = Observable.just(1).repeat();
         
         Observable<List<Integer>> result = source.buffer(2).take(1);
         
@@ -542,7 +542,7 @@ public class OperatorBufferTest {
     
     @Test(timeout = 2000)
     public void bufferWithSizeSkipTake1() {
-        Observable<Integer> source = Observable.from(1).repeat();
+        Observable<Integer> source = Observable.just(1).repeat();
         
         Observable<List<Integer>> result = source.buffer(2, 3).take(1);
         

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorCastTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorCastTest.java
@@ -29,7 +29,7 @@ public class OperatorCastTest {
 
     @Test
     public void testCast() {
-        Observable<?> source = Observable.from(1, 2);
+        Observable<?> source = Observable.just(1, 2);
         Observable<Integer> observable = source.cast(Integer.class);
 
         @SuppressWarnings("unchecked")
@@ -44,7 +44,7 @@ public class OperatorCastTest {
 
     @Test
     public void testCastWithWrongType() {
-        Observable<?> source = Observable.from(1, 2);
+        Observable<?> source = Observable.just(1, 2);
         Observable<Boolean> observable = source.cast(Boolean.class);
 
         @SuppressWarnings("unchecked")

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -600,7 +600,7 @@ public class OperatorConcatTest {
                     if (s.isUnsubscribed()) {
                         return;
                     }
-                    s.onNext(Observable.from(i));
+                    s.onNext(Observable.just(i));
                 }
                 s.onCompleted();
             }
@@ -632,7 +632,7 @@ public class OperatorConcatTest {
                     if (s.isUnsubscribed()) {
                         return;
                     }
-                    s.onNext(Observable.from(i));
+                    s.onNext(Observable.just(i));
                 }
                 s.onCompleted();
             }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorDefaultIfEmptyTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorDefaultIfEmptyTest.java
@@ -31,7 +31,7 @@ public class OperatorDefaultIfEmptyTest {
 
     @Test
     public void testDefaultIfEmpty() {
-        Observable<Integer> source = Observable.from(1, 2, 3);
+        Observable<Integer> source = Observable.just(1, 2, 3);
         Observable<Integer> observable = source.defaultIfEmpty(10);
 
         @SuppressWarnings("unchecked")

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorDematerializeTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorDematerializeTest.java
@@ -35,7 +35,7 @@ public class OperatorDematerializeTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testDematerialize1() {
-        Observable<Notification<Integer>> notifications = Observable.from(1, 2).materialize();
+        Observable<Notification<Integer>> notifications = Observable.just(1, 2).materialize();
         Observable<Integer> dematerialize = notifications.dematerialize();
 
         Observer<Integer> observer = mock(Observer.class);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorDistinctTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorDistinctTest.java
@@ -78,7 +78,7 @@ public class OperatorDistinctTest {
 
     @Test
     public void testDistinctOfNormalSource() {
-        Observable<String> src = Observable.from("a", "b", "c", "c", "c", "b", "b", "a", "e");
+        Observable<String> src = Observable.just("a", "b", "c", "c", "c", "b", "b", "a", "e");
         src.distinct().subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -93,7 +93,7 @@ public class OperatorDistinctTest {
 
     @Test
     public void testDistinctOfNormalSourceWithKeySelector() {
-        Observable<String> src = Observable.from("a", "B", "c", "C", "c", "B", "b", "a", "E");
+        Observable<String> src = Observable.just("a", "B", "c", "C", "c", "B", "b", "a", "E");
         src.distinct(TO_UPPER_WITH_EXCEPTION).subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -108,7 +108,7 @@ public class OperatorDistinctTest {
 
     @Test
     public void testDistinctOfSourceWithNulls() {
-        Observable<String> src = Observable.from(null, "a", "a", null, null, "b", null);
+        Observable<String> src = Observable.just(null, "a", "a", null, null, "b", null);
         src.distinct().subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -122,7 +122,7 @@ public class OperatorDistinctTest {
 
     @Test
     public void testDistinctOfSourceWithExceptionsFromKeySelector() {
-        Observable<String> src = Observable.from("a", "b", null, "c");
+        Observable<String> src = Observable.just("a", "b", null, "c");
         src.distinct(TO_UPPER_WITH_EXCEPTION).subscribe(w);
 
         InOrder inOrder = inOrder(w);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorDistinctUntilChangedTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorDistinctUntilChangedTest.java
@@ -78,7 +78,7 @@ public class OperatorDistinctUntilChangedTest {
 
     @Test
     public void testDistinctUntilChangedOfNormalSource() {
-        Observable<String> src = Observable.from("a", "b", "c", "c", "c", "b", "b", "a", "e");
+        Observable<String> src = Observable.just("a", "b", "c", "c", "c", "b", "b", "a", "e");
         src.distinctUntilChanged().subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -95,7 +95,7 @@ public class OperatorDistinctUntilChangedTest {
 
     @Test
     public void testDistinctUntilChangedOfNormalSourceWithKeySelector() {
-        Observable<String> src = Observable.from("a", "b", "c", "C", "c", "B", "b", "a", "e");
+        Observable<String> src = Observable.just("a", "b", "c", "C", "c", "B", "b", "a", "e");
         src.distinctUntilChanged(TO_UPPER_WITH_EXCEPTION).subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -112,7 +112,7 @@ public class OperatorDistinctUntilChangedTest {
 
     @Test
     public void testDistinctUntilChangedOfSourceWithNulls() {
-        Observable<String> src = Observable.from(null, "a", "a", null, null, "b", null, null);
+        Observable<String> src = Observable.just(null, "a", "a", null, null, "b", null, null);
         src.distinctUntilChanged().subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -128,7 +128,7 @@ public class OperatorDistinctUntilChangedTest {
 
     @Test
     public void testDistinctUntilChangedOfSourceWithExceptionsFromKeySelector() {
-        Observable<String> src = Observable.from("a", "b", null, "c");
+        Observable<String> src = Observable.just("a", "b", null, "c");
         src.distinctUntilChanged(TO_UPPER_WITH_EXCEPTION).subscribe(w);
 
         InOrder inOrder = inOrder(w);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorDoOnEachTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorDoOnEachTest.java
@@ -48,7 +48,7 @@ public class OperatorDoOnEachTest {
 
     @Test
     public void testDoOnEach() {
-        Observable<String> base = Observable.from("a", "b", "c");
+        Observable<String> base = Observable.just("a", "b", "c");
         Observable<String> doOnEach = base.doOnEach(sideEffectObserver);
 
         doOnEach.subscribe(subscribedObserver);
@@ -70,7 +70,7 @@ public class OperatorDoOnEachTest {
 
     @Test
     public void testDoOnEachWithError() {
-        Observable<String> base = Observable.from("one", "fail", "two", "three", "fail");
+        Observable<String> base = Observable.just("one", "fail", "two", "three", "fail");
         Observable<String> errs = base.map(new Func1<String, String>() {
             @Override
             public String call(String s) {
@@ -99,7 +99,7 @@ public class OperatorDoOnEachTest {
 
     @Test
     public void testDoOnEachWithErrorInCallback() {
-        Observable<String> base = Observable.from("one", "two", "fail", "three");
+        Observable<String> base = Observable.just("one", "two", "fail", "three");
         Observable<String> doOnEach = base.doOnNext(new Action1<String>() {
             @Override
             public void call(String s) {
@@ -125,7 +125,7 @@ public class OperatorDoOnEachTest {
         final AtomicInteger count = new AtomicInteger();
         for (final int n : nums) {
             Observable
-                    .from(Boolean.TRUE, Boolean.FALSE)
+                    .just(Boolean.TRUE, Boolean.FALSE)
                     .takeWhile(new Func1<Boolean, Boolean>() {
                         @Override
                         public Boolean call(Boolean value) {
@@ -151,7 +151,7 @@ public class OperatorDoOnEachTest {
         final AtomicInteger count = new AtomicInteger();
         for (final int n : nums) {
             Observable
-                    .from(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
+                    .just(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
                     .takeWhile(new Func1<Boolean, Boolean>() {
                         @Override
                         public Boolean call(Boolean value) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorFilterTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorFilterTest.java
@@ -36,7 +36,7 @@ public class OperatorFilterTest {
 
     @Test
     public void testFilter() {
-        Observable<String> w = Observable.from("one", "two", "three");
+        Observable<String> w = Observable.just("one", "two", "three");
         Observable<String> observable = w.filter(new Func1<String, Boolean>() {
 
             @Override
@@ -60,7 +60,7 @@ public class OperatorFilterTest {
      */
     @Test(timeout = 500)
     public void testWithBackpressure() throws InterruptedException {
-        Observable<String> w = Observable.from("one", "two", "three");
+        Observable<String> w = Observable.just("one", "two", "three");
         Observable<String> o = w.filter(new Func1<String, Boolean>() {
 
             @Override

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorFirstTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorFirstTest.java
@@ -66,7 +66,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrElseOfSome() {
-        Observable<String> src = Observable.from("a", "b", "c");
+        Observable<String> src = Observable.just("a", "b", "c");
         src.firstOrDefault("default").subscribe(w);
 
         verify(w, times(1)).onNext(anyString());
@@ -77,7 +77,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrElseWithPredicateOfNoneMatchingThePredicate() {
-        Observable<String> src = Observable.from("a", "b", "c");
+        Observable<String> src = Observable.just("a", "b", "c");
         src.firstOrDefault("default", IS_D).subscribe(w);
 
         verify(w, times(1)).onNext(anyString());
@@ -88,7 +88,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrElseWithPredicateOfSome() {
-        Observable<String> src = Observable.from("a", "b", "c", "d", "e", "f");
+        Observable<String> src = Observable.just("a", "b", "c", "d", "e", "f");
         src.firstOrDefault("default", IS_D).subscribe(w);
 
         verify(w, times(1)).onNext(anyString());
@@ -99,7 +99,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirst() {
-        Observable<Integer> observable = Observable.from(1, 2, 3).first();
+        Observable<Integer> observable = Observable.just(1, 2, 3).first();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -113,7 +113,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstWithOneElement() {
-        Observable<Integer> observable = Observable.from(1).first();
+        Observable<Integer> observable = Observable.just(1).first();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -141,7 +141,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstWithPredicate() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4, 5, 6)
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4, 5, 6)
                 .first(new Func1<Integer, Boolean>() {
 
                     @Override
@@ -162,7 +162,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstWithPredicateAndOneElement() {
-        Observable<Integer> observable = Observable.from(1, 2).first(
+        Observable<Integer> observable = Observable.just(1, 2).first(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -183,7 +183,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstWithPredicateAndEmpty() {
-        Observable<Integer> observable = Observable.from(1).first(
+        Observable<Integer> observable = Observable.just(1).first(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -203,7 +203,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrDefault() {
-        Observable<Integer> observable = Observable.from(1, 2, 3)
+        Observable<Integer> observable = Observable.just(1, 2, 3)
                 .firstOrDefault(4);
 
         @SuppressWarnings("unchecked")
@@ -218,7 +218,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrDefaultWithOneElement() {
-        Observable<Integer> observable = Observable.from(1).firstOrDefault(2);
+        Observable<Integer> observable = Observable.just(1).firstOrDefault(2);
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -247,7 +247,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicate() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4, 5, 6)
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4, 5, 6)
                 .firstOrDefault(8, new Func1<Integer, Boolean>() {
 
                     @Override
@@ -268,7 +268,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndOneElement() {
-        Observable<Integer> observable = Observable.from(1, 2).firstOrDefault(
+        Observable<Integer> observable = Observable.just(1, 2).firstOrDefault(
                 4, new Func1<Integer, Boolean>() {
 
                     @Override
@@ -289,7 +289,7 @@ public class OperatorFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndEmpty() {
-        Observable<Integer> observable = Observable.from(1).firstOrDefault(2,
+        Observable<Integer> observable = Observable.just(1).firstOrDefault(2,
                 new Func1<Integer, Boolean>() {
 
                     @Override

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -62,7 +62,7 @@ public class OperatorGroupByTest {
     
     @Test
     public void testGroupBy() {
-        Observable<String> source = Observable.from("one", "two", "three", "four", "five", "six");
+        Observable<String> source = Observable.just("one", "two", "three", "four", "five", "six");
         Observable<GroupedObservable<Integer, String>> grouped = source.lift(new OperatorGroupBy<String, Integer, String>(length));
 
         Map<Integer, Collection<String>> map = toMap(grouped);
@@ -75,7 +75,7 @@ public class OperatorGroupByTest {
     
     @Test
     public void testGroupByWithElementSelector() {
-        Observable<String> source = Observable.from("one", "two", "three", "four", "five", "six");
+        Observable<String> source = Observable.just("one", "two", "three", "four", "five", "six");
         Observable<GroupedObservable<Integer, Integer>> grouped = source.lift(new OperatorGroupBy<String, Integer, Integer>(length, length));
 
         Map<Integer, Collection<Integer>> map = toMap(grouped);
@@ -88,7 +88,7 @@ public class OperatorGroupByTest {
     
     @Test
     public void testGroupByWithElementSelector2() {
-        Observable<String> source = Observable.from("one", "two", "three", "four", "five", "six");
+        Observable<String> source = Observable.just("one", "two", "three", "four", "five", "six");
         Observable<GroupedObservable<Integer, Integer>> grouped = source.groupBy(length, length);
 
         Map<Integer, Collection<Integer>> map = toMap(grouped);
@@ -111,7 +111,7 @@ public class OperatorGroupByTest {
 
     @Test
     public void testError() {
-        Observable<String> sourceStrings = Observable.from("one", "two", "three", "four", "five", "six");
+        Observable<String> sourceStrings = Observable.just("one", "two", "three", "four", "five", "six");
         Observable<String> errorSource = Observable.error(new RuntimeException("forced failure"));
         Observable<String> source = Observable.concat(sourceStrings, errorSource);
 

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorGroupByUntilTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorGroupByUntilTest.java
@@ -151,7 +151,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void behaveAsGroupBy() {
-        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
 
@@ -183,7 +183,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void keySelectorThrows() {
-        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
 
@@ -201,7 +201,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void valueSelectorThrows() {
-        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = just(Observable.never());
 
@@ -219,7 +219,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void durationSelectorThrows() {
-        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Func1<GroupedObservable<Integer, Integer>, Observable<Object>> duration = fail2((Observable<Object>) null);
 
@@ -237,7 +237,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void durationThrows() {
-        Observable<Integer> source = Observable.from(0, 1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Func1<GroupedObservable<Integer, Integer>, Integer> getkey = new Func1<GroupedObservable<Integer, Integer>, Integer>() {
 
@@ -269,7 +269,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void innerEscapeCompleted() {
-        Observable<Integer> source = Observable.from(0);
+        Observable<Integer> source = Observable.just(0);
 
         final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();
 
@@ -293,7 +293,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void innerEscapeCompletedTwice() {
-        Observable<Integer> source = Observable.from(0);
+        Observable<Integer> source = Observable.just(0);
 
         final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();
 
@@ -322,7 +322,7 @@ public class OperatorGroupByUntilTest {
 
     @Test
     public void innerEscapeError() {
-        Observable<Integer> source = Observable.concat(Observable.from(0), Observable.<Integer> error(
+        Observable<Integer> source = Observable.concat(Observable.just(0), Observable.<Integer> error(
                 new TestException("Forced failure")));
 
         final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();
@@ -356,7 +356,7 @@ public class OperatorGroupByUntilTest {
     
     @Test
     public void innerEscapeErrorTwice() {
-        Observable<Integer> source = Observable.concat(Observable.from(0), Observable.<Integer> error(
+        Observable<Integer> source = Observable.concat(Observable.just(0), Observable.<Integer> error(
                 new TestException("Forced failure")));
 
         final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorLastTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorLastTest.java
@@ -34,7 +34,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastWithElements() {
-        Observable<Integer> last = Observable.from(1, 2, 3).last();
+        Observable<Integer> last = Observable.just(1, 2, 3).last();
         assertEquals(3, last.toBlocking().single().intValue());
     }
 
@@ -46,19 +46,19 @@ public class OperatorLastTest {
 
     @Test
     public void testLastMultiSubscribe() {
-        Observable<Integer> last = Observable.from(1, 2, 3).last();
+        Observable<Integer> last = Observable.just(1, 2, 3).last();
         assertEquals(3, last.toBlocking().single().intValue());
         assertEquals(3, last.toBlocking().single().intValue());
     }
 
     @Test
     public void testLastViaObservable() {
-        Observable.from(1, 2, 3).last();
+        Observable.just(1, 2, 3).last();
     }
 
     @Test
     public void testLast() {
-        Observable<Integer> observable = Observable.from(1, 2, 3).last();
+        Observable<Integer> observable = Observable.just(1, 2, 3).last();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -72,7 +72,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastWithOneElement() {
-        Observable<Integer> observable = Observable.from(1).last();
+        Observable<Integer> observable = Observable.just(1).last();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -100,7 +100,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastWithPredicate() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4, 5, 6)
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4, 5, 6)
                 .last(new Func1<Integer, Boolean>() {
 
                     @Override
@@ -121,7 +121,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastWithPredicateAndOneElement() {
-        Observable<Integer> observable = Observable.from(1, 2).last(
+        Observable<Integer> observable = Observable.just(1, 2).last(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -142,7 +142,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastWithPredicateAndEmpty() {
-        Observable<Integer> observable = Observable.from(1).last(
+        Observable<Integer> observable = Observable.just(1).last(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -162,7 +162,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastOrDefault() {
-        Observable<Integer> observable = Observable.from(1, 2, 3)
+        Observable<Integer> observable = Observable.just(1, 2, 3)
                 .lastOrDefault(4);
 
         @SuppressWarnings("unchecked")
@@ -177,7 +177,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastOrDefaultWithOneElement() {
-        Observable<Integer> observable = Observable.from(1).lastOrDefault(2);
+        Observable<Integer> observable = Observable.just(1).lastOrDefault(2);
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -206,7 +206,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastOrDefaultWithPredicate() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4, 5, 6)
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4, 5, 6)
                 .lastOrDefault(8, new Func1<Integer, Boolean>() {
 
                     @Override
@@ -227,7 +227,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastOrDefaultWithPredicateAndOneElement() {
-        Observable<Integer> observable = Observable.from(1, 2).lastOrDefault(4,
+        Observable<Integer> observable = Observable.just(1, 2).lastOrDefault(4,
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -248,7 +248,7 @@ public class OperatorLastTest {
 
     @Test
     public void testLastOrDefaultWithPredicateAndEmpty() {
-        Observable<Integer> observable = Observable.from(1).lastOrDefault(2,
+        Observable<Integer> observable = Observable.just(1).lastOrDefault(2,
                 new Func1<Integer, Boolean>() {
 
                     @Override

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorMapTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorMapTest.java
@@ -62,7 +62,7 @@ public class OperatorMapTest {
     public void testMap() {
         Map<String, String> m1 = getMap("One");
         Map<String, String> m2 = getMap("Two");
-        Observable<Map<String, String>> observable = Observable.from(m1, m2);
+        Observable<Map<String, String>> observable = Observable.just(m1, m2);
 
         Observable<String> m = observable.lift(new OperatorMap<Map<String, String>, String>(new Func1<Map<String, String>, String>() {
 
@@ -83,7 +83,7 @@ public class OperatorMapTest {
     @Test
     public void testMapMany() {
         /* simulate a top-level async call which returns IDs */
-        Observable<Integer> ids = Observable.from(1, 2);
+        Observable<Integer> ids = Observable.just(1, 2);
 
         /* now simulate the behavior to take those IDs and perform nested async calls based on them */
         Observable<String> m = ids.flatMap(new Func1<Integer, Observable<String>>() {
@@ -95,11 +95,11 @@ public class OperatorMapTest {
                 if (id == 1) {
                     Map<String, String> m1 = getMap("One");
                     Map<String, String> m2 = getMap("Two");
-                    subObservable = Observable.from(m1, m2);
+                    subObservable = Observable.just(m1, m2);
                 } else {
                     Map<String, String> m3 = getMap("Three");
                     Map<String, String> m4 = getMap("Four");
-                    subObservable = Observable.from(m3, m4);
+                    subObservable = Observable.just(m3, m4);
                 }
 
                 /* simulate kicking off the async call and performing a select on it to transform the data */
@@ -126,13 +126,13 @@ public class OperatorMapTest {
     public void testMapMany2() {
         Map<String, String> m1 = getMap("One");
         Map<String, String> m2 = getMap("Two");
-        Observable<Map<String, String>> observable1 = Observable.from(m1, m2);
+        Observable<Map<String, String>> observable1 = Observable.just(m1, m2);
 
         Map<String, String> m3 = getMap("Three");
         Map<String, String> m4 = getMap("Four");
-        Observable<Map<String, String>> observable2 = Observable.from(m3, m4);
+        Observable<Map<String, String>> observable2 = Observable.just(m3, m4);
 
-        Observable<Observable<Map<String, String>>> observable = Observable.from(observable1, observable2);
+        Observable<Observable<Map<String, String>>> observable = Observable.just(observable1, observable2);
 
         Observable<String> m = observable.flatMap(new Func1<Observable<Map<String, String>>, Observable<String>>() {
 
@@ -161,7 +161,7 @@ public class OperatorMapTest {
 
     @Test
     public void testMapWithError() {
-        Observable<String> w = Observable.from("one", "fail", "two", "three", "fail");
+        Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         Observable<String> m = w.lift(new OperatorMap<String, String>(new Func1<String, String>() {
             @Override
             public String call(String s) {
@@ -189,7 +189,7 @@ public class OperatorMapTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testMapWithIssue417() {
-        Observable.from(1).observeOn(Schedulers.computation())
+        Observable.just(1).observeOn(Schedulers.computation())
                 .map(new Func1<Integer, Integer>() {
                     public Integer call(Integer arg0) {
                         throw new IllegalArgumentException("any error");
@@ -202,7 +202,7 @@ public class OperatorMapTest {
         // The error will throw in one of threads in the thread pool.
         // If map does not handle it, the error will disappear.
         // so map needs to handle the error by itself.
-        Observable<String> m = Observable.from("one")
+        Observable<String> m = Observable.just("one")
                 .observeOn(Schedulers.computation())
                 .map(new Func1<String, String>() {
                     public String call(String arg0) {
@@ -278,7 +278,7 @@ public class OperatorMapTest {
 
             @Override
             public Observable<Object> call(Object object) {
-                return Observable.from(object);
+                return Observable.just(object);
             }
         };
 

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -48,9 +48,9 @@ public class OperatorMergeMaxConcurrentTest {
     public void testWhenMaxConcurrentIsOne() {
         for (int i = 0; i < 100; i++) {
             List<Observable<String>> os = new ArrayList<Observable<String>>();
-            os.add(Observable.from("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
-            os.add(Observable.from("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
-            os.add(Observable.from("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
+            os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
+            os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
+            os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
 
             List<String> expected = Arrays.asList("one", "two", "three", "four", "five", "one", "two", "three", "four", "five", "one", "two", "three", "four", "five");
             Iterator<String> iter = Observable.merge(os, 1).toBlocking().toIterable().iterator();

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -146,7 +146,7 @@ public class OperatorMergeTest {
                     public void run() {
 
                         while (!unsubscribed.get()) {
-                            observer.onNext(Observable.from(1L, 2L));
+                            observer.onNext(Observable.just(1L, 2L));
                         }
                         System.out.println("Done looping after unsubscribe: " + unsubscribed.get());
                         observer.onCompleted();
@@ -751,7 +751,7 @@ public class OperatorMergeTest {
 
             @Override
             public Observable<Integer> call(Integer t1) {
-                return Observable.from(1, 2, 3);
+                return Observable.just(1, 2, 3);
             }
 
         });
@@ -792,7 +792,7 @@ public class OperatorMergeTest {
     public void mergeWithNullValues() {
         System.out.println("mergeWithNullValues");
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.merge(Observable.from(null, "one"), Observable.from("two", null)).subscribe(ts);
+        Observable.merge(Observable.just(null, "one"), Observable.just("two", null)).subscribe(ts);
         ts.assertTerminalEvent();
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Arrays.asList(null, "one", "two", null));
@@ -812,7 +812,7 @@ public class OperatorMergeTest {
             }
 
         });
-        Observable.merge(Observable.from(null, "one"), bad).subscribe(ts);
+        Observable.merge(Observable.just(null, "one"), bad).subscribe(ts);
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Arrays.asList(null, "one", "two"));
     }
@@ -820,7 +820,7 @@ public class OperatorMergeTest {
     @Test
     public void mergingNullObservable() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.merge(Observable.from("one"), null).subscribe(ts);
+        Observable.merge(Observable.just("one"), null).subscribe(ts);
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Arrays.asList("one"));
     }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -62,7 +62,7 @@ public class OperatorObserveOnTest {
     @SuppressWarnings("unchecked")
     public void testObserveOn() {
         Observer<Integer> observer = mock(Observer.class);
-        Observable.from(1, 2, 3).observeOn(Schedulers.immediate()).subscribe(observer);
+        Observable.just(1, 2, 3).observeOn(Schedulers.immediate()).subscribe(observer);
 
         verify(observer, times(1)).onNext(1);
         verify(observer, times(1)).onNext(2);
@@ -73,7 +73,7 @@ public class OperatorObserveOnTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testOrdering() throws InterruptedException {
-        Observable<String> obs = Observable.from("one", null, "two", "three", "four");
+        Observable<String> obs = Observable.just("one", null, "two", "three", "four");
 
         Observer<String> observer = mock(Observer.class);
 
@@ -103,7 +103,7 @@ public class OperatorObserveOnTest {
     @SuppressWarnings("unchecked")
     public void testThreadName() throws InterruptedException {
         System.out.println("Main Thread: " + Thread.currentThread().getName());
-        Observable<String> obs = Observable.from("one", null, "two", "three", "four");
+        Observable<String> obs = Observable.just("one", null, "two", "three", "four");
 
         Observer<String> observer = mock(Observer.class);
         final String parentThreadName = Thread.currentThread().getName();
@@ -155,7 +155,7 @@ public class OperatorObserveOnTest {
     public void observeOnTheSameSchedulerTwice() {
         Scheduler scheduler = Schedulers.immediate();
 
-        Observable<Integer> o = Observable.from(1, 2, 3);
+        Observable<Integer> o = Observable.just(1, 2, 3);
         Observable<Integer> o2 = o.observeOn(scheduler);
 
         @SuppressWarnings("unchecked")
@@ -189,7 +189,7 @@ public class OperatorObserveOnTest {
         TestScheduler scheduler1 = new TestScheduler();
         TestScheduler scheduler2 = new TestScheduler();
 
-        Observable<Integer> o = Observable.from(1, 2, 3);
+        Observable<Integer> o = Observable.just(1, 2, 3);
         Observable<Integer> o1 = o.observeOn(scheduler1);
         Observable<Integer> o2 = o.observeOn(scheduler2);
 
@@ -395,7 +395,7 @@ public class OperatorObserveOnTest {
     public void testAfterUnsubscribeCalledThenObserverOnNextNeverCalled() {
         final TestScheduler testScheduler = new TestScheduler();
         final Observer<Integer> observer = mock(Observer.class);
-        final Subscription subscription = Observable.from(1, 2, 3)
+        final Subscription subscription = Observable.just(1, 2, 3)
                 .observeOn(testScheduler)
                 .subscribe(observer);
         subscription.unsubscribe();

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorOnErrorFlatMapTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorOnErrorFlatMapTest.java
@@ -31,7 +31,7 @@ public class OperatorOnErrorFlatMapTest {
     @Test
     public void ignoreErrorsAndContinueEmitting() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.from(1, 2, 3, 4, 5, 6).map(new Func1<Integer, String>() {
+        Observable.just(1, 2, 3, 4, 5, 6).map(new Func1<Integer, String>() {
 
             @Override
             public String call(Integer v) {
@@ -60,7 +60,7 @@ public class OperatorOnErrorFlatMapTest {
     @Test
     public void spliceAndContinueEmitting() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.from(1, 2, 3, 4, 5, 6).map(new Func1<Integer, String>() {
+        Observable.just(1, 2, 3, 4, 5, 6).map(new Func1<Integer, String>() {
 
             @Override
             public String call(Integer v) {
@@ -74,7 +74,7 @@ public class OperatorOnErrorFlatMapTest {
 
             @Override
             public Observable<String> call(OnErrorThrowable t) {
-                return Observable.from("Error=" + t.getValue());
+                return Observable.just("Error=" + t.getValue());
             }
 
         }).subscribe(ts);
@@ -89,7 +89,7 @@ public class OperatorOnErrorFlatMapTest {
     @Test
     public void testOnErrorFlatMapAfterFlatMap() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        Observable.from(1, 2, 3).flatMap(new Func1<Integer, Observable<Integer>>() {
+        Observable.just(1, 2, 3).flatMap(new Func1<Integer, Observable<Integer>>() {
 
             @Override
             public Observable<Integer> call(Integer i) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
@@ -55,7 +55,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
             @Override
             public Observable<String> call(Throwable t1) {
                 receivedException.set(t1);
-                return Observable.from("twoResume", "threeResume");
+                return Observable.just("twoResume", "threeResume");
             }
 
         };
@@ -85,7 +85,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
             @Override
             public Observable<String> call(Throwable t1) {
                 receivedException.set(t1);
-                return Observable.from("twoResume", "threeResume");
+                return Observable.just("twoResume", "threeResume");
             }
 
         };
@@ -153,7 +153,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
     @Test
     public void testOnErrorResumeReceivesErrorFromPreviousNonProtectedOperator() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.from(1).lift(new Operator<String, Integer>() {
+        Observable.just(1).lift(new Operator<String, Integer>() {
 
             @Override
             public Subscriber<? super Integer> call(Subscriber<? super String> t1) {
@@ -165,7 +165,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
             @Override
             public Observable<String> call(Throwable t1) {
                 if (t1.getMessage().equals("failed")) {
-                    return Observable.from("success");
+                    return Observable.just("success");
                 } else {
                     return Observable.error(t1);
                 }
@@ -185,7 +185,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
     @Test
     public void testOnErrorResumeReceivesErrorFromPreviousNonProtectedOperatorOnNext() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.from(1).lift(new Operator<String, Integer>() {
+        Observable.just(1).lift(new Operator<String, Integer>() {
 
             @Override
             public Subscriber<? super Integer> call(Subscriber<? super String> t1) {
@@ -214,7 +214,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
             @Override
             public Observable<String> call(Throwable t1) {
                 if (t1.getMessage().equals("failed")) {
-                    return Observable.from("success");
+                    return Observable.just("success");
                 } else {
                     return Observable.error(t1);
                 }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
@@ -38,7 +38,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
         // Trigger failure on second element
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
         Observable<String> w = Observable.create(f);
-        Observable<String> resume = Observable.from("twoResume", "threeResume");
+        Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
@@ -64,7 +64,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
     public void testMapResumeAsyncNext() {
         Subscription sr = mock(Subscription.class);
         // Trigger multiple failures
-        Observable<String> w = Observable.from("one", "fail", "two", "three", "fail");
+        Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         // Resume Observable is async
         TestObservable f = new TestObservable(sr, "twoResume", "threeResume");
         Observable<String> resume = Observable.create(f);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
@@ -38,7 +38,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "EXCEPTION", "two", "three");
         Observable<String> w = Observable.create(f);
-        Observable<String> resume = Observable.from("twoResume", "threeResume");
+        Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
         @SuppressWarnings("unchecked")
@@ -66,7 +66,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "RUNTIMEEXCEPTION", "two", "three");
         Observable<String> w = Observable.create(f);
-        Observable<String> resume = Observable.from("twoResume", "threeResume");
+        Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
         @SuppressWarnings("unchecked")
@@ -94,7 +94,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "THROWABLE", "two", "three");
         Observable<String> w = Observable.create(f);
-        Observable<String> resume = Observable.from("twoResume", "threeResume");
+        Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
         @SuppressWarnings("unchecked")
@@ -122,7 +122,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "ERROR", "two", "three");
         Observable<String> w = Observable.create(f);
-        Observable<String> resume = Observable.from("twoResume", "threeResume");
+        Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
         @SuppressWarnings("unchecked")
@@ -148,7 +148,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
     @Test
     public void testMapResumeAsyncNext() {
         // Trigger multiple failures
-        Observable<String> w = Observable.from("one", "fail", "two", "three", "fail");
+        Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         // Resume Observable is async
         TestObservable f = new TestObservable("twoResume", "threeResume");
         Observable<String> resume = Observable.create(f);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorParallelMergeTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorParallelMergeTest.java
@@ -39,7 +39,7 @@ public class OperatorParallelMergeTest {
         PublishSubject<String> p3 = PublishSubject.<String> create();
         PublishSubject<String> p4 = PublishSubject.<String> create();
 
-        Observable<Observable<String>> fourStreams = Observable.<Observable<String>> from(p1, p2, p3, p4);
+        Observable<Observable<String>> fourStreams = Observable.<Observable<String>> just(p1, p2, p3, p4);
 
         Observable<Observable<String>> twoStreams = Observable.parallelMerge(fourStreams, 2);
         Observable<Observable<String>> threeStreams = Observable.parallelMerge(fourStreams, 3);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorParallelTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorParallelTest.java
@@ -93,7 +93,7 @@ public class OperatorParallelTest {
 
                             @Override
                             public Observable<String> call(Integer t) {
-                                return Observable.from(String.valueOf(t)).delay(100, TimeUnit.MILLISECONDS);
+                                return Observable.just(String.valueOf(t)).delay(100, TimeUnit.MILLISECONDS);
                             }
 
                         });

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorReduceTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorReduceTest.java
@@ -53,7 +53,7 @@ public class OperatorReduceTest {
     @Test
     public void testAggregateAsIntSum() {
 
-        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5).reduce(0, sum).map(Functions.<Integer> identity());
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5).reduce(0, sum).map(Functions.<Integer> identity());
 
         result.subscribe(observer);
 
@@ -64,7 +64,7 @@ public class OperatorReduceTest {
 
     @Test
     public void testAggregateAsIntSumSourceThrows() {
-        Observable<Integer> result = Observable.concat(Observable.from(1, 2, 3, 4, 5),
+        Observable<Integer> result = Observable.concat(Observable.just(1, 2, 3, 4, 5),
                 Observable.<Integer> error(new TestException()))
                 .reduce(0, sum).map(Functions.<Integer> identity());
 
@@ -84,7 +84,7 @@ public class OperatorReduceTest {
             }
         };
 
-        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5)
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
                 .reduce(0, sumErr).map(Functions.<Integer> identity());
 
         result.subscribe(observer);
@@ -105,7 +105,7 @@ public class OperatorReduceTest {
             }
         };
 
-        Observable<Integer> result = Observable.from(1, 2, 3, 4, 5)
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
                 .reduce(0, sum).map(error);
 
         result.subscribe(observer);
@@ -117,7 +117,7 @@ public class OperatorReduceTest {
 
     @Test
     public void testBackpressureWithNoInitialValue() throws InterruptedException {
-        Observable<Integer> source = Observable.from(1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
         Observable<Integer> reduced = source.reduce(sum);
 
         Integer r = reduced.toBlocking().first();
@@ -126,7 +126,7 @@ public class OperatorReduceTest {
 
     @Test
     public void testBackpressureWithInitialValue() throws InterruptedException {
-        Observable<Integer> source = Observable.from(1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
         Observable<Integer> reduced = source.reduce(0, sum);
 
         Integer r = reduced.toBlocking().first();

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorRepeatTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorRepeatTest.java
@@ -55,14 +55,14 @@ public class OperatorRepeatTest {
 
     @Test(timeout = 2000)
     public void testRepeatTake() {
-        Observable<Integer> xs = Observable.from(1, 2);
+        Observable<Integer> xs = Observable.just(1, 2);
         Object[] ys = xs.repeat(Schedulers.newThread()).take(4).toList().toBlocking().last().toArray();
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
     }
 
     @Test(timeout = 20000)
     public void testNoStackOverFlow() {
-        Observable.from(1).repeat(Schedulers.newThread()).take(100000).toBlocking().last();
+        Observable.just(1).repeat(Schedulers.newThread()).take(100000).toBlocking().last();
     }
 
     @Test
@@ -103,7 +103,7 @@ public class OperatorRepeatTest {
         @SuppressWarnings("unchecked")
                 Observer<Object> o = mock(Observer.class);
         
-        Observable.from(1).repeat().take(10).subscribe(o);
+        Observable.just(1).repeat().take(10).subscribe(o);
         
         verify(o, times(10)).onNext(1);
         verify(o).onCompleted();
@@ -115,7 +115,7 @@ public class OperatorRepeatTest {
         @SuppressWarnings("unchecked")
                 Observer<Object> o = mock(Observer.class);
         
-        Observable.from(1).repeat(10).subscribe(o);
+        Observable.just(1).repeat(10).subscribe(o);
         
         verify(o, times(10)).onNext(1);
         verify(o).onCompleted();
@@ -140,7 +140,7 @@ public class OperatorRepeatTest {
         @SuppressWarnings("unchecked")
                 Observer<Object> o = mock(Observer.class);
         
-        Observable.from(1).repeat(0).subscribe(o);
+        Observable.just(1).repeat(0).subscribe(o);
         
         verify(o).onCompleted();
         verify(o, never()).onNext(any());
@@ -152,7 +152,7 @@ public class OperatorRepeatTest {
         @SuppressWarnings("unchecked")
                 Observer<Object> o = mock(Observer.class);
         
-        Observable.from(1).repeat(1).subscribe(o);
+        Observable.just(1).repeat(1).subscribe(o);
         
         verify(o).onCompleted();
         verify(o, times(1)).onNext(any());

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -422,7 +422,7 @@ public class OperatorReplayTest {
     @Test
     public void testSynchronousDisconnect() {
         final AtomicInteger effectCounter = new AtomicInteger();
-        Observable<Integer> source = Observable.from(1, 2, 3, 4)
+        Observable<Integer> source = Observable.just(1, 2, 3, 4)
         .doOnNext(new Action1<Integer>() {
             @Override
             public void call(Integer v) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -43,7 +43,7 @@ public class OperatorScanTest {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
 
-        Observable<Integer> observable = Observable.from(1, 2, 3);
+        Observable<Integer> observable = Observable.just(1, 2, 3);
 
         Observable<String> m = observable.scan("", new Func2<String, Integer, String>() {
 
@@ -70,7 +70,7 @@ public class OperatorScanTest {
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = mock(Observer.class);
 
-        Observable<Integer> observable = Observable.from(1, 2, 3);
+        Observable<Integer> observable = Observable.just(1, 2, 3);
 
         Observable<Integer> m = observable.scan(new Func2<Integer, Integer, Integer>() {
 
@@ -97,7 +97,7 @@ public class OperatorScanTest {
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = mock(Observer.class);
 
-        Observable<Integer> observable = Observable.from(1);
+        Observable<Integer> observable = Observable.just(1);
 
         Observable<Integer> m = observable.scan(new Func2<Integer, Integer, Integer>() {
 

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSequenceEqualTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSequenceEqualTest.java
@@ -33,41 +33,41 @@ public class OperatorSequenceEqualTest {
     @Test
     public void test1() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from("one", "two", "three"),
-                Observable.from("one", "two", "three"));
+                Observable.just("one", "two", "three"),
+                Observable.just("one", "two", "three"));
         verifyResult(observable, true);
     }
 
     @Test
     public void test2() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from("one", "two", "three"),
-                Observable.from("one", "two", "three", "four"));
+                Observable.just("one", "two", "three"),
+                Observable.just("one", "two", "three", "four"));
         verifyResult(observable, false);
     }
 
     @Test
     public void test3() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from("one", "two", "three", "four"),
-                Observable.from("one", "two", "three"));
+                Observable.just("one", "two", "three", "four"),
+                Observable.just("one", "two", "three"));
         verifyResult(observable, false);
     }
 
     @Test
     public void testWithError1() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.concat(Observable.from("one"),
+                Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())),
-                Observable.from("one", "two", "three"));
+                Observable.just("one", "two", "three"));
         verifyError(observable);
     }
 
     @Test
     public void testWithError2() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from("one", "two", "three"),
-                Observable.concat(Observable.from("one"),
+                Observable.just("one", "two", "three"),
+                Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())));
         verifyError(observable);
     }
@@ -75,9 +75,9 @@ public class OperatorSequenceEqualTest {
     @Test
     public void testWithError3() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.concat(Observable.from("one"),
+                Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())),
-                Observable.concat(Observable.from("one"),
+                Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())));
         verifyError(observable);
     }
@@ -86,14 +86,14 @@ public class OperatorSequenceEqualTest {
     public void testWithEmpty1() {
         Observable<Boolean> observable = Observable.sequenceEqual(
                 Observable.<String> empty(),
-                Observable.from("one", "two", "three"));
+                Observable.just("one", "two", "three"));
         verifyResult(observable, false);
     }
 
     @Test
     public void testWithEmpty2() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from("one", "two", "three"),
+                Observable.just("one", "two", "three"),
                 Observable.<String> empty());
         verifyResult(observable, false);
     }
@@ -108,21 +108,21 @@ public class OperatorSequenceEqualTest {
     @Test
     public void testWithNull1() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from((String) null), Observable.from("one"));
+                Observable.just((String) null), Observable.just("one"));
         verifyResult(observable, false);
     }
 
     @Test
     public void testWithNull2() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from((String) null), Observable.from((String) null));
+                Observable.just((String) null), Observable.just((String) null));
         verifyResult(observable, true);
     }
 
     @Test
     public void testWithEqualityError() {
         Observable<Boolean> observable = Observable.sequenceEqual(
-                Observable.from("one"), Observable.from("one"),
+                Observable.just("one"), Observable.just("one"),
                 new Func2<String, String, Boolean>() {
                     @Override
                     public Boolean call(String t1, String t2) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSingleTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSingleTest.java
@@ -34,7 +34,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingle() {
-        Observable<Integer> observable = Observable.from(1).single();
+        Observable<Integer> observable = Observable.just(1).single();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -48,7 +48,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleWithTooManyElements() {
-        Observable<Integer> observable = Observable.from(1, 2).single();
+        Observable<Integer> observable = Observable.just(1, 2).single();
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -76,7 +76,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleWithPredicate() {
-        Observable<Integer> observable = Observable.from(1, 2).single(
+        Observable<Integer> observable = Observable.just(1, 2).single(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -97,7 +97,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleWithPredicateAndTooManyElements() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4).single(
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4).single(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -118,7 +118,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleWithPredicateAndEmpty() {
-        Observable<Integer> observable = Observable.from(1).single(
+        Observable<Integer> observable = Observable.just(1).single(
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -138,7 +138,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleOrDefault() {
-        Observable<Integer> observable = Observable.from(1).singleOrDefault(2);
+        Observable<Integer> observable = Observable.just(1).singleOrDefault(2);
 
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
@@ -152,7 +152,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleOrDefaultWithTooManyElements() {
-        Observable<Integer> observable = Observable.from(1, 2).singleOrDefault(
+        Observable<Integer> observable = Observable.just(1, 2).singleOrDefault(
                 3);
 
         @SuppressWarnings("unchecked")
@@ -182,7 +182,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicate() {
-        Observable<Integer> observable = Observable.from(1, 2).singleOrDefault(
+        Observable<Integer> observable = Observable.just(1, 2).singleOrDefault(
                 4, new Func1<Integer, Boolean>() {
 
                     @Override
@@ -203,7 +203,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateAndTooManyElements() {
-        Observable<Integer> observable = Observable.from(1, 2, 3, 4)
+        Observable<Integer> observable = Observable.just(1, 2, 3, 4)
                 .singleOrDefault(6, new Func1<Integer, Boolean>() {
 
                     @Override
@@ -224,7 +224,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateAndEmpty() {
-        Observable<Integer> observable = Observable.from(1).singleOrDefault(2,
+        Observable<Integer> observable = Observable.just(1).singleOrDefault(2,
                 new Func1<Integer, Boolean>() {
 
                     @Override
@@ -245,7 +245,7 @@ public class OperatorSingleTest {
 
     @Test
     public void testSingleWithBackpressure() {
-        Observable<Integer> observable = Observable.from(1, 2).single();
+        Observable<Integer> observable = Observable.just(1, 2).single();
 
         Subscriber<Integer> subscriber = spy(new Subscriber<Integer>() {
 
@@ -279,7 +279,7 @@ public class OperatorSingleTest {
     @Test(timeout = 30000)
     public void testIssue1527() throws InterruptedException {
         //https://github.com/Netflix/RxJava/pull/1527
-        Observable<Integer> source = Observable.from(1, 2, 3, 4, 5, 6);
+        Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
         Observable<Integer> reduced = source.reduce(new Func2<Integer, Integer, Integer>() {
             @Override
             public Integer call(Integer i1, Integer i2) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSkipLastTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSkipLastTest.java
@@ -77,7 +77,7 @@ public class OperatorSkipLastTest {
 
     @Test
     public void testSkipLastWithZeroCount() {
-        Observable<String> w = Observable.from("one", "two");
+        Observable<String> w = Observable.just("one", "two");
         Observable<String> observable = w.skipLast(0);
 
         @SuppressWarnings("unchecked")
@@ -116,7 +116,7 @@ public class OperatorSkipLastTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testSkipLastWithNegativeCount() {
-        Observable.from("one").skipLast(-1);
+        Observable.just("one").skipLast(-1);
     }
 
 }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSkipTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSkipTest.java
@@ -32,7 +32,7 @@ public class OperatorSkipTest {
     @Test
     public void testSkipNegativeElements() {
 
-        Observable<String> skip = Observable.from("one", "two", "three").lift(new OperatorSkip<String>(-99));
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(-99));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -47,7 +47,7 @@ public class OperatorSkipTest {
     @Test
     public void testSkipZeroElements() {
 
-        Observable<String> skip = Observable.from("one", "two", "three").lift(new OperatorSkip<String>(0));
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(0));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -62,7 +62,7 @@ public class OperatorSkipTest {
     @Test
     public void testSkipOneElement() {
 
-        Observable<String> skip = Observable.from("one", "two", "three").lift(new OperatorSkip<String>(1));
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(1));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -77,7 +77,7 @@ public class OperatorSkipTest {
     @Test
     public void testSkipTwoElements() {
 
-        Observable<String> skip = Observable.from("one", "two", "three").lift(new OperatorSkip<String>(2));
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(2));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -106,7 +106,7 @@ public class OperatorSkipTest {
     @Test
     public void testSkipMultipleObservers() {
 
-        Observable<String> skip = Observable.from("one", "two", "three").lift(new OperatorSkip<String>(2));
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(2));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer1 = mock(Observer.class);
@@ -130,7 +130,7 @@ public class OperatorSkipTest {
 
         Exception e = new Exception();
 
-        Observable<String> ok = Observable.from("one");
+        Observable<String> ok = Observable.just("one");
         Observable<String> error = Observable.error(e);
 
         Observable<String> skip = Observable.concat(ok, error).lift(new OperatorSkip<String>(100));

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSkipWhileTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSkipWhileTest.java
@@ -54,7 +54,7 @@ public class OperatorSkipWhileTest {
 
     @Test
     public void testSkipWithIndex() {
-        Observable<Integer> src = Observable.from(1, 2, 3, 4, 5);
+        Observable<Integer> src = Observable.just(1, 2, 3, 4, 5);
         src.skipWhileWithIndex(INDEX_LESS_THAN_THREE).subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -75,7 +75,7 @@ public class OperatorSkipWhileTest {
 
     @Test
     public void testSkipEverything() {
-        Observable<Integer> src = Observable.from(1, 2, 3, 4, 3, 2, 1);
+        Observable<Integer> src = Observable.just(1, 2, 3, 4, 3, 2, 1);
         src.skipWhile(LESS_THAN_FIVE).subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w, never()).onError(any(Throwable.class));
@@ -84,7 +84,7 @@ public class OperatorSkipWhileTest {
 
     @Test
     public void testSkipNothing() {
-        Observable<Integer> src = Observable.from(5, 3, 1);
+        Observable<Integer> src = Observable.just(5, 3, 1);
         src.skipWhile(LESS_THAN_FIVE).subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -97,7 +97,7 @@ public class OperatorSkipWhileTest {
 
     @Test
     public void testSkipSome() {
-        Observable<Integer> src = Observable.from(1, 2, 3, 4, 5, 3, 1, 5);
+        Observable<Integer> src = Observable.just(1, 2, 3, 4, 5, 3, 1, 5);
         src.skipWhile(LESS_THAN_FIVE).subscribe(w);
 
         InOrder inOrder = inOrder(w);
@@ -111,7 +111,7 @@ public class OperatorSkipWhileTest {
 
     @Test
     public void testSkipError() {
-        Observable<Integer> src = Observable.from(1, 2, 42, 5, 3, 1);
+        Observable<Integer> src = Observable.just(1, 2, 42, 5, 3, 1);
         src.skipWhile(LESS_THAN_FIVE).subscribe(w);
 
         InOrder inOrder = inOrder(w);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
@@ -223,7 +223,7 @@ public class OperatorSubscribeOnTest {
     @Test
     public void testSetProducerSynchronousRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        Observable.from(1, 2, 3).lift(new Operator<Integer, Integer>() {
+        Observable.just(1, 2, 3).lift(new Operator<Integer, Integer>() {
 
             @Override
             public Subscriber<? super Integer> call(final Subscriber<? super Integer> child) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
@@ -54,7 +54,7 @@ public class OperatorTakeLastTest {
 
     @Test
     public void testTakeLast1() {
-        Observable<String> w = Observable.from("one", "two", "three");
+        Observable<String> w = Observable.just("one", "two", "three");
         Observable<String> take = w.takeLast(2);
 
         @SuppressWarnings("unchecked")
@@ -70,7 +70,7 @@ public class OperatorTakeLastTest {
 
     @Test
     public void testTakeLast2() {
-        Observable<String> w = Observable.from("one");
+        Observable<String> w = Observable.just("one");
         Observable<String> take = w.takeLast(10);
 
         @SuppressWarnings("unchecked")
@@ -83,7 +83,7 @@ public class OperatorTakeLastTest {
 
     @Test
     public void testTakeLastWithZeroCount() {
-        Observable<String> w = Observable.from("one");
+        Observable<String> w = Observable.just("one");
         Observable<String> take = w.takeLast(0);
 
         @SuppressWarnings("unchecked")
@@ -96,7 +96,7 @@ public class OperatorTakeLastTest {
 
     @Test
     public void testTakeLastWithNull() {
-        Observable<String> w = Observable.from("one", null, "three");
+        Observable<String> w = Observable.just("one", null, "three");
         Observable<String> take = w.takeLast(2);
 
         @SuppressWarnings("unchecked")
@@ -111,7 +111,7 @@ public class OperatorTakeLastTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testTakeLastWithNegativeCount() {
-        Observable.from("one").takeLast(-1);
+        Observable.just("one").takeLast(-1);
     }
 
     @Test

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeLastTimedTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeLastTimedTest.java
@@ -37,7 +37,7 @@ public class OperatorTakeLastTimedTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testTakeLastTimedWithNegativeCount() {
-        Observable.from("one").takeLast(-1, 1, TimeUnit.SECONDS);
+        Observable.just("one").takeLast(-1, 1, TimeUnit.SECONDS);
     }
 
     @Test

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
@@ -38,7 +38,7 @@ public class OperatorTakeWhileTest {
 
     @Test
     public void testTakeWhile1() {
-        Observable<Integer> w = Observable.from(1, 2, 3);
+        Observable<Integer> w = Observable.just(1, 2, 3);
         Observable<Integer> take = w.takeWhile(new Func1<Integer, Boolean>() {
             @Override
             public Boolean call(Integer input) {
@@ -88,7 +88,7 @@ public class OperatorTakeWhileTest {
 
     @Test
     public void testTakeWhile2() {
-        Observable<String> w = Observable.from("one", "two", "three");
+        Observable<String> w = Observable.just("one", "two", "three");
         Observable<String> take = w.takeWhileWithIndex(new Func2<String, Integer, Boolean>() {
             @Override
             public Boolean call(String input, Integer index) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
@@ -135,7 +135,7 @@ public class OperatorTimeoutTests {
 
     @Test
     public void shouldSwitchToOtherIfOnNextNotWithinTimeout() {
-        Observable<String> other = Observable.from("a", "b", "c");
+        Observable<String> other = Observable.just("a", "b", "c");
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
 
         @SuppressWarnings("unchecked")
@@ -158,7 +158,7 @@ public class OperatorTimeoutTests {
 
     @Test
     public void shouldSwitchToOtherIfOnErrorNotWithinTimeout() {
-        Observable<String> other = Observable.from("a", "b", "c");
+        Observable<String> other = Observable.just("a", "b", "c");
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
 
         @SuppressWarnings("unchecked")
@@ -181,7 +181,7 @@ public class OperatorTimeoutTests {
 
     @Test
     public void shouldSwitchToOtherIfOnCompletedNotWithinTimeout() {
-        Observable<String> other = Observable.from("a", "b", "c");
+        Observable<String> other = Observable.just("a", "b", "c");
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
 
         @SuppressWarnings("unchecked")

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
@@ -400,7 +400,7 @@ public class OperatorTimeoutWithSelectorTest {
             @Override
             public void run() {
                 PublishSubject<Integer> source = PublishSubject.create();
-                source.timeout(timeoutFunc, Observable.from(3)).subscribe(ts);
+                source.timeout(timeoutFunc, Observable.just(3)).subscribe(ts);
                 source.onNext(1); // start timeout
                 try {
                     if(!enteredTimeoutOne.await(30, TimeUnit.SECONDS)) {

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorToMapTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorToMapTest.java
@@ -59,7 +59,7 @@ public class OperatorToMapTest {
 
     @Test
     public void testToMap() {
-        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc);
 
@@ -78,7 +78,7 @@ public class OperatorToMapTest {
 
     @Test
     public void testToMapWithValueSelector() {
-        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate);
 
@@ -97,7 +97,7 @@ public class OperatorToMapTest {
 
     @Test
     public void testToMapWithError() {
-        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Func1<String, Integer> lengthFuncErr = new Func1<String, Integer>() {
             @Override
@@ -126,7 +126,7 @@ public class OperatorToMapTest {
 
     @Test
     public void testToMapWithErrorInValueSelector() {
-        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Func1<String, String> duplicateErr = new Func1<String, String>() {
             @Override
@@ -156,7 +156,7 @@ public class OperatorToMapTest {
 
     @Test
     public void testToMapWithFactory() {
-        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Func0<Map<Integer, String>> mapFactory = new Func0<Map<Integer, String>>() {
             @Override
@@ -195,7 +195,7 @@ public class OperatorToMapTest {
 
     @Test
     public void testToMapWithErrorThrowingFactory() {
-        Observable<String> source = Observable.from("a", "bb", "ccc", "dddd");
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Func0<Map<Integer, String>> mapFactory = new Func0<Map<Integer, String>>() {
             @Override

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorToMultimapTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorToMultimapTest.java
@@ -66,7 +66,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimap() {
-        Observable<String> source = Observable.from("a", "b", "cc", "dd");
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc);
 
@@ -83,7 +83,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithValueSelector() {
-        Observable<String> source = Observable.from("a", "b", "cc", "dd");
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate);
 
@@ -100,7 +100,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithMapFactory() {
-        Observable<String> source = Observable.from("a", "b", "cc", "dd", "eee", "fff");
+        Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
         Func0<Map<Integer, Collection<String>>> mapFactory = new Func0<Map<Integer, Collection<String>>>() {
             @Override
@@ -134,7 +134,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithCollectionFactory() {
-        Observable<String> source = Observable.from("cc", "dd", "eee", "eee");
+        Observable<String> source = Observable.just("cc", "dd", "eee", "eee");
 
         Func1<Integer, Collection<String>> collectionFactory = new Func1<Integer, Collection<String>>() {
 
@@ -165,7 +165,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithError() {
-        Observable<String> source = Observable.from("a", "b", "cc", "dd");
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
 
         Func1<String, Integer> lengthFuncErr = new Func1<String, Integer>() {
             @Override
@@ -192,7 +192,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithErrorInValueSelector() {
-        Observable<String> source = Observable.from("a", "b", "cc", "dd");
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
 
         Func1<String, String> duplicateErr = new Func1<String, String>() {
             @Override
@@ -219,7 +219,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithMapThrowingFactory() {
-        Observable<String> source = Observable.from("a", "b", "cc", "dd", "eee", "fff");
+        Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
         Func0<Map<Integer, Collection<String>>> mapFactory = new Func0<Map<Integer, Collection<String>>>() {
             @Override
@@ -243,7 +243,7 @@ public class OperatorToMultimapTest {
 
     @Test
     public void testToMultimapWithThrowingCollectionFactory() {
-        Observable<String> source = Observable.from("cc", "cc", "eee", "eee");
+        Observable<String> source = Observable.just("cc", "cc", "eee", "eee");
 
         Func1<Integer, Collection<String>> collectionFactory = new Func1<Integer, Collection<String>>() {
 

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
@@ -36,7 +36,7 @@ public class OperatorToObservableSortedListTest {
 
     @Test
     public void testSortedList() {
-        Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
         Observable<List<Integer>> observable = w.lift(new OperatorToObservableSortedList<Integer>());
 
         @SuppressWarnings("unchecked")
@@ -49,7 +49,7 @@ public class OperatorToObservableSortedListTest {
 
     @Test
     public void testSortedListWithCustomFunction() {
-        Observable<Integer> w = Observable.from(1, 3, 2, 5, 4);
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
         Observable<List<Integer>> observable = w.lift(new OperatorToObservableSortedList<Integer>(new Func2<Integer, Integer, Integer>() {
 
             @Override
@@ -69,7 +69,7 @@ public class OperatorToObservableSortedListTest {
 
     @Test
     public void testWithFollowingFirst() {
-        Observable<Integer> o = Observable.from(1, 3, 2, 5, 4);
+        Observable<Integer> o = Observable.just(1, 3, 2, 5, 4);
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), o.toSortedList().toBlocking().first());
     }
 }

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorWindowTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorWindowTest.java
@@ -74,7 +74,7 @@ public class OperatorWindowTest {
 
     @Test
     public void testNonOverlappingWindows() {
-        Observable<String> subject = Observable.from("one", "two", "three", "four", "five");
+        Observable<String> subject = Observable.just("one", "two", "three", "four", "five");
         Observable<Observable<String>> windowed = subject.window(3);
 
         List<List<String>> windows = toLists(windowed);
@@ -86,7 +86,7 @@ public class OperatorWindowTest {
 
     @Test
     public void testSkipAndCountGaplessWindows() {
-        Observable<String> subject = Observable.from("one", "two", "three", "four", "five");
+        Observable<String> subject = Observable.just("one", "two", "three", "four", "five");
         Observable<Observable<String>> windowed = subject.window(3, 3);
 
         List<List<String>> windows = toLists(windowed);
@@ -114,7 +114,7 @@ public class OperatorWindowTest {
 
     @Test
     public void testSkipAndCountWindowsWithGaps() {
-        Observable<String> subject = Observable.from("one", "two", "three", "four", "five");
+        Observable<String> subject = Observable.just("one", "two", "three", "four", "five");
         Observable<Observable<String>> windowed = subject.window(2, 3);
 
         List<List<String>> windows = toLists(windowed);

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorZipIterableTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorZipIterableTest.java
@@ -369,7 +369,7 @@ public class OperatorZipIterableTest {
     }
 
     @Test public void testTake2() {
-        Observable<Integer> o = Observable.from(1, 2, 3, 4, 5);
+        Observable<Integer> o = Observable.just(1, 2, 3, 4, 5);
         Iterable<String> it = Arrays.asList("a", "b", "c", "d", "e");
         
         SquareStr squareStr = new SquareStr();

--- a/rxjava-core/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/rxjava-core/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -95,7 +95,7 @@ public class OperatorZipTest {
         Observer<String> observer = mock(Observer.class);
 
         @SuppressWarnings("rawtypes")
-        Collection ws = java.util.Collections.singleton(Observable.from("one", "two"));
+        Collection ws = java.util.Collections.singleton(Observable.just("one", "two"));
         Observable<String> w = Observable.zip(ws, zipr);
         w.subscribe(observer);
 
@@ -446,7 +446,7 @@ public class OperatorZipTest {
         /* define a Observer to receive aggregated events */
         Observer<String> observer = mock(Observer.class);
 
-        Observable<String> w = Observable.zip(Observable.from("one", "two"), Observable.from(2, 3, 4), zipr);
+        Observable<String> w = Observable.zip(Observable.just("one", "two"), Observable.just(2, 3, 4), zipr);
         w.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));
@@ -465,7 +465,7 @@ public class OperatorZipTest {
         /* define a Observer to receive aggregated events */
         Observer<String> observer = mock(Observer.class);
 
-        Observable<String> w = Observable.zip(Observable.from("one", "two"), Observable.from(2), Observable.from(new int[] { 4, 5, 6 }), zipr);
+        Observable<String> w = Observable.zip(Observable.just("one", "two"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }), zipr);
         w.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));
@@ -481,7 +481,7 @@ public class OperatorZipTest {
         @SuppressWarnings("unchecked")
         Observer<Integer> observer = mock(Observer.class);
 
-        Observable<Integer> w = Observable.zip(Observable.from(10, 20, 30), Observable.from(0, 1, 2), zipr);
+        Observable<Integer> w = Observable.zip(Observable.just(10, 20, 30), Observable.just(0, 1, 2), zipr);
         w.subscribe(observer);
 
         verify(observer, times(1)).onError(any(Throwable.class));
@@ -770,8 +770,8 @@ public class OperatorZipTest {
         @SuppressWarnings("unchecked")
         final Observer<Integer> observer = mock(Observer.class);
 
-        Observable.zip(Observable.from(1),
-                Observable.from(1), new Func2<Integer, Integer, Integer>() {
+        Observable.zip(Observable.just(1),
+                Observable.just(1), new Func2<Integer, Integer, Integer>() {
                     @Override
                     public Integer call(Integer a, Integer b) {
                         return a + b;
@@ -899,8 +899,8 @@ public class OperatorZipTest {
 
     @Test
     public void testEmitNull() {
-        Observable<Integer> oi = Observable.from(1, null, 3);
-        Observable<String> os = Observable.from("a", "b", null);
+        Observable<Integer> oi = Observable.just(1, null, 3);
+        Observable<String> os = Observable.just("a", "b", null);
         Observable<String> o = Observable.zip(oi, os, new Func2<Integer, String, String>() {
 
             @Override
@@ -928,8 +928,8 @@ public class OperatorZipTest {
 
     @Test
     public void testEmitMaterializedNotifications() {
-        Observable<Notification<Integer>> oi = Observable.from(1, 2, 3).materialize();
-        Observable<Notification<String>> os = Observable.from("a", "b", "c").materialize();
+        Observable<Notification<Integer>> oi = Observable.just(1, 2, 3).materialize();
+        Observable<Notification<String>> os = Observable.just("a", "b", "c").materialize();
         Observable<String> o = Observable.zip(oi, os, new Func2<Notification<Integer>, Notification<String>, String>() {
 
             @Override

--- a/rxjava-core/src/test/java/rx/observables/BlockingObservableTest.java
+++ b/rxjava-core/src/test/java/rx/observables/BlockingObservableTest.java
@@ -52,7 +52,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testLast() {
-        BlockingObservable<String> obs = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> obs = BlockingObservable.from(Observable.just("one", "two", "three"));
 
         assertEquals("three", obs.last());
     }
@@ -65,7 +65,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testLastOrDefault() {
-        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.from(1, 0, -1));
+        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.just(1, 0, -1));
         int last = observable.lastOrDefault(-100, new Func1<Integer, Boolean>() {
             @Override
             public Boolean call(Integer args) {
@@ -77,7 +77,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testLastOrDefault1() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         assertEquals("three", observable.lastOrDefault("default"));
     }
 
@@ -89,7 +89,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testLastOrDefaultWithPredicate() {
-        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.from(1, 0, -1));
+        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.just(1, 0, -1));
         int last = observable.lastOrDefault(0, new Func1<Integer, Boolean>() {
             @Override
             public Boolean call(Integer args) {
@@ -102,7 +102,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testLastOrDefaultWrongPredicate() {
-        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.from(-1, -2, -3));
+        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.just(-1, -2, -3));
         int last = observable.lastOrDefault(0, new Func1<Integer, Boolean>() {
             @Override
             public Boolean call(Integer args) {
@@ -114,7 +114,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testLastWithPredicate() {
-        BlockingObservable<String> obs = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> obs = BlockingObservable.from(Observable.just("one", "two", "three"));
 
         assertEquals("two", obs.last(new Func1<String, Boolean>() {
             @Override
@@ -125,7 +125,7 @@ public class BlockingObservableTest {
     }
 
     public void testSingle() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one"));
         assertEquals("one", observable.single());
     }
 
@@ -137,7 +137,7 @@ public class BlockingObservableTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testSingleDefaultPredicateMatchesMoreThanOne() {
-        BlockingObservable.from(Observable.from("one", "two")).singleOrDefault("default", new Func1<String, Boolean>() {
+        BlockingObservable.from(Observable.just("one", "two")).singleOrDefault("default", new Func1<String, Boolean>() {
             @Override
             public Boolean call(String args) {
                 return args.length() == 3;
@@ -147,7 +147,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testSingleDefaultPredicateMatchesNothing() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two"));
         String result = observable.singleOrDefault("default", new Func1<String, Boolean>() {
             @Override
             public Boolean call(String args) {
@@ -159,13 +159,13 @@ public class BlockingObservableTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testSingleDefaultWithMoreThanOne() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         observable.singleOrDefault("default");
     }
 
     @Test
     public void testSingleWithPredicateDefault() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "four"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "four"));
         assertEquals("four", observable.single(new Func1<String, Boolean>() {
             @Override
             public Boolean call(String s) {
@@ -176,13 +176,13 @@ public class BlockingObservableTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testSingleWrong() {
-        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.from(1, 2));
+        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.just(1, 2));
         observable.single();
     }
 
     @Test(expected = NoSuchElementException.class)
     public void testSingleWrongPredicate() {
-        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.from(-1));
+        BlockingObservable<Integer> observable = BlockingObservable.from(Observable.just(-1));
         observable.single(new Func1<Integer, Boolean>() {
             @Override
             public Boolean call(Integer args) {
@@ -193,7 +193,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testToIterable() {
-        BlockingObservable<String> obs = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> obs = BlockingObservable.from(Observable.just("one", "two", "three"));
 
         Iterator<String> it = obs.toIterable().iterator();
 
@@ -212,7 +212,7 @@ public class BlockingObservableTest {
 
     @Test(expected = NoSuchElementException.class)
     public void testToIterableNextOnly() {
-        BlockingObservable<Integer> obs = BlockingObservable.from(Observable.from(1, 2, 3));
+        BlockingObservable<Integer> obs = BlockingObservable.from(Observable.just(1, 2, 3));
 
         Iterator<Integer> it = obs.toIterable().iterator();
 
@@ -225,7 +225,7 @@ public class BlockingObservableTest {
 
     @Test(expected = NoSuchElementException.class)
     public void testToIterableNextOnlyTwice() {
-        BlockingObservable<Integer> obs = BlockingObservable.from(Observable.from(1, 2, 3));
+        BlockingObservable<Integer> obs = BlockingObservable.from(Observable.just(1, 2, 3));
 
         Iterator<Integer> it = obs.toIterable().iterator();
 
@@ -246,7 +246,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testToIterableManyTimes() {
-        BlockingObservable<Integer> obs = BlockingObservable.from(Observable.from(1, 2, 3));
+        BlockingObservable<Integer> obs = BlockingObservable.from(Observable.just(1, 2, 3));
 
         Iterable<Integer> iter = obs.toIterable();
 
@@ -317,7 +317,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testFirst() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         assertEquals("one", observable.first());
     }
 
@@ -328,7 +328,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testFirstWithPredicate() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         String first = observable.first(new Func1<String, Boolean>() {
             @Override
             public Boolean call(String args) {
@@ -340,7 +340,7 @@ public class BlockingObservableTest {
 
     @Test(expected = NoSuchElementException.class)
     public void testFirstWithPredicateAndEmpty() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         observable.first(new Func1<String, Boolean>() {
             @Override
             public Boolean call(String args) {
@@ -351,7 +351,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testFirstOrDefault() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         assertEquals("one", observable.firstOrDefault("default"));
     }
 
@@ -363,7 +363,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testFirstOrDefaultWithPredicate() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         String first = observable.firstOrDefault("default", new Func1<String, Boolean>() {
             @Override
             public Boolean call(String args) {
@@ -375,7 +375,7 @@ public class BlockingObservableTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndEmpty() {
-        BlockingObservable<String> observable = BlockingObservable.from(Observable.from("one", "two", "three"));
+        BlockingObservable<String> observable = BlockingObservable.from(Observable.just("one", "two", "three"));
         String first = observable.firstOrDefault("default", new Func1<String, Boolean>() {
             @Override
             public Boolean call(String args) {

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -346,7 +346,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
 
         final AtomicInteger count = new AtomicInteger();
 
-        Observable<Integer> o1 = Observable.<Integer> from(1, 2, 3, 4, 5);
+        Observable<Integer> o1 = Observable.<Integer> just(1, 2, 3, 4, 5);
 
         o1.subscribe(new Action1<Integer>() {
 

--- a/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/AbstractSchedulerTests.java
@@ -385,7 +385,7 @@ public abstract class AbstractSchedulerTests {
     public final void testObserveOn() throws InterruptedException {
         final Scheduler scheduler = getScheduler();
 
-        Observable<String> o = Observable.from("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten");
+        Observable<String> o = Observable.just("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten");
 
         ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<String>();
 
@@ -405,7 +405,7 @@ public abstract class AbstractSchedulerTests {
     public final void testSubscribeOnNestedConcurrency() throws InterruptedException {
         final Scheduler scheduler = getScheduler();
 
-        Observable<String> o = Observable.from("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten")
+        Observable<String> o = Observable.just("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten")
                 .mergeMap(new Func1<String, Observable<String>>() {
 
                     @Override

--- a/rxjava-core/src/test/java/rx/schedulers/CachedThreadSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/CachedThreadSchedulerTest.java
@@ -37,8 +37,8 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     @Test
     public final void testIOScheduler() {
 
-        Observable<Integer> o1 = Observable.from(1, 2, 3, 4, 5);
-        Observable<Integer> o2 = Observable.from(6, 7, 8, 9, 10);
+        Observable<Integer> o1 = Observable.just(1, 2, 3, 4, 5);
+        Observable<Integer> o2 = Observable.just(6, 7, 8, 9, 10);
         Observable<String> o = Observable.merge(o1, o2).map(new Func1<Integer, String>() {
 
             @Override

--- a/rxjava-core/src/test/java/rx/schedulers/ComputationSchedulerTests.java
+++ b/rxjava-core/src/test/java/rx/schedulers/ComputationSchedulerTests.java
@@ -91,8 +91,8 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
     @Test
     public final void testComputationThreadPool1() {
-        Observable<Integer> o1 = Observable.<Integer> from(1, 2, 3, 4, 5);
-        Observable<Integer> o2 = Observable.<Integer> from(6, 7, 8, 9, 10);
+        Observable<Integer> o1 = Observable.<Integer> just(1, 2, 3, 4, 5);
+        Observable<Integer> o2 = Observable.<Integer> just(6, 7, 8, 9, 10);
         Observable<String> o = Observable.<Integer> merge(o1, o2).map(new Func1<Integer, String>() {
 
             @Override
@@ -117,8 +117,8 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
         final String currentThreadName = Thread.currentThread().getName();
 
-        Observable<Integer> o1 = Observable.<Integer> from(1, 2, 3, 4, 5);
-        Observable<Integer> o2 = Observable.<Integer> from(6, 7, 8, 9, 10);
+        Observable<Integer> o1 = Observable.<Integer> just(1, 2, 3, 4, 5);
+        Observable<Integer> o2 = Observable.<Integer> just(6, 7, 8, 9, 10);
         Observable<String> o = Observable.<Integer> merge(o1, o2).subscribeOn(Schedulers.computation()).map(new Func1<Integer, String>() {
 
             @Override

--- a/rxjava-core/src/test/java/rx/schedulers/ImmediateSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/ImmediateSchedulerTest.java
@@ -57,8 +57,8 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTests {
 
         final String currentThreadName = Thread.currentThread().getName();
 
-        Observable<Integer> o1 = Observable.<Integer> from(1, 2, 3, 4, 5);
-        Observable<Integer> o2 = Observable.<Integer> from(6, 7, 8, 9, 10);
+        Observable<Integer> o1 = Observable.<Integer> just(1, 2, 3, 4, 5);
+        Observable<Integer> o2 = Observable.<Integer> just(6, 7, 8, 9, 10);
         Observable<String> o = Observable.<Integer> merge(o1, o2).map(new Func1<Integer, String>() {
 
             @Override
@@ -82,8 +82,8 @@ public class ImmediateSchedulerTest extends AbstractSchedulerTests {
 
         final String currentThreadName = Thread.currentThread().getName();
 
-        Observable<Integer> o1 = Observable.<Integer> from(1, 2, 3, 4, 5);
-        Observable<Integer> o2 = Observable.<Integer> from(6, 7, 8, 9, 10);
+        Observable<Integer> o1 = Observable.<Integer> just(1, 2, 3, 4, 5);
+        Observable<Integer> o2 = Observable.<Integer> just(6, 7, 8, 9, 10);
         Observable<String> o = Observable.<Integer> merge(o1, o2).subscribeOn(Schedulers.immediate()).map(new Func1<Integer, String>() {
 
             @Override

--- a/rxjava-core/src/test/java/rx/schedulers/TrampolineSchedulerTest.java
+++ b/rxjava-core/src/test/java/rx/schedulers/TrampolineSchedulerTest.java
@@ -42,8 +42,8 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
 
         final String currentThreadName = Thread.currentThread().getName();
 
-        Observable<Integer> o1 = Observable.<Integer> from(1, 2, 3, 4, 5);
-        Observable<Integer> o2 = Observable.<Integer> from(6, 7, 8, 9, 10);
+        Observable<Integer> o1 = Observable.<Integer> just(1, 2, 3, 4, 5);
+        Observable<Integer> o2 = Observable.<Integer> just(6, 7, 8, 9, 10);
         Observable<String> o = Observable.<Integer> merge(o1, o2).subscribeOn(Schedulers.trampoline()).map(new Func1<Integer, String>() {
 
             @Override

--- a/rxjava-core/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -262,7 +262,7 @@ public class BehaviorSubjectTest {
 
                     @Override
                     public Observable<String> call(String t1) {
-                        return Observable.from(t1 + ", " + t1);
+                        return Observable.just(t1 + ", " + t1);
                     }
                 })
                 .subscribe(new Observer<String>() {

--- a/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/PublishSubjectTest.java
@@ -320,7 +320,7 @@ public class PublishSubjectTest {
 
                     @Override
                     public Observable<String> call(String t1) {
-                        return Observable.from(t1 + ", " + t1);
+                        return Observable.just(t1 + ", " + t1);
                     }
                 })
                 .subscribe(new Observer<String>() {

--- a/rxjava-core/src/test/java/rx/subjects/ReplaySubjectTest.java
+++ b/rxjava-core/src/test/java/rx/subjects/ReplaySubjectTest.java
@@ -381,7 +381,7 @@ public class ReplaySubjectTest {
 
                     @Override
                     public Observable<String> call(String t1) {
-                        return Observable.from(t1 + ", " + t1);
+                        return Observable.just(t1 + ", " + t1);
                     }
                 })
                 .subscribe(new Observer<String>() {

--- a/rxjava-core/src/test/java/rx/util/AssertObservableTest.java
+++ b/rxjava-core/src/test/java/rx/util/AssertObservableTest.java
@@ -23,7 +23,7 @@ public class AssertObservableTest {
 
     @Test
     public void testPassNotNull() {
-        AssertObservable.assertObservableEqualsBlocking("foo", Observable.from(1, 2), Observable.from(1, 2));
+        AssertObservable.assertObservableEqualsBlocking("foo", Observable.just(1, 2), Observable.just(1, 2));
     }
 
     @Test
@@ -33,11 +33,11 @@ public class AssertObservableTest {
 
     @Test(expected = AssertionError.class)
     public void testFailNotNull() {
-        AssertObservable.assertObservableEqualsBlocking("foo", Observable.from(1, 2), Observable.from(1));
+        AssertObservable.assertObservableEqualsBlocking("foo", Observable.just(1, 2), Observable.just(1));
     }
 
     @Test(expected = AssertionError.class)
     public void testFailNull() {
-        AssertObservable.assertObservableEqualsBlocking("foo", Observable.from(1, 2), null);
+        AssertObservable.assertObservableEqualsBlocking("foo", Observable.just(1, 2), null);
     }
 }


### PR DESCRIPTION
Deprecate the from(T) methods in favor of items(T)

As per discussion in https://github.com/Netflix/RxJava/issues/1563.
