### PR TITLE
Added doOnUnsubscribed() to Observable

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -9955,4 +9955,19 @@ public class Observable<T> {
             });
         }
     }
+
+    /**
+     * Modifies the source {@code Observable} so that it invokes the given action when it is unsubscribed from
+     * its subscribers. Each un-subscription will result in an invocation of the given action except when the
+     * source {@code Observable} is reference counted, in which case the source {@code Observable} will invoke
+     * the given action for the very last un-subscription.
+     *
+     *
+     * @param unsubscribe The action that gets called when this {@code Observable} is unsubscribed.
+     *
+     * @return That modified {@code Observable}
+     */
+    public final Observable<T> doOnUnsubscribed(final Action0 unsubscribe) {
+        return lift(new OperatorDoOnUnsubscribe<T>(unsubscribe));
+    }
 }

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorDoOnUnsubscribe.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorDoOnUnsubscribe.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * This operator modifies an {@link rx.Observable} so a given action is invoked when the {@link rx.Observable} is unsubscribed.
+ * @param <T> The type of the elements in the {@link rx.Observable} that this operator modifies
+ */
+public class OperatorDoOnUnsubscribe<T> implements Observable.Operator<T, T> {
+    private final Action0 unsubscribe;
+
+    /**
+     * Constructs an instance of the operator with the callback that gets invoked when the modified Observable is unsubscribed
+     * @param unsubscribe The action that gets invoked when the modified {@link rx.Observable} is unsubscribed
+     */
+    public OperatorDoOnUnsubscribe(Action0 unsubscribe) {
+        this.unsubscribe = unsubscribe;
+    }
+
+    @Override
+    public Subscriber<? super T> call(final Subscriber<? super T> child) {
+        child.add(Subscriptions.create(unsubscribe));
+
+        // Pass through since this operator is for notification only, there is
+        // no change to the stream whatsoever.
+        return child;
+    }
+}

--- a/rxjava-core/src/test/java/rx/ObservableTests.java
+++ b/rxjava-core/src/test/java/rx/ObservableTests.java
@@ -47,6 +47,7 @@ import org.mockito.MockitoAnnotations;
 
 import rx.Observable.OnSubscribe;
 import rx.exceptions.OnErrorNotImplementedException;
+import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Action2;
 import rx.functions.Func1;
@@ -1099,5 +1100,127 @@ public class ObservableTests {
                     .subscribe();
         }
         assertEquals(nums.length, count.get());
+    }
+
+    @Test
+    public void testDoOnUnsubscribed() throws Exception {
+        int subCount = 3;
+        final CountDownLatch upperLatch = new CountDownLatch(subCount);
+        final CountDownLatch lowerLatch = new CountDownLatch(subCount);
+        final CountDownLatch onNextLatch = new CountDownLatch(subCount);
+
+        final AtomicInteger upperCount = new AtomicInteger();
+        final AtomicInteger lowerCount = new AtomicInteger();
+        Observable<Long> longs = Observable
+            // The stream needs to be infinite to ensure the stream does not terminate
+            // before it is unsubscribed
+            .interval(50, TimeUnit.MILLISECONDS)
+            .doOnUnsubscribed(new Action0() {
+                // Test that upper stream will be notified for un-subscription
+                // from a child subscriber
+                @Override
+                public void call() {
+                    upperLatch.countDown();
+                    upperCount.incrementAndGet();
+                }
+            })
+            .doOnNext(new Action1<Long>() {
+                @Override
+                public void call(Long aLong) {
+                    // Ensure there is at least some onNext events before un-subscription happens
+                    onNextLatch.countDown();
+                }
+            })
+            .doOnUnsubscribed(new Action0() {
+                // Test that lower stream will be notified for a direct un-subscription
+                @Override
+                public void call() {
+                    lowerLatch.countDown();
+                    lowerCount.incrementAndGet();
+                }
+            });
+
+        List<Subscription> subscriptions = new ArrayList<Subscription>();
+        List<TestSubscriber> subscribers = new ArrayList<TestSubscriber>();
+
+        for(int i = 0; i < subCount; ++i) {
+            TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
+            subscriptions.add(longs.subscribe(subscriber));
+            subscribers.add(subscriber);
+        }
+
+        onNextLatch.await();
+        for(int i = 0; i < subCount; ++i) {
+            subscriptions.get(i).unsubscribe();
+            // Test that unsubscribe() method is not affected in any way
+            subscribers.get(i).assertUnsubscribed();
+        }
+
+        upperLatch.await();
+        lowerLatch.await();
+        assertEquals(String.format("There should exactly %d un-subscription events for upper stream", subCount), subCount, upperCount.get());
+        assertEquals(String.format("There should exactly %d un-subscription events for lower stream", subCount), subCount, lowerCount.get());
+    }
+
+    @Test
+    public void testDoOnUnSubscribedWorksWithRefCount() throws Exception {
+        int subCount = 3;
+        final CountDownLatch upperLatch = new CountDownLatch(1);
+        final CountDownLatch lowerLatch = new CountDownLatch(1);
+        final CountDownLatch onNextLatch = new CountDownLatch(subCount);
+
+        final AtomicInteger upperCount = new AtomicInteger();
+        final AtomicInteger lowerCount = new AtomicInteger();
+        Observable<Long> longs = Observable
+            // The stream needs to be infinite to ensure the stream does not terminate
+            // before it is unsubscribed
+            .interval(50, TimeUnit.MILLISECONDS)
+            .doOnUnsubscribed(new Action0() {
+                // Test that upper stream will be notified for un-subscription
+                @Override
+                public void call() {
+                    upperLatch.countDown();
+                    upperCount.incrementAndGet();
+                }
+            })
+            .doOnNext(new Action1<Long>() {
+                @Override
+                public void call(Long aLong) {
+                    // Ensure there is at least some onNext events before un-subscription happens
+                    onNextLatch.countDown();
+                }
+            })
+            .doOnUnsubscribed(new Action0() {
+                // Test that lower stream will be notified for un-subscription
+                @Override
+                public void call() {
+                    lowerLatch.countDown();
+                    lowerCount.incrementAndGet();
+                }
+            })
+            .publish()
+            .refCount();
+
+        List<Subscription> subscriptions = new ArrayList<Subscription>();
+        List<TestSubscriber> subscribers = new ArrayList<TestSubscriber>();
+
+        for(int i = 0; i < subCount; ++i) {
+            TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
+            subscriptions.add(longs.subscribe(subscriber));
+            subscribers.add(subscriber);
+        }
+
+        onNextLatch.await();
+        for(int i = 0; i < subCount; ++i) {
+            subscriptions.get(i).unsubscribe();
+            // Test that unsubscribe() method is not affected in any way
+            subscribers.get(i).assertUnsubscribed();
+        }
+
+        upperLatch.await();
+        lowerLatch.await();
+        assertEquals("There should exactly 1 un-subscription events for upper stream", 1, upperCount.get());
+        assertEquals("There should exactly 1 un-subscription events for lower stream", 1, lowerCount.get());
+
     }
 }


### PR DESCRIPTION
We often need to be notified when an Observable is unsubscribed, for cleaning up internal states, logging, metrics gathering, and etc. With this added method, users can save the effort of writing the similar boilerplate to register a listener for un-subscription events.  
