### PR TITLE
Added doOnSubscribe() to Observable

### DIFF
--- a/rxjava-core/src/main/java/rx/Observable.java
+++ b/rxjava-core/src/main/java/rx/Observable.java
@@ -10357,4 +10357,19 @@ public class Observable<T> {
             });
         }
     }
+
+    /**
+     * Modifies the source {@code Observable} so that it invokes the given action when it is unsubscribed from
+     * its subscribers. Each un-subscription will result in an invocation of the given action except when the
+     * source {@code Observable} is reference counted, in which case the source {@code Observable} will invoke
+     * the given action for the very last un-subscription.
+     *
+     *
+     * @param unsubscribe The action that gets called when this {@code Observable} is unsubscribed.
+     *
+     * @return That modified {@code Observable}
+     */
+    public final Observable<T> doOnUnsubscribe(final Action0 unsubscribe) {
+        return lift(new OperatorDoOnUnsubscribe<T>(unsubscribe));
+    }
 }

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorDoOnUnsubscribe.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorDoOnUnsubscribe.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.Observable;
+import rx.Observable.Operator;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * This operator modifies an {@link rx.Observable} so a given action is invoked when the {@link rx.Observable} is unsubscribed.
+ * @param <T> The type of the elements in the {@link rx.Observable} that this operator modifies
+ */
+public class OperatorDoOnUnsubscribe<T> implements Operator<T, T> {
+    private final Action0 unsubscribe;
+
+    /**
+     * Constructs an instance of the operator with the callback that gets invoked when the modified Observable is unsubscribed
+     * @param unsubscribe The action that gets invoked when the modified {@link rx.Observable} is unsubscribed
+     */
+    public OperatorDoOnUnsubscribe(Action0 unsubscribe) {
+        this.unsubscribe = unsubscribe;
+    }
+
+    @Override
+    public Subscriber<? super T> call(final Subscriber<? super T> child) {
+        child.add(Subscriptions.create(unsubscribe));
+
+        // Pass through since this operator is for notification only, there is
+        // no change to the stream whatsoever.
+        return child;
+    }
+}


### PR DESCRIPTION
We often need to be notified when an Observable is unsubscribed, for cleaning up internal states, logging, metrics gathering, and etc. With this added method, users can save the effort of writing the similar boilerplate to register a listener for un-subscription events.
