### PR TITLE
RxScala: Add more operators to match RxJava

### DIFF
--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/JavaConversions.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/JavaConversions.scala
@@ -62,4 +62,12 @@ object JavaConversions {
       }
     }
   }
+
+  implicit def toJavaTransformer[T, R](transformer: Observable[T] => Observable[R]): rx.Observable.Transformer[T, R] = {
+    new rx.Observable.Transformer[T, R] {
+      override def call(o: rx.Observable[_ <: T]): rx.Observable[R] = {
+        transformer(toScalaObservable(o)).asJavaObservable.asInstanceOf[rx.Observable[R]]
+      }
+    }
+  }
 }

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Observable.scala
@@ -865,6 +865,38 @@ trait Observable[+T]
   }
 
   /**
+   * Returns an Observable that emits windows of items it collects from the source Observable. The resulting
+   * Observable starts a new window periodically, as determined by the `timeshift` argument or a maximum
+   * size as specified by the `count` argument (whichever is reached first). It emits
+   * each window after a fixed timespan, specified by the `timespan` argument. When the source
+   * Observable completes or Observable completes or encounters an error, the resulting Observable emits the
+   * current window and propagates the notification from the source Observable.
+   *
+   * <img width="640" height="335" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/window7.s.png" alt="">
+   *
+   * ===Backpressure Support:===
+   * This operator does not support backpressure as it uses time to control data flow.
+   *
+   * ===Scheduler:===
+   * you specify which `Scheduler` this operator will use
+   *
+   * @param timespan the period of time each window collects items before it should be emitted
+   * @param timeshift the period of time after which a new window will be created
+   * @param count the maximum size of each window before it should be emitted
+   * @param scheduler the `Scheduler` to use when determining the end and start of a window
+   * @return an Observable that emits new windows periodically as a fixed timespan elapses
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#window">RxJava wiki: window</a>
+   * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.window.aspx">MSDN: Observable.Window</a>
+   */
+  def sliding(timespan: Duration, timeshift: Duration, count: Int, scheduler: Scheduler): Observable[Observable[T]] = {
+    val span: Long = timespan.length
+    val shift: Long = timespan.unit.convert(timeshift.length, timeshift.unit)
+    val unit: TimeUnit = timespan.unit
+    Observable.jObsOfJObsToScObsOfScObs(asJavaObservable.window(span, shift, unit, count, scheduler))
+      : Observable[Observable[T]] // SI-7818
+  }
+
+  /**
    * Returns an Observable which only emits those items for which a given predicate holds.
    *
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/filter.png">
@@ -1578,6 +1610,41 @@ trait Observable[+T]
   }
 
   /**
+   * Caches emissions from the source Observable and replays them in order to any subsequent Subscribers.
+   * This method has similar behavior to [[Observable.replay]] except that this auto-subscribes to the source
+   * Observable rather than returning a [[ConnectableObservable]] for which you must call
+   * `connect` to activate the subscription.
+   * <p>
+   * <img width="640" height="410" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/cache.png" alt="">
+   * <p>
+   * This is useful when you want an Observable to cache responses and you can't control the
+   * `subscribe/unsubscribe` behavior of all the [[Subscriber]]s.
+   * <p>
+   * When you call `cache`, it does not yet subscribe to the source Observable and so does not yet
+   * begin cacheing items. This only happens when the first Subscriber calls the resulting Observable's
+   * `subscribe` method.
+   * <p>
+   * <em>Note:</em> You sacrifice the ability to unsubscribe from the origin when you use the `cache`
+   * Observer so be careful not to use this Observer on Observables that emit an infinite or very large number
+   * of items that will use up memory.
+   *
+   * ===Backpressure Support:===
+   * This operator does not support upstream backpressure as it is purposefully requesting and caching everything emitted.
+   *
+   * ===Scheduler:===
+   * `cache` does not operate by default on a particular `Scheduler`.
+   *
+   * @param capacity hint for number of items to cache (for optimizing underlying data structure)
+   * @return an Observable that, when first subscribed to, caches all of its items and notifications for the
+   *         benefit of subsequent subscribers
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#cache">RxJava wiki: cache</a>
+   * @since 0.20
+   */
+  def cache(capacity: Int): Observable[T] = {
+    toScalaObservable[T](asJavaObservable.cache(capacity))
+  }
+
+  /**
    * Returns a new [[Observable]] that multicasts (shares) the original [[Observable]]. As long a
    * there is more than 1 [[Subscriber]], this [[Observable]] will be subscribed and emitting data.
    * When all subscribers have unsubscribed it will unsubscribe from the source [[Observable]].
@@ -2174,6 +2241,41 @@ trait Observable[+T]
     val o1 = asJavaObservable.groupBy[K](f) : rx.Observable[_ <: rx.observables.GroupedObservable[K, _ <: T]]
     val func = (o: rx.observables.GroupedObservable[K, _ <: T]) => (o.getKey, toScalaObservable[T](o))
     toScalaObservable[(K, Observable[T])](o1.map[(K, Observable[T])](func))
+  }
+
+  /**
+   * Groups the items emitted by an [[Observable]] according to a specified criterion, and emits these
+   * grouped items as `(key, observable)` pairs.
+   *
+   * <img width="640" height="360" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/groupBy.png" alt="">
+   *
+   * Note: A `(key, observable)` will cache the items it is to emit until such time as it
+   * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
+   * `(key, observable)` pairs that do not concern you. Instead, you can signal to them that they may
+   * discard their buffers by applying an operator like `take(0)` to them.
+   *
+   * ===Backpressure Support:===
+   * This operator does not support backpressure as splitting a stream effectively turns it into a "hot observable"
+   * and blocking any one group would block the entire parent stream. If you need backpressure on individual groups
+   * then you should use operators such as `nBackpressureDrop` or `@link #onBackpressureBuffer`.</dd>
+   * ===Scheduler:===
+   * groupBy` does not operate by default on a particular `Scheduler`.
+   *
+   * @param keySelector a function that extracts the key for each item
+   * @param valueSelector a function that extracts the return element for each item
+   * @tparam K the key type
+   * @tparam V the value type
+   * @return an [[Observable]] that emits `(key, observable)` pairs, each of which corresponds to a
+   *         unique key value and each of which emits those items from the source Observable that share that
+   *         key value
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Transforming-Observables#groupby-and-groupbyuntil">RxJava wiki: groupBy</a>
+   * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.groupby.aspx">MSDN: Observable.GroupBy</a>
+   */
+  def groupBy[K, V](keySelector: T => K, valueSelector: T => V): Observable[(K, Observable[V])] = {
+    val jo: rx.Observable[rx.observables.GroupedObservable[K, V]] = asJavaObservable.groupBy[K, V](keySelector, valueSelector)
+    toScalaObservable[rx.observables.GroupedObservable[K, V]](jo).map {
+      go: rx.observables.GroupedObservable[K, V] => (go.getKey, toScalaObservable[V](go))
+    }
   }
 
   /**
@@ -4298,6 +4400,75 @@ trait Observable[+T]
   def nonEmpty: Observable[Boolean] = {
     isEmpty.map(!_)
   }
+
+  /**
+   * Transform an Observable by applying a particular Transformer function to it.
+   *
+   * This method operates on the Observable itself whereas [[Observable.lift]] operates on the Observable's
+   * Subscribers or Observers.
+   *
+   * If the operator you are creating is designed to act on the individual items emitted by a source
+   * Observable, use [[Observable.lift]]. If your operator is designed to transform the source Observable as a whole
+   * (for instance, by applying a particular set of existing RxJava operators to it) use `compose`.
+   *
+   * ===Scheduler:===
+   * `compose` does not operate by default on a particular [[Scheduler]].
+   *
+   * @param transformer implements the function that transforms the source Observable
+   * @return the source Observable, transformed by the transformer function
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
+   */
+  def compose[R](transformer: Observable[T] => Observable[R]): Observable[R] = {
+    toScalaObservable[R](asJavaObservable.compose(toJavaTransformer(transformer)))
+  }
+
+  /**
+   * Instructs an Observable that is emitting items faster than its observer can consume them to buffer these
+   * items indefinitely until they can be emitted.
+   *
+   * <img width="640" height="300" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
+   *
+   * ===Scheduler:===
+   * `onBackpressureBuffer` does not operate by default on a particular `Scheduler`.
+   *
+   * @return the source Observable modified to buffer items to the extent system resources allow
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Backpressure">RxJava wiki: Backpressure</a>
+   */
+  def onBackpressureBuffer: Observable[T] = {
+    toScalaObservable[T](asJavaObservable.onBackpressureBuffer)
+  }
+
+  /**
+   * Use this operator when the upstream does not natively support backpressure and you wish to drop
+   * `onNext` when unable to handle further events.
+   *
+   * <img width="640" height="245" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/bp.obp.drop.png" alt="">
+   *
+   * If the downstream request count hits 0 then `onNext` will be dropped until `request(long n)`
+   * is invoked again to increase the request count.
+   *
+   * ===Scheduler:===
+   * onBackpressureDrop` does not operate by default on a particular `Scheduler`.
+   *
+   * @return the source Observable modified to drop `onNext` notifications on overflow
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Backpressure">RxJava wiki: Backpressure</a>
+   */
+  def onBackpressureDrop: Observable[T] = {
+    toScalaObservable[T](asJavaObservable.onBackpressureDrop)
+  }
+
+  /**
+   * Return a new [[Observable]] by applying a partial function to all elements of this [[Observable]]
+   * on which the function is defined.
+   *
+   * @tparam R the element type of the returned [[Observable]].
+   * @param pf the partial function which filters and maps the [[Observable]].
+   * @return a new [[Observable]] by applying a partial function to all elements of this [[Observable]]
+   *         on which the function is defined.
+   */
+  def collect[R](pf: PartialFunction[T, R]): Observable[R] = {
+    filter(pf.isDefinedAt(_)).map(pf)
+  }
 }
 
 /**
@@ -4746,6 +4917,7 @@ object Observable {
    * @param observableFactory the factory function to obtain an Observable
    * @return the Observable whose lifetime controls the lifetime of the dependent resource object
    */
+  @deprecated("Use `using(=> Resource)(Resource => Observable[T], Resource => Unit)` instead", "0.20.1")
   def using[T, Resource <: Subscription](resourceFactory: () => Resource, observableFactory: Resource => Observable[T]): Observable[T] = {
     class ResourceSubscription(val resource: Resource) extends rx.Subscription {
       def unsubscribe = resource.unsubscribe
@@ -4757,6 +4929,32 @@ object Observable {
       () => new ResourceSubscription(resourceFactory()),
       (s: ResourceSubscription) => observableFactory(s.resource).asJavaObservable
     ))
+  }
+
+  /**
+   * Constructs an Observable that creates a dependent resource object.
+   *
+   * <img width="640" height="400" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/using.png" alt="" />
+   *
+   * ===Scheduler:===
+   * `using` does not operate by default on a particular `Scheduler`.
+   *
+   * @param resourceFactory the factory function to create a resource object that depends on the Observable.
+   *                        Note: this is a by-name parameter.
+   * @param observableFactory the factory function to create an Observable
+   * @param dispose the function that will dispose of the resource
+   * @return the Observable whose lifetime controls the lifetime of the dependent resource object
+   * @see <a href="https://github.com/Netflix/RxJava/wiki/Observable-Utility-Operators#using">RxJava wiki: using</a>
+   * @see <a href="http://msdn.microsoft.com/en-us/library/hh229585.aspx">MSDN: Observable.Using</a>
+   */
+  def using[T, Resource](resourceFactory: => Resource)(observableFactory: Resource => Observable[T], dispose: Resource => Unit): Observable[T] = {
+    val jResourceFactory = new rx.functions.Func0[Resource] {
+      override def call: Resource = resourceFactory
+    }
+    val jObservableFactory = new rx.functions.Func1[Resource, rx.Observable[_ <: T]] {
+      override def call(r: Resource) = observableFactory(r).asJavaObservable
+    }
+    toScalaObservable[T](rx.Observable.using[T, Resource](jResourceFactory, jObservableFactory, dispose))
   }
 
   /**

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/WithFilter.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/WithFilter.scala
@@ -38,5 +38,7 @@ private[scala] class WithFilter[+T] (p: T => Boolean, asJava: rx.Observable[_ <:
     toScalaObservable[T](asJava.filter((x: T) => p(x) && q(x)))
   }
 
-  // there is no foreach here, that's only available on BlockingObservable
+  def foreach(onNext: T => Unit): Unit = {
+    toScalaObservable[T](asJava.filter(p)).foreach(onNext)
+  }
 }

--- a/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/CompletenessTest.scala
+++ b/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/CompletenessTest.scala
@@ -84,6 +84,7 @@ class CompletenessTest extends JUnitSuite {
       "buffer(Observable[_ <: TOpening], Func1[_ >: TOpening, _ <: Observable[_ <: TClosing]])" -> "slidingBuffer(Observable[Opening])(Opening => Observable[Any])",
       "cast(Class[R])" -> "[RxJava needs this one because `rx.Observable` is invariant. `Observable` in RxScala is covariant and does not need this operator.]",
       "collect(R, Action2[R, _ >: T])" -> "foldLeft(R)((R, T) => R)",
+      "compose(Transformer[_ >: T, R])" -> "compose(Observable[T] => Observable[R])",
       "concatWith(Observable[_ <: T])" -> "[use `o1 ++ o2`]",
       "contains(Any)" -> "contains(U)",
       "count()" -> "length",
@@ -94,6 +95,8 @@ class CompletenessTest extends JUnitSuite {
       "dematerialize()" -> "dematerialize(<:<[Observable[T], Observable[Notification[U]]])",
       "doOnCompleted(Action0)" -> "doOnCompleted(=> Unit)",
       "doOnEach(Action1[Notification[_ >: T]])" -> "[use `doOnEach(T => Unit, Throwable => Unit, () => Unit)`]",
+      "doOnSubscribe(Action0)" -> "doOnSubscribe(=> Unit)",
+      "doOnUnsubscribe(Action0)" -> "doOnUnsubscribe(=> Unit)",
       "doOnTerminate(Action0)" -> "doOnTerminate(=> Unit)",
       "elementAtOrDefault(Int, T)" -> "elementAtOrDefault(Int, U)",
       "finallyDo(Action0)" -> "finallyDo(=> Unit)",
@@ -115,8 +118,9 @@ class CompletenessTest extends JUnitSuite {
       "limit(Int)" -> "take(Int)",
       "flatMap(Func1[_ >: T, _ <: Observable[_ <: U]], Func2[_ >: T, _ >: U, _ <: R])" -> "flatMapWith(T => Observable[U])((T, U) => R)",
       "flatMapIterable(Func1[_ >: T, _ <: Iterable[_ <: U]], Func2[_ >: T, _ >: U, _ <: R])" -> "flatMapIterableWith(T => Iterable[U])((T, U) => R)",
+      "groupBy(Func1[_ >: T, _ <: K], Func1[_ >: T, _ <: R])" -> "groupBy(T => K, T => V)",
       "mergeWith(Observable[_ <: T])" -> "merge(Observable[U])",
-      "multicast(Subject[_ >: T, _ <: R])" -> "multicast(Subject[R])",
+      "multicast(Func0[_ <: Subject[_ >: T, _ <: R]])" -> "multicast(=> Subject[R])",
       "multicast(Func0[_ <: Subject[_ >: T, _ <: TIntermediate]], Func1[_ >: Observable[TIntermediate], _ <: Observable[TResult]])" -> "multicast(() => Subject[R])(Observable[R] => Observable[U])",
       "ofType(Class[R])" -> "[use `filter(_.isInstanceOf[Class])`]",
       "onErrorResumeNext(Func1[Throwable, _ <: Observable[_ <: T]])" -> "onErrorResumeNext(Throwable => Observable[U])",
@@ -130,8 +134,8 @@ class CompletenessTest extends JUnitSuite {
       "publishLast(Func1[_ >: Observable[T], _ <: Observable[R]])" -> "publishLast(Observable[T] => Observable[R])",
       "reduce(Func2[T, T, T])" -> "reduce((U, U) => U)",
       "reduce(R, Func2[R, _ >: T, R])" -> "foldLeft(R)((R, T) => R)",
-      "repeatWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_ <: Notification[_]]])" -> "repeatWhen(Observable[Notification[Any]] => Observable[Notification[Any]])",
-      "repeatWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_ <: Notification[_]]], Scheduler)" -> "repeatWhen(Observable[Notification[Any]] => Observable[Notification[Any]], Scheduler)",
+      "repeatWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_]])" -> "repeatWhen(Observable[Notification[Any]] => Observable[Any])",
+      "repeatWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_]], Scheduler)" -> "repeatWhen(Observable[Notification[Any]] => Observable[Any], Scheduler)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]])" -> "replay(Observable[T] => Observable[R])",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int)" -> "replay(Observable[T] => Observable[R], Int)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int, Long, TimeUnit)" -> "replay(Observable[T] => Observable[R], Int, Duration)",
@@ -141,7 +145,7 @@ class CompletenessTest extends JUnitSuite {
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Long, TimeUnit, Scheduler)" -> "replay(Observable[T] => Observable[R], Duration, Scheduler)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Scheduler)" -> "replay(Observable[T] => Observable[R], Scheduler)",
       "retry(Func2[Integer, Throwable, Boolean])" -> "retry((Int, Throwable) => Boolean)",
-      "retryWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_ <: Notification[_]]], Scheduler)" -> "retryWhen(Observable[Notification[Any]] => Observable[Notification[Any]], Scheduler)",
+      "retryWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_]], Scheduler)" -> "retryWhen(Observable[Notification[Any]] => Observable[Any], Scheduler)",
       "retryWhen(Func1[_ >: Observable[_ <: Notification[_]], _ <: Observable[_]])" -> "retryWhen(Observable[Notification[Any]] => Observable[Any])",
       "sample(Observable[U])" -> "sample(Observable[Any])",
       "scan(Func2[T, T, T])" -> unnecessary,
@@ -156,9 +160,7 @@ class CompletenessTest extends JUnitSuite {
       "skipWhileWithIndex(Func2[_ >: T, Integer, Boolean])" -> unnecessary,
       "skipUntil(Observable[U])" -> "dropUntil(Observable[Any])",
       "startWith(T)" -> "[use `item +: o`]",
-      "startWith(Array[T], Scheduler)" -> "[use `Observable.just(items).subscribeOn(scheduler) ++ o`]",
       "startWith(Iterable[T])" -> "[use `Observable.from(iterable) ++ o`]",
-      "startWith(Iterable[T], Scheduler)" -> "[use `Observable.from(iterable).subscribeOn(scheduler) ++ o`]",
       "startWith(Observable[T])" -> "[use `++`]",
       "skipLast(Int)" -> "dropRight(Int)",
       "skipLast(Long, TimeUnit)" -> "dropRight(Duration)",
@@ -201,6 +203,7 @@ class CompletenessTest extends JUnitSuite {
       "window(Observable[_ <: TOpening], Func1[_ >: TOpening, _ <: Observable[_ <: TClosing]])" -> "sliding(Observable[Opening])(Opening => Observable[Any])",
       "window(Long, Long, TimeUnit)" -> "sliding(Duration, Duration)",
       "window(Long, Long, TimeUnit, Scheduler)" -> "sliding(Duration, Duration, Scheduler)",
+      "window(Long, Long, TimeUnit, Int, Scheduler)" -> "sliding(Duration, Duration, Int, Scheduler)",
 
       // manually added entries for Java static methods
       "amb(Iterable[_ <: Observable[_ <: T]])" -> "amb(Observable[T]*)",
@@ -209,23 +212,18 @@ class CompletenessTest extends JUnitSuite {
       "combineLatest(List[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Seq[Observable[T]])(Seq[T] => R)",
       "concat(Observable[_ <: Observable[_ <: T]])" -> "concat(<:<[Observable[T], Observable[Observable[U]]])",
       "defer(Func0[Observable[T]])" -> "defer(=> Observable[T])",
-      "from(<repeated...>[T])" -> "items(T*)",
-      "from(Array[T], Scheduler)" -> "from(Iterable[T], Scheduler)",
+      "from(Array[T])" -> "from(Iterable[T])",
       "from(Iterable[_ <: T])" -> "from(Iterable[T])",
       "from(Future[_ <: T])" -> fromFuture,
       "from(Future[_ <: T], Long, TimeUnit)" -> fromFuture,
       "from(Future[_ <: T], Scheduler)" -> fromFuture,
-      "just(T)" -> "[use `items(T*)`]",
-      "just(T, Scheduler)" -> "[use `items(T*).subscribeOn(scheduler)`]",
+      "just(T)" -> "just(T*)",
       "merge(Observable[_ <: T], Observable[_ <: T])" -> "merge(Observable[U])",
       "merge(Observable[_ <: Observable[_ <: T]])" -> "flatten(<:<[Observable[T], Observable[Observable[U]]])",
       "merge(Observable[_ <: Observable[_ <: T]], Int)" -> "flatten(Int)(<:<[Observable[T], Observable[Observable[U]]])",
       "merge(Array[Observable[_ <: T]])" -> "[use `Observable.from(array).flatten`]",
-      "merge(Array[Observable[_ <: T]], Scheduler)" -> "[use `Observable.from(array, scheduler).flatten`]",
       "merge(Iterable[_ <: Observable[_ <: T]])" -> "[use `Observable.from(iter).flatten`]",
       "merge(Iterable[_ <: Observable[_ <: T]], Int)" -> "[use `Observable.from(iter).flatten(n)`]",
-      "merge(Iterable[_ <: Observable[_ <: T]], Int, Scheduler)" -> "[use `Observable.from(iter, scheduler).flatten(n)`]",
-      "merge(Iterable[_ <: Observable[_ <: T]], Scheduler)" -> "[use `Observable.from(iter, scheduler).flatten`]",
       "mergeDelayError(Observable[_ <: T], Observable[_ <: T])" -> "mergeDelayError(Observable[U])",
       "mergeDelayError(Observable[_ <: Observable[_ <: T]])" -> "flattenDelayError(<:<[Observable[T], Observable[Observable[U]]])",
       "parallelMerge(Observable[Observable[T]], Int)" -> "parallelMerge(Int)(<:<[Observable[T], Observable[Observable[U]]])",
@@ -235,11 +233,12 @@ class CompletenessTest extends JUnitSuite {
       "range(Int, Int)" -> "[use `(start until (start + count)).toObservable` instead of `range(start, count)`]",
       "range(Int, Int, Scheduler)" -> "[use `(start until (start + count)).toObservable.subscribeOn(scheduler)` instead of `range(start, count, scheduler)`]",
       "switchOnNext(Observable[_ <: Observable[_ <: T]])" -> "switch(<:<[Observable[T], Observable[Observable[U]]])",
+      "using(Func0[Resource], Func1[_ >: Resource, _ <: Observable[_ <: T]], Action1[_ >: Resource])" -> "using(=> Resource)(Resource => Observable[T], Resource => Unit)",
       "zip(Observable[_ <: T1], Observable[_ <: T2], Func2[_ >: T1, _ >: T2, _ <: R])" -> "[use instance method `zip` and `map`]",
       "zip(Observable[_ <: Observable[_]], FuncN[_ <: R])" -> "[use `zip` in companion object and `map`]",
       "zip(Iterable[_ <: Observable[_]], FuncN[_ <: R])" -> "[use `zip` in companion object and `map`]",
       "zipWith(Observable[_ <: T2], Func2[_ >: T, _ >: T2, _ <: R])" -> "zipWith(Observable[U])((T, U) => R)",
-      "zip(Iterable[_ <: T2], Func2[_ >: T, _ >: T2, _ <: R])" -> "zipWith(Iterable[U])((T, U) => R)"
+      "zipWith(Iterable[_ <: T2], Func2[_ >: T, _ >: T2, _ <: R])" -> "zipWith(Iterable[U])((T, U) => R)"
   ) ++ List.iterate("T, T", 8)(s => s + ", T").map(
       // all 9 overloads of startWith:
       "startWith(" + _ + ")" -> "[use `Observable.just(...) ++ o`]"
@@ -248,7 +247,7 @@ class CompletenessTest extends JUnitSuite {
       "concat(" + _ + ")" -> "[unnecessary because we can use `++` instead or `Observable(o1, o2, ...).concat`]"
   ).drop(1).toMap ++ List.iterate("T", 10)(s => s + ", T").map(
       // all 10 overloads of from:
-      "from(" + _ + ")" -> "[use `items(T*)`]"
+      "just(" + _ + ")" -> "[use `just(T*)`]"
   ).toMap ++ (3 to 9).map(i => {
     // zip3-9:
     val obsArgs = (1 to i).map(j => s"Observable[_ <: T$j], ").mkString("")


### PR DESCRIPTION
including `window(span, shift, unit, count, scheduler)`, `cache(Int)`, `groupBy[K, V](keySelector: T => K, valueSelector: T => V)`, `compose`, `onBackpressureBuffer`, `onBackpressureDrop`, `collect` and `using`.

/cc @headinthebox, @samuelgruetter
