### PR TITLE
Lock-Free-IndexRingBuffer

### DIFF
--- a/rxjava-core/src/test/java/rx/internal/util/IndexedRingBufferTest.java
+++ b/rxjava-core/src/test/java/rx/internal/util/IndexedRingBufferTest.java
@@ -227,7 +227,11 @@ public class IndexedRingBufferTest {
         IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
         for (int i = 0; i < 20000; i++) {
             int index = list.add(s);
-            list.remove(index);
+            if(i > 19998){
+                list.remove(index);
+            } else {
+                list.remove(index);
+            }
         }
 
         AtomicInteger c = new AtomicInteger();


### PR DESCRIPTION
Distilled from the changes, removed need for "synchronized" keyword on several methods by changing the IndexSection to a rough version of a lock-free stack.  Before and after benchmarks on my system show an improvement on all tests, more so on the pure Add tests (not sure this is a likely real world test?).