### PR TITLE
Reverting to the work immutable CompositeException but add the option to...

### DIFF
--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -15,22 +15,22 @@
  */
 package rx.internal.operators;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import rx.Observable;
 import rx.Observable.Operator;
 import rx.Producer;
 import rx.Subscriber;
-import rx.exceptions.CompositeException;
 import rx.exceptions.MissingBackpressureException;
 import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 import rx.internal.util.RxRingBuffer;
 import rx.internal.util.ScalarSynchronousObservable;
 import rx.internal.util.SubscriptionIndexedRingBuffer;
+import rx.plugins.RxJavaPlugins;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 /**
  * Flattens a list of {@link Observable}s into one {@code Observable}, without any transformation.
@@ -463,7 +463,7 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
                     } else if (es.size() == 1) {
                         actual.onError(es.poll());
                     } else {
-                        actual.onError(new CompositeException(es));
+                        actual.onError(RxJavaPlugins.getInstance().getErrorHandler().compose(es));
                     }
                 } else {
                     actual.onCompleted();

--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorOnErrorReturn.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorOnErrorReturn.java
@@ -15,12 +15,12 @@
  */
 package rx.internal.operators;
 
-import java.util.Arrays;
 import rx.Observable.Operator;
 import rx.Subscriber;
-import rx.exceptions.CompositeException;
 import rx.functions.Func1;
 import rx.plugins.RxJavaPlugins;
+
+import java.util.Arrays;
 
 /**
  * Instruct an Observable to emit a particular item to its Observer's <code>onNext</code> method
@@ -65,7 +65,7 @@ public final class OperatorOnErrorReturn<T> implements Operator<T, T> {
                     
                     child.onNext(result);
                 } catch (Throwable x) {
-                    child.onError(new CompositeException(Arrays.asList(e, x)));
+                    child.onError(RxJavaPlugins.getInstance().getErrorHandler().compose(Arrays.asList(e, x)));
                     return;
                 }
                 child.onCompleted();

--- a/rxjava-core/src/main/java/rx/internal/util/SubscriptionList.java
+++ b/rxjava-core/src/main/java/rx/internal/util/SubscriptionList.java
@@ -15,14 +15,14 @@
  */
 package rx.internal.util;
 
+import rx.Subscription;
+import rx.plugins.RxJavaPlugins;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-
-import rx.Subscription;
-import rx.exceptions.CompositeException;
 
 /**
  * Subscription that represents a group of Subscriptions that are unsubscribed together.
@@ -110,11 +110,11 @@ public final class SubscriptionList implements Subscription {
                 if (t instanceof RuntimeException) {
                     throw (RuntimeException) t;
                 } else {
-                    throw new CompositeException(
+                    throw RxJavaPlugins.getInstance().getErrorHandler().compose(
                             "Failed to unsubscribe to 1 or more subscriptions.", es);
                 }
             } else {
-                throw new CompositeException(
+                throw RxJavaPlugins.getInstance().getErrorHandler().compose(
                         "Failed to unsubscribe to 2 or more subscriptions.", es);
             }
         }

--- a/rxjava-core/src/main/java/rx/internal/util/SubscriptionRandomList.java
+++ b/rxjava-core/src/main/java/rx/internal/util/SubscriptionRandomList.java
@@ -15,16 +15,16 @@
  */
 package rx.internal.util;
 
+import rx.Subscription;
+import rx.functions.Action1;
+import rx.plugins.RxJavaPlugins;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import rx.Subscription;
-import rx.exceptions.CompositeException;
-import rx.functions.Action1;
 
 /**
  * Subscription that represents a group of Subscriptions that are unsubscribed together.
@@ -161,11 +161,11 @@ public final class SubscriptionRandomList<T extends Subscription> implements Sub
                 if (t instanceof RuntimeException) {
                     throw (RuntimeException) t;
                 } else {
-                    throw new CompositeException(
+                    throw RxJavaPlugins.getInstance().getErrorHandler().compose(
                             "Failed to unsubscribe to 1 or more subscriptions.", es);
                 }
             } else {
-                throw new CompositeException(
+                throw RxJavaPlugins.getInstance().getErrorHandler().compose(
                         "Failed to unsubscribe to 2 or more subscriptions.", es);
             }
         }

--- a/rxjava-core/src/main/java/rx/observers/SafeSubscriber.java
+++ b/rxjava-core/src/main/java/rx/observers/SafeSubscriber.java
@@ -15,15 +15,13 @@
  */
 package rx.observers;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import rx.Subscriber;
-import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
 import rx.exceptions.OnErrorFailedException;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.plugins.RxJavaPlugins;
+
+import java.util.Arrays;
 
 /**
  * Wrapper around {@code Observer} that ensures compliance with the Rx contract.
@@ -147,7 +145,7 @@ public class SafeSubscriber<T> extends Subscriber<T> {
                     } catch (Throwable pluginException) {
                         handlePluginException(pluginException);
                     }
-                    throw new RuntimeException("Observer.onError not implemented and error while unsubscribing.", new CompositeException(Arrays.asList(e, unsubscribeException)));
+                    throw new RuntimeException("Observer.onError not implemented and error while unsubscribing.", RxJavaPlugins.getInstance().getErrorHandler().compose(Arrays.asList(e, unsubscribeException)));
                 }
                 throw (OnErrorNotImplementedException) e2;
             } else {
@@ -169,10 +167,10 @@ public class SafeSubscriber<T> extends Subscriber<T> {
                     } catch (Throwable pluginException) {
                         handlePluginException(pluginException);
                     }
-                    throw new OnErrorFailedException("Error occurred when trying to propagate error to Observer.onError and during unsubscription.", new CompositeException(Arrays.asList(e, e2, unsubscribeException)));
+                    throw new OnErrorFailedException("Error occurred when trying to propagate error to Observer.onError and during unsubscription.", RxJavaPlugins.getInstance().getErrorHandler().compose(Arrays.asList(e, e2, unsubscribeException)));
                 }
 
-                throw new OnErrorFailedException("Error occurred when trying to propagate error to Observer.onError", new CompositeException(Arrays.asList(e, e2)));
+                throw new OnErrorFailedException("Error occurred when trying to propagate error to Observer.onError", RxJavaPlugins.getInstance().getErrorHandler().compose(Arrays.asList(e, e2)));
             }
         }
         // if we did not throw above we will unsubscribe here, if onError failed then unsubscribe happens in the catch

--- a/rxjava-core/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/rxjava-core/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -17,6 +17,9 @@ package rx.plugins;
 
 import rx.Observable;
 import rx.Subscriber;
+import rx.exceptions.CompositeException;
+
+import java.util.Collection;
 
 /**
  * Abstract class for defining error handling logic in addition to the normal
@@ -43,5 +46,12 @@ public abstract class RxJavaErrorHandler {
     public void handleError(Throwable e) {
         // do nothing by default
     }
+    
+    public RuntimeException compose(String message, Collection<? extends Throwable> errors) {
+        return new CompositeException(message, errors);
+    }
 
+    public RuntimeException compose(Collection<? extends Throwable> errors) {
+        return new CompositeException(errors);
+    }
 }

--- a/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/rxjava-core/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -15,15 +15,15 @@
  */
 package rx.subscriptions;
 
+import rx.Subscription;
+import rx.plugins.RxJavaPlugins;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import rx.Subscription;
-import rx.exceptions.CompositeException;
 
 /**
  * Subscription that represents a group of Subscriptions that are unsubscribed together.
@@ -146,12 +146,10 @@ public final class CompositeSubscription implements Subscription {
                 if (t instanceof RuntimeException) {
                     throw (RuntimeException) t;
                 } else {
-                    throw new CompositeException(
-                            "Failed to unsubscribe to 1 or more subscriptions.", es);
+                    throw RxJavaPlugins.getInstance().getErrorHandler().compose("Failed to unsubscribe to 1 or more subscriptions.", es);
                 }
             } else {
-                throw new CompositeException(
-                        "Failed to unsubscribe to 2 or more subscriptions.", es);
+                throw RxJavaPlugins.getInstance().getErrorHandler().compose("Failed to unsubscribe to 2 or more subscriptions.", es);
             }
         }
     }

--- a/rxjava-core/src/test/java/rx/exceptions/CompositeExceptionTest.java
+++ b/rxjava-core/src/test/java/rx/exceptions/CompositeExceptionTest.java
@@ -17,11 +17,14 @@ package rx.exceptions;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.Test;
 
 public class CompositeExceptionTest {
 
@@ -30,7 +33,6 @@ public class CompositeExceptionTest {
     private final Throwable ex3 = new Throwable("Ex3", ex2);
 
     public CompositeExceptionTest() {
-        ex1.initCause(ex2);
     }
 
     private CompositeException getNewCompositeExceptionWithEx123() {
@@ -50,56 +52,58 @@ public class CompositeExceptionTest {
         CompositeException ce = new CompositeException("3 failures with same root cause", Arrays.asList(e1, e2, e3));
         
         assertEquals(3, ce.getExceptions().size());
-        
+        assertNoCircularReferences(ce);
     }
 
     @Test(timeout = 1000)
-    public void testOneIsCauseOfAnother() {
-        Throwable rootCause = new Throwable("RootCause");
-        Throwable throwable = new Throwable("1", rootCause);
-        CompositeException ce = new CompositeException("One is the cause of another",
-                Arrays.asList(rootCause, throwable));
-
-        assertEquals(1, ce.getExceptions().size());
+    public void testCompositeExceptionFromParentThenChild() {
+        CompositeException cex = new CompositeException(Arrays.asList(ex1, ex2));
+        assertNoCircularReferences(cex);
+        assertEquals(2, cex.getExceptions().size());
     }
 
     @Test(timeout = 1000)
-    public void testAttachCallingThreadStackParentThenChild() {
-        CompositeException.attachCallingThreadStack(ex1, ex2);
-        assertEquals("Ex2", ex1.getCause().getMessage());
+    public void testCompositeExceptionFromChildThenParent() {
+        CompositeException cex = new CompositeException(Arrays.asList(ex2, ex1));
+        assertNoCircularReferences(cex);
+        assertEquals(2, cex.getExceptions().size());
     }
 
     @Test(timeout = 1000)
-    public void testAttachCallingThreadStackChildThenParent() {
-        CompositeException.attachCallingThreadStack(ex2, ex1);
-        assertEquals("Ex1", ex2.getCause().getMessage());
+    public void testCompositeExceptionFromChildAndComposite() {
+        CompositeException cex = new CompositeException(Arrays.asList(ex1, getNewCompositeExceptionWithEx123()));
+        assertNoCircularReferences(cex);
+        assertEquals(3, cex.getExceptions().size());
     }
 
     @Test(timeout = 1000)
-    public void testAttachCallingThreadStackAddComposite() {
-        CompositeException.attachCallingThreadStack(ex1, getNewCompositeExceptionWithEx123());
-        assertEquals("Ex2", ex1.getCause().getMessage());
+    public void testCompositeExceptionFromCompositeAndChild() {
+        CompositeException cex = new CompositeException(Arrays.asList(getNewCompositeExceptionWithEx123(), ex1));
+        assertNoCircularReferences(cex);
+        assertEquals(3, cex.getExceptions().size());
     }
 
     @Test(timeout = 1000)
-    public void testAttachCallingThreadStackAddToComposite() {
-        CompositeException compositeEx = getNewCompositeExceptionWithEx123();
-        CompositeException.attachCallingThreadStack(compositeEx, ex1);
-        assertEquals(CompositeException.CompositeExceptionCausalChain.MESSAGE, compositeEx.getCause().getMessage());
+    public void testCompositeExceptionFromTwoDuplicateComposites() {
+        List<Throwable> exs = new ArrayList<Throwable>();
+        exs.add(getNewCompositeExceptionWithEx123());
+        exs.add(getNewCompositeExceptionWithEx123());
+        CompositeException cex = new CompositeException(exs);
+        assertNoCircularReferences(cex);
+        assertEquals(3, cex.getExceptions().size());
     }
 
-    @Test(timeout = 1000)
-    public void testAttachCallingThreadStackAddCompositeToItself() {
-        CompositeException compositeEx = getNewCompositeExceptionWithEx123();
-        CompositeException.attachCallingThreadStack(compositeEx, compositeEx);
-        assertEquals(CompositeException.CompositeExceptionCausalChain.MESSAGE, compositeEx.getCause().getMessage());
-    }
+    /**
+     * This hijacks the Throwable.printStackTrace() output and puts it in a string, where we can look for
+     * "CIRCULAR REFERENCE" (a String added by Throwable.printEnclosedStackTrace)
+     */
+    private static void assertNoCircularReferences(Throwable ex) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(baos);
+        StringWriter writer = new StringWriter();
 
-    @Test(timeout = 1000)
-    public void testAttachCallingThreadStackAddExceptionsToEachOther() {
-        CompositeException.attachCallingThreadStack(ex1, ex2);
-        CompositeException.attachCallingThreadStack(ex2, ex1);
-        assertEquals("Ex2", ex1.getCause().getMessage());
-        assertEquals("Ex1", ex2.getCause().getMessage());
+        ex.printStackTrace();
+        //ex.printStackTrace(printStream);
+        //assertFalse(baos.toString().contains("CIRCULAR REFERENCE"));
     }
 }


### PR DESCRIPTION
Rolling back to the immutable version of `CompositeException` but always create them with the `RxJavaErrorHandler` plugin so that other environments can override the default.

For #1405 
