### PR TITLE
WIP: Fast path for BlockingObservables.

### DIFF
--- a/rxjava/src/perf/java/rx/observables/BlockingObservablePerf.java
+++ b/rxjava/src/perf/java/rx/observables/BlockingObservablePerf.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observables;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import rx.Observable;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class BlockingObservablePerf {
+
+    @State(Scope.Thread)
+    public static class Input  {
+
+        public Observable<Integer> observable;
+
+        @Setup
+        public void setup() {
+            observable = Observable.just(1);
+        }
+
+    }
+
+    @Benchmark
+    public void benchSingle(final Input input) {
+        input.observable.toBlocking().single();
+    }
+
+}


### PR DESCRIPTION
I did more benchmarking with blocking observables and found they're quite wasteful, even in the T cases because they always use the iterator which in turn needs a LBQ. They produce quite some amount of garbage in there.

I think optimizing this is quite important because a lot of users will, even finally at the end of their observable stream, block at some point to return the result into a servlet or whatever.

I set out to fix that as as a start with single() and it seems to pan out quite nicely. I want to modify all of the T getter methods appropriately and do some refactoring, but wanted to share some early results.

Before on single():

Iteration   1: 3949703.236 ops/s
Iteration   2: 3947313.447 ops/s
Iteration   3: 3955001.570 ops/s
Iteration   4: 3839775.088 ops/s
Iteration   5: 3916265.155 ops/s

After:

Iteration   1: 13254605.691 ops/s
Iteration   2: 13115515.080 ops/s
Iteration   3: 13238426.756 ops/s
Iteration   4: 13165076.351 ops/s
Iteration   5: 13208966.944 ops/s

That's over 3x perf improvement, also we're getting rid of the LBQ in the iterator.

It basically reuses the code from forEach, so things can be refactored into helper methods later.

I'd like to get your thoughts on that @benjchristensen and others, if I don't hear back that I should stop going down that route I'll update this PR once it's done.
