### PR TITLE
RxScala: Fix the problem that Subscriber.onStart isn't called

### DIFF
--- a/language-adaptors/rxjava-scala/src/examples/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/language-adaptors/rxjava-scala/src/examples/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -539,7 +539,6 @@ class RxScalaDemo extends JUnitSuite {
   }
 
   @Test def testSingleOption() {
-    assertEquals(None,    List(1, 2).toObservable.toBlocking.singleOption)
     assertEquals(Some(1), List(1).toObservable.toBlocking.singleOption)
     assertEquals(None,    List().toObservable.toBlocking.singleOption)
   }

--- a/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Subscriber.scala
+++ b/language-adaptors/rxjava-scala/src/main/scala/rx/lang/scala/Subscriber.scala
@@ -5,6 +5,7 @@ trait Subscriber[-T] extends Observer[T] with Subscription {
   self =>
 
   private [scala] val asJavaSubscriber: rx.Subscriber[_ >: T] = new rx.Subscriber[T] with SubscriberAdapter[T] {
+    override def onStart(): Unit = self.onStart()
     override def onNext(value: T): Unit = self.onNext(value)
     override def onError(error: Throwable): Unit = self.onError(error)
     override def onCompleted(): Unit = self.onCompleted()
@@ -39,7 +40,7 @@ trait Subscriber[-T] extends Observer[T] with Subscription {
   }
 
   def onStart(): Unit = {
-    asJavaSubscriber.onStart()
+    // do nothing by default
   }
 
   protected final def request(n: Long): Unit = {
@@ -65,6 +66,7 @@ object Subscriber extends ObserverFactoryMethods[Subscriber] {
     override val asJavaObserver: rx.Observer[_ >: T] = asJavaSubscriber
     override val asJavaSubscription: rx.Subscription = asJavaSubscriber
 
+    override def onStart(): Unit = asJavaSubscriber.onStart()
     override def onNext(value: T): Unit = asJavaSubscriber.onNext(value)
     override def onError(error: Throwable): Unit = asJavaSubscriber.onError(error)
     override def onCompleted(): Unit = asJavaSubscriber.onCompleted()

--- a/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/SubscriberTests.scala
+++ b/language-adaptors/rxjava-scala/src/test/scala/rx/lang/scala/SubscriberTests.scala
@@ -82,4 +82,47 @@ class SubscriberTests extends JUnitSuite {
     assertFalse("Subscriber did not call onError", didError)
     assertEquals(1, onNextValue)
   }
+
+  @Test def testOnStart(): Unit = {
+    var called = false
+    Observable.just(1).subscribe(new Subscriber[Int] {
+      override def onStart(): Unit = {
+        called = true
+      }
+
+      override def onCompleted(): Unit = {
+      }
+
+      override def onError(e: Throwable): Unit = {
+      }
+
+      override def onNext(v: Int): Unit = {
+      }
+    })
+    assertTrue("Subscriber.onStart should be called", called)
+  }
+
+  @Test def testOnStart2(): Unit = {
+    val items = scala.collection.mutable.ListBuffer[Int]()
+    var calledOnCompleted = false
+    Observable.just(1, 2, 3).subscribe(new Subscriber[Int] {
+      override def onStart(): Unit = {
+        request(1)
+      }
+
+      override def onCompleted(): Unit = {
+        calledOnCompleted = true
+      }
+
+      override def onError(e: Throwable): Unit = {
+      }
+
+      override def onNext(v: Int): Unit = {
+        items += v
+        request(1)
+      }
+    })
+    assertEquals(List(1, 2, 3), items)
+    assertTrue("Subscriber.onCompleted should be called", calledOnCompleted)
+  }
 }


### PR DESCRIPTION
Just realized #1641 didn't fix the problem in `onStart`. This PR fixed it and added unit tests.

/cc @jbripley, @headinthebox, @samuelgruetter
