### PR TITLE
OperatorScan should check for MAX_VALUE on request

### DIFF
--- a/rxjava-core/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/rxjava-core/src/main/java/rx/internal/operators/OperatorScan.java
@@ -129,7 +129,7 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                     @Override
                     public void request(long n) {
                         if (once.compareAndSet(false, true)) {
-                            if (initialValue == NO_INITIAL_VALUE) {
+                            if (initialValue == NO_INITIAL_VALUE || n == Long.MAX_VALUE) {
                                 producer.request(n);
                             } else {
                                 producer.request(n - 1);


### PR DESCRIPTION
A check for `n == Long.MAX_VALUE` is missing from the `Producer` implementation which opens up the possibility of passing through an unintended request for `Long.MAX_VALUE-1`.
