### PR TITLE
StringObservable.split NPE fixes

### DIFF
--- a/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
+++ b/rxjava-contrib/rxjava-string/src/main/java/rx/observables/StringObservable.java
@@ -441,14 +441,16 @@ public class StringObservable {
 
                     @Override
                     public void onCompleted() {
-                        output(leftOver);
+                        if (leftOver!=null)
+                            output(leftOver);
                         if (!o.isUnsubscribed())
                             o.onCompleted();
                     }
 
                     @Override
                     public void onError(Throwable e) {
-                        output(leftOver);
+                        if (leftOver!=null)
+                            output(leftOver);
                         if (!o.isUnsubscribed())
                             o.onError(e);
                     }

--- a/rxjava-contrib/rxjava-string/src/test/java/rx/observables/StringObservableTest.java
+++ b/rxjava-contrib/rxjava-string/src/test/java/rx/observables/StringObservableTest.java
@@ -142,6 +142,24 @@ public class StringObservableTest {
     public void testSplitOnOh() {
         testSplit("boo:and:foo", "o", 0, "b", "", ":and:f");
     }
+    
+    @Test
+    public void testSplitOnEmptyStream() {
+        assertEquals(0, (int) StringObservable.split(Observable.<String>empty(), "\n")
+                .count().toBlocking().single());
+    }
+    
+    @Test
+    public void testSplitOnStreamThatThrowsExceptionImmediately() {
+        RuntimeException ex = new RuntimeException("boo");
+        try {
+            StringObservable.split(Observable.<String>error(ex), "\n")
+                .count().toBlocking().single();
+            fail();
+        } catch (RuntimeException e) {
+            assertEquals(ex, e);
+        }
+    }
 
     public void testSplit(String str, String regex, int limit, String... parts) {
         testSplit(str, regex, 0, Observable.from(str), parts);


### PR DESCRIPTION
check for null values of leftOver in onCompleted and onError.

Added two failing unit tests that passed with fix.

@benjchristensen I suppose should I make PR on RxJavaString as well? 
