### PR TITLE
Fix Javadoc README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Once we hit 1.0 it will follow the normal major.minor.patch semantic versioning 
 ## Full Documentation
 
 - [Wiki](https://github.com/ReactiveX/RxJava/wiki)
-- <a href="http://netflix.github.com/RxJava/javadoc/">Javadoc</a>
+- [Javadoc](http://reactivex.io/RxJava/javadoc/)
 
 ## Binaries
 


### PR DESCRIPTION
http://netflix.github.com/RxJava/javadoc/ gives 404. I presume this should point to http://reactivex.io/RxJava/javadoc/
