### PR TITLE
Bug in the onBackpressure operators

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -48,6 +48,10 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
         // don't pass through subscriber as we are async and doing queue draining
         // a parent being unsubscribed should not affect the children
         Subscriber<T> parent = new Subscriber<T>() {
+            @Override
+            public void onStart() {
+                request(Long.MAX_VALUE);
+            }
 
             @Override
             public void onCompleted() {

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
@@ -36,6 +36,10 @@ public class OperatorOnBackpressureDrop<T> implements Operator<T, T> {
 
         });
         return new Subscriber<T>(child) {
+            @Override
+            public void onStart() {
+                request(Long.MAX_VALUE);
+            }
 
             @Override
             public void onCompleted() {

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
@@ -17,16 +17,17 @@ package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.concurrent.CountDownLatch;
-
 import org.junit.Test;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Subscriber;
+import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
+
+import java.util.concurrent.CountDownLatch;
 
 public class OperatorOnBackpressureDropTest {
 
@@ -40,6 +41,13 @@ public class OperatorOnBackpressureDropTest {
         // it completely ignores the `request(100)` and we get 500
         assertEquals(500, ts.getOnNextEvents().size());
         ts.assertNoErrors();
+    }
+
+    @Test(timeout = 500)
+    public void testWithObserveOn() throws InterruptedException {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        Observable.range(0, RxRingBuffer.SIZE * 10).onBackpressureDrop().onBackpressureDrop().observeOn(Schedulers.io()).subscribe(ts);
+        ts.awaitTerminalEvent();
     }
 
     @Test(timeout = 500)


### PR DESCRIPTION
The onBackpressure operators need to send `request(Long.MAX_VALUE)` on start.
