### PR TITLE
Fix Slow Non-deterministic Test

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -687,7 +687,7 @@ public class OperatorObserveOnTest {
 
                     @Override
                     public void call(Notification<? super Long> n) {
-                        //                        System.out.println("BEFORE " + n);
+                        //                                                System.out.println("BEFORE " + n);
                     }
 
                 })
@@ -696,7 +696,11 @@ public class OperatorObserveOnTest {
 
                     @Override
                     public void call(Notification<? super Long> n) {
-                        //                        System.out.println("AFTER " + n);
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                        }
+                        //                                                System.out.println("AFTER " + n);
                     }
 
                 });


### PR DESCRIPTION
Somehow I missed the Thread.sleep to force the scenario so most of the time this test would run very slow (or forever).
I'm surprised the unit tests passed before... just random luck on thread scheduling.
