### PR TITLE
Fix NPE when iterable is null

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -35,14 +35,14 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
     final Iterable<? extends T> is;
 
     public OnSubscribeFromIterable(Iterable<? extends T> iterable) {
+        if (iterable == null) {
+            throw new NullPointerException("iterable must not be null");
+        }
         this.is = iterable;
     }
 
     @Override
     public void call(final Subscriber<? super T> o) {
-        if (is == null) {
-            o.onCompleted();
-        }
         final Iterator<? extends T> it = is.iterator();
         o.setProducer(new IterableProducer<T>(o, it));
     }

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -35,16 +35,9 @@ import rx.observers.TestSubscriber;
 
 public class OnSubscribeFromIterableTest {
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testNull() {
-        Observable<String> observable = Observable.create(new OnSubscribeFromIterable<String>(null));
-
-        @SuppressWarnings("unchecked")
-        Observer<String> observer = mock(Observer.class);
-        observable.subscribe(observer);
-        verify(observer, Mockito.never()).onNext(any(String.class));
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onCompleted();
+        Observable.create(new OnSubscribeFromIterable<String>(null));
     }
     
     @Test


### PR DESCRIPTION
As per #1676, I prefer that throwing an NullPointerException in the constructor of `OnSubscribeFromIterable`. 

BTW, because https://github.com/ReactiveX/RxJava/blob/v1.0.0-rc.5/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java#L43 does not return after `o.onCompleted();`, there is still a NPE bug here.
