### PR TITLE
Fix TestSubject to schedule events correctly

### DIFF
--- a/src/main/java/rx/subjects/TestSubject.java
+++ b/src/main/java/rx/subjects/TestSubject.java
@@ -68,7 +68,14 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     @Override
     public void onCompleted() {
-        onCompleted(innerScheduler.now());
+        innerScheduler.schedule(new Action0() {
+
+            @Override
+            public void call() {
+                _onCompleted();
+            }
+
+        });
     }
 
     private void _onCompleted() {
@@ -99,7 +106,14 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     @Override
     public void onError(final Throwable e) {
-        onError(e, innerScheduler.now());
+        innerScheduler.schedule(new Action0() {
+
+            @Override
+            public void call() {
+                _onError(e);
+            }
+
+        });
     }
 
     private void _onError(final Throwable e) {
@@ -131,8 +145,15 @@ public final class TestSubject<T> extends Subject<T, T> {
     }
 
     @Override
-    public void onNext(T v) {
-        onNext(v, innerScheduler.now());
+    public void onNext(final T v) {
+        innerScheduler.schedule(new Action0() {
+
+            @Override
+            public void call() {
+                _onNext(v);
+            }
+
+        });
     }
 
     private void _onNext(T v) {

--- a/src/test/java/rx/subjects/TestSubjectTest.java
+++ b/src/test/java/rx/subjects/TestSubjectTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.subjects;
+
+import org.junit.Before;
+import org.junit.Test;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestSubjectTest {
+
+    private TestScheduler testScheduler;
+
+    @Before
+    public void setUp() {
+        testScheduler = Schedulers.test();
+    }
+
+    @Test
+    public void testOnNext() {
+        TestSubject<String> testSubject = TestSubject.create(testScheduler);
+        TestSubscriber<String> observer = new TestSubscriber<String>();
+        testSubject.subscribe(observer);
+
+        testScheduler.advanceTimeBy(1, TimeUnit.HOURS);
+
+        testSubject.onNext("a");
+        testSubject.onCompleted();
+
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+        observer.assertReceivedOnNext(Arrays.asList("a"));
+        observer.assertNoErrors();
+        observer.assertTerminalEvent();
+    }
+
+    @Test
+    public void testOnError() {
+        TestSubject<String> testSubject = TestSubject.create(testScheduler);
+        TestSubscriber<String> observer = new TestSubscriber<String>();
+        testSubject.subscribe(observer);
+
+        Throwable e = new RuntimeException("test");
+
+        testScheduler.advanceTimeBy(1, TimeUnit.HOURS);
+
+        testSubject.onError(e);
+
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+        observer.assertReceivedOnNext(new ArrayList<String>());
+        assertEquals(Arrays.asList(e), observer.getOnErrorEvents());
+    }
+}


### PR DESCRIPTION
The bug is that using `innerScheduler.now()` as the delay time. This PR called `innerScheduler.schedule(Action0)` directly.
