### PR TITLE
backpressure support in onErrorResumeNext* operators

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
@@ -16,6 +16,7 @@
 package rx.internal.operators;
 
 import rx.Observable;
+import rx.Producer;
 import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.exceptions.Exceptions;
@@ -86,6 +87,16 @@ public final class OperatorOnErrorResumeNextViaFunction<T> implements Operator<T
                     return;
                 }
                 child.onNext(t);
+            }
+            
+            @Override
+            public void setProducer(final Producer producer) {
+                child.setProducer(new Producer() {
+                    @Override
+                    public void request(long n) {
+                        producer.request(n);
+                    }
+                });
             }
 
         };

--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservable.java
@@ -16,6 +16,7 @@
 package rx.internal.operators;
 
 import rx.Observable;
+import rx.Producer;
 import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.exceptions.Exceptions;
@@ -82,6 +83,16 @@ public final class OperatorOnErrorResumeNextViaObservable<T> implements Operator
                 }
                 done = true;
                 child.onCompleted();
+            }
+            
+            @Override
+            public void setProducer(final Producer producer) {
+                child.setProducer(new Producer() {
+                    @Override
+                    public void request(long n) {
+                        producer.request(n);
+                    }
+                });
             }
             
         };


### PR DESCRIPTION
set producer to allow back pressure signals to flow between parent and child
