### PR TITLE
ExecutorScheduler delivers uncaught exceptions

### DIFF
--- a/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -173,6 +173,8 @@ import rx.subscriptions.Subscriptions;
                 actual.call();
             } catch (Throwable t) {
                 RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                Thread thread = Thread.currentThread();
+                thread.getUncaughtExceptionHandler().uncaughtException(thread, t);
             } finally {
                 unsubscribe();
             }

--- a/src/test/java/rx/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/rx/schedulers/ExecutorSchedulerTest.java
@@ -15,6 +15,7 @@
  */
 package rx.schedulers;
 
+import org.junit.Test;
 import rx.Scheduler;
 import rx.internal.util.RxThreadFactory;
 
@@ -29,5 +30,14 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
     protected Scheduler getScheduler() {
         return Schedulers.from(executor);
     }
-    
+
+    @Test
+    public final void testUnhandledErrorIsDeliveredToThreadHandler() throws InterruptedException {
+        SchedulerTests.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
+    }
+
+    @Test
+    public final void testHandledErrorIsNotDeliveredToThreadHandler() throws InterruptedException {
+        SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
+    }
 }


### PR DESCRIPTION
Instead of swallowing unhandled errors, ExecutorScheduler delivers them
to the executing thread's UncaughtExceptionHandler.

This addresses the same issue as ReactiveX/RxJava#1682, but for
ExecutorScheduler which does not used ScheduledAction.
