### PR TITLE
Fix for #1791

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -206,6 +206,10 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
         final Action0 subscribeToSource = new Action0() {
             @Override
             public void call() {
+                if (child.isUnsubscribed()) {
+                    return;
+                }
+
                 Subscriber<T> terminalDelegatingSubscriber = new Subscriber<T>() {
                     @Override
                     public void onCompleted() {


### PR DESCRIPTION
Fixes #1791 

don't retry (subscribe) to source if child has unsubscribed.
