### PR TITLE
add hasObservers method to Subjects (#1772)

### DIFF
--- a/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
+++ b/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
@@ -184,7 +184,14 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
             emit(state.nl.next(t));
         }
     }
-    
+
+    @Override
+    public boolean hasObservers() {
+        synchronized (state.guard) {
+            return state.observerRef != null;
+        }
+    }
+
     @SuppressWarnings("rawtypes")
     private final static Observer EMPTY_OBSERVER = new Observer() {
 

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -99,5 +99,9 @@ public final class OperatorReplay {
             subject.onCompleted();
         }
 
+        @Override
+        public boolean hasObservers() {
+            return this.subject.hasObservers();
+        }
     }
 }

--- a/src/main/java/rx/subjects/AsyncSubject.java
+++ b/src/main/java/rx/subjects/AsyncSubject.java
@@ -136,4 +136,8 @@ public final class AsyncSubject<T> extends Subject<T, T> {
         lastValue = nl.next(v);
     }
 
+    @Override
+    public boolean hasObservers() {
+        return state.observers().length > 0;
+    }
 }

--- a/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/src/main/java/rx/subjects/BehaviorSubject.java
@@ -167,8 +167,13 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
             }
         }
     }
-    
+
     /* test support */ int subscriberCount() {
         return state.observers().length;
+    }
+
+    @Override
+    public boolean hasObservers() {
+        return state.observers().length > 0;
     }
 }

--- a/src/main/java/rx/subjects/PublishSubject.java
+++ b/src/main/java/rx/subjects/PublishSubject.java
@@ -121,4 +121,9 @@ public final class PublishSubject<T> extends Subject<T, T> {
             bo.onNext(v);
         }
     }
+
+    @Override
+    public boolean hasObservers() {
+        return state.observers().length > 0;
+    }
 }

--- a/src/main/java/rx/subjects/ReplaySubject.java
+++ b/src/main/java/rx/subjects/ReplaySubject.java
@@ -347,7 +347,12 @@ public final class ReplaySubject<T> extends Subject<T, T> {
     /* Support test. */int subscriberCount() {
         return ssm.state.observers.length;
     }
-    
+
+    @Override
+    public boolean hasObservers() {
+        return ssm.observers().length > 0;
+    }
+
     private boolean caughtUp(SubjectObserver<? super T> o) {
         if (!o.caughtUp) {
             o.caughtUp = true;

--- a/src/main/java/rx/subjects/SerializedSubject.java
+++ b/src/main/java/rx/subjects/SerializedSubject.java
@@ -34,6 +34,7 @@ import rx.observers.SerializedObserver;
  */
 public class SerializedSubject<T, R> extends Subject<T, R> {
     private final SerializedObserver<T> observer;
+    private final Subject<T, R> actual;
 
     public SerializedSubject(final Subject<T, R> actual) {
         super(new OnSubscribe<R>() {
@@ -44,6 +45,7 @@ public class SerializedSubject<T, R> extends Subject<T, R> {
             }
 
         });
+        this.actual = actual;
         this.observer = new SerializedObserver<T>(actual);
     }
 
@@ -62,4 +64,8 @@ public class SerializedSubject<T, R> extends Subject<T, R> {
         observer.onNext(t);
     }
 
+    @Override
+    public boolean hasObservers() {
+        return actual.hasObservers();
+    }
 }

--- a/src/main/java/rx/subjects/Subject.java
+++ b/src/main/java/rx/subjects/Subject.java
@@ -25,4 +25,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
     protected Subject(OnSubscribe<R> onSubscribe) {
         super(onSubscribe);
     }
+
+    /**
+     * Indicates whether the {@link Subject} has {@link Observer Observers} subscribed to it.
+     * @return true if there is at least one Observer subscribed to this Subject, false otherwise
+     */
+    public abstract boolean hasObservers();
 }

--- a/src/main/java/rx/subjects/TestSubject.java
+++ b/src/main/java/rx/subjects/TestSubject.java
@@ -86,7 +86,7 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     /**
      * Schedule a call to {@code onCompleted} relative to "now()" +n milliseconds in the future.
-     * 
+     *
      * @param timeInMilliseconds
      *         the number of milliseconds in the future relative to "now()" at which to call {@code onCompleted}
      */
@@ -119,7 +119,7 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     /**
      * Schedule a call to {@code onError} relative to "now()" +n milliseconds in the future.
-     * 
+     *
      * @param e
      *         the {@code Throwable} to pass to the {@code onError} method
      * @param timeInMilliseconds
@@ -152,7 +152,7 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     /**
      * Schedule a call to {@code onNext} relative to "now()" +n milliseconds in the future.
-     * 
+     *
      * @param v
      *         the item to emit
      * @param timeInMilliseconds
@@ -167,5 +167,10 @@ public final class TestSubject<T> extends Subject<T, T> {
             }
 
         }, timeInMilliseconds, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean hasObservers() {
+        return state.observers().length > 0;
     }
 }

--- a/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -16,6 +16,7 @@
 package rx.subjects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -370,6 +371,7 @@ public class BehaviorSubjectTest {
         verify(o, never()).onError(any(Throwable.class));
         
         assertEquals(0, source.subscriberCount());
+        assertFalse(source.hasObservers());
     }
     
     @Test


### PR DESCRIPTION
as per https://github.com/ReactiveX/RxJava/issues/1772

SerializedSubject now keeps track of the actual Subject.
BufferUntilSubscriber synchronizes on the state guard.
