### PR TITLE
Print full classname (inner class support) and fix enum output

### DIFF
--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -138,16 +138,19 @@ public final class OnErrorThrowable extends RuntimeException {
          * @return a string version of the object if primitive, otherwise the classname of the object
          */
         private static String renderValue(Object value){
-            if(value == null){
+            if (value == null) {
                 return "null";
             }
-            if(value.getClass().isPrimitive()){
+            if (value.getClass().isPrimitive()) {
                 return value.toString();
             }
-            if(value instanceof String){
-                return (String)value;
+            if (value instanceof String) {
+                return (String) value;
             }
-            return value.getClass().getSimpleName() + ".class";
+            if (value instanceof Enum) {
+                return ((Enum) value).name();
+            }
+            return value.getClass().getName() + ".class";
         }
     }
 }


### PR DESCRIPTION
@benjchristensen 

`Class.getSimpleName()` is empty for inner classes, leading to an error message that looks like this: "OnError while emitting onNext value: .class"

Also, `Enum.name()` is always safe and not expensive so we can use that when there's a failure emitting an enum value.
