### PR TITLE
Fix mergeDelayError Handling of Error in Parent Observable

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -397,6 +397,11 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
 
         @Override
         public void onError(Throwable e) {
+            completed = true;
+            innerError(e);
+        }
+        
+        private void innerError(Throwable e) {
             if (delayErrors) {
                 synchronized (this) {
                     if (exceptions == null) {
@@ -540,7 +545,7 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
         public void onError(Throwable e) {
             // it doesn't go through queues, it immediately onErrors and tears everything down
             if (ONCE_TERMINATED.compareAndSet(this, 0, 1)) {
-                parentSubscriber.onError(e);
+                parentSubscriber.innerError(e);
             }
         }
 

--- a/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
@@ -30,6 +30,7 @@ import rx.exceptions.TestException;
 import rx.observers.TestSubscriber;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -477,6 +478,20 @@ public class OperatorMergeDelayErrorTest {
         inOrder.verify(o, never()).onNext(anyInt());
         inOrder.verify(o).onError(any(TestException.class));
         verify(o, never()).onCompleted();
+    }
+
+    @Test
+    public void testErrorInParentObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        Observable.mergeDelayError(
+                Observable.just(Observable.just(1), Observable.just(2))
+                        .startWith(Observable.<Integer> error(new RuntimeException()))
+                ).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertTerminalEvent();
+        ts.assertReceivedOnNext(Arrays.asList(1, 2));
+        assertEquals(1, ts.getOnErrorEvents().size());
+
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/ReactiveX/RxJava/issues/313
