### PR TITLE
Unsubscribe when thread is interrupted

### DIFF
--- a/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
@@ -96,6 +96,7 @@ public final class BlockingOperatorLatest {
                     try {
                         notify.acquire();
                     } catch (InterruptedException ex) {
+                        unsubscribe();
                         Thread.currentThread().interrupt();
                         iNotif = Notification.createOnError(ex);
                         throw Exceptions.propagate(ex);

--- a/src/main/java/rx/internal/operators/BlockingOperatorNext.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorNext.java
@@ -117,6 +117,7 @@ public final class BlockingOperatorNext {
                 }
                 throw new IllegalStateException("Should not reach here");
             } catch (InterruptedException e) {
+                observer.unsubscribe();
                 Thread.currentThread().interrupt();
                 error = e;
                 throw Exceptions.propagate(error);

--- a/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
@@ -23,6 +23,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import rx.Notification;
 import rx.Observable;
 import rx.Subscriber;
+import rx.Subscription;
 import rx.exceptions.Exceptions;
 
 /**
@@ -49,7 +50,7 @@ public final class BlockingOperatorToIterator {
         final BlockingQueue<Notification<? extends T>> notifications = new LinkedBlockingQueue<Notification<? extends T>>();
 
         // using subscribe instead of unsafeSubscribe since this is a BlockingObservable "final subscribe"
-        source.materialize().subscribe(new Subscriber<Notification<? extends T>>() {
+        final Subscription subscription = source.materialize().subscribe(new Subscriber<Notification<? extends T>>() {
             @Override
             public void onCompleted() {
                 // ignore
@@ -94,6 +95,7 @@ public final class BlockingOperatorToIterator {
                 try {
                     return notifications.take();
                 } catch (InterruptedException e) {
+                    subscription.unsubscribe();
                     throw Exceptions.propagate(e);
                 }
             }


### PR DESCRIPTION
Originated from discussion #1804.

I was considering to make it opt-in, but it would drastically increase number of methods in public API.
What do you think?