### PR TITLE
Backpressure suppport for Window by size

### DIFF
--- a/src/main/java/rx/internal/operators/NonOverlappingBufferProducer.java
+++ b/src/main/java/rx/internal/operators/NonOverlappingBufferProducer.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.Producer;
+
+public final class NonOverlappingBufferProducer implements Producer {
+
+    private final Producer producer;
+    private final int count;
+
+    NonOverlappingBufferProducer(Producer parentProducer, int count) {
+        this.producer = parentProducer;
+        this.count = count;
+    }
+
+    private volatile boolean infinite = false;
+
+    @Override
+    public void request(long n) {
+        if (infinite) {
+            return;
+        }
+        if (n >= Long.MAX_VALUE / count) {
+            // n == Long.MAX_VALUE or n * count >= Long.MAX_VALUE
+            infinite = true;
+            producer.request(Long.MAX_VALUE);
+        } else {
+            producer.request(n * count);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.Producer;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
@@ -87,9 +88,8 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
         }
 
         @Override
-        public void onStart() {
-            // no backpressure as we are controlling data flow by window size
-            request(Long.MAX_VALUE);
+        public void setProducer(Producer producer) {
+            child.setProducer(new NonOverlappingBufferProducer(producer, size));
         }
         
         @Override
@@ -159,9 +159,8 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
         }
 
         @Override
-        public void onStart() {
-            // no backpressure as we are controlling data flow by window size
-            request(Long.MAX_VALUE);
+        public void setProducer(Producer producer) {
+            child.setProducer(new OverlappingBufferProducer(producer, size, skip));
         }
         
         @Override

--- a/src/main/java/rx/internal/operators/OverlappingBufferProducer.java
+++ b/src/main/java/rx/internal/operators/OverlappingBufferProducer.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.Producer;
+
+public final class OverlappingBufferProducer implements Producer {
+
+    private final Producer producer;
+    private final int count;
+    private final int skip;
+
+    OverlappingBufferProducer(Producer parentProducer, int count, int skip) {
+        this.producer = parentProducer;
+        this.count = count;
+        this.skip = skip;
+    }
+
+    private volatile boolean firstRequest = true;
+    private volatile boolean infinite = false;
+
+    private void requestInfinite() {
+        infinite = true;
+        producer.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void request(long n) {
+        if (infinite) {
+            return;
+        }
+        if (n == Long.MAX_VALUE) {
+            requestInfinite();
+            return;
+        } else {
+            if (firstRequest) {
+                firstRequest = false;
+                if (n - 1 >= (Long.MAX_VALUE - count) / skip) {
+                    // count + skip * (n - 1) >= Long.MAX_VALUE
+                    requestInfinite();
+                    return;
+                }
+                // count = 5, skip = 2, n = 3
+                // * * * * *
+                //     * * * * *
+                //         * * * * *
+                // request = 5 + 2 * ( 3 - 1)
+                producer.request(count + skip * (n - 1));
+            } else {
+                if (n >= Long.MAX_VALUE / skip) {
+                    // skip * n >= Long.MAX_VALUE
+                    requestInfinite();
+                    return;
+                }
+                // count = 5, skip = 2, n = 3
+                // (* * *) * *
+                // (    *) * * * *
+                //           * * * * *
+                // request = skip * n
+                // "()" means the items already emitted before this request
+                producer.request(skip * n);
+            }
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/NonOverlappingBufferProducerTest.java
+++ b/src/test/java/rx/internal/operators/NonOverlappingBufferProducerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import org.junit.Test;
+import rx.Producer;
+
+import static org.mockito.Mockito.*;
+
+public class NonOverlappingBufferProducerTest {
+
+    @Test
+    public void testRequest() {
+        Producer parentProducer = mock(Producer.class);
+        Producer producer = new NonOverlappingBufferProducer(parentProducer, 5);
+        producer.request(3);
+        verify(parentProducer).request(15);
+        producer.request(4);
+        verify(parentProducer).request(20);
+        producer.request(Long.MAX_VALUE / 5);
+        verify(parentProducer).request(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testRequest2() {
+        Producer parentProducer = mock(Producer.class);
+        Producer producer = new NonOverlappingBufferProducer(parentProducer, 5);
+        producer.request(Long.MAX_VALUE / 5 + 1);
+        verify(parentProducer).request(Long.MAX_VALUE);
+
+        producer.request(4);
+        // Ignore further requests, so only call once
+        verify(parentProducer, times(1)).request(Long.MAX_VALUE);
+    }
+}

--- a/src/test/java/rx/internal/operators/OverlappingBufferProducerTest.java
+++ b/src/test/java/rx/internal/operators/OverlappingBufferProducerTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import org.junit.Test;
+import rx.Producer;
+
+import static org.mockito.Mockito.*;
+
+public class OverlappingBufferProducerTest {
+
+    @Test
+    public void testRequest() {
+        Producer parentProducer = mock(Producer.class);
+        Producer producer = new OverlappingBufferProducer(parentProducer, 5, 2);
+        producer.request(3);
+        verify(parentProducer).request(9);
+        producer.request(4);
+        verify(parentProducer).request(8);
+        producer.request(Long.MAX_VALUE / 2);
+        verify(parentProducer).request(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testRequest2() {
+        Producer parentProducer = mock(Producer.class);
+        Producer producer = new OverlappingBufferProducer(parentProducer, 5, 2);
+        producer.request((Long.MAX_VALUE - 5) / 2 + 1);
+        verify(parentProducer).request(Long.MAX_VALUE);
+
+        producer.request(4);
+        // Ignore further requests, so only call once
+        verify(parentProducer, times(1)).request(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testRequest3() {
+        Producer parentProducer = mock(Producer.class);
+        Producer producer = new OverlappingBufferProducer(parentProducer, 5, 2);
+        producer.request((Long.MAX_VALUE - 5) / 2 + 2);
+        verify(parentProducer).request(Long.MAX_VALUE);
+
+        producer.request(4);
+        // Ignore further requests, so only call once
+        verify(parentProducer, times(1)).request(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testRequest4() {
+        Producer parentProducer = mock(Producer.class);
+        Producer producer = new OverlappingBufferProducer(parentProducer, 5, 2);
+        producer.request((Long.MAX_VALUE - 5) / 2);
+        System.out.println((Long.MAX_VALUE - 5) / 2);
+        verify(parentProducer).request(Long.MAX_VALUE - 2);
+    }
+
+}


### PR DESCRIPTION
For #1828. Extracted Producers from OperatorBufferWithSize and reused them in OperatorWindowWithSize.
