### PR TITLE
Fix Scan/Reduce/Collect Lambda Ambiguity

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -45,6 +45,7 @@ import rx.Producer;
 import rx.Scheduler;
 import rx.Subscriber;
 import rx.functions.Action0;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.schedulers.Schedulers;
@@ -105,7 +106,14 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
 
         @Override
         public Observable<? extends Notification<?>> call(Observable<? extends Notification<?>> ts) {
-            return ts.scan(Notification.createOnNext(0), new Func2<Notification<Integer>, Notification<?>, Notification<Integer>>() {
+            return ts.scan(new Func0<Notification<Integer>>() {
+
+                @Override
+                public Notification<Integer> call() {
+                    return Notification.createOnNext(0);
+                }
+                
+            }, new Func2<Notification<Integer>, Notification<?>, Notification<Integer>>() {
                 @SuppressWarnings("unchecked")
                 @Override
                 public Notification<Integer> call(Notification<Integer> n, Notification<?> term) {

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -50,6 +50,7 @@ import rx.Observable.Transformer;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.functions.Action1;
 import rx.functions.Action2;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.observables.ConnectableObservable;
@@ -277,7 +278,7 @@ public class ObservableTests {
     @Test
     public void testReduceWithEmptyObservableAndSeed() {
         Observable<Integer> observable = Observable.range(1, 0);
-        int value = observable.reduce(1, new Func2<Integer, Integer, Integer>() {
+        int value = observable.startWith(1).reduce(new Func2<Integer, Integer, Integer>() {
 
             @Override
             public Integer call(Integer t1, Integer t2) {
@@ -292,7 +293,7 @@ public class ObservableTests {
     @Test
     public void testReduceWithInitialValue() {
         Observable<Integer> observable = Observable.just(1, 2, 3, 4);
-        observable.reduce(50, new Func2<Integer, Integer, Integer>() {
+        observable.startWith(50).reduce(new Func2<Integer, Integer, Integer>() {
 
             @Override
             public Integer call(Integer t1, Integer t2) {
@@ -965,7 +966,14 @@ public class ObservableTests {
 
     @Test
     public void testCollectToList() {
-        List<Integer> list = Observable.just(1, 2, 3).collect(new ArrayList<Integer>(), new Action2<List<Integer>, Integer>() {
+        List<Integer> list = Observable.just(1, 2, 3).collect(new Func0<List<Integer>>() {
+
+            @Override
+            public List<Integer> call() {
+                return new ArrayList<Integer>();
+            }
+            
+        }, new Action2<List<Integer>, Integer>() {
 
             @Override
             public void call(List<Integer> list, Integer v) {
@@ -981,7 +989,14 @@ public class ObservableTests {
 
     @Test
     public void testCollectToString() {
-        String value = Observable.just(1, 2, 3).collect(new StringBuilder(), new Action2<StringBuilder, Integer>() {
+        String value = Observable.just(1, 2, 3).collect(new Func0<StringBuilder>() {
+
+            @Override
+            public StringBuilder call() {
+                return new StringBuilder();
+            }
+            
+        }, new Action2<StringBuilder, Integer>() {
 
             @Override
             public void call(StringBuilder sb, Integer v) {

--- a/src/test/java/rx/ScanTests.java
+++ b/src/test/java/rx/ScanTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import rx.EventStream.Event;
 import rx.functions.Action1;
+import rx.functions.Func0;
 import rx.functions.Func2;
 
 public class ScanTests {
@@ -30,7 +31,14 @@ public class ScanTests {
     public void testUnsubscribeScan() {
 
         EventStream.getEventStream("HTTP-ClusterB", 20)
-                .scan(new HashMap<String, String>(), new Func2<Map<String, String>, Event, Map<String, String>>() {
+                .scan(new Func0<Map<String, String>>() {
+
+                    @Override
+                    public Map<String, String> call() {
+                        return new HashMap<String, String>();
+                    }
+                    
+                }, new Func2<Map<String, String>, Event, Map<String, String>>() {
 
                     @Override
                     public Map<String, String> call(Map<String, String> accum, Event perInstanceEvent) {

--- a/src/test/java/rx/ZipTests.java
+++ b/src/test/java/rx/ZipTests.java
@@ -35,6 +35,7 @@ import rx.CovarianceTest.Rating;
 import rx.CovarianceTest.Result;
 import rx.EventStream.Event;
 import rx.functions.Action1;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.functions.FuncN;
@@ -57,7 +58,14 @@ public class ZipTests {
 
                     @Override
                     public Observable<Map<String, String>> call(final GroupedObservable<String, Event> ge) {
-                        return ge.scan(new HashMap<String, String>(), new Func2<Map<String, String>, Event, Map<String, String>>() {
+                        return ge.scan(new Func0<Map<String, String>>() {
+
+                            @Override
+                            public Map<String, String> call() {
+                                return new HashMap<String, String>();
+                            }
+                            
+                        }, new Func2<Map<String, String>, Event, Map<String, String>>() {
 
                             @Override
                             public Map<String, String> call(Map<String, String> accum, Event perInstanceEvent) {

--- a/src/test/java/rx/internal/operators/OperatorReduceTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReduceTest.java
@@ -30,6 +30,7 @@ import org.mockito.MockitoAnnotations;
 import rx.Observable;
 import rx.Observer;
 import rx.exceptions.TestException;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.internal.util.UtilityFunctions;
@@ -53,7 +54,7 @@ public class OperatorReduceTest {
     @Test
     public void testAggregateAsIntSum() {
 
-        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5).reduce(0, sum).map(UtilityFunctions.<Integer> identity());
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5).reduce(sum).map(UtilityFunctions.<Integer> identity());
 
         result.subscribe(observer);
 
@@ -66,7 +67,7 @@ public class OperatorReduceTest {
     public void testAggregateAsIntSumSourceThrows() {
         Observable<Integer> result = Observable.concat(Observable.just(1, 2, 3, 4, 5),
                 Observable.<Integer> error(new TestException()))
-                .reduce(0, sum).map(UtilityFunctions.<Integer> identity());
+                .reduce(sum).map(UtilityFunctions.<Integer> identity());
 
         result.subscribe(observer);
 
@@ -85,7 +86,7 @@ public class OperatorReduceTest {
         };
 
         Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
-                .reduce(0, sumErr).map(UtilityFunctions.<Integer> identity());
+                .reduce(sumErr).map(UtilityFunctions.<Integer> identity());
 
         result.subscribe(observer);
 
@@ -106,7 +107,7 @@ public class OperatorReduceTest {
         };
 
         Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
-                .reduce(0, sum).map(error);
+                .reduce(sum).map(error);
 
         result.subscribe(observer);
 
@@ -127,7 +128,14 @@ public class OperatorReduceTest {
     @Test
     public void testBackpressureWithInitialValue() throws InterruptedException {
         Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
-        Observable<Integer> reduced = source.reduce(0, sum);
+        Observable<Integer> reduced = source.reduce(new Func0<Integer>() {
+
+            @Override
+            public Integer call() {
+                return 0;
+            }
+            
+        }, sum);
 
         Integer r = reduced.toBlocking().first();
         assertEquals(21, r.intValue());

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -56,7 +56,14 @@ public class OperatorScanTest {
 
         Observable<Integer> observable = Observable.just(1, 2, 3);
 
-        Observable<String> m = observable.scan("", new Func2<String, Integer, String>() {
+        Observable<String> m = observable.scan(new Func0<String>() {
+
+            @Override
+            public String call() {
+                return "";
+            }
+            
+        }, new Func2<String, Integer, String>() {
 
             @Override
             public String call(String s, Integer n) {
@@ -131,7 +138,7 @@ public class OperatorScanTest {
     @Test
     public void shouldNotEmitUntilAfterSubscription() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        Observable.range(1, 100).scan(0, new Func2<Integer, Integer, Integer>() {
+        Observable.range(1, 100).scan(new Func2<Integer, Integer, Integer>() {
 
             @Override
             public Integer call(Integer t1, Integer t2) {
@@ -155,7 +162,14 @@ public class OperatorScanTest {
     public void testBackpressureWithInitialValue() {
         final AtomicInteger count = new AtomicInteger();
         Observable.range(1, 100)
-                .scan(0, new Func2<Integer, Integer, Integer>() {
+                .scan(new Func0<Integer>() {
+
+                    @Override
+                    public Integer call() {
+                        return 0;
+                    }
+                    
+                }, new Func2<Integer, Integer, Integer>() {
 
                     @Override
                     public Integer call(Integer t1, Integer t2) {
@@ -237,7 +251,14 @@ public class OperatorScanTest {
     public void testNoBackpressureWithInitialValue() {
         final AtomicInteger count = new AtomicInteger();
         Observable.range(1, 100)
-                .scan(0, new Func2<Integer, Integer, Integer>() {
+                .scan(new Func0<Integer>() {
+
+                    @Override
+                    public Integer call() {
+                        return 0;
+                    }
+                    
+                }, new Func2<Integer, Integer, Integer>() {
 
                     @Override
                     public Integer call(Integer t1, Integer t2) {


### PR DESCRIPTION
This fixes the Java 8 lambda ambiguity between the overloads: https://github.com/ReactiveX/RxJava/issues/1881

This is a breaking change for anyone using `scan`, `reduce`, `collect` with an initial value. 

There are two approaches to adapting.

If the initial value is the same type such as this:

``` java
stream.scan(1, Func2<Integer, Integer, Integer>)
```

then you can use `startWith`:

``` java
stream.startWith(1).scan(Func2<Integer, Integer, Integer>)
```

If it is a different type then a seed factory is needed:

``` java
stream.scan(Func0<List>, Func2< List, Integer, List >)
```

In Java 8 this would change from this:

``` java
stream.scan(new ArrayList(), (list, item) -> {
    list.add(item);
    return list;
});
```

to this:

``` java
stream.scan(() -> new ArrayList(), (list, item) -> {
    list.add(item);
    return list;
});
```

The same change happens in `reduce` and `collect`.
