### PR TITLE
Zip potential NPE fix.

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -162,6 +162,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         private Zip<R> zipper;
 
         public ZipProducer(Zip<R> zipper) {
+            super(-1L);
             this.zipper = zipper;
         }
 
@@ -198,13 +199,15 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
 
         @SuppressWarnings("unchecked")
         public void start(@SuppressWarnings("rawtypes") Observable[] os, AtomicLong requested) {
-            observers = new Object[os.length];
+            Object[] subscribers = new Object[os.length];
             this.requested = requested;
             for (int i = 0; i < os.length; i++) {
                 InnerSubscriber io = new InnerSubscriber();
-                observers[i] = io;
+                subscribers[i] = io;
                 childSubscription.add(io);
             }
+            this.observers = subscribers;
+            this.requested.incrementAndGet();
 
             for (int i = 0; i < os.length; i++) {
                 os[i].unsafeSubscribe((InnerSubscriber) observers[i]);


### PR DESCRIPTION
Issue #1891

My best guess is that the visibility of the items in the observers array is not guaranteed and some CPU/JVM optimizations may expose this. The fix initializes the observers array locally and uses the memory barrier provided by the incrementAndGet on the producer to ensure everything before that becomes visible for the subsequent subscriptions.
