### PR TITLE
Fix TestScheduler Handling of Immediate vs Virtual Time

### DIFF
--- a/src/main/java/rx/schedulers/TestScheduler.java
+++ b/src/main/java/rx/schedulers/TestScheduler.java
@@ -111,7 +111,8 @@ public class TestScheduler extends Scheduler {
             if (current.time > targetTimeInNanos) {
                 break;
             }
-            time = current.time;
+            // if scheduled time is 0 (immediate) use current virtual time
+            time = current.time == 0 ? time : current.time;
             queue.remove();
 
             // Only execute if not unsubscribed
@@ -129,7 +130,7 @@ public class TestScheduler extends Scheduler {
 
     private final class InnerTestScheduler extends Worker {
 
-        private BooleanSubscription s = new BooleanSubscription();
+        private final BooleanSubscription s = new BooleanSubscription();
 
         @Override
         public void unsubscribe() {


### PR DESCRIPTION
Manual merge of https://github.com/ReactiveX/RxJava/pull/1790 by @ylecaillez
