### PR TITLE
Fix the bug that Scan may request 0 when n is 1

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -295,4 +295,21 @@ public class OperatorScanTest {
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.toBlocking().single());
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.toBlocking().single());
     }
+
+    @Test
+    public void testScanWithRequestOne() {
+        Observable<Integer> o = Observable.just(1, 2).scan(0, new Func2<Integer, Integer, Integer>() {
+
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return t1 + t2;
+            }
+
+        }).take(1);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        o.subscribe(subscriber);
+        subscriber.assertReceivedOnNext(Arrays.asList(0));
+        subscriber.assertTerminalEvent();
+        subscriber.assertNoErrors();
+    }
 }


### PR DESCRIPTION
`Scan` may request 0 when n is 1 and `request(0)` makes the source `Observable` do nothing. The unit test demonstrates this bug.
