### PR TITLE
Experimental: ObjectPool with WeakReferences

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -273,7 +273,6 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
         private void initScalarValueQueueIfNeeded() {
             if (scalarValueQueue == null) {
                 scalarValueQueue = RxRingBuffer.getSpmcInstance();
-                add(scalarValueQueue);
             }
         }
 
@@ -539,7 +538,6 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
         public InnerSubscriber(MergeSubscriber<T> parent, MergeProducer<T> producer) {
             this.parentSubscriber = parent;
             this.producer = producer;
-            add(q);
             request(q.capacity());
         }
 

--- a/src/perf/java/rx/internal/IndexedRingBufferPerf.java
+++ b/src/perf/java/rx/internal/IndexedRingBufferPerf.java
@@ -30,18 +30,16 @@ public class IndexedRingBufferPerf {
     @Benchmark
     public void indexedRingBufferAdd(IndexedRingBufferInput input) throws InterruptedException, MissingBackpressureException {
         @SuppressWarnings("unchecked")
-        IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
+        IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance().get();
         for (int i = 0; i < input.size; i++) {
             list.add(i);
         }
-
-        list.unsubscribe();
     }
 
     @Benchmark
     public void indexedRingBufferAddRemove(IndexedRingBufferInput input) throws InterruptedException, MissingBackpressureException {
         @SuppressWarnings("unchecked")
-        IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
+        IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance().get();
         for (int i = 0; i < input.size; i++) {
             list.add(i);
         }
@@ -49,8 +47,6 @@ public class IndexedRingBufferPerf {
         for (int i = 0; i < input.size; i++) {
             list.remove(i);
         }
-
-        list.unsubscribe();
     }
 
     @State(Scope.Thread)

--- a/src/perf/java/rx/internal/RxRingBufferPerf.java
+++ b/src/perf/java/rx/internal/RxRingBufferPerf.java
@@ -57,7 +57,6 @@ public class RxRingBufferPerf {
         for (int i = 0; i < 1000; i++) {
             input.bh.consume(buffer.poll());
         }
-        buffer.release();
     }
 
     @Benchmark
@@ -65,7 +64,6 @@ public class RxRingBufferPerf {
         RxRingBuffer buffer = RxRingBuffer.getSpmcInstance();
         buffer.onNext("a");
         input.bh.consume(buffer.poll());
-        buffer.release();
     }
 
     @Benchmark
@@ -93,7 +91,6 @@ public class RxRingBufferPerf {
         for (int i = 0; i < 1000; i++) {
             input.bh.consume(buffer.poll());
         }
-        buffer.release();
     }
 
     @Benchmark
@@ -101,7 +98,6 @@ public class RxRingBufferPerf {
         RxRingBuffer buffer = RxRingBuffer.getSpscInstance();
         buffer.onNext("a");
         input.bh.consume(buffer.poll());
-        buffer.release();
     }
 
     @State(Scope.Thread)

--- a/src/test/java/rx/internal/util/IndexedRingBufferTest.java
+++ b/src/test/java/rx/internal/util/IndexedRingBufferTest.java
@@ -31,14 +31,17 @@ import rx.Scheduler;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Func1;
+import rx.internal.util.ObjectPool.Ref;
 import rx.schedulers.Schedulers;
 
 public class IndexedRingBufferTest {
 
     @Test
     public void add() {
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<LSubscription> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<LSubscription> list = ref.get();
         list.add(new LSubscription(1));
         list.add(new LSubscription(2));
         final AtomicInteger c = new AtomicInteger();
@@ -49,8 +52,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void removeEnd() {
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<LSubscription> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<LSubscription> list = ref.get();
         list.add(new LSubscription(1));
         int n2 = list.add(new LSubscription(2));
 
@@ -67,8 +72,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void removeMiddle() {
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<LSubscription> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<LSubscription> list = ref.get();
         list.add(new LSubscription(1));
         int n2 = list.add(new LSubscription(2));
         list.add(new LSubscription(3));
@@ -82,8 +89,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void addRemoveAdd() {
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<String> list = ref.get();
         list.add("one");
         list.add("two");
         list.add("three");
@@ -119,8 +128,10 @@ public class IndexedRingBufferTest {
     @Test
     public void addThousands() {
         String s = "s";
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<String> list = ref.get();
         for (int i = 0; i < 10000; i++) {
             list.add(s);
         }
@@ -145,8 +156,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testForEachWithIndex() {
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<String> buffer = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<String> buffer = ref.get();
         buffer.add("zero");
         buffer.add("one");
         buffer.add("two");
@@ -212,8 +225,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testForEachAcrossSections() {
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<Integer> buffer = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<Integer> buffer = ref.get();
         for (int i = 0; i < 10000; i++) {
             buffer.add(i);
         }
@@ -231,8 +246,10 @@ public class IndexedRingBufferTest {
     @Test
     public void longRunningAddRemoveAddDoesntLeakMemory() {
         String s = "s";
-        @SuppressWarnings("unchecked")
-        IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        IndexedRingBuffer<String> list = ref.get();
         for (int i = 0; i < 20000; i++) {
             int index = list.add(s);
             list.remove(index);
@@ -249,8 +266,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testConcurrentAdds() throws InterruptedException {
-        @SuppressWarnings("unchecked")
-        final IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        final IndexedRingBuffer<Integer> list = ref.get();
 
         Scheduler.Worker w1 = Schedulers.computation().createWorker();
         Scheduler.Worker w2 = Schedulers.computation().createWorker();
@@ -300,8 +319,10 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testConcurrentAddAndRemoves() throws InterruptedException {
-        @SuppressWarnings("unchecked")
-        final IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Ref<IndexedRingBuffer> ref = IndexedRingBuffer.getInstance();
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        final IndexedRingBuffer<Integer> list = ref.get();
 
         final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<Exception>());
 


### PR DESCRIPTION
An experimental implementation of ObjectPool that removes the explicit release and uses WeakReferences.

Part of exploration for https://github.com/ReactiveX/RxJava/issues/1908

The perf numbers on `observeOn` suggest none of this matters :-)

```
1.x Branch

Benchmark                                         (size)   Mode   Samples        Score  Score error    Units
r.o.OperatorObserveOnPerf.observeOnComputation         1  thrpt         5   108090.165     3468.773    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation      1000  thrpt         5     7010.679      283.868    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation   1000000  thrpt         5       13.588        0.354    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate           1  thrpt         5 16268519.793   707702.931    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate        1000  thrpt         5   149998.180    31025.889    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate     1000000  thrpt         5      159.109       11.987    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread           1  thrpt         5    17182.508      629.781    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread        1000  thrpt         5     7892.906      139.532    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread     1000000  thrpt         5       13.489        0.527    ops/s

This PullRequest using WeakReferences

Benchmark                                         (size)   Mode   Samples        Score  Score error    Units
r.o.OperatorObserveOnPerf.observeOnComputation         1  thrpt         5   108133.231     9569.065    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation      1000  thrpt         5     6389.620      581.448    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation   1000000  thrpt         5       13.181        1.719    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate           1  thrpt         5 15153898.775   927814.232    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate        1000  thrpt         5   169459.680    15935.085    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate     1000000  thrpt         5      154.516       32.170    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread           1  thrpt         5    15585.688     1205.259    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread        1000  thrpt         5     7871.875      295.553    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread     1000000  thrpt         5       14.040        0.628    ops/s


Pooling Disabled (create a new object each time in `borrowObject`)

Benchmark                                         (size)   Mode   Samples        Score  Score error    Units
r.o.OperatorObserveOnPerf.observeOnComputation         1  thrpt         5   108130.153    10452.845    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation      1000  thrpt         5     6948.319      123.024    ops/s
r.o.OperatorObserveOnPerf.observeOnComputation   1000000  thrpt         5       13.294        1.165    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate           1  thrpt         5 15107600.987  1565384.083    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate        1000  thrpt         5   170127.608    16674.301    ops/s
r.o.OperatorObserveOnPerf.observeOnImmediate     1000000  thrpt         5      155.075       20.204    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread           1  thrpt         5    15730.556     1586.146    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread        1000  thrpt         5     7911.561      439.432    ops/s
r.o.OperatorObserveOnPerf.observeOnNewThread     1000000  thrpt         5       14.472        0.982    ops/s
```

Need to sleep on this more but wanted to post this in case it triggers thoughts on ideas for anyone else.
