### PR TITLE
Hook usage

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -58,10 +58,10 @@ public class Observable<T> {
      *            {@link OnSubscribe} to be executed when {@link #subscribe(Subscriber)} is called
      */
     protected Observable(OnSubscribe<T> f) {
-        this.onSubscribe = f;
+        this.onSubscribe = hook.onCreate(f);
     }
 
-    private static final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
+    private final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
 
     /**
      * Returns an Observable that will execute the specified function when a {@link Subscriber} subscribes to
@@ -93,7 +93,7 @@ public class Observable<T> {
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Creating-Observables#create">RxJava wiki: create</a>
      */
     public final static <T> Observable<T> create(OnSubscribe<T> f) {
-        return new Observable<T>(hook.onCreate(f));
+        return new Observable<T>(f);
     }
 
     /**

--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -94,10 +94,9 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
                                 return;
                             }
                             o.onNext(it.next());
-
                         }
 
-                        if (!it.hasNext()) {
+                        if (!it.hasNext() && !o.isUnsubscribed()) {
                             o.onCompleted();
                             return;
                         }

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -186,7 +186,8 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
             InnerSubscriber<T> i = new InnerSubscriber<T>(this, producerIfNeeded);
             i.sindex = childrenSubscribers.add(i);
             t.unsafeSubscribe(i);
-            request(1);
+            if (!isUnsubscribed())
+                request(1);
         }
 
         private void handleScalarSynchronousObservable(ScalarSynchronousObservable<? extends T> t) {


### PR DESCRIPTION
Make the hook and instance field so that plugin reset works between unit tests.
Remove unnecessary request(n) and onCompleted() calls when unsubscribed.
