### PR TITLE
Fixed first emission racing with pre and post subscription.

### DIFF
--- a/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -25,12 +25,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.*;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
-import rx.functions.Action1;
+import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
@@ -334,6 +334,69 @@ public class ReplaySubjectBoundedConcurrencyTest {
                 value.set(v);
             } catch (Exception e) {
                 e.printStackTrace();
+            }
+        }
+    }
+    @Test
+    public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
+        Scheduler s = Schedulers.io();
+        Scheduler.Worker worker = Schedulers.io().createWorker();
+        for (int i = 0; i < 50000; i++) {
+            if (i % 1000 == 0) {
+                System.out.println(i);
+            }
+            final ReplaySubject<Object> rs = ReplaySubject.createWithSize(2);
+            
+            final CountDownLatch finish = new CountDownLatch(1); 
+            final CountDownLatch start = new CountDownLatch(1); 
+            
+            worker.schedule(new Action0() {
+                @Override
+                public void call() {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
+                    }
+                    rs.onNext(1);
+                }
+            });
+            
+            final AtomicReference<Object> o = new AtomicReference<Object>();
+            
+            rs.subscribeOn(s).observeOn(Schedulers.io())
+            .subscribe(new Observer<Object>() {
+
+                @Override
+                public void onCompleted() {
+                    o.set(-1);
+                    finish.countDown();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    o.set(e);
+                    finish.countDown();
+                }
+
+                @Override
+                public void onNext(Object t) {
+                    o.set(t);
+                    finish.countDown();
+                }
+                
+            });
+            start.countDown();
+            
+            if (!finish.await(5, TimeUnit.SECONDS)) {
+                System.out.println(o.get());
+                System.out.println(rs.hasObservers());
+                rs.onCompleted();
+                Assert.fail("Timeout @ " + i);
+                break;
+            } else {
+                Assert.assertEquals(1, o.get());
+                rs.onCompleted();
             }
         }
     }


### PR DESCRIPTION
There was a subtle race between the subscription and emission which delayed the delivery of the first emission if it happened between the pre- and post-subscription of a subscriber. The fix is the same logic used by the BehaviorSubject to avoid the same problem.
