### PR TITLE
Remove extraneous request(n) and onCompleted() calls when unsubscribed.

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -98,7 +98,9 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
                         }
 
                         if (!it.hasNext()) {
-                            o.onCompleted();
+                            if (!o.isUnsubscribed()) {
+                                o.onCompleted();
+                            }
                             return;
                         }
                         if (REQUESTED_UPDATER.addAndGet(this, -r) == 0) {

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -186,7 +186,8 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
             InnerSubscriber<T> i = new InnerSubscriber<T>(this, producerIfNeeded);
             i.sindex = childrenSubscribers.add(i);
             t.unsafeSubscribe(i);
-            request(1);
+            if (!isUnsubscribed())
+                request(1);
         }
 
         private void handleScalarSynchronousObservable(ScalarSynchronousObservable<? extends T> t) {


### PR DESCRIPTION
Added simple checks to make the best effort to not do anything after the down stream has unsubscribed.
