### PR TITLE
OnBackpressureXXX: support for common drain manager & fix for former concurrency bugs

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBlock.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBlock.java
@@ -20,8 +20,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 import rx.Observable.Operator;
-import rx.Producer;
 import rx.Subscriber;
+import rx.internal.util.BackpressureDrainManager;
 
 /**
  * Operator that blocks the producer thread in case a backpressure is needed.
@@ -38,45 +38,25 @@ public class OperatorOnBackpressureBlock<T> implements Operator<T, T> {
         return s;
     }
     
-    static final class BlockingSubscriber<T> extends Subscriber<T> {
+    static final class BlockingSubscriber<T> extends Subscriber<T> implements BackpressureDrainManager.BackpressureQueueCallback {
         final NotificationLite<T> nl = NotificationLite.instance();
         final BlockingQueue<Object> queue;
         final Subscriber<? super T> child;
-        /** Guarded by this. */
-        long requestedCount;
-        /** Guarded by this. */
-        boolean emitting;
-        volatile boolean terminated;
-        /** Set before terminated, read after terminated. */
-        Throwable exception;
+        final BackpressureDrainManager manager;
         public BlockingSubscriber(int max, Subscriber<? super T> child) {
             this.queue = new ArrayBlockingQueue<Object>(max);
             this.child = child;
+            this.manager = new BackpressureDrainManager(this);
         }
         void init() {
             child.add(this);
-            child.setProducer(new Producer() {
-                @Override
-                public void request(long n) {
-                    if (n == 0) {
-                        return;
-                    }
-                    synchronized (BlockingSubscriber.this) {
-                        if (n == Long.MAX_VALUE || requestedCount == Long.MAX_VALUE) {
-                            requestedCount = Long.MAX_VALUE;
-                        } else {
-                            requestedCount += n;
-                        }
-                    }
-                    drain();
-                }
-            });
+            child.setProducer(manager);
         }
         @Override
         public void onNext(T t) {
             try {
                 queue.put(nl.next(t));
-                drain();
+                manager.drain();
             } catch (InterruptedException ex) {
                 if (!isUnsubscribed()) {
                     onError(ex);
@@ -85,91 +65,31 @@ public class OperatorOnBackpressureBlock<T> implements Operator<T, T> {
         }
         @Override
         public void onError(Throwable e) {
-            if (!terminated) {
-                exception = e;
-                terminated = true;
-                drain();
-            }
+            manager.terminateAndDrain(e);
         }
         @Override
         public void onCompleted() {
-            terminated = true;
-            drain();
+            manager.terminateAndDrain();
         }
-        void drain() {
-            long n;
-            boolean term;
-            synchronized (this) {
-                if (emitting) {
-                    return;
-                }
-                emitting = true;
-                n = requestedCount;
-                term = terminated;
+        @Override
+        public boolean accept(Object value) {
+            return nl.accept(child, value);
+        }
+        @Override
+        public void complete(Throwable exception) {
+            if (exception != null) {
+                child.onError(exception);
+            } else {
+                child.onCompleted();
             }
-            boolean skipFinal = false;
-            try {
-                Subscriber<? super T> child = this.child;
-                BlockingQueue<Object> queue = this.queue;
-                while (true) {
-                    int emitted = 0;
-                    while (n > 0 || term) {
-                        Object o;
-                        if (term) {
-                            o = queue.peek();
-                            if (o == null) {
-                                Throwable e = exception;
-                                if (e != null) {
-                                    child.onError(e);
-                                } else {
-                                    child.onCompleted();
-                                }
-                                skipFinal = true;
-                                return;
-                            }
-                            if (n == 0) {
-                                break;
-                            }
-                        }
-                        o = queue.poll();
-                        if (o == null) {
-                            break;
-                        } else {
-                            child.onNext(nl.getValue(o));
-                            n--;
-                            emitted++;
-                        }
-                    }
-                    synchronized (this) {
-                        term = terminated;
-                        boolean more = queue.peek() != null;
-                        // if no backpressure below
-                        if (requestedCount == Long.MAX_VALUE) {
-                            // no new data arrived since the last poll
-                            if (!more && !term) {
-                                skipFinal = true;
-                                emitting = false;
-                                return;
-                            }
-                            n = Long.MAX_VALUE;
-                        } else {
-                            requestedCount -= emitted;
-                            n = requestedCount;
-                            if ((n == 0 || !more) && (!term || more)) {
-                                skipFinal = true;
-                                emitting = false;
-                                return;
-                            }
-                        }
-                    }
-                }
-            } finally {
-                if (!skipFinal) {
-                    synchronized (this) {
-                        emitting = false;
-                    }
-                }
-            }
+        }
+        @Override
+        public Object peek() {
+            return queue.peek();
+        }
+        @Override
+        public Object poll() {
+            return queue.poll();
         }
     }
 }

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -126,7 +126,7 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
         @Override
         public Object poll() {
             Object value = queue.poll();
-            if (capacity != null) {
+            if (capacity != null && value != null) {
                 capacity.incrementAndGet();
             }
             return value;

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,10 +24,9 @@ import rx.Producer;
 import rx.Subscriber;
 import rx.exceptions.MissingBackpressureException;
 import rx.functions.Action0;
+import rx.internal.util.BackpressureDrainManager;
 
 public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
-
-    private final NotificationLite<T> on = NotificationLite.instance();
 
     private final Long capacity;
     private final Action0 onOverflow;
@@ -52,122 +50,110 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
 
     @Override
     public Subscriber<? super T> call(final Subscriber<? super T> child) {
-        // TODO get a different queue implementation
-        final ConcurrentLinkedQueue<Object> queue = new ConcurrentLinkedQueue<Object>();
-        final AtomicLong capacity = (this.capacity == null) ? null : new AtomicLong(this.capacity);
-        final AtomicLong wip = new AtomicLong();
-        final AtomicLong requested = new AtomicLong();
 
-        child.setProducer(new Producer() {
-
-            @Override
-            public void request(long n) {
-                if (requested.getAndAdd(n) == 0) {
-                    pollQueue(wip, requested, capacity, queue, child);
-                }
-            }
-
-        });
         // don't pass through subscriber as we are async and doing queue draining
         // a parent being unsubscribed should not affect the children
-        Subscriber<T> parent = new Subscriber<T>() {
+        BufferSubscriber<T> parent = new BufferSubscriber<T>(child, capacity, onOverflow);
 
-            private AtomicBoolean saturated = new AtomicBoolean(false);
-
-            @Override
-            public void onStart() {
-                request(Long.MAX_VALUE);
-            }
-
-            @Override
-            public void onCompleted() {
-                if (!saturated.get()) {
-                    queue.offer(on.completed());
-                    pollQueue(wip, requested, capacity, queue, child);
-                }
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                if (!saturated.get()) {
-                    queue.offer(on.error(e));
-                    pollQueue(wip, requested, capacity, queue, child);
-                }
-            }
-
-            @Override
-            public void onNext(T t) {
-                if (!assertCapacity()) {
-                    return;
-                }
-                queue.offer(on.next(t));
-                pollQueue(wip, requested, capacity, queue, child);
-            }
-
-            private boolean assertCapacity() {
-                if (capacity == null) {
-                    return true;
-                }
-
-                long currCapacity;
-                do {
-                    currCapacity = capacity.get();
-                    if (currCapacity <= 0) {
-                        if (saturated.compareAndSet(false, true)) {
-                            unsubscribe();
-                            child.onError(new MissingBackpressureException(
-                                "Overflowed buffer of "
-                                + OperatorOnBackpressureBuffer.this.capacity));
-                            if (onOverflow != null) {
-                                onOverflow.call();
-                            }
-                        }
-                        return false;
-                    }
-                // ensure no other thread stole our slot, or retry
-                } while (!capacity.compareAndSet(currCapacity, currCapacity - 1));
-                return true;
-            }
-        };
-        
         // if child unsubscribes it should unsubscribe the parent, but not the other way around
         child.add(parent);
-        
+        child.setProducer(parent.manager());
+
         return parent;
     }
+    private static final class BufferSubscriber<T> extends Subscriber<T> implements BackpressureDrainManager.BackpressureQueueCallback {
+        // TODO get a different queue implementation
+        private final ConcurrentLinkedQueue<Object> queue = new ConcurrentLinkedQueue<Object>();
+        private final Long baseCapacity;
+        private final AtomicLong capacity;
+        private final Subscriber<? super T> child;
+        private final AtomicBoolean saturated = new AtomicBoolean(false);
+        private final BackpressureDrainManager manager;
+        private final NotificationLite<T> on = NotificationLite.instance();
+        private final Action0 onOverflow;
+        
+        public BufferSubscriber(final Subscriber<? super T> child, Long capacity, Action0 onOverflow) {
+            this.child = child;
+            this.baseCapacity = capacity;
+            this.capacity = capacity != null ? new AtomicLong(capacity) : null;
+            this.onOverflow = onOverflow;
+            this.manager = new BackpressureDrainManager(this);
+        }
+        @Override
+        public void onStart() {
+            request(Long.MAX_VALUE);
+        }
 
-    private void pollQueue(AtomicLong wip, AtomicLong requested, AtomicLong capacity, Queue<Object> queue, Subscriber<? super T> child) {
-        // TODO can we do this without putting everything in the queue first so we can fast-path the case when we don't need to queue?
-        if (requested.get() > 0) {
-            // only one draining at a time
-            try {
-                /*
-                 * This needs to protect against concurrent execution because `request` and `on*` events can come concurrently.
-                 */
-                if (wip.getAndIncrement() == 0) {
-                    while (true) {
-                        if (requested.getAndDecrement() != 0) {
-                            Object o = queue.poll();
-                            if (o == null) {
-                                // nothing in queue
-                                requested.incrementAndGet();
-                                return;
-                            }
-                            if (capacity != null) { // it's bounded
-                                capacity.incrementAndGet();
-                            }
-                            on.accept(child, o);
-                        } else {
-                            // we hit the end ... so increment back to 0 again
-                            requested.incrementAndGet();
-                            return;
+        @Override
+        public void onCompleted() {
+            if (!saturated.get()) {
+                manager.terminateAndDrain();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (!saturated.get()) {
+                manager.terminateAndDrain(e);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!assertCapacity()) {
+                return;
+            }
+            queue.offer(on.next(t));
+            manager.drain();
+        }
+
+        @Override
+        public boolean accept(Object value) {
+            return on.accept(child, value);
+        }
+        @Override
+        public void complete(Throwable exception) {
+            if (exception != null) {
+                child.onError(exception);
+            } else {
+                child.onCompleted();
+            }
+        }
+        @Override
+        public Object peek() {
+            return queue.peek();
+        }
+        @Override
+        public Object poll() {
+            return queue.poll();
+        }
+        
+        private boolean assertCapacity() {
+            if (capacity == null) {
+                return true;
+            }
+
+            long currCapacity;
+            do {
+                currCapacity = capacity.get();
+                if (currCapacity <= 0) {
+                    if (saturated.compareAndSet(false, true)) {
+                        unsubscribe();
+                        child.onError(new MissingBackpressureException(
+                                "Overflowed buffer of "
+                                        + baseCapacity));
+                        if (onOverflow != null) {
+                            onOverflow.call();
                         }
                     }
+                    return false;
                 }
-
-            } finally {
-                wip.decrementAndGet();
-            }
+                // ensure no other thread stole our slot, or retry
+            } while (!capacity.compareAndSet(currCapacity, currCapacity - 1));
+            return true;
+        }
+        protected Producer manager() {
+            return manager;
         }
     }
 }

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -125,7 +125,11 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
         }
         @Override
         public Object poll() {
-            return queue.poll();
+            Object value = queue.poll();
+            if (capacity != null) {
+                capacity.incrementAndGet();
+            }
+            return value;
         }
         
         private boolean assertCapacity() {

--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -60,12 +60,12 @@ public final class BackpressureDrainManager implements Producer {
          */
         void complete(Throwable exception);
     }
-    
+
     /** The request counter, updated via REQUESTED_COUNTER. */
     protected volatile long requestedCount;
     /** Atomically updates the the requestedCount field. */ 
     protected static final AtomicLongFieldUpdater<BackpressureDrainManager> REQUESTED_COUNT
-        = AtomicLongFieldUpdater.newUpdater(BackpressureDrainManager.class, "requestedCount");
+    = AtomicLongFieldUpdater.newUpdater(BackpressureDrainManager.class, "requestedCount");
     /** Indicates if one is in emitting phase, guarded by this. */
     protected boolean emitting;
     /** Indicates a terminal state. */
@@ -235,6 +235,6 @@ public final class BackpressureDrainManager implements Producer {
                 }
             }
         }
-    
+
     }
 }

--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -142,14 +142,17 @@ public final class BackpressureDrainManager implements Producer {
             r = requestedCount;
             mayDrain = r == 0;
             if (r == Long.MAX_VALUE) {
-                mayDrain = true;
                 break;
             }
             if (n == Long.MAX_VALUE) {
                 u = n;
                 mayDrain = true;
             } else {
-                u = r + n;
+                if (r > Long.MAX_VALUE - n) {
+                    u = Long.MAX_VALUE;
+                } else {
+                    u = r + n;
+                }
             }
         } while (!REQUESTED_COUNT.compareAndSet(this, r, u));
         // since we implement producer, we have to call drain

--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -1,19 +1,18 @@
-/*
- * Copyright 2011 David Karnok
- *
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package rx.internal.util;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;

--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2011 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.util;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import rx.Producer;
+import rx.annotations.Experimental;
+
+/**
+ * Manages the producer-backpressure-consumer interplay by
+ * matching up available elements with requested elements and/or
+ * terminal events. 
+ */
+@Experimental
+public final class BackpressureDrainManager implements Producer {
+    /**
+     * Interface representing the minimal callbacks required
+     * to operate the drain part of a backpressure system.
+     */
+    public interface BackpressureQueueCallback {
+        /**
+         * Override this method to peek for the next element,
+         * null meaning no next element available now.
+         * <p>It will be called plain and while holding this object's monitor.
+         * @return the next element or null if no next element available
+         */
+        Object peek();
+        /**
+         * Override this method to poll (consume) the next element,
+         * null meaning no next element available now.
+         * @return the next element or null if no next element available
+         */
+        Object poll();
+        /**
+         * Override this method to deliver an element to downstream.
+         * The logic ensures that this happens only in the right conditions.
+         * @param value the value to deliver, not null
+         * @return true indicates that one should terminate the emission loop unconditionally
+         * and not deliver any further elements or terminal events.
+         */
+        boolean accept(Object value);
+        /**
+         * Override this method to deliver a normal or exceptional
+         * terminal event.
+         * @param exception if not null, contains the terminal exception
+         */
+        void complete(Throwable exception);
+    }
+    
+    /** The request counter, updated via REQUESTED_COUNTER. */
+    protected volatile long requestedCount;
+    /** Atomically updates the the requestedCount field. */ 
+    protected static final AtomicLongFieldUpdater<BackpressureDrainManager> REQUESTED_COUNT
+        = AtomicLongFieldUpdater.newUpdater(BackpressureDrainManager.class, "requestedCount");
+    /** Indicates if one is in emitting phase, guarded by this. */
+    protected boolean emitting;
+    /** Indicates a terminal state. */
+    protected volatile boolean terminated;
+    /** Indicates an error state, barrier is provided via terminated. */
+    protected Throwable exception;
+    /** The callbacks to manage the drain. */
+    protected final BackpressureQueueCallback actual;
+    /**
+     * Constructs a backpressure drain manager with 0 requesedCount,
+     * no terminal event and not emitting.
+     * @param actual he queue callback to check for new element availability
+     */
+    public BackpressureDrainManager(BackpressureQueueCallback actual) {
+        this.actual = actual;
+    }
+    /**
+     * Checks if a terminal state has been reached.
+     * @return true if a terminal state has been reached
+     */
+    public final boolean isTerminated() {
+        return terminated;
+    }
+    /**
+     * Move into a terminal state. 
+     * Call drain() anytime after.
+     */
+    public final void terminate() {
+        terminated = true;
+    }
+    /**
+     * Move into a terminal state with an exception.
+     * Call drain() anytime after.
+     * <p>Serialized access is expected with respect to
+     * element emission.
+     * @param error the exception to deliver
+     */
+    public final void terminate(Throwable error) {
+        if (!terminated) {
+            exception = error;
+            terminated = true;
+        }
+    }
+    /**
+     * Move into a terminal state and drain. 
+     */
+    public final void terminateAndDrain() {
+        terminated = true;
+        drain();
+    }
+    /**
+     * Move into a terminal state with an exception and drain.
+     * <p>Serialized access is expected with respect to
+     * element emission.
+     * @param error the exception to deliver
+     */
+    public final void terminateAndDrain(Throwable error) {
+        if (!terminated) {
+            exception = error;
+            terminated = true;
+            drain();
+        }
+    }
+    @Override
+    public final void request(long n) {
+        if (n == 0) {
+            return;
+        }
+        boolean mayDrain;
+        long r;
+        long u;
+        do {
+            r = requestedCount;
+            mayDrain = r == 0;
+            if (r == Long.MAX_VALUE) {
+                mayDrain = true;
+                break;
+            }
+            if (n == Long.MAX_VALUE) {
+                u = n;
+                mayDrain = true;
+            } else {
+                u = r + n;
+            }
+        } while (!REQUESTED_COUNT.compareAndSet(this, r, u));
+        // since we implement producer, we have to call drain
+        // on a 0-n request transition
+        if (mayDrain) {
+            drain();
+        }
+    }
+    /**
+     * Try to drain the "queued" elements and terminal events
+     * by considering the available and requested event counts.
+     */
+    public final void drain() {
+        long n;
+        boolean term;
+        synchronized (this) {
+            if (emitting) {
+                return;
+            }
+            emitting = true;
+            term = terminated;
+        }
+        n = requestedCount;
+        boolean skipFinal = false;
+        try {
+            BackpressureQueueCallback a = actual;
+            while (true) {
+                int emitted = 0;
+                while (n > 0 || term) {
+                    Object o;
+                    if (term) {
+                        o = a.peek();
+                        if (o == null) {
+                            skipFinal = true;
+                            Throwable e = exception;
+                            a.complete(e);
+                            return;
+                        }
+                        if (n == 0) {
+                            break;
+                        }
+                    }
+                    o = a.poll();
+                    if (o == null) {
+                        break;
+                    } else {
+                        if (a.accept(o)) {
+                            skipFinal = true;
+                            return;
+                        }
+                        n--;
+                        emitted++;
+                    }
+                }
+                synchronized (this) {
+                    term = terminated;
+                    boolean more = a.peek() != null;
+                    // if no backpressure below
+                    if (requestedCount == Long.MAX_VALUE) {
+                        // no new data arrived since the last poll
+                        if (!more && !term) {
+                            skipFinal = true;
+                            emitting = false;
+                            return;
+                        }
+                        n = Long.MAX_VALUE;
+                    } else {
+                        n = REQUESTED_COUNT.addAndGet(this, -emitted);
+                        if ((n == 0 || !more) && (!term || more)) {
+                            skipFinal = true;
+                            emitting = false;
+                            return;
+                        }
+                    }
+                }
+            }
+        } finally {
+            if (!skipFinal) {
+                synchronized (this) {
+                    emitting = false;
+                }
+            }
+        }
+    
+    }
+}

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
@@ -47,7 +47,7 @@ public class OperatorOnBackpressureBufferTest {
         ts.assertNoErrors();
     }
 
-    @Test(timeout = 500)
+    @Test(timeout = 2000)
     public void testFixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);


### PR DESCRIPTION
This is quite a complex operator with lots of cases.

Properties:
1) If there aren't any elements queued up and nothing is requested but terminal event received, emit terminal event and quit.
2) If there are elements in the queue and a terminal flag, and at least the same amount is requested, deliver the events and the terminal event.
3) If more was requested and more became available just after the loop and before the synchronized block, keep looping.
3.a) If more was requested but nothing is available or nothing was requested and something is available: quit and let either the onNext or request do the subsequent drain.
3.b) If elements and termination was produced but not requested: quit and let the request do the drain
3.c) If termination was requested and no elements produced: loop , emit terminal event and quit.

In table form:
```
Available | Terminated | Requested | Action | Reason
   yes         yes          yes       loop    can deliver available
   yes         yes          false     quit    can't deliver available
   yes         no           yes       loop    can deliver available
   yes         no           no        quit    can't deliver available
   no          yes          yes       loop    loop will deliver termination only and quit
   no          yes          no        loop    loop will deliver termination only and quit
   no          no           yes       quit    nothing to deliver
   no          no           no        quit    nothing to deliver
```