### PR TITLE
Fixed test issuing non-serialized messages to the subject.

### DIFF
--- a/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
@@ -338,63 +338,73 @@ public class ReplaySubjectConcurrencyTest {
     public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
         Scheduler.Worker worker = Schedulers.io().createWorker();
-        for (int i = 0; i < 50000; i++) {
-            if (i % 1000 == 0) {
-                System.out.println(i);
-            }
-            final ReplaySubject<Object> rs = ReplaySubject.create();
-            
-            final CountDownLatch finish = new CountDownLatch(1); 
-            final CountDownLatch start = new CountDownLatch(1); 
-            
-            worker.schedule(new Action0() {
-                @Override
-                public void call() {
-                    try {
-                        start.await();
-                    } catch (Exception e1) {
-                        e1.printStackTrace();
-                    }
-                    rs.onNext(1);
+        try {
+            for (int i = 0; i < 50000; i++) {
+                if (i % 1000 == 0) {
+                    System.out.println(i);
                 }
-            });
-            
-            final AtomicReference<Object> o = new AtomicReference<Object>();
-            
-            rs.subscribeOn(s).observeOn(Schedulers.io())
-            .subscribe(new Observer<Object>() {
-
-                @Override
-                public void onCompleted() {
-                    o.set(-1);
-                    finish.countDown();
-                }
-
-                @Override
-                public void onError(Throwable e) {
-                    o.set(e);
-                    finish.countDown();
-                }
-
-                @Override
-                public void onNext(Object t) {
-                    o.set(t);
-                    finish.countDown();
-                }
+                final ReplaySubject<Object> rs = ReplaySubject.create();
                 
-            });
-            start.countDown();
-            
-            if (!finish.await(5, TimeUnit.SECONDS)) {
-                System.out.println(o.get());
-                System.out.println(rs.hasObservers());
-                rs.onCompleted();
-                Assert.fail("Timeout @ " + i);
-                break;
-            } else {
-                Assert.assertEquals(1, o.get());
-                rs.onCompleted();
+                final CountDownLatch finish = new CountDownLatch(1); 
+                final CountDownLatch start = new CountDownLatch(1); 
+                
+                worker.schedule(new Action0() {
+                    @Override
+                    public void call() {
+                        try {
+                            start.await();
+                        } catch (Exception e1) {
+                            e1.printStackTrace();
+                        }
+                        rs.onNext(1);
+                    }
+                });
+                
+                final AtomicReference<Object> o = new AtomicReference<Object>();
+                
+                rs.subscribeOn(s).observeOn(Schedulers.io())
+                .subscribe(new Observer<Object>() {
+    
+                    @Override
+                    public void onCompleted() {
+                        o.set(-1);
+                        finish.countDown();
+                    }
+    
+                    @Override
+                    public void onError(Throwable e) {
+                        o.set(e);
+                        finish.countDown();
+                    }
+    
+                    @Override
+                    public void onNext(Object t) {
+                        o.set(t);
+                        finish.countDown();
+                    }
+                    
+                });
+                start.countDown();
+                
+                if (!finish.await(5, TimeUnit.SECONDS)) {
+                    System.out.println(o.get());
+                    System.out.println(rs.hasObservers());
+                    rs.onCompleted();
+                    Assert.fail("Timeout @ " + i);
+                    break;
+                } else {
+                    Assert.assertEquals(1, o.get());
+                    worker.schedule(new Action0() {
+                        @Override
+                        public void call() {
+                            rs.onCompleted();
+                        }
+                    });
+                    
+                }
             }
+        } finally {
+            worker.unsubscribe();
         }
     }
 }


### PR DESCRIPTION
Should resolve the test failure of #1972 .

When the main part of the test succeded, an onCompleted was sent out from the main thread which was not serialized in respect to the onNext(1) issued from the worker thread, therefore, two replay was attempted sometimes. At first the caughtUp was seen false, the replay was entered but the next instruction cleared the index causing the IllegalStateException.
