### PR TITLE
OperatorDoOnRequest.ParentSubscriber should be static class

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
@@ -52,7 +52,7 @@ public class OperatorDoOnRequest<T> implements Operator<T, T> {
         return parent;
     }
 
-    private final class ParentSubscriber<T> extends Subscriber<T> {
+    private static final class ParentSubscriber<T> extends Subscriber<T> {
         private final Subscriber<? super T> child;
 
         private ParentSubscriber(Subscriber<? super T> child) {


### PR DESCRIPTION
minor fix this. `OperatorDoOnRequest.ParentSubscriber` does not require access to the state or methods of its surrounding class thus can be static.
