### PR TITLE
Make Publish Operator Release RingBuffer

### DIFF
--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -154,7 +154,7 @@ public class OnSubscribeRefCountTest {
         s2.unsubscribe(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one subscriber getting a value but not the other
         s1.unsubscribe();
 
-        System.out.println("onNext: " + nextCount.get());
+        System.out.println("onNext Count: " + nextCount.get());
 
         // it will emit twice because it is synchronous
         assertEquals(nextCount.get(), receivedCount.get() * 2);


### PR DESCRIPTION
It was retaining the RxRingBuffer reference between subscribes which meant it was never released to the object pool.

As per discussion in #2189 there are other issues in the `OperatorPublish` implementation but those will be fixed later. This PR is just for fixing the issue related to use of RxRingBuffer. 
