### PR TITLE
OperatorTakeLast add check for isUnsubscribed to fast path

### DIFF
--- a/src/main/java/rx/internal/operators/TakeLastQueueProducer.java
+++ b/src/main/java/rx/internal/operators/TakeLastQueueProducer.java
@@ -70,6 +70,8 @@ final class TakeLastQueueProducer<T> implements Producer {
             if (previousRequested == 0) {
                 try {
                     for (Object value : deque) {
+                        if (subscriber.isUnsubscribed())
+                            return;
                         notification.accept(subscriber, value);
                     }
                 } catch (Throwable e) {

--- a/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -263,5 +264,33 @@ public class OperatorTakeLastTest {
                 request(1);
             }
         });
+    }
+    
+    @Test
+    public void testUnsubscribeTakesEffectEarlyOnFastPath() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable.range(0, 100000).takeLast(100000).subscribe(new Subscriber<Integer>() {
+
+            @Override
+            public void onStart() {
+                request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onNext(Integer integer) {
+                count.incrementAndGet();
+                unsubscribe();
+            }
+        });
+        assertEquals(1,count.get());
     }
 }


### PR DESCRIPTION
Went looking for a bug that wasn't a bug but found this anyway.  ```OperatorTakeLast``` doesn't check ```subscriber.isUnsubscribed()``` while emitting its queued events so I added a failing unit test and the fix.