### PR TITLE
Adds a isInitialised call to check if the BehaviorSubject is initialised

### DIFF
--- a/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/src/main/java/rx/subjects/BehaviorSubject.java
@@ -176,4 +176,8 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     public boolean hasObservers() {
         return state.observers().length > 0;
     }
+
+    public boolean isInitialised() {
+        return state.get() != null;
+    }
 }

--- a/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -17,6 +17,7 @@ package rx.subjects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -482,4 +483,28 @@ public class BehaviorSubjectTest {
             }
         }
     }
+
+    @Test
+    public void testThatDefaultValueIsInitialised() {
+        BehaviorSubject<String> subject = BehaviorSubject.create("default");
+
+        assertTrue(subject.isInitialised());
+    }
+
+    @Test
+    public void testThatNoDefaultValueIsNotInitialised() {
+        BehaviorSubject<String> subject = BehaviorSubject.create();
+
+        assertFalse(subject.isInitialised());
+    }
+
+    @Test
+    public void testThatSubsequentValuesInitialise() {
+        BehaviorSubject<String> subject = BehaviorSubject.create();
+
+        subject.onNext("one");
+
+        assertTrue(subject.isInitialised());
+    }
+
 }


### PR DESCRIPTION
Since the BehaviorSubject can be created without a default value, it could be interesting to be able to know if the subject is initialised (if it holds a value).
Adding this check allows for lazy initialisation of the behavior's value.