### PR TITLE
RxRingBuffer fixes and improvements

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -83,7 +83,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
         private final MultiSourceRequestableSubscriber<T, R>[] subscribers;
 
         /* following are guarded by WIP */
-        private final RxRingBuffer buffer = RxRingBuffer.getSpmcInstance();
+        private final RxRingBuffer buffer = RxRingBuffer.getSpscInstance();
         private final Object[] collectedValues;
         private final BitSet haveValues;
         private volatile int haveValuesCount; // does this need to be volatile or is WIP sufficient?

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -282,7 +282,7 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
 
         private void initScalarValueQueueIfNeeded() {
             if (scalarValueQueue == null) {
-                scalarValueQueue = RxRingBuffer.getSpmcInstance();
+                scalarValueQueue = RxRingBuffer.getSpscInstance();
                 add(scalarValueQueue);
             }
         }
@@ -531,7 +531,7 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
         @SuppressWarnings("rawtypes")
         static final AtomicIntegerFieldUpdater<InnerSubscriber> ONCE_TERMINATED = AtomicIntegerFieldUpdater.newUpdater(InnerSubscriber.class, "terminated");
 
-        private final RxRingBuffer q = RxRingBuffer.getSpmcInstance();
+        private final RxRingBuffer q = RxRingBuffer.getSpscInstance();
 
         public InnerSubscriber(MergeSubscriber<T> parent, MergeProducer<T> producer) {
             this.parentSubscriber = parent;
@@ -627,7 +627,7 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
                     } else {
                         // this needs to check q.count() as draining above may not have drained the full queue
                         // perf tests show this to be okay, though different queue implementations could perform poorly with this
-                        if (producer.requested > 0 && q.count() == 0) {
+                        if (producer.requested > 0 && q.isEmpty()) {
                             if (complete) {
                                 parentSubscriber.completeInner(this);
                             } else {

--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -135,7 +135,7 @@ public class OperatorPublish<T> extends ConnectableObservable<T> {
         private final RequestHandler<T> requestHandler;
         private final AtomicLong originOutstanding = new AtomicLong();
         private final long THRESHOLD = RxRingBuffer.SIZE / 4;
-        private final RxRingBuffer buffer = RxRingBuffer.getSpmcInstance();
+        private final RxRingBuffer buffer = RxRingBuffer.getSpscInstance();
 
         OriginSubscriber(RequestHandler<T> requestHandler) {
             this.requestHandler = requestHandler;

--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -293,7 +293,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         @SuppressWarnings("rawtypes")
         final class InnerSubscriber extends Subscriber {
             // Concurrent* since we need to read it from across threads
-            final RxRingBuffer items = RxRingBuffer.getSpmcInstance();
+            final RxRingBuffer items = RxRingBuffer.getSpscInstance();
 
             @Override
             public void onStart() {

--- a/src/main/java/rx/internal/util/SWSRPhaser.java
+++ b/src/main/java/rx/internal/util/SWSRPhaser.java
@@ -1,0 +1,87 @@
+package rx.internal.util;
+
+/**
+* Written by Gil Tene of Azul Systems, and released to the public domain,
+* as explained at http://creativecommons.org/publicdomain/zero/1.0/
+* 
+* Originally from https://gist.github.com/giltene/b3e5490c2d7edb232644
+* Explained at http://stuff-gil-says.blogspot.com/2014/11/writerreaderphaser-story-about-new.html
+*/
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+/**
+* Single-Writer Single-Reader Phaser. 
+*/
+public final class SWSRPhaser {
+   private volatile long startEpoch = 0;
+   private volatile long evenEndEpoch = 0;
+   private volatile long oddEndEpoch = Long.MIN_VALUE;
+
+   private static final AtomicLongFieldUpdater<SWSRPhaser> startEpochUpdater =
+           AtomicLongFieldUpdater.newUpdater(SWSRPhaser.class, "startEpoch");
+   private static final AtomicLongFieldUpdater<SWSRPhaser> evenEndEpochUpdater =
+           AtomicLongFieldUpdater.newUpdater(SWSRPhaser.class, "evenEndEpoch");
+   private static final AtomicLongFieldUpdater<SWSRPhaser> oddEndEpochUpdater =
+           AtomicLongFieldUpdater.newUpdater(SWSRPhaser.class, "oddEndEpoch");
+
+   public long writerCriticalSectionEnter() {
+       return startEpochUpdater.getAndIncrement(this);
+   }
+
+   public void writerCriticalSectionExit(long criticalValueAtEnter) {
+       if (criticalValueAtEnter < 0) {
+           oddEndEpochUpdater.lazySet(this, criticalValueAtEnter + 1);
+       } else {
+           evenEndEpochUpdater.lazySet(this, criticalValueAtEnter + 1);
+       }
+   }
+
+   public boolean isEvenPhase() {
+       return startEpoch >= 0;
+   }
+   public boolean isOddPhase() {
+       return startEpoch < 0;
+   }
+   
+   public long flipPhase(long yieldTimeNsec) {
+       boolean nextPhaseIsEven = (startEpoch < 0); // Current phase is odd...
+
+       long initialStartValue;
+       // First, clear currently unused [next] phase end epoch (to proper initial value for phase):
+       if (nextPhaseIsEven) {
+           initialStartValue = 0;
+           evenEndEpochUpdater.lazySet(this, 0);
+       } else {
+           initialStartValue = Long.MIN_VALUE;
+           oddEndEpochUpdater.lazySet(this, Long.MIN_VALUE);
+       }
+
+       // Next, reset start value, indicating new phase, and retain value at flip:
+       long startValueAtFlip = startEpochUpdater.getAndSet(this, initialStartValue);
+
+       // Now, spin until previous phase end value catches up with start value at flip:
+       boolean caughtUp = false;
+       do {
+           if (nextPhaseIsEven) {
+               caughtUp = (oddEndEpoch == startValueAtFlip);
+           } else {
+               caughtUp = (evenEndEpoch == startValueAtFlip);
+           }
+           if (!caughtUp) {
+               if (yieldTimeNsec == 0) {
+                   Thread.yield();
+               } else 
+               if (yieldTimeNsec > 0) {
+                   try {
+                       TimeUnit.NANOSECONDS.sleep(yieldTimeNsec);
+                   } catch (InterruptedException ex) {
+                   }
+               }
+           }
+       } while (!caughtUp);
+       
+       return startValueAtFlip;
+   }
+}


### PR DESCRIPTION
This PR contains the fixes and improvements on the RxRingBuffer and its single-consumer-single-producer queue.

- Added ```SWSRPhaser``` which is a variant of Gil Tene's WriterReaderPhaser that uses cheaper atomic operations because the single reader and single writer use case. Note that pre Java 8 Unsafe doesn't support atomic addAndGetLong operation. The simplified phaser costs only a single atomic increment per use.
- Updated ```SpscArrayQueue``` to match JCTools' current version: the queue now can be fully utilized to its capacity.
- The ```RxRingBuffer``` now uses two phasers: one for the offer side and one for the poll/peek side. The benefits: reduced interference between readers and writers; allows using the simplified phaser because each side is now single threaded (a shared phaser implies up to 2 threads at once).

Benchmark results:
```
Benchmark              (size)        1.x   |      this   
1SyncStreamOfN              1  3779678,748 | 3767936,028 
1SyncStreamOfN           1000    21250,675 |   18530,542 
1SyncStreamOfN        1000000       20,406 |      17,712 
NAsyncStreamsOfN            1   115390,116 |  115629,480 
NAsyncStreamsOfN         1000        2,579 |       2,546 
NSyncStreamsOf1             1  3543551,254 | 3602242,709 
NSyncStreamsOf1           100   299166,910 |  301703,721 
NSyncStreamsOf1          1000    28404,751 |   28420,833 
NSyncStreamsOfN             1  4054571,577 | 4003156,953 
NSyncStreamsOfN          1000       24,324 |      20,601 
TwoAsyncStreamsOfN          1    85846,727 |   85682,983 
TwoAsyncStreamsOfN       1000     1823,137 |    1889,458 
reamOfNthatMergesIn1        1  3724179,351 | 3725068,220 
reamOfNthatMergesIn1     1000    19051,928 |   19392,595 
reamOfNthatMergesIn1  1000000       18,265 |      18,069
```