### PR TITLE
Fail early if a null subscription is added to a CompositeSubscription.

### DIFF
--- a/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2014 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -55,8 +55,8 @@ public final class CompositeSubscription implements Subscription {
      *          the {@link Subscription} to add
      */
     public void add(final Subscription s) {
-        if (s == null) {
-            throw new NullPointerException("Added Subscription cannot be null.");
+        if (s.isUnsubscribed()) {
+            return;
         }
         Subscription unsubscribe = null;
         synchronized (this) {

--- a/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -56,7 +56,7 @@ public final class CompositeSubscription implements Subscription {
      */
     public void add(final Subscription s) {
         if (s == null) {
-            throw new IllegalArgumentException("Added Subscription cannot be null.");
+            throw new NullPointerException("Added Subscription cannot be null.");
         }
         Subscription unsubscribe = null;
         synchronized (this) {

--- a/src/main/java/rx/subscriptions/CompositeSubscription.java
+++ b/src/main/java/rx/subscriptions/CompositeSubscription.java
@@ -55,6 +55,9 @@ public final class CompositeSubscription implements Subscription {
      *          the {@link Subscription} to add
      */
     public void add(final Subscription s) {
+        if (s == null) {
+            throw new IllegalArgumentException("Added Subscription cannot be null.");
+        }
         Subscription unsubscribe = null;
         synchronized (this) {
             if (unsubscribed) {

--- a/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
+++ b/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
@@ -337,4 +337,11 @@ public class CompositeSubscriptionTest {
         
         csub.remove(csub1); // try removing agian
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddingNullSubscriptionIllegal() {
+      CompositeSubscription csub = new CompositeSubscription();
+      csub.add(null);
+    }
+
 }

--- a/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
+++ b/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
@@ -338,7 +338,7 @@ public class CompositeSubscriptionTest {
         csub.remove(csub1); // try removing agian
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testAddingNullSubscriptionIllegal() {
         CompositeSubscription csub = new CompositeSubscription();
         csub.add(null);

--- a/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
+++ b/src/test/java/rx/subscriptions/CompositeSubscriptionTest.java
@@ -340,8 +340,8 @@ public class CompositeSubscriptionTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testAddingNullSubscriptionIllegal() {
-      CompositeSubscription csub = new CompositeSubscription();
-      csub.add(null);
+        CompositeSubscription csub = new CompositeSubscription();
+        csub.add(null);
     }
 
 }


### PR DESCRIPTION
Otherwise, it'll just fail late when unsubscribing, which is much harder to trace.

I discovered this while writing  a unit test, when I didn't properly mock out a method to return a valid Observable. Seems like it would be more likely to happen in test code than production, but still could be a stumbling block that's hard to track down if there's a bug in app logic adding a null subscription.