### PR TITLE
Subject state information methods & bounded ReplaySubject termination

### DIFF
--- a/src/main/java/rx/internal/operators/NotificationLite.java
+++ b/src/main/java/rx/internal/operators/NotificationLite.java
@@ -177,6 +177,23 @@ public final class NotificationLite<T> {
     }
 
     /**
+     * Indicates whether or not the lite notification represents a wrapped {@code null} {@code onNext} event.
+     * @param n the lite notification
+     * @return {@code true} if {@code n} represents a wrapped {@code null} {@code onNext} event, {@code false} otherwise
+     */
+    public boolean isNull(Object n) {
+        return n == ON_NEXT_NULL_SENTINEL;
+    }
+
+    /**
+     * Indicates whether or not the lite notification represents an {@code onNext} event.
+     * @param n the lite notification
+     * @return {@code true} if {@code n} represents an {@code onNext} event, {@code false} otherwise
+     */
+    public boolean isNext(Object n) {
+        return n != null && !isError(n) && !isCompleted(n);
+    }
+    /**
      * Indicates which variety a particular lite notification is. If you need something more complex than
      * simply calling the right method on an {@link Observer} then you can use this method to get the
      * {@link rx.Notification.Kind}.

--- a/src/main/java/rx/subjects/AsyncSubject.java
+++ b/src/main/java/rx/subjects/AsyncSubject.java
@@ -140,4 +140,61 @@ public final class AsyncSubject<T> extends Subject<T, T> {
     public boolean hasObservers() {
         return state.observers().length > 0;
     }
+    /**
+     * Check if the Subject has a value.
+     * <p>Use the {@link #getValue()} method to retrieve such a value.
+     * <p>Note that unless {@link #hasCompleted()} or {@link #hasThrowable()} returns true, the value
+     * retrieved by {@code getValue()} may get outdated.
+     * @return true if and only if the subject has some value but not an error
+     */
+    public boolean hasValue() {
+        Object v = lastValue;
+        Object o = state.get();
+        return !nl.isError(o) && nl.isNext(v);
+    }
+    /**
+     * Check if the Subject has terminated with an exception.
+     * @return true if the subject has received a throwable through {@code onError}.
+     */
+    public boolean hasThrowable() {
+        Object o = state.get();
+        return nl.isError(o);
+    }
+    /**
+     * Check if the Subject has terminated normally.
+     * @return true if the subject completed normally via {@code onCompleted()}
+     */
+    public boolean hasCompleted() {
+        Object o = state.get();
+        return o != null && !nl.isError(o);
+    }
+    /**
+     * Returns the current value of the Subject if there is such a value and
+     * the subject hasn't terminated with an exception.
+     * <p>The can return {@code null} for various reasons. Use {@link #hasValue()}, {@link #hasThrowable()}
+     * and {@link #hasCompleted()} to determine if such {@code null} is a valid value, there was an
+     * exception or the Subject terminated without receiving any value. 
+     * @return the current value or {@code null} if the Subject doesn't have a value,
+     * has terminated with an exception or has an actual {@code null} as a value.
+     */
+    public T getValue() {
+        Object v = lastValue;
+        Object o = state.get();
+        if (!nl.isError(o) && nl.isNext(v)) {
+            return nl.getValue(v);
+        }
+        return null;
+    }
+    /**
+     * Returns the Throwable that terminated the Subject.
+     * @return the Throwable that terminated the Subject or {@code null} if the
+     * subject hasn't terminated yet or it terminated normally.
+     */
+    public Throwable getThrowable() {
+        Object o = state.get();
+        if (nl.isError(o)) {
+            return nl.getError(o);
+        }
+        return null;
+    }
 }

--- a/src/main/java/rx/subjects/AsyncSubject.java
+++ b/src/main/java/rx/subjects/AsyncSubject.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import rx.Observer;
+import rx.annotations.Experimental;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
 import rx.functions.Action1;
@@ -147,6 +148,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * retrieved by {@code getValue()} may get outdated.
      * @return true if and only if the subject has some value but not an error
      */
+    @Experimental
     public boolean hasValue() {
         Object v = lastValue;
         Object o = state.get();
@@ -156,6 +158,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated with an exception.
      * @return true if the subject has received a throwable through {@code onError}.
      */
+    @Experimental
     public boolean hasThrowable() {
         Object o = state.get();
         return nl.isError(o);
@@ -164,6 +167,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated normally.
      * @return true if the subject completed normally via {@code onCompleted()}
      */
+    @Experimental
     public boolean hasCompleted() {
         Object o = state.get();
         return o != null && !nl.isError(o);
@@ -177,6 +181,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * @return the current value or {@code null} if the Subject doesn't have a value,
      * has terminated with an exception or has an actual {@code null} as a value.
      */
+    @Experimental
     public T getValue() {
         Object v = lastValue;
         Object o = state.get();
@@ -190,6 +195,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * @return the Throwable that terminated the Subject or {@code null} if the
      * subject hasn't terminated yet or it terminated normally.
      */
+    @Experimental
     public Throwable getThrowable() {
         Object o = state.get();
         if (nl.isError(o)) {

--- a/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/src/main/java/rx/subjects/BehaviorSubject.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import rx.Observer;
+import rx.annotations.Experimental;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
 import rx.functions.Action1;
@@ -183,6 +184,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * retrieved by {@code getValue()} may get outdated.
      * @return true if and only if the subject has some value and hasn't terminated yet.
      */
+    @Experimental
     public boolean hasValue() {
         Object o = state.get();
         return nl.isNext(o);
@@ -191,6 +193,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated with an exception.
      * @return true if the subject has received a throwable through {@code onError}.
      */
+    @Experimental
     public boolean hasThrowable() {
         Object o = state.get();
         return nl.isError(o);
@@ -199,6 +202,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated normally.
      * @return true if the subject completed normally via {@code onCompleted()}
      */
+    @Experimental
     public boolean hasCompleted() {
         Object o = state.get();
         return nl.isCompleted(o);
@@ -212,6 +216,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * @return the current value or {@code null} if the Subject doesn't have a value,
      * has terminated or has an actual {@code null} as a valid value.
      */
+    @Experimental
     public T getValue() {
         Object o = state.get();
         if (nl.isNext(o)) {
@@ -224,6 +229,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * @return the Throwable that terminated the Subject or {@code null} if the
      * subject hasn't terminated yet or it terminated normally.
      */
+    @Experimental
     public Throwable getThrowable() {
         Object o = state.get();
         if (nl.isError(o)) {

--- a/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/src/main/java/rx/subjects/BehaviorSubject.java
@@ -176,4 +176,59 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     public boolean hasObservers() {
         return state.observers().length > 0;
     }
+    /**
+     * Check if the Subject has a value.
+     * <p>Use the {@link #getValue()} method to retrieve such a value.
+     * <p>Note that unless {@link #hasCompleted()} or {@link #hasThrowable()} returns true, the value
+     * retrieved by {@code getValue()} may get outdated.
+     * @return true if and only if the subject has some value and hasn't terminated yet.
+     */
+    public boolean hasValue() {
+        Object o = state.get();
+        return nl.isNext(o);
+    }
+    /**
+     * Check if the Subject has terminated with an exception.
+     * @return true if the subject has received a throwable through {@code onError}.
+     */
+    public boolean hasThrowable() {
+        Object o = state.get();
+        return nl.isError(o);
+    }
+    /**
+     * Check if the Subject has terminated normally.
+     * @return true if the subject completed normally via {@code onCompleted()}
+     */
+    public boolean hasCompleted() {
+        Object o = state.get();
+        return nl.isCompleted(o);
+    }
+    /**
+     * Returns the current value of the Subject if there is such a value and
+     * the subject hasn't terminated yet.
+     * <p>The can return {@code null} for various reasons. Use {@link #hasValue()}, {@link #hasThrowable()}
+     * and {@link #hasCompleted()} to determine if such {@code null} is a valid value, there was an
+     * exception or the Subject terminated (with or without receiving any value). 
+     * @return the current value or {@code null} if the Subject doesn't have a value,
+     * has terminated or has an actual {@code null} as a valid value.
+     */
+    public T getValue() {
+        Object o = state.get();
+        if (nl.isNext(o)) {
+            return nl.getValue(o);
+        }
+        return null;
+    }
+    /**
+     * Returns the Throwable that terminated the Subject.
+     * @return the Throwable that terminated the Subject or {@code null} if the
+     * subject hasn't terminated yet or it terminated normally.
+     */
+    public Throwable getThrowable() {
+        Object o = state.get();
+        if (nl.isError(o)) {
+            return nl.getError(o);
+        }
+        return null;
+    }
 }

--- a/src/main/java/rx/subjects/PublishSubject.java
+++ b/src/main/java/rx/subjects/PublishSubject.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import rx.Observer;
+import rx.annotations.Experimental;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
 import rx.functions.Action1;
@@ -131,6 +132,7 @@ public final class PublishSubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated with an exception.
      * @return true if the subject has received a throwable through {@code onError}.
      */
+    @Experimental
     public boolean hasThrowable() {
         Object o = state.get();
         return nl.isError(o);
@@ -139,6 +141,7 @@ public final class PublishSubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated normally.
      * @return true if the subject completed normally via {@code onCompleted}
      */
+    @Experimental
     public boolean hasCompleted() {
         Object o = state.get();
         return o != null && !nl.isError(o);
@@ -148,6 +151,7 @@ public final class PublishSubject<T> extends Subject<T, T> {
      * @return the Throwable that terminated the Subject or {@code null} if the
      * subject hasn't terminated yet or it terminated normally.
      */
+    @Experimental
     public Throwable getThrowable() {
         Object o = state.get();
         if (nl.isError(o)) {

--- a/src/main/java/rx/subjects/PublishSubject.java
+++ b/src/main/java/rx/subjects/PublishSubject.java
@@ -126,4 +126,33 @@ public final class PublishSubject<T> extends Subject<T, T> {
     public boolean hasObservers() {
         return state.observers().length > 0;
     }
+    
+    /**
+     * Check if the Subject has terminated with an exception.
+     * @return true if the subject has received a throwable through {@code onError}.
+     */
+    public boolean hasThrowable() {
+        Object o = state.get();
+        return nl.isError(o);
+    }
+    /**
+     * Check if the Subject has terminated normally.
+     * @return true if the subject completed normally via {@code onCompleted}
+     */
+    public boolean hasCompleted() {
+        Object o = state.get();
+        return o != null && !nl.isError(o);
+    }
+    /**
+     * Returns the Throwable that terminated the Subject.
+     * @return the Throwable that terminated the Subject or {@code null} if the
+     * subject hasn't terminated yet or it terminated normally.
+     */
+    public Throwable getThrowable() {
+        Object o = state.get();
+        if (nl.isError(o)) {
+            return nl.getError(o);
+        }
+        return null;
+    }
 }

--- a/src/main/java/rx/subjects/ReplaySubject.java
+++ b/src/main/java/rx/subjects/ReplaySubject.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import rx.Observer;
 import rx.Scheduler;
+import rx.annotations.Experimental;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
 import rx.functions.Action1;
@@ -1061,6 +1062,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated with an exception.
      * @return true if the subject has received a throwable through {@code onError}.
      */
+    @Experimental
     public boolean hasThrowable() {
         NotificationLite<T> nl = ssm.nl;
         Object o = ssm.get();
@@ -1070,6 +1072,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
      * Check if the Subject has terminated normally.
      * @return true if the subject completed normally via {@code onCompleted}
      */
+    @Experimental
     public boolean hasCompleted() {
         NotificationLite<T> nl = ssm.nl;
         Object o = ssm.get();
@@ -1080,6 +1083,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
      * @return the Throwable that terminated the Subject or {@code null} if the
      * subject hasn't terminated yet or it terminated normally.
      */
+    @Experimental
     public Throwable getThrowable() {
         NotificationLite<T> nl = ssm.nl;
         Object o = ssm.get();
@@ -1092,12 +1096,14 @@ public final class ReplaySubject<T> extends Subject<T, T> {
      * Returns the current number of items (non-terminal events) available for replay.
      * @return the number of items available
      */
+    @Experimental
     public int size() {
         return state.size();
     }
     /**
      * @return true if the Subject holds at least one non-terminal event available for replay
      */
+    @Experimental
     public boolean hasAnyValue() {
         return !state.isEmpty();
     }
@@ -1107,6 +1113,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
      * @return returns a snapshot of the currently buffered non-terminal events.
      */
     @SuppressWarnings("unchecked")
+    @Experimental
     public Object[] getValues() {
         return state.toArray((T[])EMPTY_ARRAY);
     }
@@ -1116,6 +1123,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
      * @param a the array to fill in
      * @return the array {@code a} if it had enough capacity or a new array containing the available values 
      */
+    @Experimental
     public T[] getValues(T[] a) {
         return state.toArray(a);
     }

--- a/src/test/java/rx/internal/operators/NotificationLiteTest.java
+++ b/src/test/java/rx/internal/operators/NotificationLiteTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import rx.exceptions.TestException;
+
 
 public class NotificationLiteTest {
 
@@ -34,5 +36,20 @@ public class NotificationLiteTest {
         assertEquals("Hello", on.getValue(n));
     }
     
-    
+    @Test
+    public void testValueKind() {
+        NotificationLite<Object> on = NotificationLite.instance();
+        
+        assertTrue(on.isNull(on.next(null)));
+        assertFalse(on.isNull(on.next(1)));
+        assertFalse(on.isNull(on.error(new TestException())));
+        assertFalse(on.isNull(on.completed()));
+        assertFalse(on.isNull(null));
+        
+        assertTrue(on.isNext(on.next(null)));
+        assertTrue(on.isNext(on.next(1)));
+        assertFalse(on.isNext(on.completed()));
+        assertFalse(on.isNext(null));
+        assertFalse(on.isNext(on.error(new TestException())));
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -494,7 +494,7 @@ public class OperatorMergeTest {
         });
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testConcurrency() {
         Observable<Integer> o = Observable.range(1, 10000).subscribeOn(Schedulers.newThread());
 

--- a/src/test/java/rx/subjects/AsyncSubjectTest.java
+++ b/src/test/java/rx/subjects/AsyncSubjectTest.java
@@ -16,6 +16,9 @@
 package rx.subjects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -36,6 +39,7 @@ import rx.Observer;
 import rx.Subscription;
 import rx.exceptions.CompositeException;
 import rx.exceptions.OnErrorNotImplementedException;
+import rx.exceptions.TestException;
 import rx.functions.Action1;
 import rx.observers.TestSubscriber;
 
@@ -330,4 +334,66 @@ public class AsyncSubjectTest {
         assertEquals(1, ts.getOnErrorEvents().size());
     }
 
+    @Test
+    public void testCurrentStateMethodsNormal() {
+        AsyncSubject<Object> as = AsyncSubject.create();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onNext(1);
+        
+        assertTrue(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertEquals(1, as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        assertTrue(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertEquals(1, as.getValue());
+        assertNull(as.getThrowable());
+    }
+    
+    @Test
+    public void testCurrentStateMethodsEmpty() {
+        AsyncSubject<Object> as = AsyncSubject.create();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+    }
+    @Test
+    public void testCurrentStateMethodsError() {
+        AsyncSubject<Object> as = AsyncSubject.create();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onError(new TestException());
+        
+        assertFalse(as.hasValue());
+        assertTrue(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertTrue(as.getThrowable() instanceof TestException);
+    }
 }

--- a/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -17,6 +17,8 @@ package rx.subjects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -35,6 +37,7 @@ import org.mockito.Mockito;
 import rx.*;
 import rx.exceptions.CompositeException;
 import rx.exceptions.OnErrorNotImplementedException;
+import rx.exceptions.TestException;
 import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -481,5 +484,95 @@ public class BehaviorSubjectTest {
                 rs.onCompleted();
             }
         }
+    }
+    
+    @Test
+    public void testCurrentStateMethodsNormalEmptyStart() {
+        BehaviorSubject<Object> as = BehaviorSubject.create();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onNext(1);
+        
+        assertTrue(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertEquals(1, as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+    }
+    
+    @Test
+    public void testCurrentStateMethodsNormalSomeStart() {
+        BehaviorSubject<Object> as = BehaviorSubject.create((Object)1);
+        
+        assertTrue(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertEquals(1, as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onNext(2);
+        
+        assertTrue(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertEquals(2, as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+    }
+    
+    @Test
+    public void testCurrentStateMethodsEmpty() {
+        BehaviorSubject<Object> as = BehaviorSubject.create();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+    }
+    @Test
+    public void testCurrentStateMethodsError() {
+        BehaviorSubject<Object> as = BehaviorSubject.create();
+        
+        assertFalse(as.hasValue());
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertNull(as.getThrowable());
+        
+        as.onError(new TestException());
+        
+        assertFalse(as.hasValue());
+        assertTrue(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getValue());
+        assertTrue(as.getThrowable() instanceof TestException);
     }
 }

--- a/src/test/java/rx/subjects/PublishSubjectTest.java
+++ b/src/test/java/rx/subjects/PublishSubjectTest.java
@@ -16,6 +16,9 @@
 package rx.subjects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -36,6 +39,7 @@ import rx.Observer;
 import rx.Subscription;
 import rx.exceptions.CompositeException;
 import rx.exceptions.OnErrorNotImplementedException;
+import rx.exceptions.TestException;
 import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.observers.TestSubscriber;
@@ -394,5 +398,54 @@ public class PublishSubjectTest {
         }
         // even though the onError above throws we should still receive it on the other subscriber 
         assertEquals(1, ts.getOnErrorEvents().size());
+    }
+    @Test
+    public void testCurrentStateMethodsNormal() {
+        PublishSubject<Object> as = PublishSubject.create();
+        
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getThrowable());
+        
+        as.onNext(1);
+        
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertNull(as.getThrowable());
+    }
+    
+    @Test
+    public void testCurrentStateMethodsEmpty() {
+        PublishSubject<Object> as = PublishSubject.create();
+        
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getThrowable());
+        
+        as.onCompleted();
+        
+        assertFalse(as.hasThrowable());
+        assertTrue(as.hasCompleted());
+        assertNull(as.getThrowable());
+    }
+    @Test
+    public void testCurrentStateMethodsError() {
+        PublishSubject<Object> as = PublishSubject.create();
+        
+        assertFalse(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertNull(as.getThrowable());
+        
+        as.onError(new TestException());
+        
+        assertTrue(as.hasThrowable());
+        assertFalse(as.hasCompleted());
+        assertTrue(as.getThrowable() instanceof TestException);
     }
 }


### PR DESCRIPTION
fix.

This PR aims to support the requests in #2331 and #1897 by adding methods to the (final) subject classes that let developers access in-flight state in a snapshot fashion. 

This may be considered safe API change because all subject classes were final already so adding extra methods won't break anyone's code (and we will be careful with our Observable in the future).

  - ```NotificationLite``` is now extended with two missing value checks: isNull and isNext.
  - Each subject has ```hasCompleted```, ```hasThrowable``` and ```getThrowable``` methods, however, I can't add them to ```Subject``` because that would be an incompatible API change.
  - Where applicable, ```getValue``` and ```getThrowable``` return ```null``` instead of throwing exceptions so users are encouraged to call hasXXX methods beforehand.
  - There was a chaining bug in the bounded ReplaySubject: because the terminal value was added after a potential pruning, the node links could get broken and concurrent replays might not have seen the terminal value.
  - Since ```ReplaySubject``` can have multiple values, I've added ```size()```, ```hasAnyValue()``` (isEmpty is taken) and ```getValues()``` methods to make a snapshot of the current buffer contents whether or not the ```ReplaySubject``` has terminated (the usual toList() would wait until the subject has terminated). 
  - The unrelated ```OperatorMergeTest.testConcurrency``` hangs for me for some reason without activity (either a buffer bug or a merge bug is in play there). I've added a timeout so it doesn't stop the other tests.