### PR TITLE
Fixes NPEs reported in ReactiveX#1702 by synchronizing queue.

### DIFF
--- a/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -79,11 +79,9 @@ public final class TrampolineScheduler extends Scheduler {
                 do {
                     TimedAction polled;
                     synchronized (queue) {
-                        if (!queue.isEmpty()) {
-                            TimedAction polled = queue.poll();
-                            polled.action.call();
-                        }
+                        polled = queue.poll();
                     }
+                    polled.action.call();
                 } while (wip.decrementAndGet() > 0);
                 return Subscriptions.unsubscribed();
             } else {

--- a/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -75,7 +75,7 @@ public final class TrampolineScheduler extends Scheduler {
                 do {
                     final TimedAction polled = queue.poll();
                     if (polled != null) {
-                      polled.action.call();
+                        polled.action.call();
                     }
                 } while (wip.decrementAndGet() > 0);
                 return Subscriptions.unsubscribed();


### PR DESCRIPTION
Also adds a unit test for regression.

It appears there is a potential race condition if something adds to/removes from the PQ while it's *inside* the 'poll' operation, which is where the exceptions in #1702 seem to have actually come from. Therefore, the initial null check didn't really address the original problem. The test here seems to reliably recreate those conditions.

I considered using a PriorityBlockingQueue instead of synchronized, but since the isEmpty and poll calls should not allow something to interleave between them and access the queue, a synchronized block seemed wiser here.