### PR TITLE
Subscriber.request should throw exception if negative request made

### DIFF
--- a/src/main/java/rx/Subscriber.java
+++ b/src/main/java/rx/Subscriber.java
@@ -92,8 +92,13 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
      *
      * @param n the maximum number of items you want the Observable to emit to the Subscriber at this time, or
      *           {@code Long.MAX_VALUE} if you want the Observable to emit items at its own pace
+     * @throws IllegalArgumentException
+     *             if {@code n} is negative
      */
     protected final void request(long n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("number requested cannot be negative: " + n);
+        } 
         Producer shouldRequest = null;
         synchronized (this) {
             if (p != null) {


### PR DESCRIPTION
As per discussion in #1956 and #2545, making a call to ```Subscriber.request(n)``` with negative n should throw an ```IllegalArgumentException```.

Includes unit test.