### PR TITLE
Publish: fixed incorrect subscriber requested accounting

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -367,8 +367,10 @@ public class OperatorPublish<T> extends ConnectableObservable<T> {
 
                         for (Subscriber<? super T> s : localState.getSubscribers()) {
                             AtomicLong req = localMap.get(s);
-                            nl.accept(s, o);
-                            req.decrementAndGet();
+                            if (req != null) { // null req indicates a concurrent unsubscription happened
+                                nl.accept(s, o);
+                                req.decrementAndGet();
+                            }
                         }
                         emitted++;
                     }


### PR DESCRIPTION
Reported in a [rxjava group](https://groups.google.com/forum/#!topic/rxjava/iOA_wl-fReI) post.

The shared emissioncounter subtracted from all subscribers accounting made late coming subscribers appear to have received the same amount of events.