### PR TITLE
CombineLatest: fixed concurrent requestUpTo yielding -1 requests

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -230,9 +230,14 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
         }
 
         public void requestUpTo(long n) {
-            long r = Math.min(emitted.get(), n);
-            request(r);
-            emitted.addAndGet(-r);
+            do {
+                long r = emitted.get();
+                long u = Math.min(r, n);
+                if (emitted.compareAndSet(r, r - u)) {
+                    request(u);
+                    break;
+                }
+            } while (true);
         }
 
         @Override

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -790,6 +790,13 @@ public class OnSubscribeCombineLatestTest {
     }
 
     @Test
+    public void testBackpressureLoop() {
+        for (int i = 0; i < 5000; i++) {
+            testBackpressure();
+        }
+    }
+    
+    @Test
     public void testBackpressure() {
         Func2<String, Integer, String> combineLatestFunction = getConcatStringIntegerCombineLatestFunction();
 


### PR DESCRIPTION
sometimes.

Discovered in #2560.