### PR TITLE
Give more time to certain concurrency tests.

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -682,7 +682,7 @@ public class OperatorRetryTest {
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
     }
     
-    @Test(timeout = 10000)
+    @Test(timeout = 15000)
     public void testRetryWithBackpressure() throws InterruptedException {
         final int NUM_RETRIES = RxRingBuffer.SIZE * 2;
         for (int i = 0; i < 400; i++) {
@@ -705,7 +705,7 @@ public class OperatorRetryTest {
             inOrder.verifyNoMoreInteractions();
         }
     }
-    @Test(timeout = 10000)
+    @Test(timeout = 15000)
     public void testRetryWithBackpressureParallel() throws InterruptedException {
         final int NUM_RETRIES = RxRingBuffer.SIZE * 2;
         int ncpu = Runtime.getRuntime().availableProcessors();

--- a/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -503,7 +503,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
         
         t.join();
     }
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void testConcurrentSizeAndHasAnyValueTimeBounded() throws InterruptedException {
         final ReplaySubject<Object> rs = ReplaySubject.createWithTime(1, TimeUnit.MILLISECONDS, Schedulers.computation());
         final CyclicBarrier cb = new CyclicBarrier(2);

--- a/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
@@ -407,7 +407,7 @@ public class ReplaySubjectConcurrencyTest {
             worker.unsubscribe();
         }
     }
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void testConcurrentSizeAndHasAnyValue() throws InterruptedException {
         final ReplaySubject<Object> rs = ReplaySubject.create();
         final CyclicBarrier cb = new CyclicBarrier(2);


### PR DESCRIPTION
On my Windows machine, I've virtualized an Ubuntu machine and adjusted some tests according to the time it takes on this "slow machine".