### PR TITLE
subscribeOn drops the subscriptions returned from the scheduler.

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
+++ b/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
@@ -54,7 +54,7 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
 
             @Override
             public void onNext(final Observable<T> o) {
-                inner.schedule(new Action0() {
+                subscriber.add(inner.schedule(new Action0() {
 
                     @Override
                     public void call() {
@@ -102,7 +102,7 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
 
                         });
                     }
-                });
+                }));
             }
 
         };

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -609,6 +609,7 @@ public class OperatorReplayTest {
 
         verify(spiedWorker, times(1)).unsubscribe();
         verify(sourceUnsubscribed, times(1)).call();
+        verify(mockSubscription, times(1)).unsubscribe();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);
@@ -668,6 +669,7 @@ public class OperatorReplayTest {
 
         verify(spiedWorker, times(1)).unsubscribe();
         verify(sourceUnsubscribed, times(1)).call();
+        verify(mockSubscription, times(1)).unsubscribe();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);


### PR DESCRIPTION
@mattrjacobs noticed that the unsubscribe from timeouts of Hystrix commands was not being propagated across the subscribeOn.

https://github.com/Netflix/Hystrix/issues/354