### PR TITLE
Revert "subscribeOn drops the subscriptions returned from the scheduler....

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
+++ b/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
@@ -54,7 +54,7 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
 
             @Override
             public void onNext(final Observable<T> o) {
-                subscriber.add(inner.schedule(new Action0() {
+                inner.schedule(new Action0() {
 
                     @Override
                     public void call() {
@@ -102,7 +102,7 @@ public class OperatorSubscribeOn<T> implements Operator<T, Observable<T>> {
 
                         });
                     }
-                }));
+                });
             }
 
         };

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -609,7 +609,6 @@ public class OperatorReplayTest {
 
         verify(spiedWorker, times(1)).unsubscribe();
         verify(sourceUnsubscribed, times(1)).call();
-        verify(mockSubscription, times(1)).unsubscribe();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);
@@ -669,7 +668,6 @@ public class OperatorReplayTest {
 
         verify(spiedWorker, times(1)).unsubscribe();
         verify(sourceUnsubscribed, times(1)).call();
-        verify(mockSubscription, times(1)).unsubscribe();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);


### PR DESCRIPTION
Reverts ReactiveX/RxJava#2575

At best, the change is a no-op if the Scheduler.Worker conforms the requirements by tracking all tasks.