### PR TITLE
Perf tests for CompositeSubscription

### DIFF
--- a/src/main/java/rx/internal/util/SubscriptionList.java
+++ b/src/main/java/rx/internal/util/SubscriptionList.java
@@ -119,4 +119,14 @@ public final class SubscriptionList implements Subscription {
             }
         }
     }
+    
+    /* perf support */
+    public void clear() {
+        List<Subscription> list;
+        synchronized (this) {
+            list = subscriptions;
+            subscriptions = null;
+        }
+        unsubscribeFromAll(list);
+    }
 }

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionConcurrentPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionConcurrentPerf.java
@@ -44,18 +44,18 @@ import rx.Subscription;
 @Threads(2)
 @State(Scope.Group)
 public class CompositeSubscriptionConcurrentPerf {
-    @Param({ "1", "1000", "1000000" })
+    @Param({ "1", "1000", "100000" })
     public int loop;
     
     public final CompositeSubscription csub = new CompositeSubscription();
-    @Param({ "1", "5", "10" })
+    @Param({ "1", "5", "10", "20" })
     public int count;
     
     public Subscription[] values;
     @Setup
     public void setup() {
-        values = new Subscription[count];
-        for (int i = 0; i < count; i++) {
+        values = new Subscription[count * 2];
+        for (int i = 0; i < count * 2; i++) {
             values[i] = new Subscription() {
                 @Override
                 public boolean isUnsubscribed() {
@@ -79,10 +79,10 @@ public class CompositeSubscriptionConcurrentPerf {
             
         }
     };
-    @Group("tpt")
+    @Group("g1")
     @GroupThreads(1)
     @Benchmark
-    public void simpleAddRemoveOne() {
+    public void addRemoveT1() {
         CompositeSubscription csub = this.csub;
         Subscription[] values = this.values;
         
@@ -95,10 +95,10 @@ public class CompositeSubscriptionConcurrentPerf {
             }
         }
     }
-    @Group("tpt")
+    @Group("g1")
     @GroupThreads(1)
     @Benchmark
-    public void simpleAddRemoveOne2() {
+    public void addRemoveT2() {
         CompositeSubscription csub = this.csub;
         Subscription[] values = this.values;
         
@@ -107,6 +107,40 @@ public class CompositeSubscriptionConcurrentPerf {
                 csub.add(values[j]);
             }
             for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g2")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveHalfT1() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n / 2 - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = n / 2 - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g2")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveHalfT2() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n - 1; j >= n / 2; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = n - 1; j >= n / 2; j--) {
                 csub.remove(values[j]);
             }
         }

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionConcurrentPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionConcurrentPerf.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import rx.Subscription;
+
+/**
+ * Benchmark typical composite subscription.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*CompositeSubscriptionConcurrentPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*CompositeSubscriptionConcurrentPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(2)
+@State(Scope.Group)
+public class CompositeSubscriptionConcurrentPerf {
+    @Param({ "1", "1000", "1000000" })
+    public int loop;
+    
+    public final CompositeSubscription csub = new CompositeSubscription();
+    @Param({ "1", "5", "10" })
+    public int count;
+    
+    public Subscription[] values;
+    @Setup
+    public void setup() {
+        values = new Subscription[count];
+        for (int i = 0; i < count; i++) {
+            values[i] = new Subscription() {
+                @Override
+                public boolean isUnsubscribed() {
+                    return false;
+                }
+                @Override
+                public void unsubscribe() {
+                    
+                }
+            };
+        }
+    }
+
+    final Subscription sub = new Subscription() {
+        @Override
+        public boolean isUnsubscribed() {
+            return false;
+        }
+        @Override
+        public void unsubscribe() {
+            
+        }
+    };
+    @Group("tpt")
+    @GroupThreads(1)
+    @Benchmark
+    public void simpleAddRemoveOne() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("tpt")
+    @GroupThreads(1)
+    @Benchmark
+    public void simpleAddRemoveOne2() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
@@ -41,9 +41,9 @@ import rx.Subscription;
 public class CompositeSubscriptionPerf {
     @State(Scope.Thread)
     public static class TheState {
-        @Param({ "1", "1000", "1000000" })
+        @Param({ "1", "1000", "100000" })
         public int loop;
-        @Param({ "1", "5", "10" })
+        @Param({ "1", "5", "10", "100" })
         public int count;
         
         public final CompositeSubscription csub = new CompositeSubscription();
@@ -67,8 +67,22 @@ public class CompositeSubscriptionPerf {
         }
     }
     @Benchmark
-    public void simpleAddRemoveOne(TheState state) {
+    public void addRemove(TheState state) {
         CompositeSubscription csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(state.values[j]);
+            }
+        }
+    }
+    @Benchmark
+    public void addRemoveLocal(TheState state) {
+        CompositeSubscription csub = new CompositeSubscription();
         Subscription[] values = state.values;
         
         for (int i = state.loop; i > 0; i--) {

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Subscription;
+
+/**
+ * Benchmark typical composite subscription.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*CompositeSubscriptionPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*CompositeSubscriptionPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class CompositeSubscriptionPerf {
+    @State(Scope.Thread)
+    public static class TheState {
+        @Param({ "1", "1000", "1000000" })
+        public int loop;
+        @Param({ "1", "5", "10" })
+        public int count;
+        
+        public final CompositeSubscription csub = new CompositeSubscription();
+        
+        public Subscription[] values;
+        @Setup
+        public void setup() {
+            values = new Subscription[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+                    @Override
+                    public void unsubscribe() {
+                        
+                    }
+                };
+            }
+        }
+    }
+    @Benchmark
+    public void simpleAddRemoveOne(TheState state) {
+        CompositeSubscription csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(state.values[j]);
+            }
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/SubscriptionListPerf.java
+++ b/src/perf/java/rx/subscriptions/SubscriptionListPerf.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Subscription;
+import rx.internal.util.SubscriptionList;
+
+/**
+ * Benchmark typical composite subscription.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*SubscriptionListPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*SubscriptionListPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class SubscriptionListPerf {
+    @State(Scope.Thread)
+    public static class TheState {
+        @Param({ "1", "1000", "100000" })
+        public int loop;
+        @Param({ "1", "5", "10", "100" })
+        public int count;
+        
+        public final SubscriptionList csub = new SubscriptionList();
+        
+        public Subscription[] values;
+        @Setup
+        public void setup() {
+            values = new Subscription[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+                    @Override
+                    public void unsubscribe() {
+                        
+                    }
+                };
+            }
+        }
+    }
+    @Benchmark
+    public void addRemove(TheState state) {
+        SubscriptionList csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Benchmark
+    public void addRemoveLocal(TheState state) {
+        SubscriptionList csub = new SubscriptionList();
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            csub.clear();
+        }
+    }
+}


### PR DESCRIPTION
To have a base perf test for future enhancements into CompositeSubscription.

Results on i7 4770k:

```
Benchmark        (count) (loop)         Score  Score error
-- CompositeSubscription --
addRemove              1      1  21566280,435   897719,297
addRemove              1   1000     21744,117      725,172
addRemove              1 100000       225,767       10,520
addRemove              5      1   4244985,637   187738,731
addRemove              5   1000      4361,022      246,403
addRemove              5 100000        43,525        1,307
addRemove             10      1   2107790,393   223569,720
addRemove             10   1000      2235,458      175,819
addRemove             10 100000        21,825        4,023
addRemove            100      1    214685,299    15760,090
addRemove            100   1000       205,781       19,402
addRemove            100 100000         2,163        0,053
addRemoveLocal         1      1  20331750,587  3599949,368
addRemoveLocal         1   1000     38273,785      771,095
addRemoveLocal         1 100000       414,414       20,694
addRemoveLocal         5      1   5552091,345   162447,203
addRemoveLocal         5   1000      7960,813      805,915
addRemoveLocal         5 100000        84,715        3,972
addRemoveLocal        10      1   2949311,028   253016,154
addRemoveLocal        10   1000      4156,523      242,239
addRemoveLocal        10 100000        42,859        2,718
addRemoveLocal       100      1    333769,154    70669,910
addRemoveLocal       100   1000       423,002       57,891
addRemoveLocal       100 100000         4,258        0,180

g1                     1      1   5672134,440   223369,579
g1                     1   1000      4614,953      385,399
g1                     1 100000        51,921       16,205
g1                     5      1    882872,043   466671,880
g1                     5   1000      1051,633       76,720
g1                     5 100000        11,912        0,689
g1                    10      1    510000,808   126915,288
g1                    10   1000       559,365       34,489
g1                    10 100000         5,683        0,497
g1                    20      1    281242,876    22400,397
g1                    20   1000       272,247       10,438
g1                    20 100000         2,917        0,759
g2                     1      1   8451900,270  3096723,213
g2                     1   1000      9992,091      643,342
g2                     1 100000        94,634        9,811
g2                     5      1   2067976,003    63851,450
g2                     5   1000      2304,841       87,373
g2                     5 100000        21,572        1,270
g2                    10      1   1235938,040    81760,627
g2                    10   1000      1069,392       91,578
g2                    10 100000        10,080        1,982
g2                    20      1    535880,770    72836,543
g2                    20   1000       488,165       48,351
g2                    20 100000         5,131        1,502

-- SubscriptionList --

addRemove              1      1  20646357,391  1481026,348 
addRemove              1   1000     23566,840     1597,573 
addRemove              1 100000       226,301       17,256 
addRemove              5      1   7426681,685   342442,038 
addRemove              5   1000      7570,683      490,145 
addRemove              5 100000        76,321        4,511 
addRemove             10      1   4165400,087   103956,402 
addRemove             10   1000      4220,931      296,238 
addRemove             10 100000        42,027        2,114 
addRemove            100      1    450531,056    29060,558 
addRemove            100   1000       447,434       26,883 
addRemove            100 100000         4,647        0,364 
addRemoveLocal         1      1  97457352,781  7817228,665 
addRemoveLocal         1   1000    100282,754     3704,426 
addRemoveLocal         1 100000      1061,597       41,867 
addRemoveLocal         5      1  26634367,988   395180,351 
addRemoveLocal         5   1000     29361,364     1476,926 
addRemoveLocal         5 100000       274,888       11,303 
addRemoveLocal        10      1  13907109,655   890452,793 
addRemoveLocal        10   1000     14813,697      972,158 
addRemoveLocal        10 100000       145,607        7,493 
addRemoveLocal       100      1   1515417,558    57144,964 
addRemoveLocal       100   1000      1505,084      111,230 
addRemoveLocal       100 100000        15,258        0,665 
```
(Units: ops/s, 5 iterations, mode: throughput).