### PR TITLE
Added perf tests for various container-like subscriptions

### DIFF
--- a/src/main/java/rx/internal/util/SubscriptionList.java
+++ b/src/main/java/rx/internal/util/SubscriptionList.java
@@ -78,15 +78,17 @@ public final class SubscriptionList implements Subscription {
      */
     @Override
     public void unsubscribe() {
+        List<Subscription> list;
         synchronized (this) {
             if (unsubscribed) {
                 return;
             }
             unsubscribed = true;
+            list = subscriptions;
+            subscriptions = null;
         }
         // we will only get here once
-        unsubscribeFromAll(subscriptions);
-        subscriptions = null;
+        unsubscribeFromAll(list);
     }
 
     private static void unsubscribeFromAll(Collection<Subscription> subscriptions) {
@@ -118,5 +120,14 @@ public final class SubscriptionList implements Subscription {
                         "Failed to unsubscribe to 2 or more subscriptions.", es);
             }
         }
+    }
+    /* perf support */
+    public void clear() {
+        List<Subscription> list;
+        synchronized (this) {
+            list = subscriptions;
+            subscriptions = null;
+        }
+        unsubscribeFromAll(list);
     }
 }

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionConcurrentPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionConcurrentPerf.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import rx.Subscription;
+
+/**
+ * Benchmark typical composite subscription concurrent behavior.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*CompositeSubscriptionConcurrentPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*CompositeSubscriptionConcurrentPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(2)
+@State(Scope.Group)
+public class CompositeSubscriptionConcurrentPerf {
+    @Param({ "1", "1000", "100000" })
+    public int loop;
+    
+    public final CompositeSubscription csub = new CompositeSubscription();
+    @Param({ "1", "5", "10", "20" })
+    public int count;
+    
+    public Subscription[] values;
+    @Setup
+    public void setup() {
+        values = new Subscription[count * 2];
+        for (int i = 0; i < count * 2; i++) {
+            values[i] = new Subscription() {
+                @Override
+                public boolean isUnsubscribed() {
+                    return false;
+                }
+                @Override
+                public void unsubscribe() {
+                    
+                }
+            };
+        }
+    }
+
+    @Group("g1")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveT1() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g1")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveT2() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g2")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveHalfT1() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n / 2 - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = n / 2 - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g2")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveHalfT2() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n - 1; j >= n / 2; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = n - 1; j >= n / 2; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g3")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearT1() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Group("g3")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearT2() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(values[j]);
+            }
+        }
+    }
+    @Group("g4")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearHalfT1() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n / 2 - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Group("g4")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearHalfT2() {
+        CompositeSubscription csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n - 1; j >= n / 2; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
@@ -18,14 +18,8 @@ package rx.subscriptions;
 
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 import rx.Subscription;
 
@@ -73,26 +67,28 @@ public class CompositeSubscriptionPerf {
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.add(state.values[j]);
+                csub.add(values[j]);
             }
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.remove(state.values[j]);
+                csub.remove(values[j]);
             }
         }
     }
     @Benchmark
-    public void addRemoveLocal(TheState state) {
+    public void addRemoveLocal(TheState state, Blackhole bh) {
         CompositeSubscription csub = new CompositeSubscription();
         Subscription[] values = state.values;
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.add(state.values[j]);
+                csub.add(values[j]);
             }
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.remove(state.values[j]);
+                csub.remove(values[j]);
             }
         }
+        
+        bh.consume(csub);
     }
     @Benchmark
     public void addClear(TheState state) {
@@ -101,21 +97,22 @@ public class CompositeSubscriptionPerf {
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.add(state.values[j]);
+                csub.add(values[j]);
             }
             csub.clear();
         }
     }
     @Benchmark
-    public void addClearLocal(TheState state) {
+    public void addClearLocal(TheState state, Blackhole bh) {
         CompositeSubscription csub = new CompositeSubscription();
         Subscription[] values = state.values;
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.add(state.values[j]);
+                csub.add(values[j]);
             }
             csub.clear();
         }
+        bh.consume(csub);
     }
 }

--- a/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/CompositeSubscriptionPerf.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Subscription;
+
+/**
+ * Benchmark typical composite subscription single-threaded behavior.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*CompositeSubscriptionPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*CompositeSubscriptionPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class CompositeSubscriptionPerf {
+    @State(Scope.Thread)
+    public static class TheState {
+        @Param({ "1", "1000", "100000" })
+        public int loop;
+        @Param({ "1", "5", "10", "100" })
+        public int count;
+        
+        public final CompositeSubscription csub = new CompositeSubscription();
+        
+        public Subscription[] values;
+        @Setup
+        public void setup() {
+            values = new Subscription[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+                    @Override
+                    public void unsubscribe() {
+                        
+                    }
+                };
+            }
+        }
+    }
+    @Benchmark
+    public void addRemove(TheState state) {
+        CompositeSubscription csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(state.values[j]);
+            }
+        }
+    }
+    @Benchmark
+    public void addRemoveLocal(TheState state) {
+        CompositeSubscription csub = new CompositeSubscription();
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.remove(state.values[j]);
+            }
+        }
+    }
+    @Benchmark
+    public void addClear(TheState state) {
+        CompositeSubscription csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Benchmark
+    public void addClearLocal(TheState state) {
+        CompositeSubscription csub = new CompositeSubscription();
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            csub.clear();
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/MultipleAssignmentSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/MultipleAssignmentSubscriptionPerf.java
@@ -18,14 +18,8 @@ package rx.subscriptions;
 
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 import rx.Subscription;
 
@@ -73,19 +67,20 @@ public class MultipleAssignmentSubscriptionPerf {
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.set(state.values[j]);
+                csub.set(values[j]);
             }
         }
     }
     @Benchmark
-    public void addLocal(TheState state) {
+    public void addLocal(TheState state, Blackhole bh) {
         MultipleAssignmentSubscription csub = new MultipleAssignmentSubscription();
         Subscription[] values = state.values;
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.set(state.values[j]);
+                csub.set(values[j]);
             }
         }
+        bh.consume(csub);
     }
 }

--- a/src/perf/java/rx/subscriptions/MultipleAssignmentSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/MultipleAssignmentSubscriptionPerf.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Subscription;
+
+/**
+ * Benchmark typical multiple-assignment subscription behavior.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*MultipleAssignmentSubscriptionPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*MultipleAssignmentSubscriptionPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class MultipleAssignmentSubscriptionPerf {
+    @State(Scope.Thread)
+    public static class TheState {
+        @Param({ "1", "1000", "100000" })
+        public int loop;
+        @Param({ "1", "5", "10", "100" })
+        public int count;
+        
+        public final MultipleAssignmentSubscription csub = new MultipleAssignmentSubscription();
+        
+        public Subscription[] values;
+        @Setup
+        public void setup() {
+            values = new Subscription[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+                    @Override
+                    public void unsubscribe() {
+                        
+                    }
+                };
+            }
+        }
+    }
+    @Benchmark
+    public void add(TheState state) {
+        MultipleAssignmentSubscription csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.set(state.values[j]);
+            }
+        }
+    }
+    @Benchmark
+    public void addLocal(TheState state) {
+        MultipleAssignmentSubscription csub = new MultipleAssignmentSubscription();
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.set(state.values[j]);
+            }
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/SerialSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/SerialSubscriptionPerf.java
@@ -18,14 +18,8 @@ package rx.subscriptions;
 
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 import rx.Subscription;
 
@@ -73,19 +67,20 @@ public class SerialSubscriptionPerf {
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.set(state.values[j]);
+                csub.set(values[j]);
             }
         }
     }
     @Benchmark
-    public void addLocal(TheState state) {
+    public void addLocal(TheState state, Blackhole bh) {
         SerialSubscription csub = new SerialSubscription();
         Subscription[] values = state.values;
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.set(state.values[j]);
+                csub.set(values[j]);
             }
         }
+        bh.consume(csub);
     }
 }

--- a/src/perf/java/rx/subscriptions/SerialSubscriptionPerf.java
+++ b/src/perf/java/rx/subscriptions/SerialSubscriptionPerf.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Subscription;
+
+/**
+ * Benchmark typical serial subscription behavior.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*SerialSubscriptionPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*SerialSubscriptionPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class SerialSubscriptionPerf {
+    @State(Scope.Thread)
+    public static class TheState {
+        @Param({ "1", "1000", "100000" })
+        public int loop;
+        @Param({ "1", "5", "10", "100" })
+        public int count;
+        
+        public final SerialSubscription csub = new SerialSubscription();
+        
+        public Subscription[] values;
+        @Setup
+        public void setup() {
+            values = new Subscription[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+                    @Override
+                    public void unsubscribe() {
+                        
+                    }
+                };
+            }
+        }
+    }
+    @Benchmark
+    public void add(TheState state) {
+        SerialSubscription csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.set(state.values[j]);
+            }
+        }
+    }
+    @Benchmark
+    public void addLocal(TheState state) {
+        SerialSubscription csub = new SerialSubscription();
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.set(state.values[j]);
+            }
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/SubscriptionListConcurrentPerf.java
+++ b/src/perf/java/rx/subscriptions/SubscriptionListConcurrentPerf.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import rx.Subscription;
+import rx.internal.util.SubscriptionList;
+
+/**
+ * Benchmark typical subscription list concurrent behavior.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*CompositeSubscriptionConcurrentPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*CompositeSubscriptionConcurrentPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(2)
+@State(Scope.Group)
+public class SubscriptionListConcurrentPerf {
+    @Param({ "1", "1000", "100000" })
+    public int loop;
+    
+    public final SubscriptionList csub = new SubscriptionList();
+    @Param({ "1", "5", "10", "20" })
+    public int count;
+    
+    public Subscription[] values;
+    @Setup
+    public void setup() {
+        values = new Subscription[count * 2];
+        for (int i = 0; i < count * 2; i++) {
+            values[i] = new Subscription() {
+                @Override
+                public boolean isUnsubscribed() {
+                    return false;
+                }
+                @Override
+                public void unsubscribe() {
+                    
+                }
+            };
+        }
+    }
+
+    @Group("g1")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearT1() {
+        SubscriptionList csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Group("g1")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearT2() {
+        SubscriptionList csub = this.csub;
+        Subscription[] values = this.values;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Group("g2")
+    @GroupThreads(1)
+    @Benchmark
+    public void addClearHalfT1() {
+        SubscriptionList csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n / 2 - 1; j >= 0; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Group("g2")
+    @GroupThreads(1)
+    @Benchmark
+    public void addRemoveHalfT2() {
+        SubscriptionList csub = this.csub;
+        Subscription[] values = this.values;
+        int n = values.length;
+        
+        for (int i = loop; i > 0; i--) {
+            for (int j = n - 1; j >= n / 2; j--) {
+                csub.add(values[j]);
+            }
+            csub.clear();
+        }
+    }
+}

--- a/src/perf/java/rx/subscriptions/SubscriptionListPerf.java
+++ b/src/perf/java/rx/subscriptions/SubscriptionListPerf.java
@@ -18,14 +18,8 @@ package rx.subscriptions;
 
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 import rx.Subscription;
 import rx.internal.util.SubscriptionList;
@@ -74,21 +68,22 @@ public class SubscriptionListPerf {
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.add(state.values[j]);
+                csub.add(values[j]);
             }
             csub.clear();
         }
     }
     @Benchmark
-    public void addClearLocal(TheState state) {
+    public void addClearLocal(TheState state, Blackhole bh) {
         SubscriptionList csub = new SubscriptionList();
         Subscription[] values = state.values;
         
         for (int i = state.loop; i > 0; i--) {
             for (int j = values.length - 1; j >= 0; j--) {
-                csub.add(state.values[j]);
+                csub.add(values[j]);
             }
             csub.clear();
         }
+        bh.consume(csub);
     }
 }

--- a/src/perf/java/rx/subscriptions/SubscriptionListPerf.java
+++ b/src/perf/java/rx/subscriptions/SubscriptionListPerf.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subscriptions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Subscription;
+import rx.internal.util.SubscriptionList;
+
+/**
+ * Benchmark typical subscription list behavior.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*SubscriptionListPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*SubscriptionListPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class SubscriptionListPerf {
+    @State(Scope.Thread)
+    public static class TheState {
+        @Param({ "1", "1000", "100000" })
+        public int loop;
+        @Param({ "1", "5", "10", "100" })
+        public int count;
+        
+        public final SubscriptionList csub = new SubscriptionList();
+        
+        public Subscription[] values;
+        @Setup
+        public void setup() {
+            values = new Subscription[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return false;
+                    }
+                    @Override
+                    public void unsubscribe() {
+                        
+                    }
+                };
+            }
+        }
+    }
+    @Benchmark
+    public void addClear(TheState state) {
+        SubscriptionList csub = state.csub;
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            csub.clear();
+        }
+    }
+    @Benchmark
+    public void addClearLocal(TheState state) {
+        SubscriptionList csub = new SubscriptionList();
+        Subscription[] values = state.values;
+        
+        for (int i = state.loop; i > 0; i--) {
+            for (int j = values.length - 1; j >= 0; j--) {
+                csub.add(state.values[j]);
+            }
+            csub.clear();
+        }
+    }
+}


### PR DESCRIPTION
Subscription perf tests with JMH.

```
gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 10 -i 10 -r 1 rx.subscriptions.*Perf.*"
```

[Perf run](https://gist.github.com/akarnokd/9b493209fc27c858b85a) took 90 minutes on my i7 4770k, JDK 1.8u31, Windows 7 x64.