### PR TITLE
Zip: fixed unbounded downstream requesting above Long.MAX_VALUE

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -117,6 +117,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         return subscriber;
     }
 
+    @SuppressWarnings("rawtypes")
     private final class ZipSubscriber extends Subscriber<Observable[]> {
 
         final Subscriber<? super R> child;
@@ -158,7 +159,8 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
     }
 
     private static final class ZipProducer<R> extends AtomicLong implements Producer {
-
+        /** */
+        private static final long serialVersionUID = -1216676403723546796L;
         private Zip<R> zipper;
 
         public ZipProducer(Zip<R> zipper) {
@@ -167,7 +169,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
 
         @Override
         public void request(long n) {
-            addAndGet(n);
+            BackpressureUtils.getAndAddRequest(this, n);
             // try and claim emission if no other threads are doing so
             zipper.tick();
         }
@@ -179,6 +181,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
         private final FuncN<? extends R> zipFunction;
         private final CompositeSubscription childSubscription = new CompositeSubscription();
 
+        @SuppressWarnings("unused")
         volatile long counter;
         @SuppressWarnings("rawtypes")
         static final AtomicLongFieldUpdater<Zip> COUNTER_UPDATER = AtomicLongFieldUpdater.newUpdater(Zip.class, "counter");

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -1243,4 +1243,27 @@ public class OperatorZipTest {
         }
         assertEquals(expected, zip2.toList().toBlocking().single());
     }
+    @Test
+    public void testUnboundedDownstreamOverrequesting() {
+        Observable<Integer> source = Observable.range(1, 2).zipWith(Observable.range(1, 2), new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return t1 + 10 * t2;
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                requestMore(5);
+            }
+        };
+        
+        source.subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertTerminalEvent();
+        ts.assertReceivedOnNext(Arrays.asList(11, 22));
+    }
 }


### PR DESCRIPTION
Should fix issue reported in #2588.

Ps. What are the odds two bug reports issued so close to each other have the same cause and same fix? @davidmoten the ```BackpressureUtils``` was a fantastic idea.