### PR TITLE
Revert Behavior Change in TestSubscriber.awaitTerminalEvent

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -226,9 +226,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
      */
     public void awaitTerminalEvent(long timeout, TimeUnit unit) {
         try {
-            if (!latch.await(timeout, unit)) {
-                throw new RuntimeException(new TimeoutException());
-            }
+            latch.await(timeout, unit);
         } catch (InterruptedException e) {
             throw new RuntimeException("Interrupted", e);
         }


### PR DESCRIPTION
Reverts change made at https://github.com/ReactiveX/RxJava/pull/2332/files#diff-fbed6a16f49022fd2b10f45fd6dd015bR230

See discussion at https://github.com/ReactiveX/RxJava/issues/2549#issuecomment-72783738

The Javadoc for this method clearly states that it will wait until completion or timeout. It does not say it will throw an exception on timeout, so we can not start throwing as that is a behavioral change.