### PR TITLE
Make sure we keep a Subscriber’s subscription when passed as Observer

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -7282,24 +7282,30 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     public final Subscription subscribe(final Observer<? super T> observer) {
-        return subscribe(new Subscriber<T>() {
+        if (observer instanceof Subscriber) {
+            // this will ensure that we don't drop the Subscriber's subscription from the chain,
+            // as it would otherwise be hidden by the wrapping Subscriber
+            return subscribe((Subscriber) observer);
+        } else {
+            return subscribe(new Subscriber<T>() {
 
-            @Override
-            public void onCompleted() {
-                observer.onCompleted();
-            }
+                @Override
+                public void onCompleted() {
+                    observer.onCompleted();
+                }
 
-            @Override
-            public void onError(Throwable e) {
-                observer.onError(e);
-            }
+                @Override
+                public void onError(Throwable e) {
+                    observer.onError(e);
+                }
 
-            @Override
-            public void onNext(T t) {
-                observer.onNext(t);
-            }
+                @Override
+                public void onNext(T t) {
+                    observer.onNext(t);
+                }
 
-        });
+            });
+        }
     }
 
     /**

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1116,4 +1116,12 @@ public class ObservableTests {
         System.out.println("Done");
     }
 
+    @Test // cf. https://github.com/ReactiveX/RxJava/issues/2599
+    public void testSubscribingSubscriberAsObserverMaintainsSubscriptionChain() {
+        TestSubscriber subscriber = new TestSubscriber();
+        Subscription subscription = Observable.just("event").subscribe((Observer) subscriber);
+        subscription.unsubscribe();
+
+        subscriber.assertUnsubscribed();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/ReactiveX/RxJava/issues/2599