### PR TITLE
Optimized observeOn/subscribeOn

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5036,6 +5036,9 @@ public class Observable<T> {
      * @see #subscribeOn
      */
     public final Observable<T> observeOn(Scheduler scheduler) {
+        if (this instanceof ScalarSynchronousObservable) {
+            return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
+        }
         return lift(new OperatorObserveOn<T>(scheduler));
     }
 
@@ -7455,6 +7458,9 @@ public class Observable<T> {
      * @see #observeOn
      */
     public final Observable<T> subscribeOn(Scheduler scheduler) {
+        if (this instanceof ScalarSynchronousObservable) {
+            return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
+        }
         return nest().lift(new OperatorSubscribeOn<T>(scheduler));
     }
 

--- a/src/main/java/rx/internal/schedulers/ScheduledAction.java
+++ b/src/main/java/rx/internal/schedulers/ScheduledAction.java
@@ -16,12 +16,12 @@
 package rx.internal.schedulers;
 
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.*;
 
 import rx.Subscription;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.functions.Action0;
+import rx.internal.util.SubscriptionList;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.CompositeSubscription;
 
@@ -32,12 +32,12 @@ import rx.subscriptions.CompositeSubscription;
 public final class ScheduledAction extends AtomicReference<Thread> implements Runnable, Subscription {
     /** */
     private static final long serialVersionUID = -3962399486978279857L;
-    final CompositeSubscription cancel;
+    final SubscriptionList cancel;
     final Action0 action;
 
     public ScheduledAction(Action0 action) {
         this.action = action;
-        this.cancel = new CompositeSubscription();
+        this.cancel = new SubscriptionList();
     }
 
     @Override

--- a/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
+++ b/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
@@ -53,17 +53,7 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
     public T get() {
         return t;
     }
-    
-//    @Override
-//    public Observable<T> subscribeOn(Scheduler scheduler) {
-//        return scalarScheduleOn(scheduler);
-//    }
-//    
-//    @Override
-//    public Observable<T> observeOn(Scheduler scheduler) {
-//        return scalarScheduleOn(scheduler);
-//    }
-    
+
     /**
      * Customized observeOn/subscribeOn implementation which emits the scalar
      * value directly or with less overhead on the specified scheduler.

--- a/src/main/java/rx/internal/util/SubscriptionList.java
+++ b/src/main/java/rx/internal/util/SubscriptionList.java
@@ -32,7 +32,7 @@ import rx.exceptions.CompositeException;
 public final class SubscriptionList implements Subscription {
 
     private List<Subscription> subscriptions;
-    private boolean unsubscribed = false;
+    private volatile boolean unsubscribed = false;
 
     public SubscriptionList() {
     }
@@ -42,7 +42,7 @@ public final class SubscriptionList implements Subscription {
     }
 
     @Override
-    public synchronized boolean isUnsubscribed() {
+    public boolean isUnsubscribed() {
         return unsubscribed;
     }
 
@@ -55,21 +55,18 @@ public final class SubscriptionList implements Subscription {
      *          the {@link Subscription} to add
      */
     public void add(final Subscription s) {
-        Subscription unsubscribe = null;
-        synchronized (this) {
-            if (unsubscribed) {
-                unsubscribe = s;
-            } else {
-                if (subscriptions == null) {
-                    subscriptions = new LinkedList<Subscription>();
+        if (!unsubscribed) {
+            synchronized (this) {
+                if (!unsubscribed) {
+                    if (subscriptions == null) {
+                        subscriptions = new LinkedList<Subscription>();
+                    }
+                    subscriptions.add(s);
+                    return;
                 }
-                subscriptions.add(s);
             }
         }
-        if (unsubscribe != null) {
-            // call after leaving the synchronized block so we're not holding a lock while executing this
-            unsubscribe.unsubscribe();
-        }
+        s.unsubscribe();
     }
 
     /**
@@ -78,17 +75,19 @@ public final class SubscriptionList implements Subscription {
      */
     @Override
     public void unsubscribe() {
-        List<Subscription> list;
-        synchronized (this) {
-            if (unsubscribed) {
-                return;
+        if (!unsubscribed) {
+            List<Subscription> list;
+            synchronized (this) {
+                if (unsubscribed) {
+                    return;
+                }
+                unsubscribed = true;
+                list = subscriptions;
+                subscriptions = null;
             }
-            unsubscribed = true;
-            list = subscriptions;
-            subscriptions = null;
+            // we will only get here once
+            unsubscribeFromAll(list);
         }
-        // we will only get here once
-        unsubscribeFromAll(list);
     }
 
     private static void unsubscribeFromAll(Collection<Subscription> subscriptions) {

--- a/src/main/java/rx/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/schedulers/EventLoopsScheduler.java
@@ -76,7 +76,7 @@ public class EventLoopsScheduler extends Scheduler {
      */
     public Subscription scheduleDirect(Action0 action) {
        PoolWorker pw = pool.getEventLoop();
-       return pw.schedule(action);
+       return pw.scheduleActual(action, -1, TimeUnit.NANOSECONDS);
     }
 
     private static class EventLoopWorker extends Scheduler.Worker {

--- a/src/main/java/rx/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/schedulers/EventLoopsScheduler.java
@@ -27,7 +27,7 @@ import rx.subscriptions.Subscriptions;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-/* package */class EventLoopsScheduler extends Scheduler {
+public class EventLoopsScheduler extends Scheduler {
     /** Manages a fixed number of workers. */
     private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool-";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
@@ -66,6 +66,17 @@ import java.util.concurrent.TimeUnit;
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.getEventLoop());
+    }
+    
+    /**
+     * Schedules the action directly on one of the event loop workers
+     * without the additional infrastructure and checking.
+     * @param action the action to schedule
+     * @return the subscription
+     */
+    public Subscription scheduleDirect(Action0 action) {
+       PoolWorker pw = pool.getEventLoop();
+       return pw.schedule(action);
     }
 
     private static class EventLoopWorker extends Scheduler.Worker {

--- a/src/main/java/rx/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/schedulers/EventLoopsScheduler.java
@@ -31,7 +31,24 @@ public class EventLoopsScheduler extends Scheduler {
     /** Manages a fixed number of workers. */
     private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool-";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
-    
+    /** 
+     * Key to setting the maximum number of computation scheduler threads.
+     * Zero or less is interpreted as use available. Capped by available.
+     */
+    static final String KEY_MAX_THREADS = "rx.scheduler.max-computation-threads";
+    /** The maximum number of computation scheduler threads. */
+    static final int MAX_THREADS;
+    static {
+        int maxThreads = Integer.getInteger(KEY_MAX_THREADS, 0);
+        int ncpu = Runtime.getRuntime().availableProcessors();
+        int max;
+        if (maxThreads <= 0 || maxThreads > ncpu) {
+            max = ncpu;
+        } else {
+            max = maxThreads;
+        }
+        MAX_THREADS = max;
+    }
     static final class FixedSchedulerPool {
         final int cores;
 
@@ -40,7 +57,7 @@ public class EventLoopsScheduler extends Scheduler {
 
         FixedSchedulerPool() {
             // initialize event loops
-            this.cores = Runtime.getRuntime().availableProcessors();
+            this.cores = MAX_THREADS;
             this.eventLoops = new PoolWorker[cores];
             for (int i = 0; i < cores; i++) {
                 this.eventLoops[i] = new PoolWorker(THREAD_FACTORY);
@@ -67,7 +84,7 @@ public class EventLoopsScheduler extends Scheduler {
     public Worker createWorker() {
         return new EventLoopWorker(pool.getEventLoop());
     }
-    
+
     /**
      * Schedules the action directly on one of the event loop workers
      * without the additional infrastructure and checking.

--- a/src/perf/java/rx/schedulers/ComputationSchedulerPerf.java
+++ b/src/perf/java/rx/schedulers/ComputationSchedulerPerf.java
@@ -36,7 +36,15 @@ public class ComputationSchedulerPerf {
     @State(Scope.Thread)
     public static class Input extends InputWithIncrementingInteger {
 
-        @Param({ "1" , "10", "100", "1000", "10000", "100000", "1000000"})
+        @Param({ 
+            "1", 
+            "10", 
+            "100", 
+            "1000", 
+            "10000", 
+            "100000", 
+            "1000000"
+        })
         public int size;
 
         @Override

--- a/src/perf/java/rx/schedulers/ComputationSchedulerPerf.java
+++ b/src/perf/java/rx/schedulers/ComputationSchedulerPerf.java
@@ -36,7 +36,7 @@ public class ComputationSchedulerPerf {
     @State(Scope.Thread)
     public static class Input extends InputWithIncrementingInteger {
 
-        @Param({ "1", "10", "100", "1000", "2000", "3000", "4000", "10000", "100000", "1000000" })
+        @Param({ "1" , "10", "100", "1000", "10000", "100000", "1000000"})
         public int size;
 
         @Override


### PR DESCRIPTION
Doing observeOn/subscribeOn on these is essentially the same operation.

Benchmark results: (i7 4770k, Java 1.8u31, Windows 7 x64)
```
gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 10 -i 10 -r 5 .*ComputationSchedulerPerf.*"

Benchmark                        (size)    1.x Score  Score error   PR  Score  Score error
CompSchedulerPerf.observeOn           1   182479,416    11686,648  210536,292     9760,937  
CompSchedulerPerf.observeOn          10   174911,567    13659,846  179245,342    12725,807  
CompSchedulerPerf.observeOn         100    30997,516      958,587   27000,106      623,127  
CompSchedulerPerf.observeOn        1000     6701,672      314,471    8623,296      703,255  
CompSchedulerPerf.observeOn       10000      927,207       98,571     985,409       32,412  
CompSchedulerPerf.observeOn      100000      111,968        1,176     110,597        2,883  
CompSchedulerPerf.observeOn     1000000       11,790        0,195      11,512        0,146  
CompSchedulerPerf.subscribeOn         1   202557,014    13692,298  204616,231    11272,351  
CompSchedulerPerf.subscribeOn        10   180090,498    14058,995  190338,591     1822,349  
CompSchedulerPerf.subscribeOn       100   113625,737    32012,148  114659,399    50494,246  
CompSchedulerPerf.subscribeOn      1000    35600,359     2975,926   36856,078     1770,347  
CompSchedulerPerf.subscribeOn     10000     4220,548      311,551    3942,293      368,052  
CompSchedulerPerf.subscribeOn    100000      487,187       18,150     472,594       22,474  
CompSchedulerPerf.subscribeOn   1000000       52,191        0,349      50,250        0,510  
```

Unfortunately, the benchmark results were quite hectic even with more warmup and iteration. I'd say the changes give +10% for the size = 1 case, but running the same code twice (observeOn 1, subscribeOn 1) gives inconsistent values. I suspect the main cause is the GC.