### PR TITLE
Implement hook to render specific types in OnNextValue

### DIFF
--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -109,6 +109,9 @@ public final class OnErrorThrowable extends RuntimeException {
     public static class OnNextValue extends RuntimeException {
 
         private static final long serialVersionUID = -3454462756050397899L;
+
+        private static final RxJavaErrorHandler ERROR_HANDLER = RxJavaPlugins.getInstance().getErrorHandler();
+
         private final Object value;
 
         /**
@@ -161,7 +164,7 @@ public final class OnErrorThrowable extends RuntimeException {
                 return ((Enum<?>) value).name();
             }
 
-            String pluggedRendering = RxJavaPlugins.getInstance().getErrorHandler().handleOnNextValueRendering(value);
+            String pluggedRendering = ERROR_HANDLER.handleOnNextValueRendering(value);
             if (pluggedRendering != null) {
                 return pluggedRendering;
             }

--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -15,6 +15,9 @@
  */
 package rx.exceptions;
 
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
+
 /**
  * Represents a {@code Throwable} that an {@code Observable} might notify its subscribers of, but that then can
  * be handled by an operator that is designed to recover from or react appropriately to such an error. You can
@@ -131,11 +134,18 @@ public final class OnErrorThrowable extends RuntimeException {
 
         /**
          * Render the object if it is a basic type. This avoids the library making potentially expensive
-         * or calls to toString() which may throw exceptions. See PR #1401 for details.
+         * or calls to toString() which may throw exceptions.
+         *
+         * If a specific behavior has been defined in the {@link RxJavaErrorHandler} plugin, some types
+         * may also have a specific rendering. Non-primitive types not managed by the plugin are rendered
+         * as the classname of the object.
+         * <p>
+         * See PR #1401 and Issue #2468 for details.
          *
          * @param value
          *        the item that the Observable was trying to emit at the time of the exception
-         * @return a string version of the object if primitive, otherwise the classname of the object
+         * @return a string version of the object if primitive or managed through error plugin,
+         *        otherwise the classname of the object
          */
         private static String renderValue(Object value){
             if (value == null) {
@@ -150,6 +160,12 @@ public final class OnErrorThrowable extends RuntimeException {
             if (value instanceof Enum) {
                 return ((Enum<?>) value).name();
             }
+
+            String pluggedRendering = RxJavaPlugins.getInstance().getErrorHandler().handleOnNextValueRendering(value);
+            if (pluggedRendering != null) {
+                return pluggedRendering;
+            }
+
             return value.getClass().getName() + ".class";
         }
     }

--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -110,8 +110,6 @@ public final class OnErrorThrowable extends RuntimeException {
 
         private static final long serialVersionUID = -3454462756050397899L;
 
-        private static final RxJavaErrorHandler ERROR_HANDLER = RxJavaPlugins.getInstance().getErrorHandler();
-
         private final Object value;
 
         /**
@@ -164,7 +162,7 @@ public final class OnErrorThrowable extends RuntimeException {
                 return ((Enum<?>) value).name();
             }
 
-            String pluggedRendering = ERROR_HANDLER.handleOnNextValueRendering(value);
+            String pluggedRendering = RxJavaPlugins.getInstance().getErrorHandler().handleOnNextValueRendering(value);
             if (pluggedRendering != null) {
                 return pluggedRendering;
             }

--- a/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -17,6 +17,7 @@ package rx.plugins;
 
 import rx.Observable;
 import rx.Subscriber;
+import rx.annotations.Experimental;
 import rx.exceptions.OnErrorThrowable;
 
 /**
@@ -62,6 +63,7 @@ public abstract class RxJavaErrorHandler {
      * @param item the last emitted item, that caused the exception wrapped in {@link OnErrorThrowable.OnNextValue}.
      * @return a short {@link String} representation of the item if one is known for its type, or null for default.
      */
+    @Experimental
     public final String handleOnNextValueRendering(Object item) {
         try {
             return render(item);
@@ -83,6 +85,7 @@ public abstract class RxJavaErrorHandler {
      * @param item the last emitted item, that caused the exception wrapped in {@link OnErrorThrowable.OnNextValue}.
      * @return a short {@link String} representation of the item if one is known for its type, or null for default.
      */
+    @Experimental
     protected String render (Object item) {
         //do nothing by default
         return null;

--- a/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -18,6 +18,7 @@ package rx.plugins;
 import rx.Observable;
 import rx.Subscriber;
 import rx.annotations.Experimental;
+import rx.exceptions.Exceptions;
 import rx.exceptions.OnErrorThrowable;
 
 /**
@@ -65,11 +66,15 @@ public abstract class RxJavaErrorHandler {
      */
     @Experimental
     public final String handleOnNextValueRendering(Object item) {
+
         try {
             return render(item);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         } catch (Throwable t) {
-            return item.getClass().getName() + ERROR_IN_RENDERING_SUFFIX;
+            Exceptions.throwIfFatal(t);
         }
+        return item.getClass().getName() + ERROR_IN_RENDERING_SUFFIX;
     }
 
     /**
@@ -84,9 +89,10 @@ public abstract class RxJavaErrorHandler {
      *
      * @param item the last emitted item, that caused the exception wrapped in {@link OnErrorThrowable.OnNextValue}.
      * @return a short {@link String} representation of the item if one is known for its type, or null for default.
+     * @throws InterruptedException if the rendering thread is interrupted
      */
     @Experimental
-    protected String render (Object item) {
+    protected String render (Object item) throws InterruptedException {
         //do nothing by default
         return null;
     }

--- a/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -17,6 +17,7 @@ package rx.plugins;
 
 import rx.Observable;
 import rx.Subscriber;
+import rx.exceptions.OnErrorThrowable;
 
 /**
  * Abstract class for defining error handling logic in addition to the normal
@@ -24,6 +25,8 @@ import rx.Subscriber;
  * <p>
  * For example, all {@code Exception}s can be logged using this handler even if
  * {@link Subscriber#onError(Throwable)} is ignored or not provided when an {@link Observable} is subscribed to.
+ * <p>
+ * This plugin is also responsible for augmenting rendering of {@link OnErrorThrowable.OnNextValue}.
  * <p>
  * See {@link RxJavaPlugins} or the RxJava GitHub Wiki for information on configuring plugins: <a
  * href="https://github.com/ReactiveX/RxJava/wiki/Plugins">https://github.com/ReactiveX/RxJava/wiki/Plugins</a>.
@@ -42,6 +45,47 @@ public abstract class RxJavaErrorHandler {
      */
     public void handleError(Throwable e) {
         // do nothing by default
+    }
+
+    protected static final String ERROR_IN_RENDERING_SUFFIX = ".errorRendering";
+
+    /**
+     * Receives items causing {@link OnErrorThrowable.OnNextValue} and gives a chance to choose the String
+     * representation of the item in the OnNextValue stacktrace rendering. Returns null if this type of item
+     * is not managed and should use default rendering.
+     * <p>
+     * Note that primitive types are always rendered as their toString() value.
+     * <p>
+     * If a {@code Throwable} is caught when rendering, this will fallback to the item's classname suffixed by
+     * {@value #ERROR_IN_RENDERING_SUFFIX}.
+     *
+     * @param item the last emitted item, that caused the exception wrapped in {@link OnErrorThrowable.OnNextValue}.
+     * @return a short {@link String} representation of the item if one is known for its type, or null for default.
+     */
+    public final String handleOnNextValueRendering(Object item) {
+        try {
+            return render(item);
+        } catch (Throwable t) {
+            return item.getClass().getName() + ERROR_IN_RENDERING_SUFFIX;
+        }
+    }
+
+    /**
+     * Override this method to provide rendering for specific types other than primitive types and null.
+     * <p>
+     * For performance and overhead reasons, this should should limit to a safe production of a short {@code String}
+     * (as large renderings will bloat up the stacktrace). Prefer to try/catch({@code Throwable}) all code
+     * inside this method implementation.
+     * <p>
+     * If a {@code Throwable} is caught when rendering, this will fallback to the item's classname suffixed by
+     * {@value #ERROR_IN_RENDERING_SUFFIX}.
+     *
+     * @param item the last emitted item, that caused the exception wrapped in {@link OnErrorThrowable.OnNextValue}.
+     * @return a short {@link String} representation of the item if one is known for its type, or null for default.
+     */
+    protected String render (Object item) {
+        //do nothing by default
+        return null;
     }
 
 }


### PR DESCRIPTION
as discussed in #2468, allow implementations of RxJavaErrorHandler to define a rendering behavior for safe and known types to be rendered in the stacktrace of OnNextValue.