### PR TITLE
Fix a potential memory leak in schedulePeriodically

### DIFF
--- a/src/main/java/rx/Scheduler.java
+++ b/src/main/java/rx/Scheduler.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import rx.functions.Action0;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.MultipleAssignmentSubscription;
-import rx.subscriptions.SerialSubscription;
 
 /**
  * A {@code Scheduler} is an object that schedules units of work. You can find common implementations of this
@@ -124,7 +123,7 @@ public abstract class Scheduler {
                     }
                 }
             };
-            SerialSubscription s = new SerialSubscription();
+            MultipleAssignmentSubscription s = new MultipleAssignmentSubscription();
             // Should call `mas.set` before `schedule`, or the new Subscription may replace the old one.
             mas.set(s);
             s.set(schedule(recursiveAction, initialDelay, unit));

--- a/src/main/java/rx/Scheduler.java
+++ b/src/main/java/rx/Scheduler.java
@@ -120,10 +120,7 @@ public abstract class Scheduler {
                     if (!mas.isUnsubscribed()) {
                         action.call();
                         long nextTick = startInNanos + (++count * periodInNanos);
-                        SerialSubscription s = new SerialSubscription();
-                        // Should call `mas.set` before `schedule`, or the new Subscription may replace the old one.
-                        mas.set(s);
-                        s.set(schedule(this, nextTick - TimeUnit.MILLISECONDS.toNanos(now()), TimeUnit.NANOSECONDS));
+                        mas.set(schedule(this, nextTick - TimeUnit.MILLISECONDS.toNanos(now()), TimeUnit.NANOSECONDS));
                     }
                 }
             };


### PR DESCRIPTION
There is a potential memory leak in `schedulePeriodically` that may keep a reference to `action` after `unsubscribe`. 

Because `mas.set` is called after `schedule`,  it may replace a new Subscription (created in `recursiveAction`) with the old one. Therefore, `unsubscribe` won't be able to unsubscribe the new Subscription and will keep the reference to `action` until the period time elapses.

This PR fixed it by calling `mas.set` before `schedule`.
