### PR TITLE
Seeking various RxJavaPlugins via java.util.ServiceLoader

### DIFF
--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -15,6 +15,7 @@
  */
 package rx.plugins;
 
+import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -143,7 +144,13 @@ public class RxJavaPlugins {
     }
 
     private static <T> T getPluginImplementationViaProperty(Class<T> pluginClass) {
-        for (T o : ServiceLoader.load(pluginClass)) {
+        Iterator<T> it = ServiceLoader.load(pluginClass).iterator();
+        while (it.hasNext()) {
+            T o = it.next();
+            if (it.hasNext()) {
+                T n = it.next();
+                throw new IllegalStateException("Two plugins found on classpath! First: " + o.getClass() + " second: " + n.getClass());
+            }
             return o;
         }
         

--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -15,6 +15,7 @@
  */
 package rx.plugins;
 
+import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -141,7 +142,11 @@ public class RxJavaPlugins {
         }
     }
 
-    private static Object getPluginImplementationViaProperty(Class<?> pluginClass) {
+    private static <T> T getPluginImplementationViaProperty(Class<T> pluginClass) {
+        for (T o : ServiceLoader.load(pluginClass)) {
+            return o;
+        }
+        
         String classSimpleName = pluginClass.getSimpleName();
         /*
          * Check system properties for plugin class.
@@ -153,9 +158,7 @@ public class RxJavaPlugins {
         if (implementingClass != null) {
             try {
                 Class<?> cls = Class.forName(implementingClass);
-                // narrow the scope (cast) to the type we're expecting
-                cls = cls.asSubclass(pluginClass);
-                return cls.newInstance();
+                return pluginClass.cast(cls.newInstance());
             } catch (ClassCastException e) {
                 throw new RuntimeException(classSimpleName + " implementation is not an instance of " + classSimpleName + ": " + implementingClass);
             } catch (ClassNotFoundException e) {

--- a/src/test/java/rx/plugins/RxJavaPluginsViaLoaderTest.java
+++ b/src/test/java/rx/plugins/RxJavaPluginsViaLoaderTest.java
@@ -57,6 +57,16 @@ public class RxJavaPluginsViaLoaderTest {
         assertTrue(impl instanceof RxJavaErrorHandlerTestImpl);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testTwoErrorHandlersYieldException() {
+        mockLoader.register(
+            "META-INF/services/" + RxJavaErrorHandler.class.getName(),
+            RxJavaPluginsViaLoaderTest.class.getResource("RxJavaErrorHandlerTestBroken.txt")
+        );
+        RxJavaPlugins p = new RxJavaPlugins();
+        RxJavaErrorHandler impl = p.getErrorHandler();
+    }
+
     // inside test so it is stripped from Javadocs
     public static class RxJavaErrorHandlerTestImpl extends RxJavaErrorHandler {
 
@@ -70,6 +80,9 @@ public class RxJavaPluginsViaLoaderTest {
             count++;
         }
 
+    }
+
+    public static class RxJavaErrorHandlerTestImpl2 extends RxJavaErrorHandlerTestImpl {
     }
 
     @Test

--- a/src/test/java/rx/plugins/RxJavaPluginsViaLoaderTest.java
+++ b/src/test/java/rx/plugins/RxJavaPluginsViaLoaderTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.plugins;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class RxJavaPluginsViaLoaderTest {
+    private MockLoader mockLoader;
+
+    @Before
+    public void resetBefore() {
+        RxJavaPlugins.getInstance().reset();
+        mockLoader = new MockLoader();
+        Thread.currentThread().setContextClassLoader(mockLoader);
+    }
+
+    @After
+    public void resetAfter() {
+        Thread.currentThread().setContextClassLoader(null);
+        RxJavaPlugins.getInstance().reset();
+    }
+
+    @Test
+    public void testErrorHandlerViaServiceLoader() {
+        mockLoader.register(
+            "META-INF/services/" + RxJavaErrorHandler.class.getName(), 
+            RxJavaPluginsViaLoaderTest.class.getResource("RxJavaErrorHandlerTestImpl.txt")
+        );
+        RxJavaPlugins p = new RxJavaPlugins();
+        RxJavaErrorHandler impl = p.getErrorHandler();
+        assertTrue(impl instanceof RxJavaErrorHandlerTestImpl);
+    }
+
+    // inside test so it is stripped from Javadocs
+    public static class RxJavaErrorHandlerTestImpl extends RxJavaErrorHandler {
+
+        private volatile Throwable e;
+        private volatile int count = 0;
+
+        @Override
+        public void handleError(Throwable e) {
+            e.printStackTrace();
+            this.e = e;
+            count++;
+        }
+
+    }
+
+    @Test
+    public void testObservableExecutionHookViaLoader() {
+        mockLoader.register(
+            "META-INF/services/" + RxJavaObservableExecutionHook.class.getName(), 
+            RxJavaPluginsViaLoaderTest.class.getResource("RxJavaObservableExecutionHookTestImpl.txt")
+        );
+        RxJavaPlugins p = new RxJavaPlugins();
+        RxJavaObservableExecutionHook impl = p.getObservableExecutionHook();
+        assertTrue(impl instanceof RxJavaObservableExecutionHookTestImpl);
+    }
+
+    // inside test so it is stripped from Javadocs
+    public static class RxJavaObservableExecutionHookTestImpl extends RxJavaObservableExecutionHook {
+        // just use defaults
+    }
+
+    private static final class MockLoader extends ClassLoader {
+        private final Map<String,URL[]> resources = new HashMap<String, URL[]>();
+        
+        public void register(String resource, URL... urls) {
+            for (URL url : urls) {
+                assertNotNull("Null URL when registering " + resource, url);
+            }
+            resources.put(resource, urls);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            URL[] urls = resources.get(name);
+            if (urls != null) {
+                return Collections.enumeration(Arrays.asList(urls));
+            }
+            return super.getResources(name);
+        }
+        
+    }
+}

--- a/src/test/resources/rx/plugins/RxJavaErrorHandlerTestBroken.txt
+++ b/src/test/resources/rx/plugins/RxJavaErrorHandlerTestBroken.txt
@@ -1,0 +1,17 @@
+#
+# Copyright 2014 Netflix, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+rx.plugins.RxJavaPluginsViaLoaderTest$RxJavaErrorHandlerTestImpl
+rx.plugins.RxJavaPluginsViaLoaderTest$RxJavaErrorHandlerTestImpl2

--- a/src/test/resources/rx/plugins/RxJavaErrorHandlerTestImpl.txt
+++ b/src/test/resources/rx/plugins/RxJavaErrorHandlerTestImpl.txt
@@ -1,0 +1,16 @@
+#
+# Copyright 2014 Netflix, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+rx.plugins.RxJavaPluginsViaLoaderTest$RxJavaErrorHandlerTestImpl

--- a/src/test/resources/rx/plugins/RxJavaObservableExecutionHookTestImpl.txt
+++ b/src/test/resources/rx/plugins/RxJavaObservableExecutionHookTestImpl.txt
@@ -1,0 +1,16 @@
+#
+# Copyright 2014 Netflix, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+rx.plugins.RxJavaPluginsViaLoaderTest$RxJavaObservableExecutionHookTestImpl


### PR DESCRIPTION
The standard JDK way for registering plugins is via java.util.ServiceLoader. I can see RxJava invented few home-made solutions to such registration, but all of them require some configuration (set a property or invoke some bootstrap code). I'd like to extend the set of possible registration styles to ServiceLoader as well: all that is needed with ServiceLoader is to add a JAR with standard META-INF/services/pgk.iterface.name file on classpath which I consider the least intrusive way to register a plugin.

Btw. my notes on service loader & related stuff: http://wiki.apidesign.org/wiki/ServiceLoader