### PR TITLE
Missing Unsafe class yields NoClassDefFoundError

### DIFF
--- a/src/main/java/rx/internal/util/unsafe/UnsafeAccess.java
+++ b/src/main/java/rx/internal/util/unsafe/UnsafeAccess.java
@@ -41,7 +41,7 @@ public final class UnsafeAccess {
             Field field = Unsafe.class.getDeclaredField("theUnsafe");
             field.setAccessible(true);
             u = (Unsafe) field.get(null);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // do nothing, hasUnsafe() will return false
         }
         UNSAFE = u;


### PR DESCRIPTION
Missing Unsafe class yields NoClassDefFoundError so checking for Exception is not really appropriate. Let's catch all throwables.