### PR TITLE
TakeWhile: don't unsubscribe downstream.

### DIFF
--- a/src/main/java/rx/Subscriber.java
+++ b/src/main/java/rx/Subscriber.java
@@ -40,13 +40,24 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
     private long requested = Long.MIN_VALUE; // default to not set
 
     protected Subscriber() {
-        this.op = null;
-        this.cs = new SubscriptionList();
+        this(null, false);
     }
 
     protected Subscriber(Subscriber<?> op) {
+        this(op, true);
+    }
+    /**
+     * Construct a subscriber by using the other subscriber for backpressure
+     * and optionally sharing the underlying subscriptions list.
+     * <p>To retain the chaining of subscribers, the caller should add the
+     * created instance to the op via {@code add()}.
+     * 
+     * @param op the other subscriber
+     * @param shareSubscriptions should the subscription list in op shared with this instance?
+     */
+    protected Subscriber(Subscriber<?> op, boolean shareSubscriptions) {
         this.op = op;
-        this.cs = op.cs;
+        this.cs = shareSubscriptions && op != null ? op.cs : new SubscriptionList();
     }
 
     /**

--- a/src/main/java/rx/internal/operators/OperatorTakeWhile.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeWhile.java
@@ -45,7 +45,7 @@ public final class OperatorTakeWhile<T> implements Operator<T, T> {
 
     @Override
     public Subscriber<? super T> call(final Subscriber<? super T> subscriber) {
-        return new Subscriber<T>(subscriber) {
+        Subscriber<T> s = new Subscriber<T>(subscriber, false) {
 
             private int counter = 0;
 
@@ -86,6 +86,8 @@ public final class OperatorTakeWhile<T> implements Operator<T, T> {
             }
 
         };
+        subscriber.add(s);
+        return s;
     }
 
 }


### PR DESCRIPTION
Fixes #2647 issue with TakeWhile.