### PR TITLE
Added Subscriber#isSubscribed()

### DIFF
--- a/src/main/java/rx/Subscriber.java
+++ b/src/main/java/rx/Subscriber.java
@@ -82,6 +82,15 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
     }
 
     /**
+     * Indicates whether this Subscriber subscribed to its list of subscriptions
+     *
+     * @return {@code true} if this Subscriber subscribed to its subscriptions, {@code false} otherwise
+     */
+    public final boolean isSubscribed() {
+        return !cs.isUnsubscribed();
+    }
+
+    /**
      * Indicates whether this Subscriber has unsubscribed from its list of subscriptions.
      * 
      * @return {@code true} if this Subscriber has unsubscribed from its subscriptions, {@code false} otherwise

--- a/src/test/java/rx/SubscriberTest.java
+++ b/src/test/java/rx/SubscriberTest.java
@@ -16,6 +16,7 @@
 package rx;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -507,5 +508,53 @@ public class SubscriberTest {
                 list.add(t);
             }});
         assertEquals(Arrays.asList(1,2,3,4,5), list);
+    }
+
+    @Test
+    public void testIsSubscribedWithoutCallToUnsubscribe() {
+        Subscriber subscriber = new Subscriber() {
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Object o) {
+
+            }
+        };
+
+        assertTrue(subscriber.isSubscribed());
+        assertFalse(subscriber.isUnsubscribed());
+    }
+
+    @Test
+    public void testIsNotSubscribedAfterUnsubscribe() {
+        Subscriber subscriber = new Subscriber() {
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Object o) {
+
+            }
+        };
+
+        subscriber.unsubscribe();
+
+        assertFalse(subscriber.isSubscribed());
+        assertTrue(subscriber.isUnsubscribed());
     }
 }


### PR DESCRIPTION
How many times have you **read or write** code like this:

```java
return Observable.create(new Observable.OnSubscribe()<SomeType> {
    @Override public SomeType call(Subscriber<? super SomeType> subscriber) {
        // ...
        
        if (!subscriber.isUnsubscribed) { // <-- here is the problem
            subscriber.onNext(next);
        }

        // ...
    } 
});
```

I think it's way more clear to write it like this:
```java
if (subscriber.isSubscribed()) { // <-- 50% more readable
    subscriber.onNext(next);
}
```

My brain does not work as CPU, I don't like to do negation operations, especially when I am reading/writing code, I think, nobody likes it.

This change does not affect any `Subscriber` implementation and 100% backward compatible.

`Better tools -> better products`