### PR TITLE
Optimized scalar observeOn/subscribeOn

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5175,6 +5175,9 @@ public class Observable<T> {
      * @see #subscribeOn
      */
     public final Observable<T> observeOn(Scheduler scheduler) {
+        if (this instanceof ScalarSynchronousObservable) {
+            return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
+        }
         return lift(new OperatorObserveOn<T>(scheduler));
     }
 
@@ -7597,6 +7600,9 @@ public class Observable<T> {
      * @see #observeOn
      */
     public final Observable<T> subscribeOn(Scheduler scheduler) {
+        if (this instanceof ScalarSynchronousObservable) {
+            return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
+        }
         return nest().lift(new OperatorSubscribeOn<T>(scheduler));
     }
 

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.schedulers;
+package rx.internal.schedulers;
 
 import rx.Scheduler;
 import rx.Subscription;
 import rx.functions.Action0;
-import rx.internal.schedulers.NewThreadWorker;
-import rx.internal.schedulers.ScheduledAction;
 import rx.internal.util.RxThreadFactory;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
@@ -27,7 +25,7 @@ import rx.subscriptions.Subscriptions;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-/* package */class EventLoopsScheduler extends Scheduler {
+public class EventLoopsScheduler extends Scheduler {
     /** Manages a fixed number of workers. */
     private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool-";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
@@ -76,13 +74,24 @@ import java.util.concurrent.TimeUnit;
      * Create a scheduler with pool size equal to the available processor
      * count and using least-recent worker selection policy.
      */
-    EventLoopsScheduler() {
+    public EventLoopsScheduler() {
         pool = new FixedSchedulerPool();
     }
     
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.getEventLoop());
+    }
+    
+    /**
+     * Schedules the action directly on one of the event loop workers
+     * without the additional infrastructure and checking.
+     * @param action the action to schedule
+     * @return the subscription
+     */
+    public Subscription scheduleDirect(Action0 action) {
+       PoolWorker pw = pool.getEventLoop();
+       return pw.scheduleActual(action, -1, TimeUnit.NANOSECONDS);
     }
 
     private static class EventLoopWorker extends Scheduler.Worker {

--- a/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
+++ b/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
@@ -15,8 +15,10 @@
  */
 package rx.internal.util;
 
-import rx.Observable;
-import rx.Subscriber;
+import rx.*;
+import rx.Scheduler.Worker;
+import rx.functions.Action0;
+import rx.internal.schedulers.EventLoopsScheduler;
 
 public final class ScalarSynchronousObservable<T> extends Observable<T> {
 
@@ -49,5 +51,70 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
     public T get() {
         return t;
     }
+    /**
+     * Customized observeOn/subscribeOn implementation which emits the scalar
+     * value directly or with less overhead on the specified scheduler.
+     * @param scheduler the target scheduler
+     * @return the new observable
+     */
+    public Observable<T> scalarScheduleOn(Scheduler scheduler) {
+        if (scheduler instanceof EventLoopsScheduler) {
+            EventLoopsScheduler es = (EventLoopsScheduler) scheduler;
+            return create(new DirectScheduledEmission<T>(es, t));
+        }
+        return create(new NormalScheduledEmission<T>(scheduler, t));
+    }
+    
+    /** Optimized observeOn for scalar value observed on the EventLoopsScheduler. */
+    static final class DirectScheduledEmission<T> implements OnSubscribe<T> {
+        private final EventLoopsScheduler es;
+        private final T value;
+        DirectScheduledEmission(EventLoopsScheduler es, T value) {
+            this.es = es;
+            this.value = value;
+        }
+        @Override
+        public void call(final Subscriber<? super T> child) {
+            child.add(es.scheduleDirect(new ScalarSynchronousAction<T>(child, value)));
+        }
+    }
+    /** Emits a scalar value on a general scheduler. */
+    static final class NormalScheduledEmission<T> implements OnSubscribe<T> {
+        private final Scheduler scheduler;
+        private final T value;
 
+        NormalScheduledEmission(Scheduler scheduler, T value) {
+            this.scheduler = scheduler;
+            this.value = value;
+        }
+        
+        @Override
+        public void call(final Subscriber<? super T> subscriber) {
+            Worker worker = scheduler.createWorker();
+            subscriber.add(worker);
+            worker.schedule(new ScalarSynchronousAction<T>(subscriber, value));
+        }
+    }
+    /** Action that emits a single value when called. */
+    static final class ScalarSynchronousAction<T> implements Action0 {
+        private final Subscriber<? super T> subscriber;
+        private final T value;
+
+        private ScalarSynchronousAction(Subscriber<? super T> subscriber,
+                T value) {
+            this.subscriber = subscriber;
+            this.value = value;
+        }
+
+        @Override
+        public void call() {
+            try {
+                subscriber.onNext(value);
+            } catch (Throwable t) {
+                subscriber.onError(t);
+                return;
+            }
+            subscriber.onCompleted();
+        }
+    }
 }

--- a/src/main/java/rx/schedulers/Schedulers.java
+++ b/src/main/java/rx/schedulers/Schedulers.java
@@ -16,6 +16,7 @@
 package rx.schedulers;
 
 import rx.Scheduler;
+import rx.internal.schedulers.EventLoopsScheduler;
 import rx.plugins.RxJavaPlugins;
 
 import java.util.concurrent.Executor;


### PR DESCRIPTION
Redone #2603.

Run on i7 920, 2.6GHz, Windows 7 x64, JDK 1.8u31
```
Benchmark      (size)       this   Score error       1.x   Score error
observeOn           1  160377,408     3091,205  140913,081     7097,415
observeOn          10  132990,049     1477,661  125288,149    14304,259
observeOn         100   43701,203     2342,570   43840,921      944,682
observeOn        1000   11603,952     2377,205   11400,340     1400,628
observeOn        2000    6769,716      220,476    6853,283       71,276
observeOn        3000    4753,876      326,497    4741,108      120,612
observeOn        4000    3616,782      212,285    3632,433      433,754
observeOn       10000    1544,141       28,796    1548,504       61,419
observeOn      100000     149,573       14,974     150,924        8,331
observeOn     1000000      14,909        2,079      13,658        7,702
subscribeOn         1  160639,801    16463,799  156911,862     2463,637
subscribeOn        10  148883,172     6885,684  151514,397     9425,348
subscribeOn       100  133756,358     3329,421  133327,933     3479,124
subscribeOn      1000   56411,785    22525,962   52902,999    19948,305
subscribeOn      2000   35471,110    12240,514   34272,374    16515,454
subscribeOn      3000   25868,564     2755,244   26291,293     2435,165
subscribeOn      4000   20453,512     2996,777   19598,400     4643,195
subscribeOn     10000    8817,797      465,195    5389,428      272,784
subscribeOn    100000     958,665       22,157     900,036      320,547
subscribeOn   1000000      91,606        2,462      91,396        3,407
```
Note that since the tests create a lot of garbage, some perf numbers have quite some error margin: some appear to be faster with this PR while others appear to be slower, even if they are not affected by the changes.