### PR TITLE
OnSubscribeRange request overflow check

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeRange.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRange.java
@@ -73,7 +73,7 @@ public final class OnSubscribeRange implements OnSubscribe<Integer> {
                 }
             } else if (n > 0) {
                 // backpressure is requested
-                long _c = REQUESTED_UPDATER.getAndAdd(this, n);
+                long _c = BackpressureUtils.getAndAddRequest(REQUESTED_UPDATER,this, n);
                 if (_c == 0) {
                     while (true) {
                         /*

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Observer;
+import rx.Subscriber;
 import rx.functions.Action1;
 import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;
@@ -189,5 +190,34 @@ public class OnSubscribeRangeTest {
         
         ts.assertReceivedOnNext(list);
         ts.assertTerminalEvent();
+    }
+    
+    @Test
+    public void testRequestOverflow() {
+        final AtomicInteger count = new AtomicInteger();
+        int n = 10;
+        Observable.range(1, n).subscribe(new Subscriber<Integer>() {
+
+            @Override
+            public void onStart() {
+                request(2);
+            }
+            
+            @Override
+            public void onCompleted() {
+                //do nothing
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                count.incrementAndGet();
+                request(Long.MAX_VALUE - 1);
+            }});
+        assertEquals(n, count.get());
     }
 }


### PR DESCRIPTION
One more:

Use ```BackpressureUtils.getAndAddRequest(requested, n)``` instead of ```requested.getAndAdd(n)``` so that an overflow check takes place. Includes a unit test that failed on original code (but passes with this PR).