### PR TITLE
OperatorMulticast.connect(connection) should not return null

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMulticast.java
+++ b/src/main/java/rx/internal/operators/OperatorMulticast.java
@@ -46,7 +46,7 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
 
     /** Guarded by guard. */
     private Subscriber<T> subscription;
-    // wraps subscription above with for unsubscription using guard
+    // wraps subscription above for unsubscription using guard
     private Subscription guardedSubscription;
 
     public OperatorMulticast(Observable<? extends T> source, final Func0<? extends Subject<? super T, ? extends R>> subjectFactory) {

--- a/src/main/java/rx/internal/operators/OperatorMulticast.java
+++ b/src/main/java/rx/internal/operators/OperatorMulticast.java
@@ -79,8 +79,6 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
     public void connect(Action1<? super Subscription> connection) {
         // each time we connect we create a new Subject and Subscription
 
-        boolean shouldSubscribe = false;
-
         // subscription is the state of whether we are connected or not
         synchronized (guard) {
             if (subscription != null) {
@@ -88,7 +86,6 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
                 connection.call(guardedSubscription);
                 return;
             } else {
-                shouldSubscribe = true;
                 // we aren't connected, so let's create a new Subject and connect
                 final Subject<? super T, ? extends R> subject = subjectFactory.call();
                 // create new Subscriber that will pass-thru to the subject we just created
@@ -143,18 +140,16 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
         }
 
         // in the lock above we determined we should subscribe, do it now outside the lock
-        if (shouldSubscribe) {
-            // register a subscription that will shut this down
-            connection.call(guardedSubscription);
+        // register a subscription that will shut this down
+        connection.call(guardedSubscription);
 
-            // now that everything is hooked up let's subscribe
-            // as long as the subscription is not null (which can happen if already unsubscribed)
-            Subscriber<T> sub; 
-            synchronized (guard) {
-                sub = subscription;
-            }
-            if (sub != null)
-                source.subscribe(sub);
+        // now that everything is hooked up let's subscribe
+        // as long as the subscription is not null (which can happen if already unsubscribed)
+        Subscriber<T> sub; 
+        synchronized (guard) {
+            sub = subscription;
         }
+        if (sub != null)
+            source.subscribe(sub);
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorMulticastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMulticastTest.java
@@ -15,11 +15,13 @@
  */
 package rx.internal.operators;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import rx.Observer;
@@ -29,7 +31,7 @@ import rx.observables.ConnectableObservable;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
-public class OnSubscribeMulticastTest {
+public class OperatorMulticastTest {
 
     @Test
     public void testMulticast() {
@@ -70,15 +72,17 @@ public class OnSubscribeMulticastTest {
 
         source.onNext("one");
 
-        multicasted.connect();
-        multicasted.connect();
-
+        Subscription sub = multicasted.connect();
+        Subscription sub2 = multicasted.connect();
+        
         source.onNext("two");
         source.onCompleted();
 
         verify(observer, never()).onNext("one");
         verify(observer, times(1)).onNext("two");
         verify(observer, times(1)).onCompleted();
+        
+        assertEquals(sub, sub2);
 
     }
 


### PR DESCRIPTION
See discussion in  #2774 

Changes include 

* fix for #2774 just for ```OperatorMulticast``` (will do ```OperatorPublish``` in another PR once have sorted this one out)
* made fields private that had default visibility
* renamed ```OnSubscribeMulticastTest``` to ```OperatorMulticastTest```
* addressed a possible race condition that could provoke an IAE when ```Observable.subscribe(sub)``` is called with sub=null (unsubscription occurs between L144 and L145 on old code).