### PR TITLE
Fix for non-deterministic: testOnBackpressureDropWithAction

### DIFF
--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -446,7 +446,7 @@ public class BackpressureTests {
             final AtomicInteger emitCount = new AtomicInteger();
             final AtomicInteger dropCount = new AtomicInteger();
             final AtomicInteger passCount = new AtomicInteger();
-            final int NUM = (int) (RxRingBuffer.SIZE * 1.5); // > 1 so that take doesn't prevent buffer overflow
+            final int NUM = RxRingBuffer.SIZE * 3; // > 1 so that take doesn't prevent buffer overflow
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             firehose(emitCount).onBackpressureDrop(new Action1<Integer>() {
                 @Override


### PR DESCRIPTION
It is possible the synchronized block inside RxRingBuffer blocks out the firehose thread long enough that there will be enough requests cumulating up and no values have to be dropped. The change increases the taken value count and should decrease the likelihood of such no-drop situation.