### PR TITLE
Backpressure for window(size)

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -8896,7 +8896,8 @@ public class Observable<T> {
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window3.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses {@code count} to control data flow.</dd>
+     *  <dd>The operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
+     *  but each of them will emit at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -8920,7 +8921,8 @@ public class Observable<T> {
      * <img width="640" height="365" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window4.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses {@code count} to control data flow.</dd>
+     *  <dd>The operator has limited backpressure support. If {@code count} == {@code skip}, the operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
+     *  but each of them will emit at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>


### PR DESCRIPTION
Changes to the ```window(size)``` operator to respect the backpressure on its *outer* Observable: asking for 1 window will request ```size``` values from upstream. 

Backpressure is ignored on the inner Observable for now, partially because the ```BufferUntilSubscriber``` doesn't support it, partially because coordinating the inner requests with the outer requests needs more thoughts. The problem is that the outer has to request at least 1 element from upstream in order to open the window, but the inner subscriber may not want that single element just yet or would request more than the remaining window size and it would trigger new windows whose value it can't receive but would overflow the next window's observers.

```window(size, skip)``` is not changed as I need to think about it more.