### PR TITLE
match operator

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9307,9 +9307,7 @@ public class Observable<T> {
     }
 
     /**
-     * Filters items emitted by an Observable by only emitting those that satisfy a specified predicate.
-     *
-     * Match emits a MatchBuilder that lets you chain a series of matches a series of matches together. To finish the chain
+     * Returns a MatchBuilder that lets you chain a series of matches together. To finish the chain
      * matchDefault is called which emits an Observable.
      *
      * @param predicate

--- a/src/main/java/rx/internal/operators/OperatorMatch.java
+++ b/src/main/java/rx/internal/operators/OperatorMatch.java
@@ -1,0 +1,74 @@
+package rx.internal.operators;
+
+import rx.Observable.Operator;
+import rx.Subscriber;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnErrorThrowable;
+import rx.functions.Func1;
+
+import java.util.List;
+
+public final class OperatorMatch<T, R> implements Operator<R, T> {
+
+    public static class MatchPair<T,R> {
+        final Func1<T, Boolean> predicate;
+        final Func1<? super T, ? extends R> mapping;
+
+        public MatchPair(Func1<T, Boolean> predicate, Func1<? super T, ? extends R> mapping) {
+            this.predicate = predicate;
+            this.mapping = mapping;
+        }
+
+        public Func1<T, Boolean> getPredicate() {
+            return predicate;
+        }
+
+        public Func1<? super T, ? extends R> getMapping() {
+            return mapping;
+        }
+    }
+
+    private final List<MatchPair<T,R>> mappings;
+
+    private final Func1<? super T, ? extends R> defaultMapping;
+
+    public OperatorMatch(List<MatchPair<T,R>> mappings,
+                         Func1<? super T, ? extends R> defaultMapping) {
+        this.mappings = mappings;
+        this.defaultMapping = defaultMapping;
+    }
+
+    @Override
+    public Subscriber<? super T> call(final Subscriber<? super R> o) {
+        return new Subscriber<T>(o) {
+            @Override
+            public void onCompleted() {
+                o.onCompleted();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onNext(T t) {
+                try {
+                    int size = mappings.size();
+                    for (int i = 0; i < size; i++) {
+                        MatchPair<T,R> pair = mappings.get(i);
+                        Func1<T, Boolean> predicate = pair.getPredicate();
+                        if (predicate.call(t)) {
+                            o.onNext(pair.getMapping().call(t));
+                            return;
+                        }
+                    }
+                    o.onNext(defaultMapping.call(t));
+                } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
+                    onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/rx/internal/operators/OperatorMatch.java
+++ b/src/main/java/rx/internal/operators/OperatorMatch.java
@@ -6,36 +6,12 @@ import rx.exceptions.Exceptions;
 import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
-import java.util.List;
-
 public final class OperatorMatch<T, R> implements Operator<R, T> {
 
-    public static class MatchPair<T,R> {
-        final Func1<T, Boolean> predicate;
-        final Func1<? super T, ? extends R> mapping;
+    private final Func1<T, Func1<? super T, ? extends R>> findMappingFunc;
 
-        public MatchPair(Func1<T, Boolean> predicate, Func1<? super T, ? extends R> mapping) {
-            this.predicate = predicate;
-            this.mapping = mapping;
-        }
-
-        public Func1<T, Boolean> getPredicate() {
-            return predicate;
-        }
-
-        public Func1<? super T, ? extends R> getMapping() {
-            return mapping;
-        }
-    }
-
-    private final List<MatchPair<T,R>> mappings;
-
-    private final Func1<? super T, ? extends R> defaultMapping;
-
-    public OperatorMatch(List<MatchPair<T,R>> mappings,
-                         Func1<? super T, ? extends R> defaultMapping) {
-        this.mappings = mappings;
-        this.defaultMapping = defaultMapping;
+    public OperatorMatch(Func1<T, Func1<? super T, ? extends R>> findMappingFunc) {
+        this.findMappingFunc = findMappingFunc;
     }
 
     @Override
@@ -54,16 +30,8 @@ public final class OperatorMatch<T, R> implements Operator<R, T> {
             @Override
             public void onNext(T t) {
                 try {
-                    int size = mappings.size();
-                    for (int i = 0; i < size; i++) {
-                        MatchPair<T,R> pair = mappings.get(i);
-                        Func1<T, Boolean> predicate = pair.getPredicate();
-                        if (predicate.call(t)) {
-                            o.onNext(pair.getMapping().call(t));
-                            return;
-                        }
-                    }
-                    o.onNext(defaultMapping.call(t));
+                    Func1<? super T, ? extends R> mapping = findMappingFunc.call(t);
+                    o.onNext(mapping.call(t));
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     onError(OnErrorThrowable.addValueAsLastCause(e, t));

--- a/src/perf/java/rx/operators/OperatorMatchPerf.java
+++ b/src/perf/java/rx/operators/OperatorMatchPerf.java
@@ -1,0 +1,113 @@
+package rx.operators;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import rx.Observable;
+import rx.functions.Func1;
+import rx.jmh.InputWithIncrementingInteger;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class OperatorMatchPerf {
+    @State(Scope.Thread)
+    public static class Input extends InputWithIncrementingInteger {
+
+        @Param({ "1", "1000", "1000000" })
+        public int size;
+
+        @Override
+        public int getSize() {
+            return size;
+        }
+
+    }
+
+    @Benchmark
+    public void mapPassThruBaseline(Input input) {
+        input.observable.map(BASELINE_FUNC);
+    }
+
+    @Benchmark
+    public void flapMapPassThru(Input input) {
+        input.observable.flatMap(new Func1<Integer, Observable<?>>() {
+            @Override
+            public Observable<?> call(Integer integer) {
+                if (EVEN_PREDICATE.call(integer)) {
+                    return Observable.just(TIMES_TWO.call(integer));
+                } else if (DIVISIBLE_BY_THREE_PREDICATE.call(integer)) {
+                    return Observable.just(TIMES_THREE.call(integer));
+                } else {
+                    return Observable.just(TIMES_FOUR.call(integer));
+                }
+            }
+        });
+    }
+
+    @Benchmark
+    public void multipleMatchAndDefaultPassThru(Input input) {
+        input
+            .observable
+            .match(EVEN_PREDICATE, TIMES_TWO)
+            .match(DIVISIBLE_BY_THREE_PREDICATE, TIMES_THREE)
+            .matchDefault(TIMES_FOUR);
+    }
+
+    private static final Func1<Integer, Integer> BASELINE_FUNC = new Func1<Integer, Integer>() {
+        @Override
+        public Integer call(Integer integer) {
+            if (integer % 2 == 0) {
+                return integer * 2;
+            } else if (integer % 3 == 0) {
+                return integer * 3;
+            } else {
+                return integer * 4;
+            }
+        }
+    };
+
+    private static final Func1<Integer, Boolean> EVEN_PREDICATE = new Func1<Integer, Boolean>() {
+        @Override
+        public Boolean call(Integer i) {
+            return i % 2 == 0;
+        }
+    };
+
+    private static final Func1<Integer, Boolean> DIVISIBLE_BY_THREE_PREDICATE = new Func1<Integer, Boolean>() {
+        @Override
+        public Boolean call(Integer i) {
+            return i % 3 == 0;
+        }
+    };
+
+    private static final Func1<Integer, Integer> TIMES_TWO = new Func1<Integer, Integer>() {
+        @Override
+        public Integer call(Integer integer) {
+            return integer * 2;
+        }
+    };
+
+
+    private static final Func1<Integer, Integer> TIMES_THREE = new Func1<Integer, Integer>() {
+        @Override
+        public Integer call(Integer integer) {
+            return integer * 3;
+        }
+    };
+
+
+    private static final Func1<Integer, Integer> TIMES_FOUR = new Func1<Integer, Integer>() {
+        @Override
+        public Integer call(Integer integer) {
+            return integer * 4;
+        }
+    };
+
+
+}

--- a/src/test/java/rx/internal/operators/OperatorMatchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMatchTest.java
@@ -1,0 +1,161 @@
+package rx.internal.operators;
+
+
+import junit.framework.Assert;
+import org.junit.Test;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OperatorMatchTest {
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMatchOperator() {
+        List<OperatorMatch.MatchPair<String, String>> mappings = new ArrayList<OperatorMatch.MatchPair<String, String>>();
+
+        Func1<String, Boolean> truePredicate = mock(Func1.class);
+        Func1<String, Boolean> falsePredicate = mock(Func1.class);
+        Func1<String, Boolean> falsePredicate2 = mock(Func1.class);
+        Func1<String, String> defaultMapping = mock(Func1.class);
+        Func1<String, String> trueMapping = mock(Func1.class);
+        Func1<String, String> falseMapping = mock(Func1.class);
+        Func1<String, String> falseMapping2 = mock(Func1.class);
+
+        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
+        mappings.add(new OperatorMatch.MatchPair<String, String>(truePredicate, trueMapping));
+        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate2, falseMapping2));
+
+        OperatorMatch<String, String> match = new OperatorMatch<String, String>(mappings, defaultMapping);
+
+        Subscriber<String> subscriber = mock(Subscriber.class);
+
+        when(truePredicate.call(anyString())).thenReturn(true);
+        when(falsePredicate.call(anyString())).thenReturn(false);
+        when(trueMapping.call(anyString())).thenReturn("true mapping");
+
+        match.call(subscriber).onNext("on next");
+
+        verify(falsePredicate, times(1)).call(anyString());
+        verify(truePredicate, times(1)).call(anyString());
+        verify(defaultMapping, times(0)).call(anyString());
+        verify(trueMapping, times(1)).call(anyString());
+        verify(falseMapping, times(0)).call(anyString());
+        verify(falsePredicate2, times(0)).call(anyString());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMatchOperatorDefault() {
+        List<OperatorMatch.MatchPair<String, String>> mappings = new ArrayList<OperatorMatch.MatchPair<String, String>>();
+
+        Func1<String, Boolean> falsePredicate = mock(Func1.class);
+        Func1<String, String> defaultMapping = mock(Func1.class);
+        Func1<String, String> falseMapping = mock(Func1.class);
+
+        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
+        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
+        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
+
+        OperatorMatch<String, String> match = new OperatorMatch<String, String>(mappings, defaultMapping);
+
+        Subscriber<String> subscriber = mock(Subscriber.class);
+
+        when(falsePredicate.call(anyString())).thenReturn(false);
+
+        match.call(subscriber).onNext("on next");
+
+        verify(falsePredicate, times(3)).call(anyString());
+        verify(defaultMapping, times(1)).call(anyString());
+        verify(falseMapping, times(0)).call(anyString());
+    }
+
+    @Test
+    public void testMatch() {
+        List<Integer> expected = new ArrayList<Integer>();
+        expected.add(0);
+        expected.add(2);
+        expected.add(2);
+        expected.add(6);
+        expected.add(4);
+        expected.add(10);
+        expected.add(6);
+        expected.add(14);
+        expected.add(8);
+        expected.add(18);
+
+        List<Integer> result = Observable
+            .range(0, 10)
+            .match(new Func1<Integer, Boolean>() {
+                @Override
+                public Boolean call(Integer integer) {
+                    return integer % 2 == 1;
+                }
+            }, new Func1<Integer, Integer>() {
+                @Override
+                public Integer call(Integer integer) {
+                    return integer * 2;
+                }
+            })
+            .matchDefault(new Func1<Integer, Integer>() {
+                @Override
+                public Integer call(Integer integer) {
+                    return integer;
+                }
+            }).toList().toBlocking().single();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals(expected.size(), result.size());
+
+        for (int i = 0; i < result.size(); i++) {
+            Assert.assertEquals(expected.get(i), result.get(i));
+        }
+    }
+
+    @Test
+    public void testFlatMatch() {
+        List<Integer> expected = new ArrayList<Integer>();
+        expected.add(6);
+        expected.add(7);
+        expected.add(8);
+        expected.add(9);
+
+        List<Integer> result = Observable
+            .just(true)
+            .flatMatch(new Func1<Boolean, Boolean>() {
+                @Override
+                public Boolean call(Boolean aBoolean) {
+                    return !aBoolean;
+                }
+            }, new Func1<Boolean, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> call(Boolean aBoolean) {
+                    return Observable.just(1, 2, 3, 4, 5);
+                }
+            }).matchDefault(new Func1<Boolean, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> call(Boolean aBoolean) {
+                    return Observable.just(6, 7, 8, 9);
+                }
+            }).toList().toBlocking().single();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals(expected.size(), result.size());
+
+        for (int i = 0; i < result.size(); i++) {
+            Assert.assertEquals(expected.get(i), result.get(i));
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/OperatorMatchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMatchTest.java
@@ -18,67 +18,22 @@ import static org.mockito.Mockito.when;
 
 public class OperatorMatchTest {
 
-
     @Test
-    @SuppressWarnings("unchecked")
-    public void testMatchOperator() {
-        List<OperatorMatch.MatchPair<String, String>> mappings = new ArrayList<OperatorMatch.MatchPair<String, String>>();
+    public void testOperatorMatch() {
+        Func1<String, Func1<String, String>> findMappingFunc = mock(Func1.class);
+        Func1<String, String> mapping = mock(Func1.class);
 
-        Func1<String, Boolean> truePredicate = mock(Func1.class);
-        Func1<String, Boolean> falsePredicate = mock(Func1.class);
-        Func1<String, Boolean> falsePredicate2 = mock(Func1.class);
-        Func1<String, String> defaultMapping = mock(Func1.class);
-        Func1<String, String> trueMapping = mock(Func1.class);
-        Func1<String, String> falseMapping = mock(Func1.class);
-        Func1<String, String> falseMapping2 = mock(Func1.class);
+        when(findMappingFunc.call(anyString())).thenReturn(mapping);
 
-        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
-        mappings.add(new OperatorMatch.MatchPair<String, String>(truePredicate, trueMapping));
-        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate2, falseMapping2));
-
-        OperatorMatch<String, String> match = new OperatorMatch<String, String>(mappings, defaultMapping);
+        OperatorMatch match = new OperatorMatch(findMappingFunc);
 
         Subscriber<String> subscriber = mock(Subscriber.class);
 
-        when(truePredicate.call(anyString())).thenReturn(true);
-        when(falsePredicate.call(anyString())).thenReturn(false);
-        when(trueMapping.call(anyString())).thenReturn("true mapping");
-
         match.call(subscriber).onNext("on next");
 
-        verify(falsePredicate, times(1)).call(anyString());
-        verify(truePredicate, times(1)).call(anyString());
-        verify(defaultMapping, times(0)).call(anyString());
-        verify(trueMapping, times(1)).call(anyString());
-        verify(falseMapping, times(0)).call(anyString());
-        verify(falsePredicate2, times(0)).call(anyString());
+        verify(mapping, times(1)).call(anyString());
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testMatchOperatorDefault() {
-        List<OperatorMatch.MatchPair<String, String>> mappings = new ArrayList<OperatorMatch.MatchPair<String, String>>();
-
-        Func1<String, Boolean> falsePredicate = mock(Func1.class);
-        Func1<String, String> defaultMapping = mock(Func1.class);
-        Func1<String, String> falseMapping = mock(Func1.class);
-
-        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
-        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
-        mappings.add(new OperatorMatch.MatchPair<String, String>(falsePredicate, falseMapping));
-
-        OperatorMatch<String, String> match = new OperatorMatch<String, String>(mappings, defaultMapping);
-
-        Subscriber<String> subscriber = mock(Subscriber.class);
-
-        when(falsePredicate.call(anyString())).thenReturn(false);
-
-        match.call(subscriber).onNext("on next");
-
-        verify(falsePredicate, times(3)).call(anyString());
-        verify(defaultMapping, times(1)).call(anyString());
-        verify(falseMapping, times(0)).call(anyString());
-    }
 
     @Test
     public void testMatch() {
@@ -124,6 +79,67 @@ public class OperatorMatchTest {
     }
 
     @Test
+    public void testMatchFollowedByMatch() {
+        List<Integer> expected = new ArrayList<Integer>();
+        expected.add(0);
+        expected.add(2);
+        expected.add(2);
+        expected.add(6);
+        expected.add(4);
+        expected.add(0);
+        expected.add(6);
+        expected.add(0);
+        expected.add(8);
+        expected.add(0);
+
+        List<Integer> result = Observable
+            .range(0, 10)
+            .match(new Func1<Integer, Boolean>() {
+                @Override
+                public Boolean call(Integer integer) {
+                    return integer % 2 == 1;
+                }
+            }, new Func1<Integer, Integer>() {
+                @Override
+                public Integer call(Integer integer) {
+                    return integer * 2;
+                }
+            })
+            .matchDefault(new Func1<Integer, Integer>() {
+                @Override
+                public Integer call(Integer integer) {
+                    return integer;
+                }
+            })
+            .match(new Func1<Integer, Boolean>() {
+                @Override
+                public Boolean call(Integer integer) {
+                    return integer >= 10;
+                }
+            }, new Func1<Integer, Integer>() {
+                @Override
+                public Integer call(Integer integer) {
+                    return 0;
+                }
+            })
+            .matchDefault(new Func1<Integer, Integer>() {
+                @Override
+                public Integer call(Integer integer) {
+                    return integer;
+                }
+            }).toList().toBlocking().single();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals(expected.size(), result.size());
+
+        for (int i = 0; i < result.size(); i++) {
+            Assert.assertEquals(expected.get(i), result.get(i));
+        }
+
+    }
+
+    @Test
     public void testFlatMatch() {
         List<Integer> expected = new ArrayList<Integer>();
         expected.add(6);
@@ -149,6 +165,76 @@ public class OperatorMatchTest {
                     return Observable.just(6, 7, 8, 9);
                 }
             }).toList().toBlocking().single();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals(expected.size(), result.size());
+
+        for (int i = 0; i < result.size(); i++) {
+            Assert.assertEquals(expected.get(i), result.get(i));
+        }
+    }
+
+    @Test
+    public void testFlatMatchWithinFlatMatch() {
+
+        List<Integer> expected = new ArrayList<Integer>();
+        expected.add(0);
+        expected.add(1);
+        expected.add(4);
+        expected.add(3);
+        expected.add(4);
+        expected.add(5);
+        expected.add(6);
+        expected.add(7);
+        expected.add(8);
+        expected.add(9);
+        expected.add(10);
+        expected.add(11);
+        expected.add(12);
+        expected.add(13);
+        expected.add(14);
+        expected.add(15);
+        expected.add(16);
+        expected.add(17);
+        expected.add(18);
+        expected.add(19);
+
+        List<Integer> result = Observable
+            .range(0, 20)
+            .flatMatch(new Func1<Integer, Boolean>() {
+                @Override
+                public Boolean call(Integer integer) {
+                    return integer % 2 == 0;
+                }
+            }, new Func1<Integer, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> call(Integer integer) {
+                    return Observable.just(integer).flatMatch(new Func1<Integer, Boolean>() {
+                        @Override
+                        public Boolean call(Integer integer) {
+                            return integer == 2;
+                        }
+                    }, new Func1<Integer, Observable<Integer>>() {
+                        @Override
+                        public Observable<Integer> call(Integer integer) {
+                            return Observable.just(integer * 2);
+                        }
+                    })
+                        .matchDefault(new Func1<Integer, Observable<Integer>>() {
+                            @Override
+                            public Observable<Integer> call(Integer integer) {
+                                return Observable.just(integer);
+                            }
+                        });
+
+                }
+            }).matchDefault(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer integer) {
+                return Observable.just(integer);
+            }
+        }).toList().toBlocking().single();
 
         Assert.assertNotNull(result);
         Assert.assertFalse(result.isEmpty());


### PR DESCRIPTION
Added an match operator that constructs chain of predicates mapped to a function. The predicate will be applied to what an Observable emits, and if the predicate returns true the function mapped to the predicate will be applied.

The match operator creates a MatchBuilder which can either chain subsequent matches or return the Observable back when the defaultMatch method is called. This ensures there is a default match provided.
