### PR TITLE
Fixed javadoc for Observable.repeat() method

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5610,7 +5610,7 @@ public class Observable<T> {
      * </dl>
      * 
      * @return an Observable that emits the items emitted by the source Observable repeatedly and in sequence
-     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeahttp://reactivex.io/documentation/operators/create.htmlt</a>
+     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
      */
     public final Observable<T> repeat() {
         return OnSubscribeRedo.<T>repeat(this);


### PR DESCRIPTION
Removed wrong link inside of JavaDoc for Observable.repeat() method