### PR TITLE
testOnBackpressureDropWithAction restored original test count

### DIFF
--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -446,7 +446,7 @@ public class BackpressureTests {
             final AtomicInteger emitCount = new AtomicInteger();
             final AtomicInteger dropCount = new AtomicInteger();
             final AtomicInteger passCount = new AtomicInteger();
-            final int NUM = RxRingBuffer.SIZE * 3; // > 1 so that take doesn't prevent buffer overflow
+            final int NUM = RxRingBuffer.SIZE * 3 / 2; // > 1 so that take doesn't prevent buffer overflow
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             firehose(emitCount).onBackpressureDrop(new Action1<Integer>() {
                 @Override


### PR DESCRIPTION
Not for merge. Diagnosing travis build failure.