### PR TITLE
Revert "Corrected all Java interfaces declarations"

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -98,7 +98,7 @@ public class Observable<T> {
     /**
      * Invoked when Observable.subscribe is called.
      */
-    public interface OnSubscribe<T> extends Action1<Subscriber<? super T>> {
+    public static interface OnSubscribe<T> extends Action1<Subscriber<? super T>> {
         // cover for generics insanity
     }
 
@@ -191,7 +191,7 @@ public class Observable<T> {
      * Transformer function used by {@link #compose}.
      * @warn more complete description needed
      */
-    public interface Transformer<T, R> extends Func1<Observable<T>, Observable<R>> {
+    public static interface Transformer<T, R> extends Func1<Observable<T>, Observable<R>> {
         // cover for generics insanity
     }
     

--- a/src/main/java/rx/Observer.java
+++ b/src/main/java/rx/Observer.java
@@ -34,7 +34,7 @@ public interface Observer<T> {
      * <p>
      * The {@link Observable} will not call this method if it calls {@link #onError}.
      */
-    void onCompleted();
+    public abstract void onCompleted();
 
     /**
      * Notifies the Observer that the {@link Observable} has experienced an error condition.
@@ -45,7 +45,7 @@ public interface Observer<T> {
      * @param e
      *          the exception encountered by the Observable
      */
-    void onError(Throwable e);
+    public abstract void onError(Throwable e);
 
     /**
      * Provides the Observer with a new item to observe.
@@ -58,6 +58,6 @@ public interface Observer<T> {
      * @param t
      *          the item emitted by the Observable
      */
-    void onNext(T t);
+    public abstract void onNext(T t);
 
 }

--- a/src/main/java/rx/Producer.java
+++ b/src/main/java/rx/Producer.java
@@ -37,6 +37,6 @@ public interface Producer {
      * @param n the maximum number of items you want this Producer to produce, or {@code Long.MAX_VALUE} if you
      *          want the Producer to produce items at its own pace
      */
-    void request(long n);
+    public void request(long n);
 
 }

--- a/src/main/java/rx/Subscription.java
+++ b/src/main/java/rx/Subscription.java
@@ -33,13 +33,13 @@ public interface Subscription {
      * This allows unregistering an {@link Subscriber} before it has finished receiving all events (i.e. before
      * onCompleted is called).
      */
-    void unsubscribe();
+    public void unsubscribe();
 
     /**
      * Indicates whether this {@code Subscription} is currently unsubscribed.
      *
      * @return {@code true} if this {@code Subscription} is currently unsubscribed, {@code false} otherwise
      */
-    boolean isUnsubscribed();
+    public boolean isUnsubscribed();
 
 }

--- a/src/main/java/rx/functions/Action0.java
+++ b/src/main/java/rx/functions/Action0.java
@@ -19,5 +19,5 @@ package rx.functions;
  * A zero-argument action.
  */
 public interface Action0 extends Action {
-    void call();
+    public void call();
 }

--- a/src/main/java/rx/functions/Action1.java
+++ b/src/main/java/rx/functions/Action1.java
@@ -19,5 +19,5 @@ package rx.functions;
  * A one-argument action.
  */
 public interface Action1<T1> extends Action {
-    void call(T1 t1);
+    public void call(T1 t1);
 }

--- a/src/main/java/rx/functions/Action2.java
+++ b/src/main/java/rx/functions/Action2.java
@@ -19,5 +19,5 @@ package rx.functions;
  * A two-argument action.
  */
 public interface Action2<T1, T2> extends Action {
-    void call(T1 t1, T2 t2);
+    public void call(T1 t1, T2 t2);
 }

--- a/src/main/java/rx/functions/Action3.java
+++ b/src/main/java/rx/functions/Action3.java
@@ -19,5 +19,5 @@ package rx.functions;
  * A three-argument action.
  */
 public interface Action3<T1, T2, T3> extends Action {
-    void call(T1 t1, T2 t2, T3 t3);
+    public void call(T1 t1, T2 t2, T3 t3);
 }

--- a/src/main/java/rx/functions/Func0.java
+++ b/src/main/java/rx/functions/Func0.java
@@ -22,5 +22,5 @@ import java.util.concurrent.Callable;
  */
 public interface Func0<R> extends Function, Callable<R> {
     @Override
-    R call();
+    public R call();
 }

--- a/src/main/java/rx/functions/Func1.java
+++ b/src/main/java/rx/functions/Func1.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with one argument.
  */
 public interface Func1<T1, R> extends Function {
-    R call(T1 t1);
+    public R call(T1 t1);
 }

--- a/src/main/java/rx/functions/Func2.java
+++ b/src/main/java/rx/functions/Func2.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with two arguments.
  */
 public interface Func2<T1, T2, R> extends Function {
-    R call(T1 t1, T2 t2);
+    public R call(T1 t1, T2 t2);
 }

--- a/src/main/java/rx/functions/Func3.java
+++ b/src/main/java/rx/functions/Func3.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with three arguments.
  */
 public interface Func3<T1, T2, T3, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3);
+    public R call(T1 t1, T2 t2, T3 t3);
 }

--- a/src/main/java/rx/functions/Func4.java
+++ b/src/main/java/rx/functions/Func4.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with four arguments.
  */
 public interface Func4<T1, T2, T3, T4, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3, T4 t4);
+    public R call(T1 t1, T2 t2, T3 t3, T4 t4);
 }

--- a/src/main/java/rx/functions/Func5.java
+++ b/src/main/java/rx/functions/Func5.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with five arguments.
  */
 public interface Func5<T1, T2, T3, T4, T5, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+    public R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
 }

--- a/src/main/java/rx/functions/Func6.java
+++ b/src/main/java/rx/functions/Func6.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with six arguments.
  */
 public interface Func6<T1, T2, T3, T4, T5, T6, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+    public R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
 }

--- a/src/main/java/rx/functions/Func7.java
+++ b/src/main/java/rx/functions/Func7.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with seven arguments.
  */
 public interface Func7<T1, T2, T3, T4, T5, T6, T7, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
+    public R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
 }

--- a/src/main/java/rx/functions/Func8.java
+++ b/src/main/java/rx/functions/Func8.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with eight arguments.
  */
 public interface Func8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);
+    public R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);
 }

--- a/src/main/java/rx/functions/Func9.java
+++ b/src/main/java/rx/functions/Func9.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a function with nine arguments.
  */
 public interface Func9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends Function {
-    R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9);
+    public R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9);
 }

--- a/src/main/java/rx/functions/FuncN.java
+++ b/src/main/java/rx/functions/FuncN.java
@@ -19,5 +19,5 @@ package rx.functions;
  * Represents a vector-argument function.
  */
 public interface FuncN<R> extends Function {
-    R call(Object... args);
+    public R call(Object... args);
 }

--- a/src/main/java/rx/internal/operators/OperatorTimeoutBase.java
+++ b/src/main/java/rx/internal/operators/OperatorTimeoutBase.java
@@ -36,7 +36,7 @@ class OperatorTimeoutBase<T> implements Operator<T, T> {
      * 
      * @param <T>
      */
-    /* package-private */interface FirstTimeoutStub<T> extends
+    /* package-private */static interface FirstTimeoutStub<T> extends
             Func3<TimeoutSubscriber<T>, Long, Scheduler.Worker, Subscription> {
     }
 
@@ -45,7 +45,7 @@ class OperatorTimeoutBase<T> implements Operator<T, T> {
      * 
      * @param <T>
      */
-    /* package-private */interface TimeoutStub<T> extends
+    /* package-private */static interface TimeoutStub<T> extends
             Func4<TimeoutSubscriber<T>, Long, T, Scheduler.Worker, Subscription> {
     }
 

--- a/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
@@ -44,7 +44,7 @@ import rx.subscriptions.Subscriptions;
 
 public class OnSubscribeUsingTest {
 
-    private interface Resource {
+    private static interface Resource {
         public String getTextFromWeb();
 
         public void dispose();


### PR DESCRIPTION
Reverts ReactiveX/RxJava#2807

Revert because they are breaking changes. RxScala needs the `public` modifier so that it can wrap them into Scala classes.