### PR TITLE
toBlocking.single should not request more than needed

### DIFF
--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -440,6 +440,12 @@ public final class BlockingObservable<T> {
         final CountDownLatch latch = new CountDownLatch(1);
 
         Subscription subscription = observable.subscribe(new Subscriber<T>() {
+            
+            @Override
+            public void onStart() {
+                request(1);
+            }
+            
             @Override
             public void onCompleted() {
                 latch.countDown();


### PR DESCRIPTION
When ```observable.toBlocking().single()``` was called the number requested from ```observable``` was ```Long.MAX_VALUE``` due to ```OperatorSingle``` not overriding the request number.
