### PR TITLE
Cleanup warnings in test source

### DIFF
--- a/src/test/java/rx/CovarianceTest.java
+++ b/src/test/java/rx/CovarianceTest.java
@@ -106,6 +106,7 @@ public class CovarianceTest {
         assertEquals(6, ts.getOnNextEvents().size());
     }
 
+    @SuppressWarnings("unused")
     @Test
     public void testCovarianceOfCompose() {
         Observable<HorrorMovie> movie = Observable.just(new HorrorMovie());
@@ -119,6 +120,7 @@ public class CovarianceTest {
         });
     }
     
+    @SuppressWarnings("unused")
     @Test
     public void testCovarianceOfCompose2() {
         Observable<Movie> movie = Observable.<Movie> just(new HorrorMovie());
@@ -130,6 +132,7 @@ public class CovarianceTest {
         });
     }
 
+    @SuppressWarnings("unused")
     @Test
     public void testCovarianceOfCompose3() {
         Observable<Movie> movie = Observable.<Movie>just(new HorrorMovie());
@@ -147,6 +150,7 @@ public class CovarianceTest {
         });
     }
 
+    @SuppressWarnings("unused")
     @Test
     public void testCovarianceOfCompose4() {
         Observable<HorrorMovie> movie = Observable.just(new HorrorMovie());
@@ -201,7 +205,7 @@ public class CovarianceTest {
                 oldList.removeAll(newList);
 
                 // for all left in the oldList we'll create DROP events
-                for (Movie old : oldList) {
+                for (@SuppressWarnings("unused") Movie old : oldList) {
                     delta.add(new Movie());
                 }
 

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1054,9 +1054,9 @@ public class ObservableTests {
 
     @Test
     public void testTakeWhileToList() {
-        int[] nums = {1, 2, 3};
+        final int expectedCount = 3;
         final AtomicInteger count = new AtomicInteger();
-        for(final int n: nums) {
+        for (int i = 0;i < expectedCount; i++) {
             Observable
                     .just(Boolean.TRUE, Boolean.FALSE)
                     .takeWhile(new Func1<Boolean, Boolean>() {
@@ -1074,7 +1074,7 @@ public class ObservableTests {
                     })
                     .subscribe();
         }
-        assertEquals(nums.length, count.get());
+        assertEquals(expectedCount, count.get());
     }
     
     @Test

--- a/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
@@ -88,7 +88,7 @@ public class OnSubscribeToObservableFutureTest {
 
         TestSubscriber<Object> testSubscriber = new TestSubscriber<Object>(o);
         testSubscriber.unsubscribe();
-        Subscription sub = Observable.from(future).subscribe(testSubscriber);
+        Observable.from(future).subscribe(testSubscriber);
         assertEquals(0, testSubscriber.getOnErrorEvents().size());
         assertEquals(0, testSubscriber.getOnCompletedEvents().size());
     }

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -485,11 +485,11 @@ public class OperatorConcatTest {
         private final T seed;
         private final int size;
 
-        public TestObservable(T... values) {
+        public TestObservable(@SuppressWarnings("unchecked") T... values) {
             this(null, null, values);
         }
 
-        public TestObservable(CountDownLatch once, CountDownLatch okToContinue, T... values) {
+        public TestObservable(CountDownLatch once, CountDownLatch okToContinue, @SuppressWarnings("unchecked") T... values) {
             this.values = Arrays.asList(values);
             this.size = this.values.size();
             this.once = once;

--- a/src/test/java/rx/internal/operators/OperatorDoOnEachTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoOnEachTest.java
@@ -123,9 +123,9 @@ public class OperatorDoOnEachTest {
     @Test
     public void testIssue1451Case1() {
         // https://github.com/Netflix/RxJava/issues/1451
-        int[] nums = { 1, 2, 3 };
+        final int expectedCount = 3;
         final AtomicInteger count = new AtomicInteger();
-        for (final int n : nums) {
+        for (int i=0; i < expectedCount; i++) {
             Observable
                     .just(Boolean.TRUE, Boolean.FALSE)
                     .takeWhile(new Func1<Boolean, Boolean>() {
@@ -143,15 +143,15 @@ public class OperatorDoOnEachTest {
                     })
                     .subscribe();
         }
-        assertEquals(nums.length, count.get());
+        assertEquals(expectedCount, count.get());
     }
 
     @Test
     public void testIssue1451Case2() {
         // https://github.com/Netflix/RxJava/issues/1451
-        int[] nums = { 1, 2, 3 };
+        final int expectedCount = 3;
         final AtomicInteger count = new AtomicInteger();
-        for (final int n : nums) {
+        for (int i=0; i < expectedCount; i++) {
             Observable
                     .just(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
                     .takeWhile(new Func1<Boolean, Boolean>() {
@@ -169,7 +169,7 @@ public class OperatorDoOnEachTest {
                     })
                     .subscribe();
         }
-        assertEquals(nums.length, count.get());
+        assertEquals(expectedCount, count.get());
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorMulticastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMulticastTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import rx.Observer;

--- a/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -109,7 +107,6 @@ public class OperatorOnErrorResumeNextViaObservableTest {
     
     @Test
     public void testResumeNextWithFailedOnSubscribe() {
-        Subscription s = mock(Subscription.class);
         Observable<String> testObservable = Observable.create(new OnSubscribe<String>() {
 
             @Override
@@ -132,7 +129,6 @@ public class OperatorOnErrorResumeNextViaObservableTest {
     
     @Test
     public void testResumeNextWithFailedOnSubscribeAsync() {
-        Subscription s = mock(Subscription.class);
         Observable<String> testObservable = Observable.create(new OnSubscribe<String>() {
 
             @Override

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -251,7 +251,7 @@ public class OperatorPublishTest {
         co.connect();
         // Emit 0
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
-        TestSubscriber subscriber = new TestSubscriber<Long>();
+        TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
         co.subscribe(subscriber);
         // Emit 1 and 2
         scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -15,17 +15,23 @@
  */
 package rx.internal.operators;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.mockito.InOrder;
-
 
 import rx.Observable;
 import rx.Observer;
@@ -523,14 +529,15 @@ public class OperatorReplayTest {
     /**
      * test the basic expectation of OperatorMulticast via replay
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testIssue2191_UnsubscribeSource() {
         // setup mocks
-        Action1 sourceNext = mock(Action1.class);
+        Action1<Integer> sourceNext = mock(Action1.class);
         Action0 sourceCompleted = mock(Action0.class);
         Action0 sourceUnsubscribed = mock(Action0.class);
-        Observer spiedSubscriberBeforeConnect = mock(Observer.class);
-        Observer spiedSubscriberAfterConnect = mock(Observer.class);
+        Observer<Integer> spiedSubscriberBeforeConnect = mock(Observer.class);
+        Observer<Integer> spiedSubscriberAfterConnect = mock(Observer.class);
 
         // Observable under test
         Observable<Integer> source = Observable.just(1,2);
@@ -570,17 +577,18 @@ public class OperatorReplayTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testIssue2191_SchedulerUnsubscribe() throws Exception {
         // setup mocks
-        Action1 sourceNext = mock(Action1.class);
+        Action1<Integer> sourceNext = mock(Action1.class);
         Action0 sourceCompleted = mock(Action0.class);
         Action0 sourceUnsubscribed = mock(Action0.class);
         final Scheduler mockScheduler = mock(Scheduler.class);
         final Subscription mockSubscription = mock(Subscription.class);
         Worker spiedWorker = workerSpy(mockSubscription);
-        Observer mockObserverBeforeConnect = mock(Observer.class);
-        Observer mockObserverAfterConnect = mock(Observer.class);
+        Observer<Integer> mockObserverBeforeConnect = mock(Observer.class);
+        Observer<Integer> mockObserverAfterConnect = mock(Observer.class);
 
         when(mockScheduler.createWorker()).thenReturn(spiedWorker);
 
@@ -626,18 +634,19 @@ public class OperatorReplayTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testIssue2191_SchedulerUnsubscribeOnError() throws Exception {
         // setup mocks
-        Action1 sourceNext = mock(Action1.class);
+        Action1<Integer> sourceNext = mock(Action1.class);
         Action0 sourceCompleted = mock(Action0.class);
-        Action1 sourceError = mock(Action1.class);
+        Action1<Throwable> sourceError = mock(Action1.class);
         Action0 sourceUnsubscribed = mock(Action0.class);
         final Scheduler mockScheduler = mock(Scheduler.class);
         final Subscription mockSubscription = mock(Subscription.class);
         Worker spiedWorker = workerSpy(mockSubscription);
-        Observer mockObserverBeforeConnect = mock(Observer.class);
-        Observer mockObserverAfterConnect = mock(Observer.class);
+        Observer<Integer> mockObserverBeforeConnect = mock(Observer.class);
+        Observer<Integer> mockObserverAfterConnect = mock(Observer.class);
 
         when(mockScheduler.createWorker()).thenReturn(spiedWorker);
 
@@ -682,14 +691,14 @@ public class OperatorReplayTest {
         verifyNoMoreInteractions(mockObserverAfterConnect);
     }
 
-    private static void verifyObserverMock(Observer mock, int numSubscriptions, int numItemsExpected) {
-        verify(mock, times(numItemsExpected)).onNext(notNull());
+    private static void verifyObserverMock(Observer<Integer> mock, int numSubscriptions, int numItemsExpected) {
+        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
         verify(mock, times(numSubscriptions)).onCompleted();
         verifyNoMoreInteractions(mock);
     }
 
-    private static void verifyObserver(Observer mock, int numSubscriptions, int numItemsExpected, Throwable error) {
-        verify(mock, times(numItemsExpected)).onNext(notNull());
+    private static void verifyObserver(Observer<Integer> mock, int numSubscriptions, int numItemsExpected, Throwable error) {
+        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
         verify(mock, times(numSubscriptions)).onError(error);
         verifyNoMoreInteractions(mock);
     }

--- a/src/test/java/rx/internal/operators/OperatorSampleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSampleTest.java
@@ -33,7 +33,6 @@ import rx.Observable.OnSubscribe;
 import rx.functions.Action0;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
-import rx.subscriptions.Subscriptions;
 
 public class OperatorSampleTest {
     private TestScheduler scheduler;

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -318,7 +318,7 @@ public class OperatorScanTest {
         final AtomicReference<Producer> producer = new AtomicReference<Producer>();
         Observable<Integer> o = Observable.create(new Observable.OnSubscribe<Integer>() {
             @Override
-            public void call(final Subscriber subscriber) {
+            public void call(final Subscriber<? super Integer> subscriber) {
                 Producer p = spy(new Producer() {
 
                     private AtomicBoolean requested = new AtomicBoolean(false);

--- a/src/test/java/rx/internal/operators/OperatorSkipWhileTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipWhileTest.java
@@ -29,7 +29,6 @@ import org.mockito.InOrder;
 import rx.Observable;
 import rx.Observer;
 import rx.functions.Func1;
-import rx.functions.Func2;
 
 public class OperatorSkipWhileTest {
 

--- a/src/test/java/rx/internal/util/IndexedRingBufferTest.java
+++ b/src/test/java/rx/internal/util/IndexedRingBufferTest.java
@@ -242,7 +242,7 @@ public class IndexedRingBufferTest {
         list.forEach(newCounterAction(c));
         assertEquals(0, c.get());
         //        System.out.println("Index is: " + list.index.get() + " when it should be no bigger than " + list.SIZE);
-        assertTrue(list.index.get() < list.SIZE);
+        assertTrue(list.index.get() < IndexedRingBuffer.SIZE);
         // it should actually be 1 since we only did add/remove sequentially
         assertEquals(1, list.index.get());
     }


### PR DESCRIPTION
Made changes to test source to avoid or suppress these warnings:

* raw types 
* unused imports
* unused variables