### PR TITLE
IndexedRingBuffer.getInstance can infer type

### DIFF
--- a/src/main/java/rx/internal/util/IndexedRingBuffer.java
+++ b/src/main/java/rx/internal/util/IndexedRingBuffer.java
@@ -48,17 +48,18 @@ import rx.functions.Func1;
  */
 public final class IndexedRingBuffer<E> implements Subscription {
 
-    private static final ObjectPool<IndexedRingBuffer> POOL = new ObjectPool<IndexedRingBuffer>() {
+    private static final ObjectPool<IndexedRingBuffer<?>> POOL = new ObjectPool<IndexedRingBuffer<?>>() {
 
         @Override
-        protected IndexedRingBuffer createObject() {
-            return new IndexedRingBuffer();
+        protected IndexedRingBuffer<?> createObject() {
+            return new IndexedRingBuffer<Object>();
         }
 
     };
 
-    public final static IndexedRingBuffer getInstance() {
-        return POOL.borrowObject();
+    @SuppressWarnings("unchecked")
+    public final static <T> IndexedRingBuffer<T> getInstance() {
+        return (IndexedRingBuffer<T>) POOL.borrowObject();
     }
 
     private final ElementSection<E> elements = new ElementSection<E>();

--- a/src/main/java/rx/internal/util/SubscriptionIndexedRingBuffer.java
+++ b/src/main/java/rx/internal/util/SubscriptionIndexedRingBuffer.java
@@ -27,7 +27,6 @@ import rx.functions.Func1;
  */
 public final class SubscriptionIndexedRingBuffer<T extends Subscription> implements Subscription {
 
-    @SuppressWarnings("unchecked")
     private volatile IndexedRingBuffer<T> subscriptions = IndexedRingBuffer.getInstance();
     private volatile int unsubscribed = 0;
     @SuppressWarnings("rawtypes")

--- a/src/perf/java/rx/internal/IndexedRingBufferPerf.java
+++ b/src/perf/java/rx/internal/IndexedRingBufferPerf.java
@@ -29,7 +29,6 @@ public class IndexedRingBufferPerf {
 
     @Benchmark
     public void indexedRingBufferAdd(IndexedRingBufferInput input) throws InterruptedException, MissingBackpressureException {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
         for (int i = 0; i < input.size; i++) {
             list.add(i);
@@ -40,7 +39,6 @@ public class IndexedRingBufferPerf {
 
     @Benchmark
     public void indexedRingBufferAddRemove(IndexedRingBufferInput input) throws InterruptedException, MissingBackpressureException {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
         for (int i = 0; i < input.size; i++) {
             list.add(i);

--- a/src/test/java/rx/internal/util/IndexedRingBufferTest.java
+++ b/src/test/java/rx/internal/util/IndexedRingBufferTest.java
@@ -37,7 +37,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void add() {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<LSubscription> list = IndexedRingBuffer.getInstance();
         list.add(new LSubscription(1));
         list.add(new LSubscription(2));
@@ -49,7 +48,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void removeEnd() {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<LSubscription> list = IndexedRingBuffer.getInstance();
         list.add(new LSubscription(1));
         int n2 = list.add(new LSubscription(2));
@@ -67,7 +65,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void removeMiddle() {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<LSubscription> list = IndexedRingBuffer.getInstance();
         list.add(new LSubscription(1));
         int n2 = list.add(new LSubscription(2));
@@ -82,7 +79,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void addRemoveAdd() {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
         list.add("one");
         list.add("two");
@@ -119,7 +115,6 @@ public class IndexedRingBufferTest {
     @Test
     public void addThousands() {
         String s = "s";
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
         for (int i = 0; i < 10000; i++) {
             list.add(s);
@@ -145,7 +140,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testForEachWithIndex() {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<String> buffer = IndexedRingBuffer.getInstance();
         buffer.add("zero");
         buffer.add("one");
@@ -212,7 +206,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testForEachAcrossSections() {
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<Integer> buffer = IndexedRingBuffer.getInstance();
         for (int i = 0; i < 10000; i++) {
             buffer.add(i);
@@ -231,7 +224,6 @@ public class IndexedRingBufferTest {
     @Test
     public void longRunningAddRemoveAddDoesntLeakMemory() {
         String s = "s";
-        @SuppressWarnings("unchecked")
         IndexedRingBuffer<String> list = IndexedRingBuffer.getInstance();
         for (int i = 0; i < 20000; i++) {
             int index = list.add(s);
@@ -242,14 +234,13 @@ public class IndexedRingBufferTest {
         list.forEach(newCounterAction(c));
         assertEquals(0, c.get());
         //        System.out.println("Index is: " + list.index.get() + " when it should be no bigger than " + list.SIZE);
-        assertTrue(list.index.get() < list.SIZE);
+        assertTrue(list.index.get() < IndexedRingBuffer.SIZE);
         // it should actually be 1 since we only did add/remove sequentially
         assertEquals(1, list.index.get());
     }
 
     @Test
     public void testConcurrentAdds() throws InterruptedException {
-        @SuppressWarnings("unchecked")
         final IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
 
         Scheduler.Worker w1 = Schedulers.computation().createWorker();
@@ -300,7 +291,6 @@ public class IndexedRingBufferTest {
 
     @Test
     public void testConcurrentAddAndRemoves() throws InterruptedException {
-        @SuppressWarnings("unchecked")
         final IndexedRingBuffer<Integer> list = IndexedRingBuffer.getInstance();
 
         final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<Exception>());


### PR DESCRIPTION
Added type to IndexedRingBuffer.POOL (to get rid of raw types warning) and changed signature of ```IndexedRingBuffer.getInstance``` so that it infers type. Means that 13 ```unchecked``` warnings in the code base can be removed.