### PR TITLE
Use simpler naming in Action1, Func1 to assist IDEs

### DIFF
--- a/src/main/java/rx/functions/Action1.java
+++ b/src/main/java/rx/functions/Action1.java
@@ -18,6 +18,6 @@ package rx.functions;
 /**
  * A one-argument action.
  */
-public interface Action1<T1> extends Action {
-    void call(T1 t1);
+public interface Action1<T> extends Action {
+    void call(T t);
 }

--- a/src/main/java/rx/functions/Func1.java
+++ b/src/main/java/rx/functions/Func1.java
@@ -18,6 +18,6 @@ package rx.functions;
 /**
  * Represents a function with one argument.
  */
-public interface Func1<T1, R> extends Function {
-    R call(T1 t1);
+public interface Func1<T, R> extends Function {
+    R call(T t);
 }


### PR DESCRIPTION
Use simpler naming in ```Action1```, ```Func1``` because is used as a default for IDEs when generating implementing methods. For instance,  in Eclipse when auto-generating the implementing methods for an ```Action1``` I get by default:

```java
new Action1<Integer>() {

    @Override
    public void call(Integer t1) {
         //TODO auto-generated
    }
}
```

I can't count the number of times I've removed the trailing 1 from the parameter before continuing and I'd appreciate not having to do it! (unfortunately I can't use Java 8 lambdas in all my code).

I'd also be open to a name other than ```t``` like ```value``` but would be happy just to see the 1 go.