### PR TITLE
More warnings cleanup

### DIFF
--- a/src/main/java/rx/internal/util/SubscriptionIndexedRingBuffer.java
+++ b/src/main/java/rx/internal/util/SubscriptionIndexedRingBuffer.java
@@ -35,12 +35,6 @@ public final class SubscriptionIndexedRingBuffer<T extends Subscription> impleme
     public SubscriptionIndexedRingBuffer() {
     }
 
-    public SubscriptionIndexedRingBuffer(final T... subscriptions) {
-        for (T t : subscriptions) {
-            this.subscriptions.add(t);
-        }
-    }
-
     @Override
     public boolean isUnsubscribed() {
         return unsubscribed == 1;

--- a/src/main/java/rx/internal/util/SubscriptionRandomList.java
+++ b/src/main/java/rx/internal/util/SubscriptionRandomList.java
@@ -16,14 +16,13 @@
 package rx.internal.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import rx.Subscription;
-import rx.exceptions.*;
+import rx.exceptions.Exceptions;
 import rx.functions.Action1;
 
 /**
@@ -37,10 +36,6 @@ public final class SubscriptionRandomList<T extends Subscription> implements Sub
     private boolean unsubscribed = false;
 
     public SubscriptionRandomList() {
-    }
-
-    public SubscriptionRandomList(final T... subscriptions) {
-        this.subscriptions = new HashSet<T>(Arrays.asList(subscriptions));
     }
 
     @Override

--- a/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -19,7 +19,6 @@ import rx.Observable;
 import rx.Subscriber;
 import rx.annotations.Experimental;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
 
 /**
  * Abstract class for defining error handling logic in addition to the normal


### PR DESCRIPTION
* removed unused constructors that were the subject of varargs warnings
* removed unused import

I think that cleans up all java source warnings (not including javadoc issues).