### PR TITLE
Use explicit versioning for gradle-rxjava-project-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories { jcenter() }
-  dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.+' }
+  dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.2.3' }
 }
 
 description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'


### PR DESCRIPTION
When a release is created the tagged version should build deterministically at any time. The wildcard dependency on ```gradle-rxjava-project-plugin``` in ```build.gradle``` means this will not be the case. This PR sets the version at 2.2.3 (the latest on Maven Central). 