### PR TITLE
VarArg parameters for the assertReceivedOnNext(T... items)

### DIFF
--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -16,6 +16,7 @@
 package rx.observers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -111,6 +112,18 @@ public class TestObserver<T> implements Observer<T> {
      * @throws AssertionError
      *          if the sequence of items observed does not exactly match {@code items}
      */
+    public void assertReceivedOnNext(T... items) {
+        assertReceivedOnNext(Arrays.asList(items));
+    }
+
+    /**
+     * Assert that a particular sequence of items was received in order.
+     *
+     * @param items
+     *          the sequence of items expected to have been observed
+     * @throws AssertionError
+     *          if the sequence of items observed does not exactly match {@code items}
+     */
     public void assertReceivedOnNext(List<T> items) {
         if (onNextEvents.size() != items.size()) {
             throw new AssertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + onNextEvents.size());
@@ -127,7 +140,6 @@ public class TestObserver<T> implements Observer<T> {
 
             }
         }
-
     }
 
     /**

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -157,6 +157,18 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * @throws AssertionError
      *          if the sequence of items observed does not exactly match {@code items}
      */
+    public void assertReceivedOnNext(T... items) {
+        testObserver.assertReceivedOnNext(items);
+    }
+
+    /**
+     * Assert that a particular sequence of items was received by this {@link Subscriber} in order.
+     *
+     * @param items
+     *          the sequence of items expected to have been observed
+     * @throws AssertionError
+     *          if the sequence of items observed does not exactly match {@code items}
+     */
     public void assertReceivedOnNext(List<T> items) {
         testObserver.assertReceivedOnNext(items);
     }

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1024,21 +1024,21 @@ public class ObservableTests {
     public void testMergeWith() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Observable.just(1).mergeWith(Observable.just(2)).subscribe(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2));
+        ts.assertReceivedOnNext(1, 2);
     }
     
     @Test
     public void testConcatWith() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Observable.just(1).concatWith(Observable.just(2)).subscribe(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2));
+        ts.assertReceivedOnNext(1, 2);
     }
     
     @Test
     public void testAmbWith() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Observable.just(1).ambWith(Observable.just(2)).subscribe(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
     }
 
     @Test(expected = OnErrorNotImplementedException.class)
@@ -1097,7 +1097,7 @@ public class ObservableTests {
         }).subscribe(ts);
         ts.assertTerminalEvent();
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList("1", "2", "3"));
+        ts.assertReceivedOnNext("1", "2", "3");
     }
     
     @Test

--- a/src/test/java/rx/internal/operators/OnBackpressureBlockTest.java
+++ b/src/test/java/rx/internal/operators/OnBackpressureBlockTest.java
@@ -51,7 +51,7 @@ public class OnBackpressureBlockTest {
         TestObserver<Integer> o = new TestObserver<Integer>();
         source.subscribe(o);
         
-        o.assertReceivedOnNext(Arrays.asList(1));
+        o.assertReceivedOnNext(1);
         o.assertTerminalEvent();
         assertTrue(o.getOnErrorEvents().isEmpty());
     }
@@ -71,13 +71,13 @@ public class OnBackpressureBlockTest {
 
         Thread.sleep(WAIT);
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         
         o.requestMore(10);
         
         Thread.sleep(WAIT);
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 
         o.assertTerminalEvent();
         assertTrue(o.getOnErrorEvents().isEmpty());
@@ -132,7 +132,7 @@ public class OnBackpressureBlockTest {
 
         Thread.sleep(WAIT);
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5);
         o.assertNoErrors();
         assertTrue(o.getOnCompletedEvents().isEmpty());
     }
@@ -155,7 +155,7 @@ public class OnBackpressureBlockTest {
 
         Thread.sleep(WAIT);
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7);
         o.assertNoErrors();
         assertTrue(o.getOnCompletedEvents().isEmpty());
 
@@ -163,7 +163,7 @@ public class OnBackpressureBlockTest {
         
         Thread.sleep(WAIT);
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         o.assertTerminalEvent();
         assertEquals(1, o.getOnErrorEvents().size());
         assertTrue(o.getOnErrorEvents().get(0) instanceof TestException);
@@ -172,7 +172,7 @@ public class OnBackpressureBlockTest {
         
         Thread.sleep(WAIT);
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         o.assertTerminalEvent();
         assertEquals(1, o.getOnErrorEvents().size());
         assertTrue(o.getOnErrorEvents().get(0) instanceof TestException);
@@ -196,7 +196,7 @@ public class OnBackpressureBlockTest {
 
         Thread.sleep(WAIT);
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7);
         o.assertNoErrors();
         assertTrue(o.getOnCompletedEvents().isEmpty());
 
@@ -204,7 +204,7 @@ public class OnBackpressureBlockTest {
         
         Thread.sleep(WAIT);
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertEquals(1, o.getOnErrorEvents().size());
         assertTrue(o.getOnErrorEvents().get(0) instanceof TestException);
         assertTrue(o.getOnCompletedEvents().isEmpty());
@@ -228,7 +228,7 @@ public class OnBackpressureBlockTest {
 
         o.awaitTerminalEvent();
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7);
         o.assertNoErrors();
         o.assertTerminalEvent();
     }
@@ -244,7 +244,7 @@ public class OnBackpressureBlockTest {
 
         o.awaitTerminalEvent();
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7);
         o.assertNoErrors();
         o.assertTerminalEvent();
     }
@@ -260,7 +260,7 @@ public class OnBackpressureBlockTest {
 
         o.awaitTerminalEvent();
         
-        o.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+        o.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7);
         o.assertNoErrors();
         o.assertTerminalEvent();
     }
@@ -314,7 +314,7 @@ public class OnBackpressureBlockTest {
         
         o.assertNoErrors();
         o.assertTerminalEvent();
-        o.assertReceivedOnNext(Arrays.asList(1));
+        o.assertReceivedOnNext(1);
     }
     @Test(timeout = 10000)
     public void testOnCompletedDoesntWaitIfNoEvents3() {
@@ -342,6 +342,6 @@ public class OnBackpressureBlockTest {
         
         o.assertNoErrors();
         o.assertTerminalEvent();
-        o.assertReceivedOnNext(Arrays.asList(1, 2));
+        o.assertReceivedOnNext(1, 2);
     }
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeCacheTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCacheTest.java
@@ -127,7 +127,7 @@ public class OnSubscribeCacheTest {
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
         System.out.println(ts.getOnNextEvents());
-        ts.assertReceivedOnNext(Arrays.asList(expected));
+        ts.assertReceivedOnNext(expected);
     }
 
     @Test(timeout = 10000)

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -127,11 +127,11 @@ public class OnSubscribeFromIterableTest {
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
         ts.requestMore(1);
         o.call(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         ts.requestMore(2);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3));
+        ts.assertReceivedOnNext(1, 2, 3);
         ts.requestMore(3);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 6);
         ts.requestMore(list.size());
         ts.assertTerminalEvent();
     }
@@ -143,7 +143,7 @@ public class OnSubscribeFromIterableTest {
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
         ts.requestMore(Long.MAX_VALUE); // infinite
         o.call(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5);
         ts.assertTerminalEvent();
     }
 
@@ -152,15 +152,15 @@ public class OnSubscribeFromIterableTest {
         OnSubscribeFromIterable<Integer> o = new OnSubscribeFromIterable<Integer>(Arrays.asList(1, 2, 3));
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         o.call(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3));
+        ts.assertReceivedOnNext(1, 2, 3);
 
         ts = new TestSubscriber<Integer>();
         o.call(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3));
+        ts.assertReceivedOnNext(1, 2, 3);
 
         ts = new TestSubscriber<Integer>();
         o.call(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3));
+        ts.assertReceivedOnNext(1, 2, 3);
     }
     
     @Test

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -108,11 +108,11 @@ public class OnSubscribeRangeTest {
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
         ts.requestMore(1);
         o.call(ts);
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         ts.requestMore(2);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3));
+        ts.assertReceivedOnNext(1, 2, 3);
         ts.requestMore(3);
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 6);
         ts.requestMore(RxRingBuffer.SIZE);
         ts.assertTerminalEvent();
     }

--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -519,11 +519,11 @@ public class OnSubscribeRefCountTest {
 
         ts1.assertTerminalEvent();
         ts1.assertNoErrors();
-        ts1.assertReceivedOnNext(Arrays.asList(30));
+        ts1.assertReceivedOnNext(30);
 
         ts2.assertTerminalEvent();
         ts2.assertNoErrors();
-        ts2.assertReceivedOnNext(Arrays.asList(30));
+        ts2.assertReceivedOnNext(30);
     }
 
     @Test(timeout = 10000)

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -715,7 +715,7 @@ public class OperatorConcatTest {
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertTerminalEvent();
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList("hello", "hello"));
+        ts.assertReceivedOnNext("hello", "hello");
     }
 
 }

--- a/src/test/java/rx/internal/operators/OperatorDebounceTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDebounceTest.java
@@ -301,7 +301,7 @@ public class OperatorDebounceTest {
 
         scheduler.advanceTimeBy(30, TimeUnit.MILLISECONDS);
 
-        subscriber.assertReceivedOnNext(Arrays.asList(2));
+        subscriber.assertReceivedOnNext(2);
         subscriber.assertTerminalEvent();
         subscriber.assertNoErrors();
     }

--- a/src/test/java/rx/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDelayTest.java
@@ -663,7 +663,7 @@ public class OperatorDelayTest {
         delayed.subscribe(observer);
         // all will be delivered after 500ms since range does not delay between them
         scheduler.advanceTimeBy(500L, TimeUnit.MILLISECONDS);
-        observer.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
+        observer.assertReceivedOnNext(1, 2, 3, 4, 5);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
@@ -489,7 +489,7 @@ public class OperatorMergeDelayErrorTest {
                 ).subscribe(ts);
         ts.awaitTerminalEvent();
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2));
+        ts.assertReceivedOnNext(1, 2);
         assertEquals(1, ts.getOnErrorEvents().size());
 
     }

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -418,7 +418,7 @@ public class OperatorMergeTest {
         scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
         scheduler2.advanceTimeBy(2, TimeUnit.SECONDS);
 
-        ts.assertReceivedOnNext(Arrays.asList(0L, 1L, 2L, 0L, 1L));
+        ts.assertReceivedOnNext(0L, 1L, 2L, 0L, 1L);
         // not unsubscribed yet
         assertFalse(os1.get());
         assertFalse(os2.get());
@@ -426,14 +426,14 @@ public class OperatorMergeTest {
         // advance to the end at which point it should complete
         scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
 
-        ts.assertReceivedOnNext(Arrays.asList(0L, 1L, 2L, 0L, 1L, 3L, 4L));
+        ts.assertReceivedOnNext(0L, 1L, 2L, 0L, 1L, 3L, 4L);
         assertTrue(os1.get());
         assertFalse(os2.get());
 
         // both should be completed now
         scheduler2.advanceTimeBy(3, TimeUnit.SECONDS);
 
-        ts.assertReceivedOnNext(Arrays.asList(0L, 1L, 2L, 0L, 1L, 3L, 4L, 2L, 3L, 4L));
+        ts.assertReceivedOnNext(0L, 1L, 2L, 0L, 1L, 3L, 4L, 2L, 3L, 4L);
         assertTrue(os1.get());
         assertTrue(os2.get());
 
@@ -460,7 +460,7 @@ public class OperatorMergeTest {
             scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
             scheduler2.advanceTimeBy(2, TimeUnit.SECONDS);
 
-            ts.assertReceivedOnNext(Arrays.asList(0L, 1L, 2L, 0L, 1L));
+            ts.assertReceivedOnNext(0L, 1L, 2L, 0L, 1L);
             // not unsubscribed yet
             assertFalse(os1.get());
             assertFalse(os2.get());
@@ -471,7 +471,7 @@ public class OperatorMergeTest {
             assertTrue(os1.get());
             assertTrue(os2.get());
 
-            ts.assertReceivedOnNext(Arrays.asList(0L, 1L, 2L, 0L, 1L));
+            ts.assertReceivedOnNext(0L, 1L, 2L, 0L, 1L);
             ts.assertUnsubscribed();
         }
     }
@@ -811,7 +811,7 @@ public class OperatorMergeTest {
         Observable.merge(Observable.just(null, "one"), Observable.just("two", null)).subscribe(ts);
         ts.assertTerminalEvent();
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(null, "one", "two", null));
+        ts.assertReceivedOnNext(null, "one", "two", null);
     }
 
     @Test
@@ -830,7 +830,7 @@ public class OperatorMergeTest {
         });
         Observable.merge(Observable.just(null, "one"), bad).subscribe(ts);
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(null, "one", "two"));
+        ts.assertReceivedOnNext(null, "one", "two");
     }
 
     @Test
@@ -838,7 +838,7 @@ public class OperatorMergeTest {
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Observable.merge(Observable.just("one"), null).subscribe(ts);
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList("one"));
+        ts.assertReceivedOnNext("one");
     }
 
     @Test
@@ -1028,7 +1028,7 @@ public class OperatorMergeTest {
         subscriber.requestMore(0);
         source.subscribe(subscriber);
         subscriber.requestMore(3); // 1, 2, <complete> - with requestMore(2) we get the 1 and 2 but not the <complete>
-        subscriber.assertReceivedOnNext(asList(1, 2));
+        subscriber.assertReceivedOnNext(1, 2);
         subscriber.assertTerminalEvent();
     }
 
@@ -1039,7 +1039,7 @@ public class OperatorMergeTest {
         subscriber.requestMore(0);
         source.subscribe(subscriber);
         subscriber.requestMore(2); // 1, <complete> - should work as per .._NormalPath above
-        subscriber.assertReceivedOnNext(asList(1));
+        subscriber.assertReceivedOnNext(1);
         subscriber.assertTerminalEvent();
     }
 
@@ -1054,7 +1054,7 @@ public class OperatorMergeTest {
         subscriber.assertReceivedOnNext(Collections.<Long>emptyList());
         assertEquals(Collections.<Notification<Long>>emptyList(), subscriber.getOnCompletedEvents());
         subscriber.requestMore(1);
-        subscriber.assertReceivedOnNext(asList(1L));
+        subscriber.assertReceivedOnNext(1L);
         assertEquals(Collections.<Notification<Long>>emptyList(), subscriber.getOnCompletedEvents());
         subscriber.requestMore(1);
         subscriber.assertTerminalEvent();
@@ -1068,7 +1068,7 @@ public class OperatorMergeTest {
         subscriber.requestMore(0);
         source.subscribe(subscriber);
         subscriber.requestMore(3); // 1, 2, <error>
-        subscriber.assertReceivedOnNext(asList(1, 2));
+        subscriber.assertReceivedOnNext(1, 2);
         subscriber.assertTerminalEvent();
         assertEquals(asList(exception), subscriber.getOnErrorEvents());
     }
@@ -1081,7 +1081,7 @@ public class OperatorMergeTest {
         subscriber.requestMore(0);
         source.subscribe(subscriber);
         subscriber.requestMore(2); // 1, <error>
-        subscriber.assertReceivedOnNext(asList(1));
+        subscriber.assertReceivedOnNext(1);
         subscriber.assertTerminalEvent();
         assertEquals(asList(exception), subscriber.getOnErrorEvents());
     }
@@ -1092,9 +1092,9 @@ public class OperatorMergeTest {
         TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
         subscriber.requestMore(1);
         source.subscribe(subscriber);
-        subscriber.assertReceivedOnNext(asList(1));
+        subscriber.assertReceivedOnNext(1);
         subscriber.requestMore(1);
-        subscriber.assertReceivedOnNext(asList(1, 2));
+        subscriber.assertReceivedOnNext(1, 2);
     }
 
     @Test
@@ -1104,10 +1104,10 @@ public class OperatorMergeTest {
         TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
         subscriber.requestMore(1);
         source.subscribe(subscriber);
-        subscriber.assertReceivedOnNext(asList(1));
+        subscriber.assertReceivedOnNext(1);
         assertEquals(Collections.<Throwable>emptyList(), subscriber.getOnErrorEvents());
         subscriber.requestMore(1);
-        subscriber.assertReceivedOnNext(asList(1, 2));
+        subscriber.assertReceivedOnNext(1, 2);
         assertEquals(asList(exception), subscriber.getOnErrorEvents());
     }
 
@@ -1118,10 +1118,10 @@ public class OperatorMergeTest {
         TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
         subscriber.requestMore(3);
         source.subscribe(subscriber);
-        subscriber.assertReceivedOnNext(asList(1, 2, 3));
+        subscriber.assertReceivedOnNext(1, 2, 3);
         assertEquals(Collections.<Throwable>emptyList(), subscriber.getOnErrorEvents());
         subscriber.requestMore(2);
-        subscriber.assertReceivedOnNext(asList(1, 2, 3, 4));
+        subscriber.assertReceivedOnNext(1, 2, 3, 4);
         assertEquals(asList(exception), subscriber.getOnErrorEvents());
     }
     

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -455,7 +455,7 @@ public class OperatorObserveOnTest {
                 .subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         System.err.println(testSubscriber.getOnNextEvents());
-        testSubscriber.assertReceivedOnNext(Arrays.asList(0, 1, 2));
+        testSubscriber.assertReceivedOnNext(0, 1, 2);
         // it should be between the take num and requested batch size across the async boundary
         System.out.println("Generated: " + generated.get());
         assertTrue(generated.get() >= 3 && generated.get() <= RxRingBuffer.SIZE);
@@ -538,7 +538,7 @@ public class OperatorObserveOnTest {
                 .subscribe(testSubscriber);
 
         testSubscriber.awaitTerminalEvent();
-        testSubscriber.assertReceivedOnNext(Arrays.asList(0, 1, 2, 3, 4, 5, 6));
+        testSubscriber.assertReceivedOnNext(0, 1, 2, 3, 4, 5, 6);
         assertEquals(7, generated.get());
     }
 

--- a/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
@@ -178,7 +178,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
 
         ts.assertTerminalEvent();
         System.out.println(ts.getOnNextEvents());
-        ts.assertReceivedOnNext(Arrays.asList("success"));
+        ts.assertReceivedOnNext("success");
     }
 
     /**
@@ -227,7 +227,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
 
         ts.assertTerminalEvent();
         System.out.println(ts.getOnNextEvents());
-        ts.assertReceivedOnNext(Arrays.asList("success"));
+        ts.assertReceivedOnNext("success");
     }
     
     @Test

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -159,7 +159,7 @@ public class OperatorPublishTest {
         }).subscribe(ts);
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(0, 1, 2, 3));
+        ts.assertReceivedOnNext(0, 1, 2, 3);
         assertEquals(5, emitted.get());
         System.out.println(ts.getOnNextEvents());
     }
@@ -238,8 +238,8 @@ public class OperatorPublishTest {
         assertTrue(child1Unsubscribed.get());
         assertTrue(child2Unsubscribed.get());
         
-        ts1.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
-        ts2.assertReceivedOnNext(Arrays.asList(4, 5, 6, 7, 8));
+        ts1.assertReceivedOnNext(1, 2, 3, 4, 5);
+        ts2.assertReceivedOnNext(4, 5, 6, 7, 8);
         
         assertEquals(8, sourceEmission.get());
     }
@@ -255,7 +255,7 @@ public class OperatorPublishTest {
         co.subscribe(subscriber);
         // Emit 1 and 2
         scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
-        subscriber.assertReceivedOnNext(Arrays.asList(1L, 2L));
+        subscriber.assertReceivedOnNext(1L, 2L);
         subscriber.assertNoErrors();
         subscriber.assertTerminalEvent();
     }

--- a/src/test/java/rx/internal/operators/OperatorRepeatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRepeatTest.java
@@ -173,7 +173,7 @@ public class OperatorRepeatTest {
         
         ts.assertNoErrors();
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3));
+        ts.assertReceivedOnNext(1, 2, 3);
     }
     /** Issue #2844: wrong target of request. */
     @Test(timeout = 3000)

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -308,7 +308,7 @@ public class OperatorScanTest {
         }).take(1);
         TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
         o.subscribe(subscriber);
-        subscriber.assertReceivedOnNext(Arrays.asList(0));
+        subscriber.assertReceivedOnNext(0);
         subscriber.assertTerminalEvent();
         subscriber.assertNoErrors();
     }

--- a/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
@@ -185,7 +185,7 @@ public class OperatorSubscribeOnTest {
 
         ts.awaitTerminalEventAndUnsubscribeOnTimeout(1000, TimeUnit.MILLISECONDS);
         Thread.sleep(200); // give time for the loop to continue
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertEquals(10, count.get());
     }
 

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -513,7 +513,7 @@ public class OperatorSwitchTest {
             }
         });
         scheduler.advanceTimeBy(10, TimeUnit.MILLISECONDS);
-        testSubscriber.assertReceivedOnNext(Arrays.asList("a1", "b1", "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10"));
+        testSubscriber.assertReceivedOnNext("a1", "b1", "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10");
         testSubscriber.assertNoErrors();
         testSubscriber.assertTerminalEvent();
     }

--- a/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
@@ -121,7 +121,7 @@ public class OperatorTakeLastTest {
         Observable.range(1, 100000).takeLast(1).observeOn(Schedulers.newThread()).map(newSlowProcessor()).subscribe(ts);
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(100000));
+        ts.assertReceivedOnNext(100000);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -129,7 +129,7 @@ public class OperatorTakeUntilPredicateTest {
         Observable.range(1, 1000).takeUntil(UtilityFunctions.alwaysFalse()).subscribe(ts);
         
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5);
         Assert.assertEquals(0, ts.getOnCompletedEvents().size());
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilTest.java
@@ -207,10 +207,10 @@ public class OperatorTakeUntilTest {
 
         source.onNext(1);
         
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         until.onNext(1);
         
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         ts.assertNoErrors();
         ts.assertTerminalEvent();
         
@@ -233,7 +233,7 @@ public class OperatorTakeUntilTest {
         source.onNext(1);
         source.onCompleted();
         
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         ts.assertNoErrors();
         ts.assertTerminalEvent();
         
@@ -255,7 +255,7 @@ public class OperatorTakeUntilTest {
 
         source.onNext(1);
         
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         ts.assertNoErrors();
         ts.assertTerminalEvent();
         
@@ -279,7 +279,7 @@ public class OperatorTakeUntilTest {
 
         ts.requestMore(1);
         
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         ts.assertNoErrors();
         assertTrue("TestSubscriber completed", ts.getOnCompletedEvents().isEmpty());
         

--- a/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
@@ -236,12 +236,12 @@ public class OperatorTakeWhileTest {
         source.subscribe(ts);
         
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5);
         
         ts.requestMore(5);
 
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
     
     @Test
@@ -257,7 +257,7 @@ public class OperatorTakeWhileTest {
         source.unsafeSubscribe(ts);
         
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
         
         Assert.assertFalse("Unsubscribed!", ts.isUnsubscribed());
     }

--- a/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
@@ -71,7 +71,7 @@ public class OperatorUnsubscribeOnTest {
             System.out.println("subscribeThread.get(): " + subscribeThread.get());
             assertTrue(unsubscribeThread == UI_EVENT_LOOP.getThread());
 
-            observer.assertReceivedOnNext(Arrays.asList(1, 2));
+            observer.assertReceivedOnNext(1, 2);
             observer.assertTerminalEvent();
         } finally {
             UI_EVENT_LOOP.shutdown();
@@ -112,7 +112,7 @@ public class OperatorUnsubscribeOnTest {
             System.out.println("subscribeThread.get(): " + subscribeThread.get());
             assertTrue(unsubscribeThread == UI_EVENT_LOOP.getThread());
 
-            observer.assertReceivedOnNext(Arrays.asList(1, 2));
+            observer.assertReceivedOnNext(1, 2);
             observer.assertTerminalEvent();
         } finally {
             UI_EVENT_LOOP.shutdown();

--- a/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
@@ -119,7 +119,7 @@ public class OperatorWindowWithSizeTest {
         }).window(5).take(2)).subscribe(ts);
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         //        System.out.println(ts.getOnNextEvents());
         assertEquals(10, count.get());
     }
@@ -143,7 +143,7 @@ public class OperatorWindowWithSizeTest {
                 .subscribe(ts);
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         // make sure we don't emit all values ... the unsubscribe should propagate
         assertTrue(count.get() < 100000);
     }
@@ -163,7 +163,7 @@ public class OperatorWindowWithSizeTest {
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertTerminalEvent();
         //        System.out.println(ts.getOnNextEvents());
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 5, 6, 7, 8, 9));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
         assertEquals(9, count.get());
     }
 
@@ -186,7 +186,7 @@ public class OperatorWindowWithSizeTest {
                 .subscribe(ts);
         ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 5, 6, 7, 8, 9));
+        ts.assertReceivedOnNext(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
         // make sure we don't emit all values ... the unsubscribe should propagate
         assertTrue(count.get() < 100000);
     }

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -1266,7 +1266,7 @@ public class OperatorZipTest {
         
         ts.assertNoErrors();
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(11, 22));
+        ts.assertReceivedOnNext(11, 22);
     }
     @Test(timeout = 10000)
     public void testZipRace() {
@@ -1311,6 +1311,6 @@ public class OperatorZipTest {
         
         ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
         ts.assertNoErrors();
-        ts.assertReceivedOnNext(Arrays.asList(11));
+        ts.assertReceivedOnNext(11);
     }
 }

--- a/src/test/java/rx/observables/AbstractOnSubscribeTest.java
+++ b/src/test/java/rx/observables/AbstractOnSubscribeTest.java
@@ -56,7 +56,7 @@ public class AbstractOnSubscribeTest {
         
         ts.assertNoErrors();
         ts.assertTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList(1));
+        ts.assertReceivedOnNext(1);
     }
     @Test
     public void testJustMisbehaving() {

--- a/src/test/java/rx/observers/TestObserverTest.java
+++ b/src/test/java/rx/observers/TestObserverTest.java
@@ -42,7 +42,7 @@ public class TestObserverTest {
         TestObserver<Integer> o = new TestObserver<Integer>();
         oi.subscribe(o);
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2));
+        o.assertReceivedOnNext(1, 2);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }
@@ -56,7 +56,7 @@ public class TestObserverTest {
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
 
-        o.assertReceivedOnNext(Arrays.asList(1));
+        o.assertReceivedOnNext(1);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }
@@ -70,7 +70,7 @@ public class TestObserverTest {
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
 
-        o.assertReceivedOnNext(Arrays.asList(1, 3));
+        o.assertReceivedOnNext(1, 3);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }
@@ -87,7 +87,7 @@ public class TestObserverTest {
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No terminal events received.");
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2));
+        o.assertReceivedOnNext(1, 2);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -42,7 +42,7 @@ public class TestSubscriberTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>();
         oi.subscribe(o);
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2));
+        o.assertReceivedOnNext(1, 2);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }
@@ -56,7 +56,7 @@ public class TestSubscriberTest {
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
 
-        o.assertReceivedOnNext(Arrays.asList(1));
+        o.assertReceivedOnNext(1);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }
@@ -71,7 +71,7 @@ public class TestSubscriberTest {
         thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
 
 
-        o.assertReceivedOnNext(Arrays.asList(1, 3));
+        o.assertReceivedOnNext(1, 3);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }
@@ -88,7 +88,7 @@ public class TestSubscriberTest {
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No terminal events received.");
 
-        o.assertReceivedOnNext(Arrays.asList(1, 2));
+        o.assertReceivedOnNext(1, 2);
         assertEquals(2, o.getOnNextEvents().size());
         o.assertTerminalEvent();
     }

--- a/src/test/java/rx/subjects/SerializedSubjectTest.java
+++ b/src/test/java/rx/subjects/SerializedSubjectTest.java
@@ -31,6 +31,6 @@ public class SerializedSubjectTest {
         subject.onNext("hello");
         subject.onCompleted();
         ts.awaitTerminalEvent();
-        ts.assertReceivedOnNext(Arrays.asList("hello"));
+        ts.assertReceivedOnNext("hello");
     }
 }


### PR DESCRIPTION
Syntactic simplification for the `assertReceivedOnNext(List<T> items)`.
Instead of 
```
testSubscriber.assertReceivedOnNext(Arrays.asList(1, 2, 3))
```
(almost all existing calls use Arrays.asList())
 proposed vararg method 
```
testSubscriber.assertReceivedOnNext(1, 2, 3)
```
 looks simplier and nicer.