### PR TITLE
Proposal: standardized Subject state-peeking methods.

### DIFF
--- a/src/main/java/rx/subjects/AsyncSubject.java
+++ b/src/main/java/rx/subjects/AsyncSubject.java
@@ -15,6 +15,7 @@
  */
 package rx.subjects;
 
+import java.lang.reflect.Array;
 import java.util.*;
 
 import rx.Observer;
@@ -141,6 +142,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * @return true if and only if the subject has some value but not an error
      */
     @Experimental
+    @Override
     public boolean hasValue() {
         Object v = lastValue;
         Object o = state.get();
@@ -151,6 +153,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * @return true if the subject has received a throwable through {@code onError}.
      */
     @Experimental
+    @Override
     public boolean hasThrowable() {
         Object o = state.get();
         return nl.isError(o);
@@ -160,6 +163,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * @return true if the subject completed normally via {@code onCompleted()}
      */
     @Experimental
+    @Override
     public boolean hasCompleted() {
         Object o = state.get();
         return o != null && !nl.isError(o);
@@ -174,6 +178,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * has terminated with an exception or has an actual {@code null} as a value.
      */
     @Experimental
+    @Override
     public T getValue() {
         Object v = lastValue;
         Object o = state.get();
@@ -188,11 +193,33 @@ public final class AsyncSubject<T> extends Subject<T, T> {
      * subject hasn't terminated yet or it terminated normally.
      */
     @Experimental
+    @Override
     public Throwable getThrowable() {
         Object o = state.get();
         if (nl.isError(o)) {
             return nl.getError(o);
         }
         return null;
+    }
+    @Override
+    @Experimental
+    @SuppressWarnings("unchecked")
+    public T[] getValues(T[] a) {
+        Object v = lastValue;
+        Object o = state.get();
+        if (!nl.isError(o) && nl.isNext(v)) {
+            T val = nl.getValue(v);
+            if (a.length == 0) {
+                a = (T[])Array.newInstance(a.getClass().getComponentType(), 1);
+            }
+            a[0] = val;
+            if (a.length > 1) {
+                a[1] = null;
+            }
+        } else
+        if (a.length > 0) {
+            a[0] = null;
+        }
+        return a;
     }
 }

--- a/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/src/main/java/rx/subjects/BehaviorSubject.java
@@ -16,6 +16,7 @@
 package rx.subjects;
 
 
+import java.lang.reflect.Array;
 import java.util.*;
 
 import rx.Observer;
@@ -177,6 +178,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * @return true if and only if the subject has some value and hasn't terminated yet.
      */
     @Experimental
+    @Override
     public boolean hasValue() {
         Object o = state.get();
         return nl.isNext(o);
@@ -186,6 +188,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * @return true if the subject has received a throwable through {@code onError}.
      */
     @Experimental
+    @Override
     public boolean hasThrowable() {
         Object o = state.get();
         return nl.isError(o);
@@ -195,6 +198,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * @return true if the subject completed normally via {@code onCompleted()}
      */
     @Experimental
+    @Override
     public boolean hasCompleted() {
         Object o = state.get();
         return nl.isCompleted(o);
@@ -209,6 +213,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * has terminated or has an actual {@code null} as a valid value.
      */
     @Experimental
+    @Override
     public T getValue() {
         Object o = state.get();
         if (nl.isNext(o)) {
@@ -222,11 +227,31 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      * subject hasn't terminated yet or it terminated normally.
      */
     @Experimental
+    @Override
     public Throwable getThrowable() {
         Object o = state.get();
         if (nl.isError(o)) {
             return nl.getError(o);
         }
         return null;
+    }
+    @Override
+    @Experimental
+    @SuppressWarnings("unchecked")
+    public T[] getValues(T[] a) {
+        Object o = state.get();
+        if (nl.isNext(o)) {
+            if (a.length == 0) {
+                a = (T[])Array.newInstance(a.getClass().getComponentType(), 1);
+            }
+            a[0] = nl.getValue(o);
+            if (a.length > 1) {
+                a[1] = null;
+            }
+        } else
+        if (a.length > 0) {
+            a[0] = null;
+        }
+        return a;
     }
 }

--- a/src/main/java/rx/subjects/PublishSubject.java
+++ b/src/main/java/rx/subjects/PublishSubject.java
@@ -125,6 +125,7 @@ public final class PublishSubject<T> extends Subject<T, T> {
      * @return true if the subject has received a throwable through {@code onError}.
      */
     @Experimental
+    @Override
     public boolean hasThrowable() {
         Object o = state.get();
         return nl.isError(o);
@@ -134,6 +135,7 @@ public final class PublishSubject<T> extends Subject<T, T> {
      * @return true if the subject completed normally via {@code onCompleted}
      */
     @Experimental
+    @Override
     public boolean hasCompleted() {
         Object o = state.get();
         return o != null && !nl.isError(o);
@@ -144,11 +146,36 @@ public final class PublishSubject<T> extends Subject<T, T> {
      * subject hasn't terminated yet or it terminated normally.
      */
     @Experimental
+    @Override
     public Throwable getThrowable() {
         Object o = state.get();
         if (nl.isError(o)) {
             return nl.getError(o);
         }
         return null;
+    }
+    
+    @Override
+    @Experimental
+    public boolean hasValue() {
+        return false;
+    }
+    @Override
+    @Experimental
+    public T getValue() {
+        return null;
+    }
+    @Override
+    @Experimental
+    public Object[] getValues() {
+        return new Object[0];
+    }
+    @Override
+    @Experimental
+    public T[] getValues(T[] a) {
+        if (a.length > 0) {
+            a[0] = null;
+        }
+        return a;
     }
 }

--- a/src/main/java/rx/subjects/SerializedSubject.java
+++ b/src/main/java/rx/subjects/SerializedSubject.java
@@ -16,6 +16,7 @@
 package rx.subjects;
 
 import rx.Subscriber;
+import rx.annotations.Experimental;
 import rx.observers.SerializedObserver;
 
 /**
@@ -67,5 +68,40 @@ public class SerializedSubject<T, R> extends Subject<T, R> {
     @Override
     public boolean hasObservers() {
         return actual.hasObservers();
+    }
+    @Override
+    @Experimental
+    public boolean hasCompleted() {
+        return actual.hasCompleted();
+    }
+    @Override
+    @Experimental
+    public boolean hasThrowable() {
+        return actual.hasThrowable();
+    }
+    @Override
+    @Experimental
+    public boolean hasValue() {
+        return actual.hasValue();
+    }
+    @Override
+    @Experimental
+    public Throwable getThrowable() {
+        return actual.getThrowable();
+    }
+    @Override
+    @Experimental
+    public T getValue() {
+        return actual.getValue();
+    }
+    @Override
+    @Experimental
+    public Object[] getValues() {
+        return actual.getValues();
+    }
+    @Override
+    @Experimental
+    public T[] getValues(T[] a) {
+        return actual.getValues(a);
     }
 }

--- a/src/main/java/rx/subjects/Subject.java
+++ b/src/main/java/rx/subjects/Subject.java
@@ -18,6 +18,7 @@ package rx.subjects;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
+import rx.annotations.Experimental;
 
 /**
  * Represents an object that is both an Observable and an Observer.
@@ -49,6 +50,94 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      * @return SerializedSubject wrapping the current Subject
      */
     public final SerializedSubject<T, R> toSerialized() {
+        if (getClass() == SerializedSubject.class) {
+            return (SerializedSubject<T, R>)this;
+        }
         return new SerializedSubject<T, R>(this);
+    }
+    /**
+     * Check if the Subject has terminated with an exception.
+     * <p>The operation is threadsafe.
+     * @return true if the subject has received a throwable through {@code onError}.
+     */
+    @Experimental
+    public boolean hasThrowable() {
+        throw new UnsupportedOperationException();
+    }
+    /**
+     * Check if the Subject has terminated normally.
+     * <p>The operation is threadsafe.
+     * @return true if the subject completed normally via {@code onCompleted}
+     */
+    @Experimental
+    public boolean hasCompleted() {
+        throw new UnsupportedOperationException();
+    }
+    /**
+     * Returns the Throwable that terminated the Subject.
+     * <p>The operation is threadsafe.
+     * @return the Throwable that terminated the Subject or {@code null} if the
+     * subject hasn't terminated yet or it terminated normally.
+     */
+    @Experimental
+    public Throwable getThrowable() {
+        throw new UnsupportedOperationException();
+    }
+    /**
+     * Check if the Subject has any value.
+     * <p>Use the {@link #getValue()} method to retrieve such a value.
+     * <p>Note that unless {@link #hasCompleted()} or {@link #hasThrowable()} returns true, the value
+     * retrieved by {@code getValue()} may get outdated.
+     * <p>The operation is threadsafe.
+     * @return true if and only if the subject has some value but not an error
+     */
+    @Experimental
+    public boolean hasValue() {
+        throw new UnsupportedOperationException();
+    }
+    /**
+     * Returns the current or latest value of the Subject if there is such a value and
+     * the subject hasn't terminated with an exception.
+     * <p>The method can return {@code null} for various reasons. Use {@link #hasValue()}, {@link #hasThrowable()}
+     * and {@link #hasCompleted()} to determine if such {@code null} is a valid value, there was an
+     * exception or the Subject terminated without receiving any value. 
+     * <p>The operation is threadsafe.
+     * @return the current value or {@code null} if the Subject doesn't have a value,
+     * has terminated with an exception or has an actual {@code null} as a value.
+     */
+    @Experimental
+    public T getValue() {
+        throw new UnsupportedOperationException();
+    }
+    /** An empty array to trigger getValues() to return a new array. */
+    private static final Object[] EMPTY_ARRAY = new Object[0];
+    /**
+     * Returns a snapshot of the currently buffered non-terminal events.
+     * <p>The operation is threadsafe.
+     * @return a snapshot of the currently buffered non-terminal events.
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public Object[] getValues() {
+        T[] r = getValues((T[])EMPTY_ARRAY);
+        if (r == EMPTY_ARRAY) {
+            return new Object[0]; // don't leak the default empty array.
+        }
+        return r;
+    }
+    /**
+     * Returns a snapshot of the currently buffered non-terminal events into 
+     * the provided {@code a} array or creates a new array if it has not enough capacity.
+     * <p>If the subject's values fit in the specified array with room to spare
+     * (i.e., the array has more elements than the list), the element in
+     * the array immediately following the end of the subject's values is set to
+     * <tt>null</tt>.
+     * <p>The operation is threadsafe.
+     * @param a the array to fill in
+     * @return the array {@code a} if it had enough capacity or a new array containing the available values 
+     */
+    @Experimental
+    public T[] getValues(T[] a) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/test/java/rx/subjects/SerializedSubjectTest.java
+++ b/src/test/java/rx/subjects/SerializedSubjectTest.java
@@ -15,10 +15,13 @@
  */
 package rx.subjects;
 
+import static org.junit.Assert.*;
+
 import java.util.Arrays;
 
 import org.junit.Test;
 
+import rx.exceptions.TestException;
 import rx.observers.TestSubscriber;
 
 public class SerializedSubjectTest {
@@ -32,5 +35,386 @@ public class SerializedSubjectTest {
         subject.onCompleted();
         ts.awaitTerminalEvent();
         ts.assertReceivedOnNext(Arrays.asList("hello"));
+    }
+    
+    @Test
+    public void testAsyncSubjectValueRelay() {
+        AsyncSubject<Integer> async = AsyncSubject.create();
+        async.onNext(1);
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertEquals((Integer)1, serial.getValue());
+        assertTrue(serial.hasValue());
+        assertArrayEquals(new Object[] { 1 }, serial.getValues());
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testAsyncSubjectValueEmpty() {
+        AsyncSubject<Integer> async = AsyncSubject.create();
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testAsyncSubjectValueError() {
+        AsyncSubject<Integer> async = AsyncSubject.create();
+        TestException te = new TestException();
+        async.onError(te);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertTrue(serial.hasThrowable());
+        assertSame(te, serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testPublishSubjectValueRelay() {
+        PublishSubject<Integer> async = PublishSubject.create();
+        async.onNext(1);
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        
+        assertArrayEquals(new Object[0], serial.getValues());
+        assertArrayEquals(new Integer[0], serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    
+    @Test
+    public void testPublishSubjectValueEmpty() {
+        PublishSubject<Integer> async = PublishSubject.create();
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testPublishSubjectValueError() {
+        PublishSubject<Integer> async = PublishSubject.create();
+        TestException te = new TestException();
+        async.onError(te);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertTrue(serial.hasThrowable());
+        assertSame(te, serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+
+    @Test
+    public void testBehaviorSubjectValueRelay() {
+        BehaviorSubject<Integer> async = BehaviorSubject.create();
+        async.onNext(1);
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testBehaviorSubjectValueRelayIncomplete() {
+        BehaviorSubject<Integer> async = BehaviorSubject.create();
+        async.onNext(1);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertEquals((Integer)1, serial.getValue());
+        assertTrue(serial.hasValue());
+        assertArrayEquals(new Object[] { 1 }, serial.getValues());
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testBehaviorSubjectIncompleteEmpty() {
+        BehaviorSubject<Integer> async = BehaviorSubject.create();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testBehaviorSubjectEmpty() {
+        BehaviorSubject<Integer> async = BehaviorSubject.create();
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testBehaviorSubjectError() {
+        BehaviorSubject<Integer> async = BehaviorSubject.create();
+        TestException te = new TestException();
+        async.onError(te);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertTrue(serial.hasThrowable());
+        assertSame(te, serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    
+    @Test
+    public void testReplaySubjectValueRelay() {
+        ReplaySubject<Integer> async = ReplaySubject.create();
+        async.onNext(1);
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertEquals((Integer)1, serial.getValue());
+        assertTrue(serial.hasValue());
+        assertArrayEquals(new Object[] { 1 }, serial.getValues());
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectValueRelayIncomplete() {
+        ReplaySubject<Integer> async = ReplaySubject.create();
+        async.onNext(1);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertEquals((Integer)1, serial.getValue());
+        assertTrue(serial.hasValue());
+        assertArrayEquals(new Object[] { 1 }, serial.getValues());
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectValueRelayBounded() {
+        ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
+        async.onNext(0);
+        async.onNext(1);
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertEquals((Integer)1, serial.getValue());
+        assertTrue(serial.hasValue());
+        assertArrayEquals(new Object[] { 1 }, serial.getValues());
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectValueRelayBoundedIncomplete() {
+        ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
+        async.onNext(0);
+        async.onNext(1);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertEquals((Integer)1, serial.getValue());
+        assertTrue(serial.hasValue());
+        assertArrayEquals(new Object[] { 1 }, serial.getValues());
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectValueRelayBoundedEmptyIncomplete() {
+        ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectValueRelayEmptyIncomplete() {
+        ReplaySubject<Integer> async = ReplaySubject.create();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    
+    @Test
+    public void testReplaySubjectEmpty() {
+        ReplaySubject<Integer> async = ReplaySubject.create();
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectError() {
+        ReplaySubject<Integer> async = ReplaySubject.create();
+        TestException te = new TestException();
+        async.onError(te);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertTrue(serial.hasThrowable());
+        assertSame(te, serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    
+    @Test
+    public void testReplaySubjectBoundedEmpty() {
+        ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
+        async.onCompleted();
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertTrue(serial.hasCompleted());
+        assertFalse(serial.hasThrowable());
+        assertNull(serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    @Test
+    public void testReplaySubjectBoundedError() {
+        ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
+        TestException te = new TestException();
+        async.onError(te);
+        Subject<Integer, Integer> serial = async.toSerialized();
+        
+        assertFalse(serial.hasObservers());
+        assertFalse(serial.hasCompleted());
+        assertTrue(serial.hasThrowable());
+        assertSame(te, serial.getThrowable());
+        assertNull(serial.getValue());
+        assertFalse(serial.hasValue());
+        assertArrayEquals(new Object[] { }, serial.getValues());
+        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+    }
+    
+    @Test
+    public void testDontWrapSerializedSubjectAgain() {
+        PublishSubject<Object> s = PublishSubject.create();
+        Subject<Object, Object> s1 = s.toSerialized();
+        Subject<Object, Object> s2 = s1.toSerialized();
+        assertSame(s1, s2);
     }
 }


### PR DESCRIPTION
This PR modifies the ```Subject``` class to host the union of the state-peeking methods of the various ```Subject``` implementations and fixes the inconsistent behavior of ```ReplaySubject.getValues(T[])```.

The changes enable the ```SerializedSubject``` to relay such state-peeking method calls into the wrapped subject and allows future ```Subject``` wrappers to do the same (#2458).