### PR TITLE
Fix Observable.range race condition

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeRange.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRange.java
@@ -55,12 +55,11 @@ public final class OnSubscribeRange implements OnSubscribe<Integer> {
 
         @Override
         public void request(long n) {
-            if (REQUESTED_UPDATER.get(this) == Long.MAX_VALUE) {
+            if (requested == Long.MAX_VALUE) {
                 // already started with fast-path
                 return;
             }
-            if (n == Long.MAX_VALUE) {
-                REQUESTED_UPDATER.set(this, n);
+            if (n == Long.MAX_VALUE && REQUESTED_UPDATER.compareAndSet(this, 0, Long.MAX_VALUE)) {
                 // fast-path without backpressure
                 for (long i = index; i <= end; i++) {
                     if (o.isUnsubscribed()) {


### PR DESCRIPTION
In `RangeProducer` if the first two requests come concurrently and are both for `Long.MAX_VALUE` then there is a possible race condition where the fast path is started twice thus emitting some or all elements twice.

This PR fixes the race by only allowing the fast path if the current request count is 0 (using ```compareAndSet```).