### PR TITLE
Observable.from(empty) to emit onComplete even when 0 requested

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -44,7 +44,10 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
     @Override
     public void call(final Subscriber<? super T> o) {
         final Iterator<? extends T> it = is.iterator();
-        o.setProducer(new IterableProducer<T>(o, it));
+        if (!it.hasNext() && !o.isUnsubscribed())
+            o.onCompleted();
+        else 
+            o.setProducer(new IterableProducer<T>(o, it));
     }
 
     private static final class IterableProducer<T> implements Producer {

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -74,12 +75,12 @@ public class OnSubscribeFromIterableTest {
 
                     @Override
                     public boolean hasNext() {
-                        return i++ < 3;
+                        return i < 3;
                     }
 
                     @Override
                     public String next() {
-                        return String.valueOf(i);
+                        return String.valueOf(++i);
                     }
 
                     @Override
@@ -193,5 +194,31 @@ public class OnSubscribeFromIterableTest {
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
+    @Test
+    public void testFromEmptyIterableWhenZeroRequestedShouldStillEmitOnCompletedEagerly() {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        Observable.from(Collections.emptyList()).subscribe(new Subscriber<Object>() {
 
+            @Override
+            public void onStart() {
+                request(0);
+            }
+            
+            @Override
+            public void onCompleted() {
+                completed.set(true);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                
+            }
+
+            @Override
+            public void onNext(Object t) {
+                
+            }});
+        assertTrue(completed.get());
+    }
+    
 }


### PR DESCRIPTION
As per discussion in #2884, `Observable.from(iterable)` is preferred to emit `onCompleted` when `iterable` is empty even when nothing has been requested.

This PR adds a check on `iterator.hasNext` before the `Producer` is assigned and emits `onCompleted` immediately if `hasNext` returns false.

Includes unit test that failed on existing code base.

