### PR TITLE
Operators toList and toSortedList now support backpressure

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -8578,7 +8578,7 @@ public class Observable<T> {
      * you do not have the option to unsubscribe.
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>This operator does not support backpressure as by intent it is requesting and buffering everything.</dd>
+     *  <dd>The operator buffers everything from its upstream but it only emits the aggregated list when the downstream requests at least one item.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toList} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -8779,7 +8779,7 @@ public class Observable<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toSortedList.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>This operator does not support backpressure as by intent it is requesting and buffering everything.</dd>
+     *  <dd>The operator buffers everything from its upstream but it only emits the sorted list when the downstream requests at least one item.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toSortedList} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -8792,7 +8792,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     public final Observable<List<T>> toSortedList() {
-        return lift(new OperatorToObservableSortedList<T>());
+        return lift(new OperatorToObservableSortedList<T>(10));
     }
 
     /**
@@ -8802,7 +8802,7 @@ public class Observable<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toSortedList.f.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>This operator does not support backpressure as by intent it is requesting and buffering everything.</dd>
+     *  <dd>The operator buffers everything from its upstream but it only emits the sorted list when the downstream requests at least one item.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toSortedList} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -8815,7 +8815,60 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     public final Observable<List<T>> toSortedList(Func2<? super T, ? super T, Integer> sortFunction) {
-        return lift(new OperatorToObservableSortedList<T>(sortFunction));
+        return lift(new OperatorToObservableSortedList<T>(sortFunction, 10));
+    }
+
+    /**
+     * Returns an Observable that emits a list that contains the items emitted by the source Observable, in a
+     * sorted order. Each item emitted by the Observable must implement {@link Comparable} with respect to all
+     * other items in the sequence.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toSortedList.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>The operator buffers everything from its upstream but it only emits the sorted list when the downstream requests at least one item.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toSortedList} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @throws ClassCastException
+     *             if any item emitted by the Observable does not implement {@link Comparable} with respect to
+     *             all other items emitted by the Observable
+     * @param initialCapacity 
+     *             the initial capacity of the ArrayList used to accumulate items before sorting
+     * @return an Observable that emits a list that contains the items emitted by the source Observable in
+     *         sorted order
+     * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
+     */
+    @Experimental
+    public final Observable<List<T>> toSortedList(int initialCapacity) {
+        return lift(new OperatorToObservableSortedList<T>(initialCapacity));
+    }
+
+    /**
+     * Returns an Observable that emits a list that contains the items emitted by the source Observable, in a
+     * sorted order based on a specified comparison function.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toSortedList.f.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>The operator buffers everything from its upstream but it only emits the sorted list when the downstream requests at least one item.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toSortedList} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param sortFunction
+     *            a function that compares two items emitted by the source Observable and returns an Integer
+     *            that indicates their sort order
+     * @param initialCapacity 
+     *             the initial capacity of the ArrayList used to accumulate items before sorting
+     * @return an Observable that emits a list that contains the items emitted by the source Observable in
+     *         sorted order
+     * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
+     */
+    @Experimental
+    public final Observable<List<T>> toSortedList(Func2<? super T, ? super T, Integer> sortFunction, int initialCapacity) {
+        return lift(new OperatorToObservableSortedList<T>(sortFunction, initialCapacity));
     }
 
     /**

--- a/src/main/java/rx/internal/operators/OperatorToObservableList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableList.java
@@ -52,10 +52,11 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
     private OperatorToObservableList() { }
     @Override
     public Subscriber<? super T> call(final Subscriber<? super List<T>> o) {
-        return new Subscriber<T>(o) {
+        final SingleDelayedProducer<List<T>> producer = new SingleDelayedProducer<List<T>>(o);
+        Subscriber<T> result =  new Subscriber<T>() {
 
-            private boolean completed = false;
-            final List<T> list = new LinkedList<T>();
+            boolean completed = false;
+            List<T> list = new LinkedList<T>();
 
             @Override
             public void onStart() {
@@ -64,27 +65,32 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
 
             @Override
             public void onCompleted() {
-                try {
+                if (!completed) {
                     completed = true;
-                    /*
-                     * Ideally this should just return Collections.unmodifiableList(list) and not copy it, 
-                     * but, it ends up being a breaking change if we make that modification. 
-                     * 
-                     * Here is an example of is being done with these lists that breaks if we make it immutable:
-                     * 
-                     * Caused by: java.lang.UnsupportedOperationException
-                     *     at java.util.Collections$UnmodifiableList$1.set(Collections.java:1244)
-                     *     at java.util.Collections.sort(Collections.java:221)
-                     *     ...
-                     * Caused by: rx.exceptions.OnErrorThrowable$OnNextValue: OnError while emitting onNext value: UnmodifiableList.class
-                     *     at rx.exceptions.OnErrorThrowable.addValueAsLastCause(OnErrorThrowable.java:98)
-                     *     at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:56)
-                     *     ... 419 more
-                     */
-                    o.onNext(new ArrayList<T>(list));
-                    o.onCompleted();
-                } catch (Throwable e) {
-                    onError(e);
+                    List<T> result;
+                    try {
+                        /*
+                         * Ideally this should just return Collections.unmodifiableList(list) and not copy it, 
+                         * but, it ends up being a breaking change if we make that modification. 
+                         * 
+                         * Here is an example of is being done with these lists that breaks if we make it immutable:
+                         * 
+                         * Caused by: java.lang.UnsupportedOperationException
+                         *     at java.util.Collections$UnmodifiableList$1.set(Collections.java:1244)
+                         *     at java.util.Collections.sort(Collections.java:221)
+                         *     ...
+                         * Caused by: rx.exceptions.OnErrorThrowable$OnNextValue: OnError while emitting onNext value: UnmodifiableList.class
+                         *     at rx.exceptions.OnErrorThrowable.addValueAsLastCause(OnErrorThrowable.java:98)
+                         *     at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:56)
+                         *     ... 419 more
+                         */
+                        result = new ArrayList<T>(list);
+                    } catch (Throwable t) {
+                        onError(t);
+                        return;
+                    }
+                    list = null;
+                    producer.set(result);
                 }
             }
 
@@ -101,6 +107,9 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
             }
 
         };
+        o.add(result);
+        o.setProducer(producer);
+        return result;
     }
 
 }

--- a/src/main/java/rx/internal/operators/SingleDelayedProducer.java
+++ b/src/main/java/rx/internal/operators/SingleDelayedProducer.java
@@ -1,0 +1,87 @@
+package rx.internal.operators;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import rx.*;
+
+/**
+ * A producer that holds a single value until it is requested and emits it followed by an onCompleted. 
+ */
+public final class SingleDelayedProducer<T> extends AtomicInteger implements Producer {
+    /** */
+    private static final long serialVersionUID = 4721551710164477552L;
+    /** The actual child. */
+    final Subscriber<? super T> child;
+    /** The value to emit, acquired and released by compareAndSet. */
+    T value;
+    /** State flag: request() called with positive value. */
+    static final int REQUESTED = 1;
+    /** State flag: set() called. */
+    static final int SET = 2;
+    /**
+     * Constructs a SingleDelayedProducer with the given child as output.
+     * @param child the subscriber to emit the value and completion events
+     */
+    public SingleDelayedProducer(Subscriber<? super T> child) {
+        this.child = child;
+    }
+    @Override
+    public void request(long n) {
+        if (n > 0) {
+            for (;;) {
+                int s = get();
+                // if already requested
+                if ((s & REQUESTED) != 0) {
+                    break;
+                }
+                int u = s | REQUESTED;
+                if (compareAndSet(s, u)) {
+                    if ((s & SET) != 0) {
+                        emit();
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    /**
+     * Sets the value to be emitted and emits it if there was a request.
+     * Should be called only once and from a single thread
+     * @param value the value to set and possibly emit
+     */
+    public void set(T value) {
+        for (;;) {
+            int s = get();
+            // if already set
+            if ((s & SET) != 0) {
+                break;
+            }
+            int u = s | SET;
+            this.value = value;
+            if (compareAndSet(s, u)) {
+                if ((s & REQUESTED) != 0) {
+                    emit();
+                }
+                break;
+            }
+        }
+    }
+    /** 
+     * Emits the set value if the child is not unsubscribed and bounces back
+     * exceptions caught from child.onNext.
+     */
+    void emit() {
+        try {
+            T v = value;
+            value = null; // do not hold onto the value
+            if (child.isUnsubscribed()) {
+                return;
+            }
+            child.onNext(v);
+        } catch (Throwable t) {
+            child.onError(t);
+            return;
+        }
+        child.onCompleted();
+    }
+}


### PR DESCRIPTION
Added support for backpressure in ```toList``` and ```toSortedList```: they emit their buffered content only when downstream actually requested it.

Few other notes:
  - Added overload to ```toSortedList``` taking a ```initialCapacity``` argument which should help reduce the number of times the buffer needs to be resized.
  - The Func2 parameter of ```toSortedList``` is now wrapped once per operator instead of once per subscriber.
  - Using non-final list buffers which are set to null on completion to not hold onto the buffer.
  - ```toSortedList```now returns a modifiable ```ArrayList```: since it is a handoff procedure, there is no value in forcing a non-modification constraint on the emitted list (similar to ```toList``` even before this PR).