### PR TITLE
OperatorPublish - use BackpressureUtils

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -234,19 +234,7 @@ public class OperatorPublish<T> extends ConnectableObservable<T> {
             if (r == null) {
                 subs.put(subscriber, new AtomicLong(request));
             } else {
-                do {
-                    long current = r.get();
-                    if (current == Long.MAX_VALUE) {
-                        break;
-                    }
-                    long u = current + request;
-                    if (u < 0) {
-                        u = Long.MAX_VALUE;
-                    }
-                    if (r.compareAndSet(current, u)) {
-                        break;
-                    }
-                } while (true);
+                BackpressureUtils.getAndAddRequest(r, request);
             }
 
             return resetAfterSubscriberUpdate(subs);


### PR DESCRIPTION
Logic is fine, can replace a block of code with a call to `BackpressureUtils.getAndAddRequest`.