### PR TITLE
Fix the performance degradation due to different schedule execution and

### DIFF
--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -117,10 +117,7 @@ public class EventLoopsScheduler extends Scheduler {
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
-            ScheduledAction s = poolWorker.scheduleActual(action, 0, null);
-            
-            serial.add(s);
-            s.addParent(serial);
+            ScheduledAction s = poolWorker.scheduleActual(action, 0, null, serial);
             
             return s;
         }


### PR DESCRIPTION
SubscriptionList.add() and thread unparking.

This PR partially reverts some changes from earlier scheduler optimizations and fixes a case where if multiple concurrent schedule() calls happen, the order in the SubscriptionList might be different from the actual execution order which degrades performance on task termination due to remove() being O(n).

This might be the source of degradation in #2857 as well.

I'll post the ```ComputationSchedulerPerf``` results later.