### PR TITLE
OperatorObserveOn - handle request overflow correctly

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -16,15 +16,22 @@
 package rx.internal.operators;
 
 import java.util.Queue;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import rx.Observable.Operator;
-import rx.*;
+import rx.Producer;
+import rx.Scheduler;
+import rx.Subscriber;
+import rx.Subscription;
 import rx.exceptions.MissingBackpressureException;
 import rx.functions.Action0;
-import rx.internal.util.*;
-import rx.internal.util.unsafe.*;
-import rx.schedulers.*;
+import rx.internal.util.RxRingBuffer;
+import rx.internal.util.SynchronizedQueue;
+import rx.internal.util.unsafe.SpscArrayQueue;
+import rx.internal.util.unsafe.UnsafeAccess;
+import rx.schedulers.ImmediateScheduler;
+import rx.schedulers.TrampolineScheduler;
 
 /**
  * Delivers events on the specified {@code Scheduler} asynchronously via an unbounded buffer.
@@ -96,7 +103,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
 
                 @Override
                 public void request(long n) {
-                    REQUESTED.getAndAdd(ObserveOnSubscriber.this, n);
+                    BackpressureUtils.getAndAddRequest(REQUESTED, ObserveOnSubscriber.this, n);
                     schedule();
                 }
 

--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -61,7 +61,9 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
             // avoid overhead, execute directly
             return child;
         } else {
-            return new ObserveOnSubscriber<T>(scheduler, child);
+            ObserveOnSubscriber<T> parent = new ObserveOnSubscriber<T>(scheduler, child);
+            parent.init();
+            return parent;
         }
     }
 
@@ -98,6 +100,11 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
                 queue = new SynchronizedQueue<Object>(RxRingBuffer.SIZE);
             }
             this.scheduledUnsubscribe = new ScheduledUnsubscribe(recursiveScheduler);
+        }
+        
+        void init() {
+            // don't want this code in the constructor because `this` can escape through the 
+            // setProducer call
             child.add(scheduledUnsubscribe);
             child.setProducer(new Producer() {
 


### PR DESCRIPTION
Use `BackpressureUtils.getAndAddRequest` in the `Producer` in `OperatorObserveOn`.

Includes unit test that failed on codebase before this change.