### PR TITLE
OperatorObserveOn onComplete can be emitted despite onError being called

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -214,7 +214,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
                         break;
                     }
                 }
-                if (produced > 0) {
+                if (produced > 0 && requested != Long.MAX_VALUE) {
                     REQUESTED.addAndGet(this, -produced);
                 }
             } while (COUNTER_UPDATER.decrementAndGet(this) > 0);

--- a/src/perf/java/rx/operators/OperatorObserveOnPerf.java
+++ b/src/perf/java/rx/operators/OperatorObserveOnPerf.java
@@ -66,5 +66,26 @@ public class OperatorObserveOnPerf {
         input.observable.observeOn(Schedulers.immediate()).subscribe(o);
         o.latch.await();
     }
+    
+    @Benchmark
+    public void observeOnComputationSubscribedOnComputation(Input input) throws InterruptedException {
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        input.observable.subscribeOn(Schedulers.computation()).observeOn(Schedulers.computation()).subscribe(o);
+        o.latch.await();
+    }
+
+    @Benchmark
+    public void observeOnNewThreadSubscribedOnComputation(Input input) throws InterruptedException {
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        input.observable.subscribeOn(Schedulers.computation()).observeOn(Schedulers.newThread()).subscribe(o);
+        o.latch.await();
+    }
+
+    @Benchmark
+    public void observeOnImmediateSubscribedOnComputation(Input input) throws InterruptedException {
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        input.observable.subscribeOn(Schedulers.computation()).observeOn(Schedulers.immediate()).subscribe(o);
+        o.latch.await();
+    }
 
 }


### PR DESCRIPTION
This is a fix for a race condition in `OperatorObserveOn` where if thread A gets to L164 and thread B starts the pollQueue loop then it will act as if the stream had completed normally instead of with an error. 

The effect is that a stream could appear to complete normally when in fact an error had occurred.

Using two boolean volatiles `completed` and `failed` that as a pair were not atomically updated/read exposed us to this race condition. 

The fix is to use a single volatile integer `status` to represent the  states ACTIVE, COMPLETED, ERRORED to replace `completed` and `failed`.


