### PR TITLE
CachedObservable that supports backpressure and disconnection.

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -3481,6 +3481,47 @@ public class Observable<T> {
     }
 
     /**
+     * Caches the emission of this Observable and replays them to any subscribers.
+     * The returned CachedObservable auto-subscribes to this Observable on the first subscriber and
+     * it allows disconnecting the cache by either triggering an completion or error.
+     * <p>
+     * Note that the underlying buffer is expanded incrementally by 16 elements at once.
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>The operator ignores upstream backpressure support and requests everything but honors 
+     *  the backpressure behavior of its Subscribers.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the CachedObservable instance wrapping this Observable
+     */
+    public final CachedObservable<T> toCached() {
+        return CachedObservable.from(this);
+    }
+    
+    /**
+     * Caches the emission of this Observable and replays them to any subscribers while using the
+     * given capacityHint in the underlying buffer to reduce its allocation frequency..
+     * The returned CachedObservable auto-subscribes to this Observable on the first subscriber and
+     * it allows disconnecting the cache by either triggering an completion or error.
+     * <p>
+     * Note that the underlying buffer is expanded incrementally by the specified {@code capacityHint}
+     * number of elements at once.
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>The operator ignores upstream backpressure support and requests everything but honors 
+     *  the backpressure behavior of its Subscribers.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param capacityHint hint for number of items to cache (for optimizing underlying data structure)
+     * @return the CachedObservable instance wrapping this Observable
+     */
+    public final CachedObservable<T> toCached(int capacityHint) {
+        return CachedObservable.from(this, capacityHint);
+    }
+    
+    /**
      * Returns an Observable that emits the items emitted by the source Observable, converted to the specified
      * type.
      * <p>

--- a/src/main/java/rx/internal/util/LinkedArrayList.java
+++ b/src/main/java/rx/internal/util/LinkedArrayList.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.util;
+
+import java.util.*;
+
+/**
+ * A list implementation which combines an ArrayList with a LinkedList to 
+ * avoid copying values when the capacity needs to be increased.
+ * <p>
+ * The class is non final to allow embedding it directly and thus saving on object allocation.
+ */
+public class LinkedArrayList {
+    /** The capacity of each array segment. */
+    final int capacityHint;
+    /** 
+     * Contains the head of the linked array list if not null. The 
+     * length is always capacityHint + 1 and the last element is an Object[] pointing
+     * to the next element of the linked array list.
+     */
+    Object[] head;
+    /** The tail array where new elements will be added. */
+    Object[] tail;
+    /** 
+     * The total size of the list; written after elements have been added (release) and
+     * and when read, the value indicates how many elements can be safely read (acquire).
+     */
+    volatile int size;
+    /** The next available slot in the current tail. */
+    int indexInTail;
+    /**
+     * Constructor with the capacity hint of each array segment.
+     * @param capacityHint
+     */
+    public LinkedArrayList(int capacityHint) {
+        this.capacityHint = capacityHint;
+    }
+    /**
+     * Adds a new element to this list.
+     * @param o the object to add, nulls are accepted
+     */
+    public void add(Object o) {
+        // if no value yet, create the first array
+        if (size == 0) {
+            head = new Object[capacityHint + 1];
+            tail = head;
+            head[0] = o;
+            indexInTail = 1;
+            size = 1;
+        } else
+        // if the tail is full, create a new tail and link
+        if (indexInTail == capacityHint) {
+            Object[] t = new Object[capacityHint + 1];
+            t[0] = o;
+            tail[capacityHint] = t;
+            tail = t;
+            indexInTail = 1;
+            size++;
+        } else {
+            tail[indexInTail] = o;
+            indexInTail++;
+            size++;
+        }
+    }
+    /**
+     * Returns the head buffer segment or null if the list is empty.
+     * @return
+     */
+    public Object[] head() {
+        return head;
+    }
+    /**
+     * Returns the tail buffer segment or null if the list is empty.
+     * @return
+     */
+    public Object[] tail() {
+        return tail;
+    }
+    /**
+     * Returns the total size of the list.
+     * @return
+     */
+    public int size() {
+        return size;
+    }
+    /**
+     * Returns the index of the next slot in the tail buffer segment.
+     * @return
+     */
+    public int indexInTail() {
+        return indexInTail;
+    }
+    /**
+     * Returns the capacity hint that indicates the capacity of each buffer segment.
+     * @return
+     */
+    public int capacityHint() {
+        return capacityHint;
+    }
+    /* Test support */List<Object> toList() {
+        final int cap = capacityHint;
+        final int s = size;
+        final List<Object> list = new ArrayList<Object>(s + 1);
+        
+        Object[] h = head();
+        int j = 0;
+        int k = 0;
+        while (j < s) {
+            list.add(h[k]);
+            j++;
+            if (++k == cap) {
+                k = 0;
+                h = (Object[])h[cap];
+            }
+        }
+        
+        return list;
+    }
+    @Override
+    public String toString() {
+        return toList().toString();
+    }
+}

--- a/src/main/java/rx/observables/CachedObservable.java
+++ b/src/main/java/rx/observables/CachedObservable.java
@@ -1,0 +1,478 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */package rx.observables;
+
+import java.util.concurrent.atomic.*;
+
+import rx.*;
+import rx.internal.operators.NotificationLite;
+import rx.internal.util.LinkedArrayList;
+import rx.subscriptions.SerialSubscription;
+
+/**
+ * An observable which auto-connects to another observable, caches the elements
+ * from that observable but allows terminating the connection and completing the cache.
+ *
+ * @param <T> the source element type
+ */
+public final class CachedObservable<T> extends Observable<T> implements Subscription {
+    /** The cache and replay state. */
+    private CacheState<T> state;
+
+    /**
+     * Creates a cached Observable with a default capacity hint of 16.
+     * @param source the source Observable to cache
+     * @return the CachedObservable instance
+     */
+    public static <T> CachedObservable<T> from(Observable<? extends T> source) {
+        return from(source, 16);
+    }
+    
+    /**
+     * Creates a cached Observable with the given capacity hint.
+     * @param source the source Observable to cache
+     * @param capacityHint the hint for the internal buffer size
+     * @return the CachedObservable instance
+     */
+    public static <T> CachedObservable<T> from(Observable<? extends T> source, int capacityHint) {
+        if (capacityHint < 1) {
+            throw new IllegalArgumentException("capacityHint > 0 required");
+        }
+        CacheState<T> state = new CacheState<T>(source, capacityHint);
+        CachedSubscribe<T> onSubscribe = new CachedSubscribe<T>(state);
+        return new CachedObservable<T>(onSubscribe, state);
+    }
+    
+    /**
+     * Private constructor because state needs to be shared between the Observable body and
+     * the onSubscribe function.
+     * @param onSubscribe
+     * @param state
+     */
+    private CachedObservable(OnSubscribe<T> onSubscribe, CacheState<T> state) {
+        super(onSubscribe);
+        this.state = state;
+    }
+    @Override
+    public void unsubscribe() {
+        state.complete(null);
+    }
+    
+    /**
+     * Force the completion of the cache via an onCompleted() message.
+     * <p>It is an alias for {@link #unsubscribe()}.
+     */
+    public void complete() {
+        state.complete(null);
+    }
+    
+    /**
+     * Force the completion of the cache via an onError() message.
+     * @param e the exception to complete with
+     */
+    public void completeExceptionally(Throwable e) {
+        state.complete(e);
+    }
+
+    @Override
+    public boolean isUnsubscribed() {
+        return state.connection.isUnsubscribed();
+    }
+
+    /**
+     * Check if this cached observable is connected to its source.
+     * @return true if already connected
+     */
+    /* public */boolean isConnected() {
+        return state.isConnected;
+    }
+    
+    /**
+     * Returns true if there are observers subscribed to this observable.
+     * @return
+     */
+    public boolean hasObservers() {
+        return state.producers.length != 0;
+    }
+    
+    /**
+     * Returns the number of events currently cached.
+     * @return
+     */
+    /* public */ int cachedEventCount() {
+        return state.size();
+    }
+    
+    /**
+     * Contains the active child producers and the values to replay.
+     *
+     * @param <T>
+     */
+    static final class CacheState<T> extends LinkedArrayList implements Observer<T> {
+        /** The source observable to connect to. */
+        final Observable<? extends T> source;
+        /** Holds onto the subscriber connected to source. */
+        final SerialSubscription connection;
+        /** Guarded by connection (not this). */
+        volatile ReplayProducer<?>[] producers;
+        /** The default empty array of producers. */
+        static final ReplayProducer<?>[] EMPTY = new ReplayProducer<?>[0];
+        
+        /** Indicates the observable has been completed manually. */
+        volatile int done;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<CacheState> DONE
+        = AtomicIntegerFieldUpdater.newUpdater(CacheState.class, "done");
+        
+        final NotificationLite<T> nl;
+        
+        /** Set to true after connection. */
+        volatile boolean isConnected;
+        /** 
+         * Indicates that the source has completed emitting values or the
+         * Observable was forcefully terminated.
+         */
+        boolean sourceDone;
+        
+        public CacheState(Observable<? extends T> source, int capacityHint) {
+            super(capacityHint);
+            this.source = source;
+            this.producers = EMPTY;
+            this.nl = NotificationLite.instance();
+            this.connection = new SerialSubscription();
+        }
+        /**
+         * Adds a ReplayProducer to the producers array atomically.
+         * @param p
+         */
+        public void addProducer(ReplayProducer<T> p) {
+            // guarding by connection to save on allocating another object
+            // thus there are two distinct locks guarding the value-addition and child come-and-go
+            synchronized (connection) {
+                ReplayProducer<?>[] a = producers;
+                int n = a.length;
+                ReplayProducer<?>[] b = new ReplayProducer<?>[n + 1];
+                System.arraycopy(a, 0, b, 0, n);
+                b[n] = p;
+                producers = b;
+            }
+        }
+        /**
+         * Removes the ReplayProducer (if present) from the producers array atomically.
+         * @param p
+         */
+        public void removeProducer(ReplayProducer<T> p) {
+            synchronized (connection) {
+                ReplayProducer<?>[] a = producers;
+                int n = a.length;
+                int j = -1;
+                for (int i = 0; i < n; i++) {
+                    if (a[i].equals(p)) {
+                        j = i;
+                        break;
+                    }
+                }
+                if (j < 0) {
+                    return;
+                }
+                if (n == 1) {
+                    producers = EMPTY;
+                    return;
+                }
+                ReplayProducer<?>[] b = new ReplayProducer<?>[n - 1];
+                System.arraycopy(a, 0, b, 0, j);
+                System.arraycopy(a, j + 1, b, j, n - j - 1);
+                producers = b;
+            }
+        }
+        /**
+         * Connects the cache to the source.
+         * Make sure this is called only once.
+         */
+        public void connect() {
+            connection.set(source.subscribe(this));
+            isConnected = true;
+        }
+        /**
+         * Completes this cache with either an onCompleted() or an onError() if
+         * the provided Throwable is not null.
+         * @param e
+         */
+        public void complete(Throwable e) {
+            if (DONE.compareAndSet(this, 0, 1)) {
+                if (e == null) {
+                    onCompleted();
+                } else {
+                    onError(e);
+                }
+            }
+        }
+        @Override
+        public void onNext(T t) {
+            Object o = nl.next(t);
+            synchronized (this) {
+                if (!sourceDone) {
+                    add(o);
+                } else {
+                    return;
+                }
+            }
+            dispatch();
+        }
+        @Override
+        public void onError(Throwable e) {
+            Object o = nl.error(e);
+            synchronized (this) {
+                if (!sourceDone) {
+                    sourceDone = true;
+                    add(o);
+                } else {
+                    return;
+                }
+            }
+            connection.unsubscribe();
+            dispatch();
+        }
+        @Override
+        public void onCompleted() {
+            Object o = nl.completed();
+            synchronized (this) {
+                if (!sourceDone) {
+                    sourceDone = true;
+                    add(o);
+                } else {
+                    return;
+                }
+            }
+            connection.unsubscribe();
+            dispatch();
+        }
+        /**
+         * Signals all known children there is work to do.
+         */
+        void dispatch() {
+            ReplayProducer<?>[] a = producers;
+            for (ReplayProducer<?> rp : a) {
+                rp.replay();
+            }
+        }
+    }
+    
+    /**
+     * Manages the subscription of child subscribers by setting up a replay producer and
+     * performs auto-connection of the very first subscription.
+     * @param <T> the value type emitted
+     */
+    static final class CachedSubscribe<T> extends AtomicBoolean implements OnSubscribe<T> {
+        /** */
+        private static final long serialVersionUID = -2817751667698696782L;
+        final CacheState<T> state;
+        public CachedSubscribe(CacheState<T> state) {
+            this.state = state;
+        }
+        @Override
+        public void call(Subscriber<? super T> t) {
+            // we can connect first because we replay everything anyway
+            ReplayProducer<T> rp = new ReplayProducer<T>(t, state);
+            state.addProducer(rp);
+            
+            t.add(rp);
+            t.setProducer(rp);
+
+            // we ensure a single connection here to save an instance field of AtomicBoolean in state.
+            if (!get() && compareAndSet(false, true)) {
+                state.connect();
+            }
+            
+            // no need to call rp.replay() here because the very first request will trigger it anyway
+        }
+    }
+    
+    /**
+     * Keeps track of the current request amount and the replay position for a child Subscriber.
+     *
+     * @param <T>
+     */
+    static final class ReplayProducer<T> extends AtomicLong implements Producer, Subscription {
+        /** */
+        private static final long serialVersionUID = -2557562030197141021L;
+        /** The actual child subscriber. */
+        final Subscriber<? super T> child;
+        /** The cache state object. */
+        final CacheState<T> state;
+        
+        /** 
+         * Contains the reference to the buffer segment in replay.
+         * Accessed after reading state.size() and when emitting == true.
+         */
+        Object[] currentBuffer;
+        /** 
+         * Contains the index into the currentBuffer where the next value is expected. 
+         * Accessed after reading state.size() and when emitting == true.
+         */
+        int currentIndexInBuffer;
+        /**
+         * Contains the absolute index up until the values have been replayed so far.
+         */
+        int index;
+
+        /** Indicates there is a replay going on; guarded by this. */
+        boolean emitting;
+        /** Indicates there were some state changes/replay attempts; guarded by this. */
+        boolean missed;
+        
+        public ReplayProducer(Subscriber<? super T> child, CacheState<T> state) {
+            this.child = child;
+            this.state = state;
+        }
+        @Override
+        public void request(long n) {
+            for (;;) {
+                long r = get();
+                if (r < 0) {
+                    return;
+                }
+                long u = r + n;
+                if (u < 0) {
+                    u = Long.MAX_VALUE;
+                }
+                if (compareAndSet(r, u)) {
+                    replay();
+                    return;
+                }
+            }
+        }
+        /**
+         * Updates the request count to reflect values have been produced.
+         * @param n
+         * @return
+         */
+        public long produced(long n) {
+            return addAndGet(-n);
+        }
+        
+        @Override
+        public boolean isUnsubscribed() {
+            return get() < 0;
+        }
+        @Override
+        public void unsubscribe() {
+            long r = get();
+            if (r >= 0) {
+                r = getAndSet(-1L); // unsubscribed state is negative
+                if (r >= 0) {
+                    state.removeProducer(this);
+                }
+            }
+        }
+        
+        /**
+         * Continue replaying available values if there are requests for them.
+         */
+        public void replay() {
+            // make sure there is only a single thread emitting
+            synchronized (this) {
+                if (emitting) {
+                    missed = true;
+                    return;
+                }
+                emitting = true;
+            }
+            boolean skipFinal = false;
+            try {
+                final NotificationLite<T> nl = state.nl;
+                final Subscriber<? super T> child = this.child;
+                
+                for (;;) {
+                    
+                    long r = get();
+                    // read the size, if it is non-zero, we can safely read the head and
+                    // read values up to the given absolute index
+                    int s = state.size();
+                    if (s != 0) {
+                        Object[] b = currentBuffer;
+                        
+                        // latch onto the very first buffer now that it is available.
+                        if (b == null) {
+                            b = state.head();
+                            currentBuffer = b;
+                        }
+                        final int n = b.length - 1;
+                        int j = index;
+                        int k = currentIndexInBuffer;
+                        // eagerly emit any terminal event
+                        if (r == 0) {
+                            Object o = b[k];
+                            if (nl.isCompleted(o)) {
+                                child.onCompleted();
+                                skipFinal = true;
+                                unsubscribe();
+                                return;
+                            } else
+                            if (nl.isError(o)) {
+                                child.onError(nl.getError(o));
+                                skipFinal = true;
+                                unsubscribe();
+                                return;
+                            }
+                        } else
+                        if (r > 0) {
+                            int valuesProduced = 0;
+                            
+                            while (j < s && r > 0 && !child.isUnsubscribed()) {
+                                if (k == n) {
+                                    b = (Object[])b[n];
+                                    k = 0;
+                                }
+                                Object o = b[k];
+                                
+                                if (nl.accept(child, o)) {
+                                    skipFinal = true;
+                                    unsubscribe();
+                                    return;
+                                }
+                                
+                                k++;
+                                j++;
+                                r--;
+                                valuesProduced++;
+                            }
+                            
+                            index = j;
+                            currentIndexInBuffer = k;
+                            currentBuffer = b;
+                            produced(valuesProduced);
+                        }
+                    }
+                    
+                    synchronized (this) {
+                        if (!missed) {
+                            emitting = false;
+                            skipFinal = true;
+                            return;
+                        }
+                        missed = false;
+                    }
+                }
+            } finally {
+                if (!skipFinal) {
+                    synchronized (this) {
+                        emitting = false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/rx/internal/util/LinkedArrayListTest.java
+++ b/src/test/java/rx/internal/util/LinkedArrayListTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.util;
+
+import java.util.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class LinkedArrayListTest {
+    @Test
+    public void testAdd() {
+        LinkedArrayList list = new LinkedArrayList(16);
+        
+        List<Integer> expected = new ArrayList<Integer>(32);
+        for (int i = 0; i < 32; i++) {
+            list.add(i);
+            expected.add(i);
+        }
+        
+        assertEquals(expected, list.toList());
+        assertEquals(32, list.size());
+    }
+}

--- a/src/test/java/rx/observables/CachedObservableTest.java
+++ b/src/test/java/rx/observables/CachedObservableTest.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observables;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+import rx.Observable;
+import rx.exceptions.TestException;
+import rx.functions.*;
+import rx.observers.TestSubscriber;
+import rx.schedulers.*;
+import rx.subjects.PublishSubject;
+
+public class CachedObservableTest {
+    @Test
+    public void testColdReplayNoBackpressure() {
+        CachedObservable<Integer> source = CachedObservable.from(Observable.range(0, 1000));
+        
+        assertFalse("Source is connected!", source.isConnected());
+        assertFalse("Source is unsubscribed!", source.isUnsubscribed());
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        source.subscribe(ts);
+
+        assertTrue("Source is not connected!", source.isConnected());
+        assertTrue("Source is not unsubscribed!", source.isUnsubscribed());
+        assertFalse("Subscribers retained!", source.hasObservers());
+        
+        ts.assertNoErrors();
+        ts.assertTerminalEvent();
+        List<Integer> onNextEvents = ts.getOnNextEvents();
+        assertEquals(1000, onNextEvents.size());
+
+        for (int i = 0; i < 1000; i++) {
+            assertEquals((Integer)i, onNextEvents.get(i));
+        }
+    }
+    @Test
+    public void testColdReplayBackpressure() {
+        CachedObservable<Integer> source = Observable.range(0, 1000).toCached();
+        
+        assertFalse("Source is connected!", source.isConnected());
+        assertFalse("Source is unsubscribed!", source.isUnsubscribed());
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.requestMore(10);
+        
+        source.subscribe(ts);
+
+        assertTrue("Source is not connected!", source.isConnected());
+        assertTrue("Source is not unsubscribed!", source.isUnsubscribed());
+        assertTrue("Subscribers not retained!", source.hasObservers());
+        
+        ts.assertNoErrors();
+        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        List<Integer> onNextEvents = ts.getOnNextEvents();
+        assertEquals(10, onNextEvents.size());
+
+        for (int i = 0; i < 10; i++) {
+            assertEquals((Integer)i, onNextEvents.get(i));
+        }
+        
+        ts.unsubscribe();
+        assertFalse("Subscribers retained!", source.hasObservers());
+    }
+    
+    @Test
+    public void testTerminalReplayedWithoutRequest() {
+        CachedObservable<Integer> source = Observable.range(1, 1000).toCached();
+        source.complete();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.requestMore(0);
+        
+        source.subscribe(ts);
+        
+        ts.assertTerminalEvent();
+        
+        assertEquals(1, source.cachedEventCount());
+    }
+    
+    @Test
+    public void testRegularTerminalNotOverwritten() {
+        CachedObservable<Integer> source = Observable.<Integer>error(new TestException()).toCached();
+        // trigger the first connection
+        source.subscribe(new TestSubscriber<Integer>());
+        
+        source.complete();
+
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.requestMore(0);
+        
+        source.subscribe(ts);
+
+        ts.assertTerminalEvent();
+        assertEquals(1, ts.getOnErrorEvents().size());
+        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        
+        assertEquals(1, source.cachedEventCount());
+    }
+    
+    @Test
+    public void testForcedComplete() {
+        CachedObservable<Integer> source = Observable.<Integer>never().toCached();
+        source.complete();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        source.subscribe(ts);
+        
+        ts.assertTerminalEvent();
+        ts.assertNoErrors();
+    }
+    @Test
+    public void testForcedError() {
+        CachedObservable<Integer> source = Observable.<Integer>never().toCached();
+        source.completeExceptionally(new TestException());
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        source.subscribe(ts);
+        ts.assertTerminalEvent();
+        
+        assertEquals(1, ts.getOnErrorEvents().size());
+        assertTrue(ts.getOnErrorEvents().get(0) instanceof TestException);
+    }
+    
+    @Test
+    public void testForcedCompetionWhileActive() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        CachedObservable<Integer> cached = source.toCached();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        cached.subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+        source.onNext(4);
+        
+        cached.complete();
+        
+        source.onNext(5);
+        source.onNext(6);
+        source.onNext(7);
+        source.onCompleted();
+        
+        ts.assertTerminalEvent();
+        ts.assertNoErrors();
+        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4));
+    }
+    
+    @Test
+    public void testCache() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        Observable<String> o = Observable.create(new Observable.OnSubscribe<String>() {
+
+            @Override
+            public void call(final Subscriber<? super String> observer) {
+                new Thread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        counter.incrementAndGet();
+                        System.out.println("published observable being executed");
+                        observer.onNext("one");
+                        observer.onCompleted();
+                    }
+                }).start();
+            }
+        }).toCached();
+
+        // we then expect the following 2 subscriptions to get that same value
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        // subscribe once
+        o.subscribe(new Action1<String>() {
+
+            @Override
+            public void call(String v) {
+                assertEquals("one", v);
+                System.out.println("v: " + v);
+                latch.countDown();
+            }
+        });
+
+        // subscribe again
+        o.subscribe(new Action1<String>() {
+
+            @Override
+            public void call(String v) {
+                assertEquals("one", v);
+                System.out.println("v: " + v);
+                latch.countDown();
+            }
+        });
+
+        if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
+            fail("subscriptions did not receive values");
+        }
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testUnsubscribeSource() {
+        Action0 unsubscribe = mock(Action0.class);
+        Observable<Integer> o = Observable.just(1).doOnUnsubscribe(unsubscribe).toCached();
+        o.subscribe();
+        o.subscribe();
+        o.subscribe();
+        verify(unsubscribe, times(1)).call();
+    }
+    
+    @Test
+    public void testTake() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        CachedObservable<Integer> cached = Observable.range(1, 100).toCached();
+        cached.take(10).subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertTerminalEvent();
+        ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        ts.assertUnsubscribed();
+        assertFalse(cached.hasObservers());
+    }
+    
+    @Test
+    public void testAsync() {
+        Observable<Integer> source = Observable.range(1, 10000);
+        for (int i = 0; i < 100; i++) {
+            TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            
+            CachedObservable<Integer> cached = source.toCached();
+            
+            cached.observeOn(Schedulers.computation()).subscribe(ts1);
+            
+            ts1.awaitTerminalEvent(2, TimeUnit.SECONDS);
+            ts1.assertNoErrors();
+            ts1.assertTerminalEvent();
+            assertEquals(10000, ts1.getOnNextEvents().size());
+            
+            TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            cached.observeOn(Schedulers.computation()).subscribe(ts2);
+            
+            ts2.awaitTerminalEvent(2, TimeUnit.SECONDS);
+            ts2.assertNoErrors();
+            ts2.assertTerminalEvent();
+            assertEquals(10000, ts2.getOnNextEvents().size());
+        }
+    }
+    @Test
+    public void testAsyncComeAndGo() {
+        Observable<Long> source = Observable.timer(1, 1, TimeUnit.MILLISECONDS)
+                .take(1000)
+                .subscribeOn(Schedulers.io());
+        CachedObservable<Long> cached = source.toCached();
+        
+        Observable<Long> output = cached.observeOn(Schedulers.computation());
+        
+        List<TestSubscriber<Long>> list = new ArrayList<TestSubscriber<Long>>(100);
+        for (int i = 0; i < 100; i++) {
+            TestSubscriber<Long> ts = new TestSubscriber<Long>();
+            list.add(ts);
+            output.skip(i * 10).take(10).subscribe(ts);
+        }
+
+        List<Long> expected = new ArrayList<Long>();
+        for (int i = 0; i < 10; i++) {
+            expected.add((long)(i - 10));
+        }
+        int j = 0;
+        for (TestSubscriber<Long> ts : list) {
+            ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
+            ts.assertNoErrors();
+            ts.assertTerminalEvent();
+            
+            for (int i = j * 10; i < j * 10 + 10; i++) {
+                expected.set(i - j * 10, (long)i);
+            }
+            
+            ts.assertReceivedOnNext(expected);
+            
+            j++;
+        }
+    }
+    
+    @Test
+    public void testNoMissingBackpressureException() {
+        final int m = 4 * 1000 * 1000;
+        Observable<Integer> firehose = Observable.create(new OnSubscribe<Integer>() {
+            @Override
+            public void call(Subscriber<? super Integer> t) {
+                for (int i = 0; i < m; i++) {
+                    t.onNext(i);
+                }
+                t.onCompleted();
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        firehose.toCached().observeOn(Schedulers.computation()).takeLast(100).subscribe(ts);
+        
+        ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
+        ts.assertNoErrors();
+        ts.assertTerminalEvent();
+        
+        assertEquals(100, ts.getOnNextEvents().size());
+    }
+}


### PR DESCRIPTION
I've written a ```cache()``` alternative that supports backpressure on its client side and can be disconnected from the upstream.

I've omitted the Experimental annotation for now because I'd like to have some feedback:

  - Should this replace ```cache()``` completely? Note that this implies changing the return type of ```cache()```.
  - Are the method names satisfactory?
  - Should I add state-peeking methods similar to ReplaySubject?