### PR TITLE
Add code quality plugins to build.gradle (jacoco, findbugs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,47 @@ description = 'RxJava: Reactive Extensions for the JVM – a library for composi
 
 apply plugin: 'rxjava-project'
 apply plugin: 'java'
+apply plugin: 'findbugs'
+apply plugin: 'jacoco'
 
 dependencies {
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
+}
+
+////////////////////////////////////////////////////////////////////
+// to run findbugs: 
+//     ./gradlew check
+// then open build/reports/findbugs/main.html
+////////////////////////////////////////////////////////////////////
+
+findbugs {
+  ignoreFailures = true
+  toolVersion = "+"
+  sourceSets = [sourceSets.main]
+  reportsDir = file("$project.buildDir/reports/findbugs")
+  effort = "max"
+}
+
+//////////////////////////////////////////////////////////////////
+// to run jacoco: 
+//     ./gradlew test jacocoTestReport
+// to run jacoco on a single test (matches OperatorRetry to OperatorRetryTest in test code base):
+//     ./gradlew -Dtest.single=OperatorRetry test jacocoTestReport
+// then open build/reports/jacoco/index.html
+/////////////////////////////////////////////////////////////////
+
+jacoco {
+    toolVersion = "+"
+    reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination "${buildDir}/reports/jacoco"
+    }
 }
 
 javadoc {
@@ -30,3 +67,10 @@ if (project.hasProperty('release.useLastTag')) {
 test{
      maxHeapSize = "2g"
 }
+
+tasks.withType(FindBugs) {
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+ }


### PR DESCRIPTION
This is one thing I've missed for a while so I figured out how to get gradle to provide them. This PR enables production of Jacoco coverage reports and Findbugs reports as html in the build directory. It doesn't happen by default, the plugins are run like this (instructions in comments in `build.gradle`):

To run Findbugs:
```./gradlew check```

To run Jacoco test coverage:
```./gradlew test jacocoTestReport```

To run Jacoco on a single test:
```./gradlew -Dtest.single=OperatorRetry test jacocoTestReport```

Then open up the reports in `build/reports`.

