### PR TITLE
Fixed Observable.combineLatest overflow bug on Android

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -49,10 +49,10 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
     public OnSubscribeCombineLatest(List<? extends Observable<? extends T>> sources, FuncN<? extends R> combinator) {
         this.sources = sources;
         this.combinator = combinator;
-        if (sources.size() > 128) {
-            // For design simplicity this is limited to 128. If more are really needed we'll need to adjust 
-            // the design of how RxRingBuffer is used in the implementation below.
-            throw new IllegalArgumentException("More than 128 sources to combineLatest is not supported.");
+        if (sources.size() > RxRingBuffer.SIZE) {
+            // For design simplicity this is limited to RxRingBuffer.SIZE. If more are really needed we'll need to
+            // adjust the design of how RxRingBuffer is used in the implementation below.
+            throw new IllegalArgumentException("More than RxRingBuffer.SIZE sources to combineLatest is not supported.");
         }
     }
 


### PR DESCRIPTION
RxRingBuffer size is not a constant and on Android is
less then 128 (16). So it causing silent issues when
there were given 16 < Observers < 128.