### PR TITLE
OperatorObserveOn should not request more after child is unsubscribed

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -185,7 +185,9 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
                 counter = 1;
                 long produced = 0;
                 long r = requested;
-                while (!child.isUnsubscribed()) {
+                for (;;) {
+                    if (child.isUnsubscribed())
+                        return;
                     Throwable error;
                     if (finished) {
                         if ((error = this.error) != null) {


### PR DESCRIPTION
In existing code if unsubscription happens immediately after a `child.onNext` call from `pollQueue` then the number of emissions made in the loop will be requested of upstream despite `child` being unsubscribed.

This PR adds a local variable `isUnsubscribed` and when set to true no further requests will be made.

This PR includes a unit test that failed on the existing codebase.