### PR TITLE
fix OperatorConcat race condition where request lost

### DIFF
--- a/src/main/java/rx/internal/producers/ProducerArbiter.java
+++ b/src/main/java/rx/internal/producers/ProducerArbiter.java
@@ -95,7 +95,7 @@ public final class ProducerArbiter implements Producer {
             if (r != Long.MAX_VALUE) {
                 long u = r - n;
                 if (u < 0) {
-                    throw new IllegalStateException();
+                    throw new IllegalStateException("more items arrived than were requested");
                 }
                 requested = u;
             }


### PR DESCRIPTION
If a request arrives while `ConcatInnerSubscriber` is being constructed ([L199-201](https://github.com/ReactiveX/RxJava/blob/bad4d40a7b59cb443c3cb19d00ab80000e017a5f/src/main/java/rx/internal/operators/OperatorConcat.java#L199-L201)) then that additional request does not induce a request from the subscriber and could stall the stream. The fix is not to pass `requested` value in the constructor but to call `ConcatInnerSubscriber.requestMore` with `requested` only once `currentSubscriber` is set.