### PR TITLE
Fixed window(time) to work properly with unsubscription, added

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9017,7 +9017,7 @@ public class Observable<T> {
      * <img width="640" height="365" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window4.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>The operator has limited backpressure support. If {@code count} == {@code skip}, the operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
+     *  <dd>The operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
      *  but each of them will emit at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/test/java/rx/internal/operators/OperatorWindowWithTimeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithTimeTest.java
@@ -26,6 +26,7 @@ import rx.*;
 import rx.Observable;
 import rx.Observer;
 import rx.functions.*;
+import rx.observers.TestSubscriber;
 import rx.schedulers.TestScheduler;
 
 public class OperatorWindowWithTimeTest {
@@ -169,6 +170,27 @@ public class OperatorWindowWithTimeTest {
         assertEquals(Arrays.asList(7, 8, 9), lists.get(2));
         assertEquals(1, lists.get(3).size());
         assertEquals(Arrays.asList(10), lists.get(3));
+    }
+    
+    @Test
+    public void testTakeFlatMapCompletes() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final int indicator = 999999999;
+        
+        OperatorWindowWithSizeTest.hotStream()
+        .window(300, TimeUnit.MILLISECONDS)
+        .take(10)
+        .flatMap(new Func1<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Observable<Integer> w) {
+                return w.startWith(indicator);
+            }
+        }).subscribe(ts);
+        
+        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        ts.assertCompleted();
+        Assert.assertFalse(ts.getOnNextEvents().isEmpty());
     }
     
 }


### PR DESCRIPTION
backpressure support to window(size, skip).

See #1880.