### PR TITLE
TestSubscriber - add factory methods

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -95,6 +95,31 @@ public class TestSubscriber<T> extends Subscriber<T> {
         this(-1);
     }
     
+    @Experimental
+    public static <T> TestSubscriber<T> create() {
+        return new TestSubscriber<T>();
+    }
+    
+    @Experimental
+    public static <T> TestSubscriber<T> create(long initialRequest) {
+        return new TestSubscriber<T>(initialRequest);
+    }
+    
+    @Experimental
+    public static <T> TestSubscriber<T> create(Observer<T> delegate, long initialRequest) {
+        return new TestSubscriber<T>(delegate, initialRequest);
+    }
+    
+    @Experimental
+    public static <T> TestSubscriber<T> create(Subscriber<T> delegate) {
+        return new TestSubscriber<T>(delegate);
+    }
+    
+    @Experimental
+    public static <T> TestSubscriber<T> create(Observer<T> delegate) {
+        return new TestSubscriber<T>(delegate);
+    }
+    
     @Override
     public void onStart() {
         if  (initialRequest >= 0) {

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -106,7 +106,7 @@ public class OnSubscribeRangeTest {
     @Test
     public void testBackpressureViaRequest() {
         OnSubscribeRange o = new OnSubscribeRange(1, RxRingBuffer.SIZE);
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
         ts.requestMore(1);
         o.call(ts);
@@ -127,7 +127,7 @@ public class OnSubscribeRangeTest {
         }
 
         OnSubscribeRange o = new OnSubscribeRange(1, list.size());
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.assertReceivedOnNext(Collections.<Integer> emptyList());
         ts.requestMore(Long.MAX_VALUE); // infinite
         o.call(ts);
@@ -137,7 +137,7 @@ public class OnSubscribeRangeTest {
     void testWithBackpressureOneByOne(int start) {
         Observable<Integer> source = Observable.range(start, 100);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestMore(1);
         source.subscribe(ts);
         
@@ -152,7 +152,7 @@ public class OnSubscribeRangeTest {
     void testWithBackpressureAllAtOnce(int start) {
         Observable<Integer> source = Observable.range(start, 100);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestMore(100);
         source.subscribe(ts);
         
@@ -179,7 +179,7 @@ public class OnSubscribeRangeTest {
     public void testWithBackpressureRequestWayMore() {
         Observable<Integer> source = Observable.range(50, 100);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.requestMore(150);
         source.subscribe(ts);
         


### PR DESCRIPTION
Since we use this so much I've added factory methods so we can infer types. 

Instead of 

```java
TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
```

We can write
```java
TestSubscriber<Integer> ts = TestSubscriber.create();
```

I changed the tests in `OnSubscribeRangeTest` to demo the usage.