### PR TITLE
Fixed multiple calls to onStart.

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeDefer.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeDefer.java
@@ -38,7 +38,7 @@ public final class OnSubscribeDefer<T> implements OnSubscribe<T> {
     }
 
     @Override
-    public void call(Subscriber<? super T> s) {
+    public void call(final Subscriber<? super T> s) {
         Observable<? extends T> o;
         try {
             o = observableFactory.call();
@@ -46,7 +46,20 @@ public final class OnSubscribeDefer<T> implements OnSubscribe<T> {
             s.onError(t);
             return;
         }
-        o.unsafeSubscribe(s);
+        o.unsafeSubscribe(new Subscriber<T>(s) {
+            @Override
+            public void onNext(T t) {
+                s.onNext(t);
+            }
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            @Override
+            public void onCompleted() {
+                s.onCompleted();
+            }
+        });
     }
     
 }

--- a/src/main/java/rx/internal/operators/OnSubscribeDelaySubscription.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeDelaySubscription.java
@@ -16,11 +16,10 @@
 package rx.internal.operators;
 
 import java.util.concurrent.TimeUnit;
-import rx.Observable;
+
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Scheduler;
 import rx.Scheduler.Worker;
-import rx.Subscriber;
 import rx.functions.Action0;
 
 /**
@@ -50,7 +49,20 @@ public final class OnSubscribeDelaySubscription<T> implements OnSubscribe<T> {
             @Override
             public void call() {
                 if (!s.isUnsubscribed()) {
-                    source.unsafeSubscribe(s);
+                    source.unsafeSubscribe(new Subscriber<T>(s) {
+                        @Override
+                        public void onNext(T t) {
+                            s.onNext(t);
+                        }
+                        @Override
+                        public void onError(Throwable e) {
+                            s.onError(e);
+                        }
+                        @Override
+                        public void onCompleted() {
+                            s.onCompleted();
+                        }
+                    });
                 }
             }
         }, time, unit);

--- a/src/main/java/rx/internal/operators/OnSubscribeDelaySubscriptionWithSelector.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeDelaySubscriptionWithSelector.java
@@ -15,9 +15,8 @@
  */
 package rx.internal.operators;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Subscriber;
 import rx.functions.Func0;
 
 /**
@@ -43,7 +42,20 @@ public final class OnSubscribeDelaySubscriptionWithSelector<T, U> implements OnS
                 @Override
                 public void onCompleted() {
                     // subscribe to actual source
-                    source.unsafeSubscribe(child);
+                    source.unsafeSubscribe(new Subscriber<T>(child) {
+                        @Override
+                        public void onNext(T t) {
+                            child.onNext(t);
+                        }
+                        @Override
+                        public void onError(Throwable e) {
+                            child.onError(e);
+                        }
+                        @Override
+                        public void onCompleted() {
+                            child.onCompleted();
+                        }
+                    });
                 }
 
                 @Override

--- a/src/main/java/rx/internal/operators/OnSubscribeUsing.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeUsing.java
@@ -18,15 +18,10 @@ package rx.internal.operators;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Subscriber;
-import rx.Subscription;
 import rx.exceptions.CompositeException;
-import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.functions.Func0;
-import rx.functions.Func1;
+import rx.functions.*;
 
 /**
  * Constructs an observable sequence that depends on a resource object.
@@ -48,7 +43,7 @@ public final class OnSubscribeUsing<T, Resource> implements OnSubscribe<T> {
     }
 
     @Override
-    public void call(Subscriber<? super T> subscriber) {
+    public void call(final Subscriber<? super T> subscriber) {
 
         try {
 
@@ -73,7 +68,20 @@ public final class OnSubscribeUsing<T, Resource> implements OnSubscribe<T> {
                 observable = source;
             try {
                 // start
-                observable.unsafeSubscribe(subscriber);
+                observable.unsafeSubscribe(new Subscriber<T>(subscriber) {
+                    @Override
+                    public void onNext(T t) {
+                        subscriber.onNext(t);
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        subscriber.onError(e);
+                    }
+                    @Override
+                    public void onCompleted() {
+                        subscriber.onCompleted();
+                    }
+                });
             } catch (Throwable e) {
                 Throwable disposeError = disposeEagerlyIfRequested(disposeOnceOnly);
                 if (disposeError != null)

--- a/src/main/java/rx/internal/operators/OperatorDoOnSubscribe.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnSubscribe.java
@@ -39,6 +39,19 @@ public class OperatorDoOnSubscribe<T> implements Operator<T, T> {
         subscribe.call();
         // Pass through since this operator is for notification only, there is
         // no change to the stream whatsoever.
-        return child;
+        return new Subscriber<T>(child) {
+            @Override
+            public void onNext(T t) {
+                child.onNext(t);
+            }
+            @Override
+            public void onError(Throwable e) {
+                child.onError(e);
+            }
+            @Override
+            public void onCompleted() {
+                child.onCompleted();
+            }
+        };
     }
 }

--- a/src/main/java/rx/internal/operators/OperatorDoOnUnsubscribe.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnUnsubscribe.java
@@ -16,7 +16,7 @@
 package rx.internal.operators;
 
 import rx.Observable.Operator;
-import rx.Subscriber;
+import rx.*;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
 
@@ -41,6 +41,22 @@ public class OperatorDoOnUnsubscribe<T> implements Operator<T, T> {
 
         // Pass through since this operator is for notification only, there is
         // no change to the stream whatsoever.
-        return child;
+        return new Subscriber<T>(child) {
+            @Override
+            public void onStart() {
+            }
+            @Override
+            public void onNext(T t) {
+                child.onNext(t);
+            }
+            @Override
+            public void onError(Throwable e) {
+                child.onError(e);
+            }
+            @Override
+            public void onCompleted() {
+                child.onCompleted();
+            }
+        };
     }
 }

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -259,7 +259,9 @@ public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R
                         }
 
                     }).unsafeSubscribe(new Subscriber<T>(o) {
-
+                        @Override
+                        public void onStart() {
+                        }
                         @Override
                         public void onCompleted() {
                             o.onCompleted();

--- a/src/main/java/rx/internal/operators/OperatorMulticast.java
+++ b/src/main/java/rx/internal/operators/OperatorMulticast.java
@@ -128,8 +128,21 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
                 guardedSubscription = gs.get();
                 
                 // register any subscribers that are waiting with this new subject
-                for(Subscriber<? super R> s : waitingForConnect) {
-                    subject.unsafeSubscribe(s);
+                for(final Subscriber<? super R> s : waitingForConnect) {
+                    subject.unsafeSubscribe(new Subscriber<R>(s) {
+                        @Override
+                        public void onNext(R t) {
+                            s.onNext(t);
+                        }
+                        @Override
+                        public void onError(Throwable e) {
+                            s.onError(e);
+                        }
+                        @Override
+                        public void onCompleted() {
+                            s.onCompleted();
+                        }
+                    });
                 }
                 // clear the waiting list as any new ones that come in after leaving this synchronized block will go direct to the Subject
                 waitingForConnect.clear();

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -99,8 +99,6 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void onStart() {
         if  (initialRequest >= 0) {
             requestMore(initialRequest);
-        } else {
-            super.onStart();
         }
     }
 

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -226,7 +226,8 @@ public class OperatorPublishTest {
             public void call() {
                 child1Unsubscribed.set(true);
             }
-        }).take(5).subscribe(ts1);
+        }).take(5)
+        .subscribe(ts1);
         
         ts1.awaitTerminalEvent();
         ts2.awaitTerminalEvent();


### PR DESCRIPTION
Started investigating multiple calls to onStart based on #2979 and found a bunch, but since onStart can be overridden, I might have missed cases. In addition, I've found a single place where a producer is set twice on a subscriber but again, many other places may exist.