### PR TITLE
OperatorAll  - implement backpressure and include last value in exception cause

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorAll.java
+++ b/src/main/java/rx/internal/operators/OperatorAll.java
@@ -17,7 +17,10 @@ package rx.internal.operators;
 
 import rx.Observable.Operator;
 import rx.Subscriber;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
+import rx.internal.producers.SingleDelayedProducer;
 
 /**
  * Returns an Observable that emits a Boolean that indicates whether all items emitted by an
@@ -34,21 +37,27 @@ public final class OperatorAll<T> implements Operator<Boolean, T> {
 
     @Override
     public Subscriber<? super T> call(final Subscriber<? super Boolean> child) {
+        final SingleDelayedProducer<Boolean> producer = new SingleDelayedProducer<Boolean>(child);
         Subscriber<T> s = new Subscriber<T>() {
             boolean done;
 
             @Override
             public void onNext(T t) {
-                boolean result = predicate.call(t);
+                Boolean result;
+                try {
+                    result = predicate.call(t);
+                } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
+                    onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    return;
+                }
                 if (!result && !done) {
                     done = true;
-                    child.onNext(false);
-                    child.onCompleted();
+                    producer.setValue(false);
                     unsubscribe();
-                } else {
-                	// if we drop values we must replace them upstream as downstream won't receive and request more
-                	request(1);
-                }
+                } 
+                // note that don't need to request more of upstream because this subscriber 
+                // defaults to requesting Long.MAX_VALUE
             }
 
             @Override
@@ -60,12 +69,12 @@ public final class OperatorAll<T> implements Operator<Boolean, T> {
             public void onCompleted() {
                 if (!done) {
                     done = true;
-                    child.onNext(true);
-                    child.onCompleted();
+                    producer.setValue(true);
                 }
             }
         };
         child.add(s);
+        child.setProducer(producer);
         return s;
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorAllTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAllTest.java
@@ -19,12 +19,14 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import rx.*;
 import rx.functions.Func1;
+import rx.observers.TestSubscriber;
 
 public class OperatorAllTest {
 
@@ -127,5 +129,53 @@ public class OperatorAllTest {
                 }
         });
         assertEquals((Object)2, source.toBlocking().first());
+    }
+    
+    @Test
+    public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0);
+        Observable.empty().all(new Func1<Object, Boolean>() {
+            @Override
+            public Boolean call(Object t1) {
+                return false;
+            }
+        }).subscribe(ts);
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+    }
+    
+    @Test
+    public void testBackpressureIfOneRequestedOneShouldBeDelivered() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(1);
+        Observable.empty().all(new Func1<Object, Boolean>() {
+            @Override
+            public Boolean call(Object object) {
+                return false;
+            }
+        }).subscribe(ts);
+        ts.assertTerminalEvent();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        ts.assertValue(true);
+    }
+    
+    @Test
+    public void testPredicateThrowsExceptionAndValueInCauseMessage() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0);
+        final IllegalArgumentException ex = new IllegalArgumentException();
+        Observable.just("Boo!").all(new Func1<Object, Boolean>() {
+            @Override
+            public Boolean call(Object object) {
+                throw ex;
+            }
+        }).subscribe(ts);
+        ts.assertTerminalEvent();
+        ts.assertNoValues();
+        ts.assertNotCompleted();
+        List<Throwable> errors = ts.getOnErrorEvents();
+        assertEquals(1, errors.size());
+        assertEquals(ex, errors.get(0));
+        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }
 }


### PR DESCRIPTION
Implemented backpressure using `SingleDelayedProducer` (thanks @akarnokd) and while I was there ensured that the last value is in the exception cause when the predicate throws an exception.
