### PR TITLE
fix skip() race condition and request overflow

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSkip.java
+++ b/src/main/java/rx/internal/operators/OperatorSkip.java
@@ -15,6 +15,8 @@
  */
 package rx.internal.operators;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import rx.Observable;
 import rx.Producer;
 import rx.Subscriber;
@@ -63,19 +65,8 @@ public final class OperatorSkip<T> implements Observable.Operator<T, T> {
 
             @Override
             public void setProducer(final Producer producer) {
-                child.setProducer(new Producer() {
-
-                    @Override
-                    public void request(long n) {
-                        if (n == Long.MAX_VALUE) {
-                            // infinite so leave it alone
-                            producer.request(n);
-                        } else if (n > 0) {
-                            // add the skip num to the requested amount, since we'll skip everything and then emit to the buffer downstream
-                            producer.request(n + (toSkip - skipped));
-                        }
-                    }
-                });
+                child.setProducer(producer);
+                producer.request(toSkip);
             }
 
         };

--- a/src/test/java/rx/internal/operators/OperatorSkipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipTest.java
@@ -15,17 +15,23 @@
  */
 package rx.internal.operators;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.Test;
 
 import rx.Observable;
 import rx.Observer;
-import rx.internal.operators.OperatorSkip;
+import rx.functions.Action1;
+import rx.observers.TestSubscriber;
 
 public class OperatorSkipTest {
 
@@ -144,4 +150,36 @@ public class OperatorSkipTest {
         verify(observer, never()).onCompleted();
 
     }
+    
+    @Test
+    public void testBackpressureMultipleSmallAsyncRequests() throws InterruptedException {
+        final AtomicLong requests = new AtomicLong(0);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0);
+        Observable.interval(100, TimeUnit.MILLISECONDS)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long n) {
+                        requests.addAndGet(n);
+                    }
+                }).skip(4).subscribe(ts);
+        Thread.sleep(100);
+        ts.requestMore(1);
+        ts.requestMore(1);
+        Thread.sleep(100);
+        ts.unsubscribe();
+        ts.assertUnsubscribed();
+        ts.assertNoErrors();
+        assertEquals(6, requests.get());
+    }
+    
+    @Test
+    public void testRequestOverflowDoesNotOccur() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(Long.MAX_VALUE-1);
+        Observable.range(1, 10).skip(5).subscribe(ts);
+        ts.assertTerminalEvent();
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        assertEquals(Arrays.asList(6,7,8,9,10), ts.getOnNextEvents());
+    }
+    
 }


### PR DESCRIPTION
`OperatorSkip` suffered from this race condition:

Suppose we wanted to skip 5 elements, then

* two concurrent requests of say 1 between onStart request of 0 and first emission would request 1+ (5-0) and 1 + (5-0) elements = 12 elements. To deliver the two requested we only need 7 from upstream so we have overrequested.

It also lacked protection from request overflow.

Two unit tests have been added that failed on previous code and now pass.