### PR TITLE
takeUntil(predicate) - include last value in error cause

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
@@ -18,6 +18,8 @@ package rx.internal.operators;
 import rx.Observable.Operator;
 import rx.*;
 import rx.annotations.Experimental;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
 /**
@@ -37,15 +39,16 @@ public final class OperatorTakeUntilPredicate<T> implements Operator<T, T> {
         }
 
         @Override
-        public void onNext(T args) {
-            child.onNext(args);
+        public void onNext(T t) {
+            child.onNext(t);
             
             boolean stop = false;
             try {
-                stop = stopPredicate.call(args);
+                stop = stopPredicate.call(t);
             } catch (Throwable e) {
                 done = true;
-                child.onError(e);
+                Exceptions.throwIfFatal(e);
+                child.onError(OnErrorThrowable.addValueAsLastCause(e, t));
                 unsubscribe();
                 return;
             }

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -16,6 +16,8 @@
 
 package rx.internal.operators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -131,5 +133,21 @@ public class OperatorTakeUntilPredicateTest {
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
         Assert.assertEquals(0, ts.getOnCompletedEvents().size());
+    }
+    
+    @Test
+    public void testErrorIncludesLastValueAsCause() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        final TestException e = new TestException("Forced failure");
+        Observable.just("abc").takeUntil(new Func1<String, Boolean>() {
+            @Override
+            public Boolean call(String t) {
+                throw e;
+            }
+        }).subscribe(ts);
+        ts.assertTerminalEvent();
+        ts.assertNotCompleted();
+        assertEquals(1, (int) ts.getOnErrorEvents().size());
+        assertTrue(ts.getOnErrorEvents().get(0).getCause().getMessage().contains("abc"));
     }
 }


### PR DESCRIPTION
As per title, unit test included.