### PR TITLE
Fix value rendering in error last cause for primitive types

### DIFF
--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -15,6 +15,9 @@
  */
 package rx.exceptions;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import rx.plugins.RxJavaErrorHandler;
 import rx.plugins.RxJavaPlugins;
 
@@ -109,6 +112,27 @@ public final class OnErrorThrowable extends RuntimeException {
     public static class OnNextValue extends RuntimeException {
 
         private static final long serialVersionUID = -3454462756050397899L;
+        
+        // Lazy loaded singleton 
+        private static final class Primitives {
+            
+            static final Set<Class<?>> INSTANCE = create();
+
+            private static Set<Class<?>> create() {
+                Set<Class<?>> set = new HashSet<Class<?>>();
+                set.add(Boolean.class);
+                set.add(Character.class);
+                set.add(Byte.class);
+                set.add(Short.class);
+                set.add(Integer.class);
+                set.add(Long.class);
+                set.add(Float.class);
+                set.add(Double.class);
+                // Void is another primitive but cannot be instantiated 
+                // and is caught by the null check in renderValue
+                return set;
+            }
+        }
 
         private final Object value;
 
@@ -148,11 +172,11 @@ public final class OnErrorThrowable extends RuntimeException {
          * @return a string version of the object if primitive or managed through error plugin,
          *        otherwise the classname of the object
          */
-        private static String renderValue(Object value){
+        static String renderValue(Object value){
             if (value == null) {
                 return "null";
             }
-            if (value.getClass().isPrimitive()) {
+            if (Primitives.INSTANCE.contains(value.getClass())) {
                 return value.toString();
             }
             if (value instanceof String) {

--- a/src/test/java/rx/exceptions/OnNextValueTest.java
+++ b/src/test/java/rx/exceptions/OnNextValueTest.java
@@ -15,14 +15,18 @@
  */
 package rx.exceptions;
 
+import org.junit.Assert;
 import org.junit.Test;
+
 import rx.Observable;
 import rx.Observer;
+import rx.exceptions.OnErrorThrowable.OnNextValue;
 import rx.functions.Func1;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -117,5 +121,50 @@ public final class OnNextValueTest {
                     }
                 }).subscribe(observer);
 
+    }
+    
+    @Test
+    public void testRenderInteger() {
+        assertEquals("123", OnNextValue.renderValue(123));
+    }
+    
+    @Test
+    public void testRenderByte() {
+        assertEquals("10", OnNextValue.renderValue((byte) 10));
+    }
+    
+    @Test
+    public void testRenderBoolean() {
+        assertEquals("true", OnNextValue.renderValue(true));
+    }
+    
+    @Test
+    public void testRenderShort() {
+        assertEquals("10", OnNextValue.renderValue((short) 10));
+    }
+    
+    @Test
+    public void testRenderLong() {
+        assertEquals("10", OnNextValue.renderValue(10L));
+    }
+    
+    @Test
+    public void testRenderCharacter() {
+        assertEquals("10", OnNextValue.renderValue(10L));
+    }
+    
+    @Test
+    public void testRenderFloat() {
+        assertEquals("10.0", OnNextValue.renderValue(10.0f));
+    }
+    
+    @Test
+    public void testRenderDouble() {
+        assertEquals("10.0", OnNextValue.renderValue(10.0));
+    }
+    
+    @Test
+    public void testRenderVoid() {
+        assertEquals("null", OnNextValue.renderValue((Void) null));
     }
 }


### PR DESCRIPTION
When an error occurs some `Operator`s (like `map`) include the value in the exception cause to help debugging. The intent is that for the 9 primitive types (int/Integer, double/Double, byte/Byte, char/Character etc) we render the value using `value.toString` but the test for being a primitive does not work because `.isPrimitive` always returns false (primitives have always been autoboxed by the time they get here).

The fix is to create a lazy loaded singleton set of the primitive classes (Integer.class, Double.class, etc) and check for membership in that set.

Unit tests included for each primitive type.