### PR TITLE
Scheduler shutdown capability

### DIFF
--- a/src/main/java/rx/Scheduler.java
+++ b/src/main/java/rx/Scheduler.java
@@ -18,7 +18,7 @@ package rx;
 import java.util.concurrent.TimeUnit;
 
 import rx.functions.Action0;
-import rx.schedulers.Schedulers;
+import rx.schedulers.*;
 import rx.subscriptions.MultipleAssignmentSubscription;
 
 /**

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -104,8 +104,10 @@ public class EventLoopsScheduler extends Scheduler implements SchedulerLifecycle
     
     @Override
     public void start() {
-        // we don't care if this fails: it means some other thread has started the pool already
-        pool.compareAndSet(NONE, new FixedSchedulerPool(MAX_THREADS));
+        FixedSchedulerPool update = new FixedSchedulerPool(MAX_THREADS);
+        if (!pool.compareAndSet(NONE, update)) {
+            update.shutdown();
+        }
     }
     
     @Override

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -16,13 +16,15 @@
 package rx.internal.schedulers;
 
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import rx.*;
 import rx.functions.Action0;
 import rx.internal.util.*;
+import rx.schedulers.SchedulerLifecycle;
 import rx.subscriptions.*;
 
-public class EventLoopsScheduler extends Scheduler {
+public class EventLoopsScheduler extends Scheduler implements SchedulerLifecycle {
     /** Manages a fixed number of workers. */
     private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool-";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
@@ -44,40 +46,80 @@ public class EventLoopsScheduler extends Scheduler {
         }
         MAX_THREADS = max;
     }
+    
+    static final PoolWorker SHUTDOWN_WORKER;
+    static {
+        SHUTDOWN_WORKER = new PoolWorker(new RxThreadFactory("RxComputationShutdown-"));
+        SHUTDOWN_WORKER.unsubscribe();
+    }
+    
     static final class FixedSchedulerPool {
         final int cores;
 
         final PoolWorker[] eventLoops;
         long n;
 
-        FixedSchedulerPool() {
+        FixedSchedulerPool(int maxThreads) {
             // initialize event loops
-            this.cores = MAX_THREADS;
-            this.eventLoops = new PoolWorker[cores];
-            for (int i = 0; i < cores; i++) {
+            this.cores = maxThreads;
+            this.eventLoops = new PoolWorker[maxThreads];
+            for (int i = 0; i < maxThreads; i++) {
                 this.eventLoops[i] = new PoolWorker(THREAD_FACTORY);
             }
         }
 
         public PoolWorker getEventLoop() {
+            int c = cores;
+            if (c == 0) {
+                return SHUTDOWN_WORKER;
+            }
             // simple round robin, improvements to come
-            return eventLoops[(int)(n++ % cores)];
+            return eventLoops[(int)(n++ % c)];
+        }
+        
+        public void shutdown() {
+            for (PoolWorker w : eventLoops) {
+                w.unsubscribe();
+            }
         }
     }
+    /** This will indicate no pool is active. */
+    static final FixedSchedulerPool NONE = new FixedSchedulerPool(0);
 
-    final FixedSchedulerPool pool;
+    final AtomicReference<FixedSchedulerPool> pool;
     
     /**
      * Create a scheduler with pool size equal to the available processor
      * count and using least-recent worker selection policy.
      */
     public EventLoopsScheduler() {
-        pool = new FixedSchedulerPool();
+        this.pool = new AtomicReference<FixedSchedulerPool>(NONE);
+        start();
     }
     
     @Override
     public Worker createWorker() {
-        return new EventLoopWorker(pool.getEventLoop());
+        return new EventLoopWorker(pool.get().getEventLoop());
+    }
+    
+    @Override
+    public void start() {
+        // we don't care if this fails: it means some other thread has started the pool already
+        pool.compareAndSet(NONE, new FixedSchedulerPool(MAX_THREADS));
+    }
+    
+    @Override
+    public void shutdown() {
+        for (;;) {
+            FixedSchedulerPool curr = pool.get();
+            if (curr == NONE) {
+                return;
+            }
+            if (pool.compareAndSet(curr, NONE)) {
+                curr.shutdown();
+                return;
+            }
+        }
     }
     
     /**
@@ -87,7 +129,7 @@ public class EventLoopsScheduler extends Scheduler {
      * @return the subscription
      */
     public Subscription scheduleDirect(Action0 action) {
-       PoolWorker pw = pool.getEventLoop();
+       PoolWorker pw = pool.get().getEventLoop();
        return pw.scheduleActual(action, -1, TimeUnit.NANOSECONDS);
     }
 

--- a/src/main/java/rx/internal/schedulers/GenericScheduledExecutorService.java
+++ b/src/main/java/rx/internal/schedulers/GenericScheduledExecutorService.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.schedulers;
-
-import rx.Scheduler;
-import rx.internal.schedulers.NewThreadWorker;
-import rx.internal.util.RxThreadFactory;
+package rx.internal.schedulers;
 
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import rx.Scheduler;
+import rx.internal.util.RxThreadFactory;
+import rx.schedulers.*;
 
 /**
  * A default {@link ScheduledExecutorService} that can be used for scheduling actions when a {@link Scheduler} implementation doesn't have that ability.
@@ -30,15 +31,29 @@ import java.util.concurrent.*;
  * the work asynchronously on the appropriate {@link Scheduler} implementation. This means for example that you would not use this approach
  * along with {@link TrampolineScheduler} or {@link ImmediateScheduler}.
  */
-/* package */final class GenericScheduledExecutorService {
+public final class GenericScheduledExecutorService implements SchedulerLifecycle{
 
     private static final String THREAD_NAME_PREFIX = "RxScheduledExecutorPool-";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
     
-    private final static GenericScheduledExecutorService INSTANCE = new GenericScheduledExecutorService();
-    private final ScheduledExecutorService executor;
-
+    /* Schedulers needs acces to this in order to work with the lifecycle. */
+    public final static GenericScheduledExecutorService INSTANCE = new GenericScheduledExecutorService();
+    
+    private final AtomicReference<ScheduledExecutorService> executor;
+    
+    static final ScheduledExecutorService NONE;
+    static {
+        NONE = Executors.newScheduledThreadPool(0);
+        NONE.shutdownNow();
+    }
+    
     private GenericScheduledExecutorService() {
+        executor = new AtomicReference<ScheduledExecutorService>(NONE);
+        start();
+    }
+
+    @Override
+    public void start() {
         int count = Runtime.getRuntime().availableProcessors();
         if (count > 4) {
             count = count / 2;
@@ -47,21 +62,41 @@ import java.util.concurrent.*;
         if (count > 8) {
             count = 8;
         }
+        
         ScheduledExecutorService exec = Executors.newScheduledThreadPool(count, THREAD_FACTORY);
-        if (!NewThreadWorker.tryEnableCancelPolicy(exec)) {
-            if (exec instanceof ScheduledThreadPoolExecutor) {
-                NewThreadWorker.registerExecutor((ScheduledThreadPoolExecutor)exec);
+        if (executor.compareAndSet(NONE, exec)) {
+            if (!NewThreadWorker.tryEnableCancelPolicy(exec)) {
+                if (exec instanceof ScheduledThreadPoolExecutor) {
+                    NewThreadWorker.registerExecutor((ScheduledThreadPoolExecutor)exec);
+                }
+            }
+            return;
+        } else {
+            exec.shutdown();
+        }
+    }
+    
+    @Override
+    public void shutdown() {
+        for (;;) {
+            ScheduledExecutorService exec = executor.get();
+            if (exec == NONE) {
+                return;
+            }
+            if (executor.compareAndSet(exec, NONE)) {
+                NewThreadWorker.deregisterExecutor(exec);
+                exec.shutdownNow();
+                return;
             }
         }
-        executor = exec;
     }
-
+    
     /**
      * See class Javadoc for information on what this is for and how to use.
      * 
      * @return {@link ScheduledExecutorService} for generic use.
      */
     public static ScheduledExecutorService getInstance() {
-        return INSTANCE.executor;
+        return INSTANCE.executor.get();
     }
 }

--- a/src/main/java/rx/internal/util/ObjectPool.java
+++ b/src/main/java/rx/internal/util/ObjectPool.java
@@ -18,20 +18,21 @@
 package rx.internal.util;
 
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
-import rx.Scheduler;
+import rx.Scheduler.Worker;
 import rx.functions.Action0;
-import rx.internal.util.unsafe.MpmcArrayQueue;
-import rx.internal.util.unsafe.UnsafeAccess;
-import rx.schedulers.Schedulers;
+import rx.internal.util.unsafe.*;
+import rx.schedulers.*;
 
-public abstract class ObjectPool<T> {
+public abstract class ObjectPool<T> implements SchedulerLifecycle {
     private Queue<T> pool;
+    private final int minSize;
     private final int maxSize;
+    private final long validationInterval;
 
-    private Scheduler.Worker schedulerWorker;
+    private final AtomicReference<Worker> schedulerWorker;
 
     public ObjectPool() {
         this(0, 0, 67);
@@ -50,31 +51,14 @@ public abstract class ObjectPool<T> {
      *            When the number of objects is greater than maxIdle, too many instances will be removed.
      */
     private ObjectPool(final int min, final int max, final long validationInterval) {
+        this.minSize = min;
         this.maxSize = max;
+        this.validationInterval = validationInterval;
+        this.schedulerWorker = new AtomicReference<Worker>();
         // initialize pool
         initialize(min);
 
-        schedulerWorker = Schedulers.computation().createWorker();
-        schedulerWorker.schedulePeriodically(new Action0() {
-
-            @Override
-            public void call() {
-                int size = pool.size();
-                if (size < min) {
-                    int sizeToBeAdded = max - size;
-                    for (int i = 0; i < sizeToBeAdded; i++) {
-                        pool.add(createObject());
-                    }
-                } else if (size > max) {
-                    int sizeToBeRemoved = size - max;
-                    for (int i = 0; i < sizeToBeRemoved; i++) {
-                        //                        pool.pollLast();
-                        pool.poll();
-                    }
-                }
-            }
-
-        }, validationInterval, validationInterval, TimeUnit.SECONDS);
+        start();
     }
 
     /**
@@ -109,10 +93,43 @@ public abstract class ObjectPool<T> {
     /**
      * Shutdown this pool.
      */
+    @Override
     public void shutdown() {
-        schedulerWorker.unsubscribe();
+        Worker w = schedulerWorker.getAndSet(null);
+        if (w != null) {
+            w.unsubscribe();
+        }
     }
 
+    @Override
+    public void start() {
+        Worker w = Schedulers.computation().createWorker();
+        if (schedulerWorker.compareAndSet(null, w)) {
+            w.schedulePeriodically(new Action0() {
+    
+                @Override
+                public void call() {
+                    int size = pool.size();
+                    if (size < minSize) {
+                        int sizeToBeAdded = maxSize - size;
+                        for (int i = 0; i < sizeToBeAdded; i++) {
+                            pool.add(createObject());
+                        }
+                    } else if (size > maxSize) {
+                        int sizeToBeRemoved = size - maxSize;
+                        for (int i = 0; i < sizeToBeRemoved; i++) {
+                            //                        pool.pollLast();
+                            pool.poll();
+                        }
+                    }
+                }
+    
+            }, validationInterval, validationInterval, TimeUnit.SECONDS);
+        } else {
+            w.unsubscribe();
+        }
+    }
+    
     /**
      * Creates a new object.
      *

--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -275,7 +275,8 @@ public class RxRingBuffer implements Subscription {
     }
     public static final int SIZE = _size;
 
-    private static ObjectPool<Queue<Object>> SPSC_POOL = new ObjectPool<Queue<Object>>() {
+    /* Public so Schedulers can manage the lifecycle of the inner worker. */
+    public static ObjectPool<Queue<Object>> SPSC_POOL = new ObjectPool<Queue<Object>>() {
 
         @Override
         protected SpscArrayQueue<Object> createObject() {
@@ -284,7 +285,8 @@ public class RxRingBuffer implements Subscription {
 
     };
 
-    private static ObjectPool<Queue<Object>> SPMC_POOL = new ObjectPool<Queue<Object>>() {
+    /* Public so Schedulers can manage the lifecycle of the inner worker. */
+    public static ObjectPool<Queue<Object>> SPMC_POOL = new ObjectPool<Queue<Object>>() {
 
         @Override
         protected SpmcArrayQueue<Object> createObject() {

--- a/src/main/java/rx/schedulers/CachedThreadScheduler.java
+++ b/src/main/java/rx/schedulers/CachedThreadScheduler.java
@@ -25,9 +25,9 @@ import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
 
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.*;
 
-/* package */final class CachedThreadScheduler extends Scheduler {
+/* package */final class CachedThreadScheduler extends Scheduler implements SchedulerLifecycle {
     private static final String WORKER_THREAD_NAME_PREFIX = "RxCachedThreadScheduler-";
     private static final RxThreadFactory WORKER_THREAD_FACTORY =
             new RxThreadFactory(WORKER_THREAD_NAME_PREFIX);
@@ -36,31 +36,45 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
     private static final RxThreadFactory EVICTOR_THREAD_FACTORY =
             new RxThreadFactory(EVICTOR_THREAD_NAME_PREFIX);
 
+    private static final long KEEP_ALIVE_TIME = 60;
+    private static final TimeUnit KEEP_ALIVE_UNIT = TimeUnit.SECONDS;
+    
+    static final ThreadWorker SHUTDOWN_THREADWORKER;
+    static {
+        SHUTDOWN_THREADWORKER = new ThreadWorker(new RxThreadFactory("RxCachedThreadSchedulerShutdown-"));
+        SHUTDOWN_THREADWORKER.unsubscribe();
+    }
+    
     private static final class CachedWorkerPool {
         private final long keepAliveTime;
         private final ConcurrentLinkedQueue<ThreadWorker> expiringWorkerQueue;
-        private final ScheduledExecutorService evictExpiredWorkerExecutor;
+        private final CompositeSubscription allWorkers;
+        private final ScheduledExecutorService evictorService;
 
         CachedWorkerPool(long keepAliveTime, TimeUnit unit) {
-            this.keepAliveTime = unit.toNanos(keepAliveTime);
+            this.keepAliveTime = unit != null ? unit.toNanos(keepAliveTime) : 0L;
             this.expiringWorkerQueue = new ConcurrentLinkedQueue<ThreadWorker>();
+            this.allWorkers = new CompositeSubscription();
 
-            evictExpiredWorkerExecutor = Executors.newScheduledThreadPool(1, EVICTOR_THREAD_FACTORY);
-            evictExpiredWorkerExecutor.scheduleWithFixedDelay(
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            evictExpiredWorkers();
-                        }
-                    }, this.keepAliveTime, this.keepAliveTime, TimeUnit.NANOSECONDS
-            );
+            ScheduledExecutorService evictor = null;
+            if (unit != null) {
+                evictor = Executors.newScheduledThreadPool(1, EVICTOR_THREAD_FACTORY);
+                evictor.scheduleWithFixedDelay(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                evictExpiredWorkers();
+                            }
+                        }, this.keepAliveTime, this.keepAliveTime, TimeUnit.NANOSECONDS
+                );
+            }
+            evictorService = evictor;
         }
 
-        private static CachedWorkerPool INSTANCE = new CachedWorkerPool(
-                60L, TimeUnit.SECONDS
-        );
-
         ThreadWorker get() {
+            if (allWorkers.isUnsubscribed()) {
+                return SHUTDOWN_THREADWORKER;
+            }
             while (!expiringWorkerQueue.isEmpty()) {
                 ThreadWorker threadWorker = expiringWorkerQueue.poll();
                 if (threadWorker != null) {
@@ -69,7 +83,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
             }
 
             // No cached worker found, so create a new one.
-            return new ThreadWorker(WORKER_THREAD_FACTORY);
+            ThreadWorker w = new ThreadWorker(WORKER_THREAD_FACTORY);
+            allWorkers.add(w);
+            return w;
         }
 
         void release(ThreadWorker threadWorker) {
@@ -86,7 +102,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
                 for (ThreadWorker threadWorker : expiringWorkerQueue) {
                     if (threadWorker.getExpirationTime() <= currentTimestamp) {
                         if (expiringWorkerQueue.remove(threadWorker)) {
-                            threadWorker.unsubscribe();
+                            allWorkers.remove(threadWorker);
                         }
                     } else {
                         // Queue is ordered with the worker that will expire first in the beginning, so when we
@@ -100,30 +116,70 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
         long now() {
             return System.nanoTime();
         }
+        
+        void shutdown() {
+            if (evictorService != null) {
+                evictorService.shutdownNow();
+            }
+            allWorkers.unsubscribe();
+        }
     }
 
+    final AtomicReference<CachedWorkerPool> pool;
+    
+    static final CachedWorkerPool NONE;
+    static {
+        NONE = new CachedWorkerPool(0, null);
+        NONE.shutdown();
+    }
+    
+    public CachedThreadScheduler() {
+        this.pool = new AtomicReference<CachedWorkerPool>(NONE);
+        start();
+    }
+    
+    @Override
+    public void start() {
+        pool.compareAndSet(NONE, new CachedWorkerPool(KEEP_ALIVE_TIME, KEEP_ALIVE_UNIT));
+    }
+    @Override
+    public void shutdown() {
+        for (;;) {
+            CachedWorkerPool curr = pool.get();
+            if (curr == NONE) {
+                return;
+            }
+            if (pool.compareAndSet(curr, NONE)) {
+                curr.shutdown();
+                return;
+            }
+        }
+    }
+    
     @Override
     public Worker createWorker() {
-        return new EventLoopWorker(CachedWorkerPool.INSTANCE.get());
+        return new EventLoopWorker(pool.get());
     }
 
     private static final class EventLoopWorker extends Scheduler.Worker {
         private final CompositeSubscription innerSubscription = new CompositeSubscription();
+        private final CachedWorkerPool pool;
         private final ThreadWorker threadWorker;
         @SuppressWarnings("unused")
         volatile int once;
         static final AtomicIntegerFieldUpdater<EventLoopWorker> ONCE_UPDATER
                 = AtomicIntegerFieldUpdater.newUpdater(EventLoopWorker.class, "once");
 
-        EventLoopWorker(ThreadWorker threadWorker) {
-            this.threadWorker = threadWorker;
+        EventLoopWorker(CachedWorkerPool pool) {
+            this.pool = pool;
+            this.threadWorker = pool.get();
         }
 
         @Override
         public void unsubscribe() {
             if (ONCE_UPDATER.compareAndSet(this, 0, 1)) {
                 // unsubscribe should be idempotent, so only do this once
-                CachedWorkerPool.INSTANCE.release(threadWorker);
+                pool.release(threadWorker);
             }
             innerSubscription.unsubscribe();
         }

--- a/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
 import rx.functions.Action0;
-import rx.internal.schedulers.ScheduledAction;
+import rx.internal.schedulers.*;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.*;
 

--- a/src/main/java/rx/schedulers/SchedulerLifecycle.java
+++ b/src/main/java/rx/schedulers/SchedulerLifecycle.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.schedulers;
+
+/**
+ * Represents the capability of a Scheduler to be start or shut down its maintained
+ * threads.
+ */
+public interface SchedulerLifecycle {
+    /** 
+     * Allows the Scheduler instance to start threads 
+     * and accept tasks on them.
+     * <p>Implementations should make sure the call is idempotent and threadsafe. 
+     */
+    void start();
+    /** 
+     * Instructs the Scheduler instance to stop threads 
+     * and stop accepting tasks on any outstanding Workers. 
+     * <p>Implementations should make sure the call is idempotent and threadsafe. 
+     */
+    void shutdown();
+}

--- a/src/main/java/rx/schedulers/Schedulers.java
+++ b/src/main/java/rx/schedulers/Schedulers.java
@@ -137,4 +137,37 @@ public final class Schedulers {
     public static Scheduler from(Executor executor) {
         return new ExecutorScheduler(executor);
     }
+    
+    /**
+     * Starts those standard Schedulers which support the SchedulerLifecycle interface.
+     * <p>The operation is idempotent and threadsafe.
+     */
+    public static void start() {
+        Schedulers s = INSTANCE;
+        if (s.computationScheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) s.computationScheduler).start();
+        }
+        if (s.ioScheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) s.computationScheduler).start();
+        }
+        if (s.newThreadScheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) s.computationScheduler).start();
+        }
+    }
+    /**
+     * Shuts down those standard Schedulers which support the SchedulerLifecycle interface.
+     * <p>The operation is idempotent and threadsafe
+     */
+    public static void shutdown() {
+        Schedulers s = INSTANCE;
+        if (s.computationScheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) s.computationScheduler).shutdown();
+        }
+        if (s.ioScheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) s.computationScheduler).shutdown();
+        }
+        if (s.newThreadScheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) s.computationScheduler).shutdown();
+        }
+    }
 }

--- a/src/test/java/rx/schedulers/SchedulerLifecycleTest.java
+++ b/src/test/java/rx/schedulers/SchedulerLifecycleTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import rx.Scheduler.Worker;
+import rx.functions.Action0;
+import rx.subscriptions.CompositeSubscription;
+
+public class SchedulerLifecycleTest {
+    @Test
+    public void testShutdown() throws InterruptedException {
+        Set<Thread> rxThreads = new HashSet<Thread>();
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().startsWith("Rx")) {
+                rxThreads.add(t);
+            }
+        }
+        Schedulers.shutdown();
+        System.out.println("testShutdown >> Giving time to threads to stop");
+        Thread.sleep(500);
+        
+        for (Thread t : rxThreads) {
+            assertFalse(t.isAlive());
+        }
+        
+        System.out.println("testShutdown >> Restarting schedulers...");
+        Schedulers.start();
+        
+        final CountDownLatch cdl = new CountDownLatch(3);
+        
+        Action0 countAction = new Action0() {
+            @Override
+            public void call() {
+                cdl.countDown();
+            }
+        };
+        
+        CompositeSubscription csub = new CompositeSubscription();
+        
+        try {
+            Worker w1 = Schedulers.computation().createWorker();
+            csub.add(w1);
+            w1.schedule(countAction);
+            
+            Worker w2 = Schedulers.io().createWorker();
+            csub.add(w2);
+            w2.schedule(countAction);
+            
+            Worker w3 = Schedulers.newThread().createWorker();
+            csub.add(w3);
+            w3.schedule(countAction);
+            
+            if (!cdl.await(3, TimeUnit.SECONDS)) {
+                fail("countAction was not run by every worker");
+            }
+        } finally {
+            csub.unsubscribe();
+        }
+    }
+    
+    @Test
+    public void testStartIdempotence() throws InterruptedException {
+        Set<Thread> rxThreads = new HashSet<Thread>();
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().startsWith("Rx")) {
+                rxThreads.add(t);
+            }
+        }
+        System.out.println("testStartIdempotence >> trying to start again");
+        Schedulers.start();
+        System.out.println("testStartIdempotence >> giving some time");
+        Thread.sleep(500);
+        
+        Set<Thread> rxThreads2 = new HashSet<Thread>();
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().startsWith("Rx")) {
+                rxThreads2.add(t);
+            }
+        }
+        
+        assertEquals(rxThreads, rxThreads2);
+    }
+}


### PR DESCRIPTION
This comes back from time to time (#1730): some containers, when removing RxJava enabled applications expect it to shut down all its threads but by default, computation threads can't be shut down manually and io threads take 1 minute to shut down on their own. 

This PR adds the capability to make them shut down their worker threads more eagerly. Since such shutdown would be terminal and thus break any subsequent test, a restart capability is required.

Therefore, I've introduced the optional `SchedulerLifecycle` interface which if implemented by a Scheduler, makes it eligible for the `Schedulers` factory to trigger a shutdown or restart for all kinds of schedulers.

Naturally, this implies some extra cost:

  - The underlying pool of the computation scheduler is no longer constant and involves a volatile get every time a worker is requested. I haven't benchmarked this but it just adds a cheap load on x86 and shouldn't be a performance hit.
  - Since we need to track all ThreadWorkers of the io scheduler, this involves a `CompositeSubscription` and the cost of starting new workers is increased by the synchronization and HashSet.add() operations. However, since starting a new thread in itself is somewhat expensive, again this shouldn't be a performance hit although it's hard to benchmark it.

In addition, to support proper task rejection after the scheduler has shut down, both scheduler types require a constant shutdown worker. These workers are created at class load time and will spin up a thread for a short duration before they shut it down. They don't affect, performance wise, the normal operations but the app startup time might get increased. The tradeoff here is to save on a mandatory class cast whenever a worker is requested.