### PR TITLE
Delay: error cut ahead was not properly serialized

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDelayTest.java
@@ -798,4 +798,27 @@ public class OperatorDelayTest {
         ts.assertNoErrors();
         assertEquals(RxRingBuffer.SIZE * 2, ts.getOnNextEvents().size());
     }
+    
+    @Test
+    public void testErrorRunsBeforeOnNext() {
+        TestScheduler test = Schedulers.test();
+        
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        ps.delay(1, TimeUnit.SECONDS, test).subscribe(ts);
+        
+        ps.onNext(1);
+        
+        test.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        
+        ps.onError(new TestException());
+        
+        test.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
 }


### PR DESCRIPTION
Originally, the error through `delay` was emitted directly to the child without serializing in respect of an in-flight `onNext()`. This change schedules the error on the worker with no delay which ensures proper serialization. (The alternative would be to wrap the child into a `SerializedSubscriber`, however, that wouldn't immediately cancel any in-flight onNext schedules.)