### PR TITLE
Operator requestBatching to change the in-flight event amounts

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -6613,6 +6613,24 @@ public class Observable<T> {
     }
 
     /**
+     * Returns an Observable that batches the backpressure requests to the upstream
+     * if the downstream requests more than a specified batch size.
+     * @param batchSize the number of elements to request upfront and otherwise keep in-flight
+     * @param replenishLevel the lower bound for in-flight values that triggers a replenishment
+     * @return an Observable that batches the backpressure requests to the upstream
+     */
+    @Experimental
+    public final Observable<T> requestBatching(int batchSize, int replenishLevel) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize > 0 required");
+        }
+        if (replenishLevel < 0) {
+            throw new IllegalArgumentException("replenishLevel >= 0 required");
+        }
+        return lift(new OperatorRequestBatcher<T>(batchSize, replenishLevel));
+    }
+    
+    /**
      * Returns an Observable that emits the most recently emitted item (if any) emitted by the source Observable
      * within periodic time intervals.
      * <p>

--- a/src/main/java/rx/internal/operators/OperatorRequestBatcher.java
+++ b/src/main/java/rx/internal/operators/OperatorRequestBatcher.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.Observable.Operator;
+import rx.*;
+
+public final class OperatorRequestBatcher<T> implements Operator<T, T> {
+    final int batchSize;
+    final int replenishLevel;
+    
+    public OperatorRequestBatcher(int batchSize, int replenishLevel) {
+        this.batchSize = batchSize;
+        this.replenishLevel = replenishLevel;
+    }
+    @Override
+    public Subscriber<? super T> call(Subscriber<? super T> child) {
+        RequestBatcherSubscriber<T> parent = new RequestBatcherSubscriber<T>(
+                child, batchSize, replenishLevel);
+        RequestBatcherProducer<T> producer = new RequestBatcherProducer<T>(parent);
+        child.add(parent);
+        child.setProducer(producer);
+        return parent;
+    }
+
+    static final class RequestBatcherSubscriber<T> extends Subscriber<T> {
+        final Subscriber<? super T> child;
+        final int batchSize;
+        final int replenishLevel;
+        RequestBatcherProducer<T> producer;
+        
+        public RequestBatcherSubscriber(Subscriber<? super T> child, int batchSize, int replenishLevel) {
+            this.child = child;
+            this.batchSize = batchSize;
+            this.replenishLevel = replenishLevel;
+            this.request(0);
+        }
+        @Override
+        public void onNext(T t) {
+            child.onNext(t);
+            producer.produced();
+        }
+        @Override
+        public void onError(Throwable e) {
+            child.onError(e);
+        }
+        @Override
+        public void onCompleted() {
+            child.onCompleted();
+        }
+        public void requestMore(long n) {
+            request(n);
+        }
+    }
+    
+    static final class RequestBatcherProducer<T> implements Producer {
+        
+        final RequestBatcherSubscriber<T> parent;
+        long childRequested;
+        long upstreamRequested;
+        
+        public RequestBatcherProducer(RequestBatcherSubscriber<T> parent) {
+            parent.producer = this;
+            this.parent = parent;
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n < 0) {
+                throw new IllegalArgumentException("n >= 0 required");
+            }
+            if (n > 0) {
+                long n0;
+                synchronized (this) {
+                    long r = childRequested;
+                    long u = r + n;
+                    if (u < 0) {
+                        u = Long.MAX_VALUE;
+                    }
+                    childRequested = u;
+
+                    if (r != 0) {
+                        return;
+                    }
+                    long k = upstreamRequested;
+                    n0 = Math.min(parent.batchSize, u) - k;
+                    upstreamRequested = k + n0;
+                }
+                if (n0 != 0L) {
+                    parent.requestMore(n0);
+                }
+            }
+        }
+        void produced() {
+            long n0;
+            synchronized (this) {
+                long c = --childRequested;
+                
+                long k = --upstreamRequested;
+                if (k > parent.replenishLevel) {
+                    return;
+                }
+                
+                n0 = Math.min(parent.batchSize - k, c - k);
+                upstreamRequested = k + n0;
+            }
+            if (n0 != 0L) {
+                parent.requestMore(n0);
+            }
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/OperatorRequestBatcherTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRequestBatcherTest.java
@@ -1,0 +1,318 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.*;
+
+import rx.Observable;
+import rx.functions.Action1;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
+
+public class OperatorRequestBatcherTest {
+    @Test
+    public void testMaxValueSubscriber() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testMaxValueSubscriber >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        source.subscribe(ts);
+        
+        ts.assertValueCount(100);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        
+        Assert.assertEquals(Arrays.asList(20L, 15L, 15L, 15L, 15L, 15L, 15L), requests);
+    }
+    @Test
+    public void testTotalGreaterValueSubscriber() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testTotalGreaterValueSubscriber >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(200);
+        
+        source.subscribe(ts);
+        
+        ts.assertValueCount(100);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        
+        Assert.assertEquals(Arrays.asList(20L, 15L, 15L, 15L, 15L, 15L, 15L), requests);
+    }
+    
+    @Test
+    public void testLargerValueSubscriber() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testLargerValueSubscriber >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(30) {
+            int remaining = 30;
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (--remaining == 0) {
+                    remaining = 30;
+                    request(30);
+                }
+            }
+            @Override
+            public void onError(Throwable e) {
+                super.onError(e);
+            }
+            @Override
+            public void onCompleted() {
+                super.onCompleted();
+            }
+        };
+        
+        source.subscribe(ts);
+        
+        ts.assertValueCount(100);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        
+        Assert.assertEquals(Arrays.asList(20L, 10L, 20L, 10L, 20L, 10L, 20L), requests);
+    }
+    @Test
+    public void testSmallerValueSubscriber() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testSmallerValueSubscriber >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(30) {
+            int remaining = 10;
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (--remaining == 0) {
+                    remaining = 10;
+                    request(10);
+                }
+            }
+            @Override
+            public void onError(Throwable e) {
+                super.onError(e);
+            }
+            @Override
+            public void onCompleted() {
+                super.onCompleted();
+            }
+        };
+        
+        source.subscribe(ts);
+        
+        ts.assertValueCount(100);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        
+        Assert.assertEquals(Arrays.asList(20L, 15L, 15L, 15L, 15L, 15L, 15L), requests);
+    }
+    
+    @Test
+    public void testBackpressureHonored() {
+        final List<Long> requests = new ArrayList<Long>();
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testBackpressureHonored >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testBackpressureHonored 2 >> " + t);
+                    }
+                })
+                ;
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(15);
+        
+        source.subscribe(ts);
+        
+        ts.assertValueCount(15);
+        
+        ts.requestMore(15);
+        
+        ts.assertValueCount(30);
+        
+        ts.requestMore(69);
+
+        ts.assertValueCount(99);
+        
+        ts.assertNotCompleted();
+        ts.assertNoErrors();
+    }
+    @Test
+    public void testBackpressureHonoredModulo() {
+        final List<Long> requests = new ArrayList<Long>();
+        Observable<Integer> source = Observable.range(0, 120)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testBackpressureHonored >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testBackpressureHonored 2 >> " + t);
+                    }
+                })
+                ;
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(15);
+        
+        source.subscribe(ts);
+        int tally = 15;
+        for (int i = 0; i < 8; i++) {
+            ts.assertValueCount(tally);
+            tally += 15;
+            ts.requestMore(15);
+        }
+
+        ts.assertValueCount(120);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+    @Test
+    public void testBackpressureHonoredAsync() {
+        final List<Long> requests = new ArrayList<Long>();
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testBackpressureHonoredAsync >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 5)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testBackpressureHonoredAsync 2 >> " + t);
+                    }
+                })
+                .observeOn(Schedulers.computation())
+                ;
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        source.subscribe(ts);
+
+        ts.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        ts.assertValueCount(100);
+    }
+    
+    @Test
+    public void testZeroLevelValueSubscriber() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testZeroLevelValueSubscriber >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 0);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(200);
+        
+        source.subscribe(ts);
+        
+        ts.assertValueCount(100);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        
+        Assert.assertEquals(Arrays.asList(20L, 20L, 20L, 20L, 20L, 20L), requests);
+    }
+    
+    @Test
+    public void testZeroLevelLargeRequestValueSubscriber() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        Observable<Integer> source = Observable.range(0, 100)
+                .doOnRequest(new Action1<Long>() {
+                    @Override
+                    public void call(Long t) {
+                        System.out.println("testZeroLevelValueSubscriber >> " + t);
+                        requests.add(t);
+                    }
+                })
+                .requestBatching(20, 0);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(50);
+        
+        source.subscribe(ts);
+
+        ts.assertValueCount(50);
+        
+        ts.requestMore(50);
+        
+        ts.assertValueCount(100);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        
+        Assert.assertEquals(Arrays.asList(20L, 20L, 10L, 20L, 20L, 10L), requests);
+    }
+}


### PR DESCRIPTION
I'm proposing an operator that can change (lower) the in-flight request amount for both an unlimited downstream and for a backpressuring downstream.

I'm not certain about its use cases besides forcing a slow-path emission in a stream where the Subscriber requests Long.MAX_VALUE, for example with the rewritten merge of #2928 where one merges long streams asynchronously, the internal serialization buffer can get quite large. The use of this operator would switch it back to a slower-path merging where bounded buffers are employed.