### PR TITLE
Fix OperatorFlatMapPerf.flatMapIntPassthruAsync Perf Test

### DIFF
--- a/src/perf/java/rx/operators/OperatorFlatMapPerf.java
+++ b/src/perf/java/rx/operators/OperatorFlatMapPerf.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.State;
 import rx.Observable;
 import rx.functions.Func1;
 import rx.jmh.InputWithIncrementingInteger;
+import rx.jmh.LatchedObserver;
 import rx.schedulers.Schedulers;
 
 @BenchmarkMode(Mode.Throughput)
@@ -62,6 +63,7 @@ public class OperatorFlatMapPerf {
 
     @Benchmark
     public void flatMapIntPassthruAsync(Input input) throws InterruptedException {
+        LatchedObserver<Integer> latchedObserver = input.newLatchedObserver();
         input.observable.flatMap(new Func1<Integer, Observable<Integer>>() {
 
             @Override
@@ -69,7 +71,8 @@ public class OperatorFlatMapPerf {
                 return Observable.just(i).subscribeOn(Schedulers.computation());
             }
 
-        }).subscribe(input.observer);
+        }).subscribe(latchedObserver);
+        latchedObserver.latch.await();
     }
 
     @Benchmark


### PR DESCRIPTION
This test was reported broken in https://github.com/ReactiveX/RxJava/pull/2928#issuecomment-113229698

Fixing by adding the use of LatchedObserver.

Previously broken test results:

```
r.o.OperatorFlatMapPerf.flatMapIntPassthruAsync         1  thrpt         5   363615.622   115041.519    ops/s
r.o.OperatorFlatMapPerf.flatMapIntPassthruAsync      1000  thrpt         5      350.204      125.773    ops/s
r.o.OperatorFlatMapPerf.flatMapIntPassthruAsync   1000000  thrpt         5        0.319        0.184    ops/s
```

Fixed results:

```
r.o.OperatorFlatMapPerf.flatMapIntPassthruAsync         1  thrpt         5   102109.681     8709.920    ops/s
r.o.OperatorFlatMapPerf.flatMapIntPassthruAsync      1000  thrpt         5      403.071      130.651    ops/s
r.o.OperatorFlatMapPerf.flatMapIntPassthruAsync   1000000  thrpt         5        0.355        0.070    ops/s
```