### PR TITLE
Window with Observable: fixed unsubscription and behavior

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9060,7 +9060,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/window.html">ReactiveX operators documentation: Window</a>
      */
     public final <TClosing> Observable<Observable<T>> window(Func0<? extends Observable<? extends TClosing>> closingSelector) {
-        return lift(new OperatorWindowWithObservable<T, TClosing>(closingSelector));
+        return lift(new OperatorWindowWithObservableFactory<T, TClosing>(closingSelector));
     }
 
     /**

--- a/src/main/java/rx/internal/operators/OperatorWindowWithStartEndObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithStartEndObservable.java
@@ -15,17 +15,14 @@
  */
 package rx.internal.operators;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import rx.Observable;
+import java.util.*;
+
+import rx.*;
 import rx.Observable.Operator;
+import rx.Observable;
 import rx.Observer;
-import rx.Subscriber;
 import rx.functions.Func1;
-import rx.observers.SerializedObserver;
-import rx.observers.SerializedSubscriber;
+import rx.observers.*;
 import rx.subscriptions.CompositeSubscription;
 
 /**
@@ -49,9 +46,12 @@ public final class OperatorWindowWithStartEndObservable<T, U, V> implements Oper
     
     @Override
     public Subscriber<? super T> call(Subscriber<? super Observable<T>> child) {
-        final SourceSubscriber sub = new SourceSubscriber(child);
+        CompositeSubscription csub = new CompositeSubscription();
+        child.add(csub);
         
-        Subscriber<U> open = new Subscriber<U>(child) {
+        final SourceSubscriber sub = new SourceSubscriber(child, csub);
+        
+        Subscriber<U> open = new Subscriber<U>() {
 
             @Override
             public void onStart() {
@@ -73,7 +73,10 @@ public final class OperatorWindowWithStartEndObservable<T, U, V> implements Oper
                 sub.onCompleted();
             }
         };
-           
+        
+        csub.add(sub);
+        csub.add(open);
+        
         windowOpenings.unsafeSubscribe(open);
         
         return sub;
@@ -97,13 +100,11 @@ public final class OperatorWindowWithStartEndObservable<T, U, V> implements Oper
         final List<SerializedSubject<T>> chunks;
         /** Guarded by guard. */
         boolean done;
-        public SourceSubscriber(Subscriber<? super Observable<T>> child) {
-            super(child);
+        public SourceSubscriber(Subscriber<? super Observable<T>> child, CompositeSubscription csub) {
             this.child = new SerializedSubscriber<Observable<T>>(child);
             this.guard = new Object();
             this.chunks = new LinkedList<SerializedSubject<T>>();
-            this.csub = new CompositeSubscription();
-            child.add(csub);
+            this.csub = csub;
         }
         
         @Override
@@ -127,36 +128,44 @@ public final class OperatorWindowWithStartEndObservable<T, U, V> implements Oper
 
         @Override
         public void onError(Throwable e) {
-            List<SerializedSubject<T>> list;
-            synchronized (guard) {
-                if (done) {
-                    return;
+            try {
+                List<SerializedSubject<T>> list;
+                synchronized (guard) {
+                    if (done) {
+                        return;
+                    }
+                    done = true;
+                    list = new ArrayList<SerializedSubject<T>>(chunks);
+                    chunks.clear();
                 }
-                done = true;
-                list = new ArrayList<SerializedSubject<T>>(chunks);
-                chunks.clear();
+                for (SerializedSubject<T> cs : list) {
+                    cs.consumer.onError(e);
+                }
+                child.onError(e);
+            } finally {
+                csub.unsubscribe();
             }
-            for (SerializedSubject<T> cs : list) {
-                cs.consumer.onError(e);
-            }
-            child.onError(e);
         }
 
         @Override
         public void onCompleted() {
-            List<SerializedSubject<T>> list;
-            synchronized (guard) {
-                if (done) {
-                    return;
+            try {
+                List<SerializedSubject<T>> list;
+                synchronized (guard) {
+                    if (done) {
+                        return;
+                    }
+                    done = true;
+                    list = new ArrayList<SerializedSubject<T>>(chunks);
+                    chunks.clear();
                 }
-                done = true;
-                list = new ArrayList<SerializedSubject<T>>(chunks);
-                chunks.clear();
+                for (SerializedSubject<T> cs : list) {
+                    cs.consumer.onCompleted();
+                }
+                child.onCompleted();
+            } finally {
+                csub.unsubscribe();
             }
-            for (SerializedSubject<T> cs : list) {
-                cs.consumer.onCompleted();
-            }
-            child.onCompleted();
         }
         
         void beginWindow(U token) {

--- a/src/test/java/rx/internal/operators/OperatorWindowWithStartEndObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithStartEndObservableTest.java
@@ -15,25 +15,20 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
+import rx.*;
 import rx.Observable;
 import rx.Observer;
-import rx.Scheduler;
-import rx.Subscriber;
-import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.functions.Func0;
-import rx.functions.Func1;
+import rx.functions.*;
+import rx.observers.TestSubscriber;
 import rx.schedulers.TestScheduler;
+import rx.subjects.PublishSubject;
 
 public class OperatorWindowWithStartEndObservableTest {
 
@@ -112,14 +107,21 @@ public class OperatorWindowWithStartEndObservableTest {
         });
 
         Func0<Observable<Object>> closer = new Func0<Observable<Object>>() {
+            int calls;
             @Override
             public Observable<Object> call() {
                 return Observable.create(new Observable.OnSubscribe<Object>() {
                     @Override
                     public void call(Subscriber<? super Object> observer) {
-                        push(observer, new Object(), 100);
-                        push(observer, new Object(), 200);
-                        complete(observer, 301);
+                        int c = calls++;
+                        if (c == 0) {
+                            push(observer, new Object(), 100);
+                        } else
+                        if (c == 1) {
+                            push(observer, new Object(), 100);
+                        } else {
+                            complete(observer, 101);
+                        }
                     }
                 });
             }
@@ -184,5 +186,69 @@ public class OperatorWindowWithStartEndObservableTest {
                 });
             }
         };
+    }
+    
+    @Test
+    public void testNoUnsubscribeAndNoLeak() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        PublishSubject<Integer> open = PublishSubject.create();
+        final PublishSubject<Integer> close = PublishSubject.create();
+        
+        TestSubscriber<Observable<Integer>> ts = TestSubscriber.create();
+        
+        source.window(open, new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer t) {
+                return close;
+            }
+        }).unsafeSubscribe(ts);
+        
+        open.onNext(1);
+        source.onNext(1);
+        
+        assertTrue(open.hasObservers());
+        assertTrue(close.hasObservers());
+
+        close.onNext(1);
+        
+        assertFalse(close.hasObservers());
+        
+        source.onCompleted();
+        
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        ts.assertValueCount(1);
+        
+        assertFalse(ts.isUnsubscribed());
+        assertFalse(open.hasObservers());
+        assertFalse(close.hasObservers());
+    }
+    
+    @Test
+    public void testUnsubscribeAll() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        PublishSubject<Integer> open = PublishSubject.create();
+        final PublishSubject<Integer> close = PublishSubject.create();
+        
+        TestSubscriber<Observable<Integer>> ts = TestSubscriber.create();
+        
+        source.window(open, new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer t) {
+                return close;
+            }
+        }).unsafeSubscribe(ts);
+        
+        open.onNext(1);
+        
+        assertTrue(open.hasObservers());
+        assertTrue(close.hasObservers());
+
+        ts.unsubscribe();
+        
+        assertFalse(open.hasObservers());
+        assertFalse(close.hasObservers());
     }
 }


### PR DESCRIPTION
Fixed unsubscription propagation of two Window variants (boundary, start-end).

In addition, there was a discrepancy reported on [StackOverflow](http://stackoverflow.com/questions/30963993/rxjava-window-buffer-overload-questions-incompatibility-with-rx-net) regarding the factory-boundary version. In Rx.NET, the factory is called whenever the previous boundary observable has produced a value. I.e., instead of a series of `onNexts` from the same `Observable`, it uses a series of `Observable`s with a single `onNext` emission as a boundary indicator.