### PR TITLE
CompositeException extra NPE protection

### DIFF
--- a/src/main/java/rx/exceptions/CompositeException.java
+++ b/src/main/java/rx/exceptions/CompositeException.java
@@ -49,12 +49,19 @@ public final class CompositeException extends RuntimeException {
     public CompositeException(String messagePrefix, Collection<? extends Throwable> errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();
         List<Throwable> _exceptions = new ArrayList<Throwable>();
-        for (Throwable ex : errors) {
-            if (ex instanceof CompositeException) {
-                deDupedExceptions.addAll(((CompositeException) ex).getExceptions());
-            } else {
-                deDupedExceptions.add(ex);
+        if (errors != null) {
+            for (Throwable ex : errors) {
+                if (ex instanceof CompositeException) {
+                    deDupedExceptions.addAll(((CompositeException) ex).getExceptions());
+                } else 
+                if (ex != null) {
+                    deDupedExceptions.add(ex);
+                } else {
+                    deDupedExceptions.add(new NullPointerException());
+                }
             }
+        } else {
+            deDupedExceptions.add(new NullPointerException());
         }
 
         _exceptions.addAll(deDupedExceptions);

--- a/src/test/java/rx/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/rx/exceptions/CompositeExceptionTest.java
@@ -165,4 +165,17 @@ public class CompositeExceptionTest {
             }
         }
     }
+    
+    @Test
+    public void testNullCollection() {
+        CompositeException composite = new CompositeException(null);
+        composite.getCause();
+        composite.printStackTrace();
+    }
+    @Test
+    public void testNullElement() {
+        CompositeException composite = new CompositeException(Arrays.asList((Throwable)null));
+        composite.getCause();
+        composite.printStackTrace();
+    }
 }


### PR DESCRIPTION
`CompositeException` won't crash if it received null by some means. A `null` collection or `null` collection item is replaced by a `NullPointerException` instance.

See also: #3046.