### PR TITLE
toSingle() should use unsafeSubscribe

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeSingle.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeSingle.java
@@ -80,7 +80,7 @@ public class OnSubscribeSingle<T> implements Single.OnSubscribe<T> {
             }
         };
         child.add(parent);
-        observable.subscribe(parent);
+        observable.unsafeSubscribe(parent);
     }
 
     public static <T> OnSubscribeSingle<T> create(Observable<T> observable) {

--- a/src/test/java/rx/internal/operators/OnSubscribeSingleTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeSingleTest.java
@@ -15,13 +15,18 @@
  */
 package rx.internal.operators;
 
-import org.junit.Test;
-import rx.Observable;
-import rx.Single;
-import rx.observers.TestSubscriber;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Collections;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.Single;
+import rx.functions.Action0;
+import rx.observers.TestSubscriber;
 
 public class OnSubscribeSingleTest {
 
@@ -69,5 +74,20 @@ public class OnSubscribeSingleTest {
         single.subscribe(subscriber);
 
         subscriber.assertError(IllegalArgumentException.class);
+    }
+    
+    @Test
+    public void testShouldUseUnsafeSubscribeInternallyNotSubscribe() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        final AtomicBoolean unsubscribed = new AtomicBoolean(false);
+        Single<String> single = Observable.just("Hello World!").doOnUnsubscribe(new Action0() {
+
+            @Override
+            public void call() {
+                unsubscribed.set(true);
+            }}).toSingle();
+        single.unsafeSubscribe(subscriber);
+        subscriber.assertCompleted();
+        assertFalse(unsubscribed.get());
     }
 }


### PR DESCRIPTION
As per my comment in #3049, `Observable.toSingle` should use `unsafeSubscribe` internally.

This PR includes a unit test that failed on previous code.