### PR TITLE
switchOnNext() - fix lost requests race condition 

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorSwitchIfEmptyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchIfEmptyTest.java
@@ -27,7 +27,6 @@ import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.functions.Action0;
-import rx.functions.Action1;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.Subscriptions;


### PR DESCRIPTION
As per #3073 a race condition in `OperatorSwitch` means that requests can be lost. This PR uses `ProducerArbiter` to ensure all unfulfilled requests are carried through to the next `Observable`.

I also changed `InnerSubscriber` to be a static class as opposed to an inner class just to decouple it from surrounding state. 