### PR TITLE
break tests as approach timeout so that don't fail on slow machines

### DIFF
--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -419,7 +419,13 @@ public class BackpressureTests {
 
     @Test(timeout = 10000)
     public void testOnBackpressureDrop() {
+        long t = System.currentTimeMillis();
         for (int i = 0; i < 100; i++) {
+            // stop the test if we are getting close to the timeout because slow machines 
+            // may not get through 100 iterations
+            if (System.currentTimeMillis() - t > TimeUnit.SECONDS.toMillis(9)) {
+                break;
+            }
             int NUM = (int) (RxRingBuffer.SIZE * 1.1); // > 1 so that take doesn't prevent buffer overflow
             AtomicInteger c = new AtomicInteger();
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -224,7 +224,11 @@ public class OperatorMergeMaxConcurrentTest {
     }
     @Test(timeout = 10000)
     public void testSimpleOneLessAsync() {
+        long t = System.currentTimeMillis();
         for (int i = 2; i < 50; i++) {
+            if (System.currentTimeMillis() - t > TimeUnit.SECONDS.toMillis(9)) {
+                break;
+            }
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
             Set<Integer> expected = new HashSet<Integer>(i);


### PR DESCRIPTION
These tests were giving me regular failures on my slow laptop:

* `OperatorMergeMaxConcurrentTest.testSimpleOneLessAsync`
* `BackpressureTests.testOnBackpressureDrop`

They both loop repeatedly looking for failure or lockup. If the machine running the tests isn't fast enough then the tests timeout before reaching the desired number of loops. This PR adds a break to the tests when the loop has run for 9 seconds (timeout is 10 seconds).