### PR TITLE
improve ExecutorSchedulerTest.testOnBackpressureDrop

### DIFF
--- a/src/test/java/rx/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/rx/schedulers/ExecutorSchedulerTest.java
@@ -177,11 +177,11 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         };
         ExecutorSchedulerWorker w = (ExecutorSchedulerWorker)Schedulers.from(e).createWorker();
         
-        w.schedule(Actions.empty(), 1, TimeUnit.MILLISECONDS);
+        w.schedule(Actions.empty(), 50, TimeUnit.MILLISECONDS);
         
         assertTrue(w.tasks.hasSubscriptions());
         
-        Thread.sleep(100);
+        Thread.sleep(150);
         
         assertFalse(w.tasks.hasSubscriptions());
     }


### PR DESCRIPTION
This test fails for me occasionally on my slow laptop when full test suite run because work is scheduled for only 1ms in the future. I've decreased the probability of this one failing by changing the schedule to 50ms in the future.