### PR TITLE
add code quality plugins to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,52 @@ description = 'RxJava: Reactive Extensions for the JVM – a library for composi
 
 apply plugin: 'rxjava-project'
 apply plugin: 'java'
+apply plugin: 'findbugs'
+apply plugin: 'jacoco'
 
 dependencies {
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
 }
 
+////////////////////////////////////////////////////////////////////
+// to run findbugs: 
+//     ./gradlew findbugsMain
+// then open build/reports/findbugs/main.html
+////////////////////////////////////////////////////////////////////
+
+findbugs {
+  ignoreFailures = false
+  toolVersion = '+'
+  // disable findbugs for default runs of `check` or `build`
+  sourceSets = [] 
+  reportsDir = file("$project.buildDir/reports/findbugs")
+  effort = 'max'
+}
+
+//////////////////////////////////////////////////////////////////
+// to run jacoco: 
+//     ./gradlew test jacocoTestReport
+// to run jacoco on a single test (matches OperatorRetry to OperatorRetryTest in test code base):
+//     ./gradlew -Dtest.single=OperatorRetry test jacocoTestReport
+// then open build/reports/jacoco/index.html
+/////////////////////////////////////////////////////////////////
+
+jacoco {
+    toolVersion = '+'
+    reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination "${buildDir}/reports/jacoco"
+    }
+}
+
 javadoc {
-    exclude "**/rx/internal/**"
+    exclude '**/rx/internal/**'
 }
 
 // support for snapshot/final releases with the various branches RxJava uses
@@ -28,5 +66,12 @@ if (project.hasProperty('release.useLastTag')) {
 }
 
 test{
-     maxHeapSize = "2g"
+     maxHeapSize = '2g'
 }
+
+tasks.withType(FindBugs) {
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+ }


### PR DESCRIPTION
This PR adds plugins for 

* findbugs
* jacoco (code coverage)

The plugins do not run by default and are run as below:

`./gradlew findbugsMain` then open `build/reports/findbugs/main.html`.

`./gradlew test jacocoTestReport` then open `build/reports/jacoco/index.html`

Coverage can be run on a single test like so:

`./gradlew -Dtest.single=OperatorRetry test jacocoTestReport`

All these instructions are in comments in `build.gradle`.

