### PR TITLE
Fix request != 0 checking in the scalar paths of merge()

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -315,7 +315,8 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             if (r != 0L) {
                 synchronized (this) {
                     // if nobody is emitting and child has available requests
-                    if (!emitting) {
+                    r = producer.get();
+                    if (!emitting && r != 0L) {
                         emitting = true;
                         success = true;
                     }
@@ -422,7 +423,8 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             if (r != 0L) {
                 synchronized (this) {
                     // if nobody is emitting and child has available requests
-                    if (!emitting) {
+                    r = producer.get();
+                    if (!emitting && r != 0L) {
                         emitting = true;
                         success = true;
                     }


### PR DESCRIPTION
Requested amount could reach zero between the first check and entering the synchronized block where it has to be re-read in order to verify the scalar emission can really happen at that point; the new `testMergeAsyncThenObserveOnLoop` test failed with `MissingBackpressureException` after ~20 rounds on my i7 4770K.

This might or might not relate to the canary failure; if combined with retry(), it could have failed over and over, but I'm not sure where the worker retention might have happened.