### PR TITLE
Fix take swallowing exception if thrown by exactly the nth onNext call to it.

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorTakeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeTest.java
@@ -16,36 +16,21 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Observer;
-import rx.Producer;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.functions.Action1;
-import rx.functions.Func1;
-import rx.observers.Subscribers;
-import rx.observers.TestSubscriber;
+import rx.exceptions.TestException;
+import rx.functions.*;
+import rx.observers.*;
 import rx.schedulers.Schedulers;
 
 public class OperatorTakeTest {
@@ -413,5 +398,23 @@ public class OperatorTakeTest {
         ts.assertCompleted();
         ts.assertNoErrors();
         assertEquals(2,requests.get());
+    }
+    
+    @Test
+    public void takeFinalValueThrows() {
+        Observable<Integer> source = Observable.just(1).take(1);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                throw new TestException();
+            }
+        };
+        
+        source.subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
     }
 }


### PR DESCRIPTION
Fixes the case uncovered by #3095.