### PR TITLE
Fix SynchronizedQueue.equals

### DIFF
--- a/src/main/java/rx/internal/util/SynchronizedQueue.java
+++ b/src/main/java/rx/internal/util/SynchronizedQueue.java
@@ -99,13 +99,25 @@ public class SynchronizedQueue<T> implements Queue<T> {
     }
 
     @Override
-    public synchronized boolean equals(Object o) {
-        return list.equals(o);
+    public int hashCode() {
+        return list.hashCode();
     }
 
     @Override
-    public synchronized int hashCode() {
-        return list.hashCode();
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SynchronizedQueue<?> other = (SynchronizedQueue<?>) obj;
+        if (list == null) {
+            if (other.list != null)
+                return false;
+        } else if (!list.equals(other.list))
+            return false;
+        return true;
     }
 
     @Override

--- a/src/test/java/rx/internal/util/SynchronizedQueueTest.java
+++ b/src/test/java/rx/internal/util/SynchronizedQueueTest.java
@@ -1,0 +1,15 @@
+package rx.internal.util;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SynchronizedQueueTest {
+    
+    @Test
+    public void testEquals() {
+         SynchronizedQueue<Object> q = new SynchronizedQueue<Object>();
+         assertTrue(q.equals(q));
+    }
+
+}


### PR DESCRIPTION
Courtesy of findBugs, `SynchronizedQueue.equals()` is improperly implemented. I used Eclipse to generate a new `equals()` method based on the `list` field.

The existing code would even have failed to return true when testing queue equality with itself.

I don't think this is causing problems anywhere but this PR will ensure that it doesn't cause a problem in the future.