### PR TITLE
Observers package test coverage and fixes.

### DIFF
--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -117,13 +117,17 @@ public class TestObserver<T> implements Observer<T> {
         }
 
         for (int i = 0; i < items.size(); i++) {
-            if (items.get(i) == null) {
+            T expected = items.get(i);
+            T actual = onNextEvents.get(i);
+            if (expected == null) {
                 // check for null equality
-                if (onNextEvents.get(i) != null) {
-                    throw new AssertionError("Value at index: " + i + " expected to be [null] but was: [" + onNextEvents.get(i) + "]");
+                if (actual != null) {
+                    throw new AssertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]");
                 }
-            } else if (!items.get(i).equals(onNextEvents.get(i))) {
-                throw new AssertionError("Value at index: " + i + " expected to be [" + items.get(i) + "] (" + items.get(i).getClass().getSimpleName() + ") but was: [" + onNextEvents.get(i) + "] (" + onNextEvents.get(i).getClass().getSimpleName() + ")");
+            } else if (!expected.equals(actual)) {
+                throw new AssertionError("Value at index: " + i 
+                        + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName() 
+                        + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")");
 
             }
         }

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -258,10 +258,15 @@ public class TestSubscriber<T> extends Subscriber<T> {
      *          if this {@code Subscriber} has received one or more {@code onError} notifications
      */
     public void assertNoErrors() {
-        if (getOnErrorEvents().size() > 0) {
-            // can't use AssertionError because (message, cause) doesn't exist until Java 7
-            throw new RuntimeException("Unexpected onError events: " + getOnErrorEvents().size(), getOnErrorEvents().get(0));
-            // TODO possibly check for Java7+ and then use AssertionError at runtime (since we always compile with 7)
+        List<Throwable> onErrorEvents = getOnErrorEvents();
+        if (onErrorEvents.size() > 0) {
+            AssertionError ae = new AssertionError("Unexpected onError events: " + getOnErrorEvents().size());
+            if (onErrorEvents.size() == 1) {
+                ae.initCause(getOnErrorEvents().get(0));
+            } else {
+                ae.initCause(new CompositeException(onErrorEvents));
+            }
+            throw ae;
         }
     }
 

--- a/src/test/java/rx/observers/ObserversTest.java
+++ b/src/test/java/rx/observers/ObserversTest.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.*;
+import java.util.concurrent.atomic.*;
+
+import org.junit.Test;
+
+import rx.exceptions.*;
+import rx.functions.*;
+
+public class ObserversTest {
+    @Test
+    public void testNotInstantiable() {
+        try {
+            Constructor<?> c = Observers.class.getDeclaredConstructor();
+            c.setAccessible(true);
+            Object instance = c.newInstance();
+            fail("Could instantiate Actions! " + instance);
+        } catch (NoSuchMethodException ex) {
+            ex.printStackTrace();
+        } catch (InvocationTargetException ex) {
+            ex.printStackTrace();
+        } catch (InstantiationException ex) {
+            ex.printStackTrace();
+        } catch (IllegalAccessException ex) {
+            ex.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testEmptyOnErrorNotImplemented() {
+        try {
+            Observers.empty().onError(new TestException());
+            fail("OnErrorNotImplementedException not thrown!");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                fail("TestException not wrapped, instead: " + ex.getCause());
+            }
+        }
+    }
+    @Test
+    public void testCreate1OnErrorNotImplemented() {
+        try {
+            Observers.create(Actions.empty()).onError(new TestException());
+            fail("OnErrorNotImplementedException not thrown!");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                fail("TestException not wrapped, instead: " + ex.getCause());
+            }
+        }
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate1Null() {
+        Observers.create(null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate2Null() {
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(null, throwAction);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate3Null() {
+        Observers.create(Actions.empty(), null);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate4Null() {
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(null, throwAction, Actions.empty());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate5Null() {
+        Observers.create(Actions.empty(), null, Actions.empty());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate6Null() {
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(Actions.empty(), throwAction, null);
+    }
+    
+    @Test
+    public void testCreate1Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Action1<Integer> action = new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                value.set(t);
+            }
+        };
+        Observers.create(action).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    @Test
+    public void testCreate2Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Action1<Integer> action = new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                value.set(t);
+            }
+        };
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(action, throwAction).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testCreate3Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Action1<Integer> action = new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                value.set(t);
+            }
+        };
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(action, throwAction, Actions.empty()).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testError2() {
+        final AtomicReference<Throwable> value = new AtomicReference<Throwable>();
+        Action1<Throwable> action = new Action1<Throwable>() {
+            @Override
+            public void call(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Observers.create(Actions.empty(), action).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testError3() {
+        final AtomicReference<Throwable> value = new AtomicReference<Throwable>();
+        Action1<Throwable> action = new Action1<Throwable>() {
+            @Override
+            public void call(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Observers.create(Actions.empty(), action, Actions.empty()).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testCompleted() {
+        Action0 action = mock(Action0.class);
+        
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(Actions.empty(), throwAction, action).onCompleted();
+
+        verify(action).call();
+    }
+    
+    @Test
+    public void testEmptyCompleted() {
+        Observers.create(Actions.empty()).onCompleted();
+        
+        Action1<Throwable> throwAction = Actions.empty();
+        Observers.create(Actions.empty(), throwAction).onCompleted();
+    }
+}

--- a/src/test/java/rx/observers/SafeObserverTest.java
+++ b/src/test/java/rx/observers/SafeObserverTest.java
@@ -15,11 +15,7 @@
  */
 package rx.observers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,9 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import rx.Subscriber;
-import rx.exceptions.CompositeException;
-import rx.exceptions.OnErrorFailedException;
-import rx.exceptions.OnErrorNotImplementedException;
+import rx.exceptions.*;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
 
@@ -461,5 +455,46 @@ public class SafeObserverTest {
         public SafeObserverTestException(String message) {
             super(message);
         }
+    }
+    
+    @Test
+    public void testOnCompletedThrows() {
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(new Subscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                
+            }
+            @Override
+            public void onError(Throwable e) {
+                error.set(e);
+            }
+            @Override
+            public void onCompleted() {
+                throw new TestException();
+            }
+        });
+        
+        s.onCompleted();
+        
+        assertTrue("Error not received", error.get() instanceof TestException);
+    }
+    
+    @Test
+    public void testActual() {
+        Subscriber<Integer> actual = new Subscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+            }
+            @Override
+            public void onError(Throwable e) {
+            }
+            @Override
+            public void onCompleted() {
+            }
+        };
+        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(actual);
+        
+        assertSame(actual, s.getActual());
     }
 }

--- a/src/test/java/rx/observers/SafeSubscriberTest.java
+++ b/src/test/java/rx/observers/SafeSubscriberTest.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.*;
+
+import rx.exceptions.*;
+import rx.functions.Action0;
+import rx.plugins.*;
+import rx.subscriptions.Subscriptions;
+
+public class SafeSubscriberTest {
+    
+    @Before
+    @After
+    public void resetBefore() {
+        RxJavaPlugins ps = RxJavaPlugins.getInstance();
+        
+        try {
+            Method m = ps.getClass().getDeclaredMethod("reset");
+            m.setAccessible(true);
+            m.invoke(ps);
+        } catch (Throwable ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testOnCompletedThrows() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onCompleted() {
+                throw new TestException();
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        
+        safe.onCompleted();
+        
+        assertTrue(safe.isUnsubscribed());
+    }
+    
+    @Test
+    public void testOnCompletedThrows2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onCompleted() {
+                throw new OnErrorNotImplementedException(new TestException());
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        
+        try {
+            safe.onCompleted();
+        } catch (OnErrorNotImplementedException ex) {
+            // expected
+        }
+        
+        assertTrue(safe.isUnsubscribed());
+    }
+    
+    @Test
+    public void testPluginException() {
+        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+            @Override
+            public void handleError(Throwable e) {
+                throw new RuntimeException();
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onCompleted() {
+                throw new TestException();
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        
+        safe.onCompleted();
+    }
+    
+    @Test(expected = OnErrorFailedException.class)
+    public void testPluginExceptionWhileOnErrorUnsubscribeThrows() {
+        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+            int calls;
+            @Override
+            public void handleError(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        safe.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                throw new RuntimeException();
+            }
+        }));
+        
+        safe.onError(new TestException());
+    }
+    
+    @Test(expected = RuntimeException.class)
+    public void testPluginExceptionWhileOnErrorThrowsNotImplAndUnsubscribeThrows() {
+        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+            int calls;
+            @Override
+            public void handleError(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new OnErrorNotImplementedException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        safe.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                throw new RuntimeException();
+            }
+        }));
+        
+        safe.onError(new TestException());
+    }
+    
+    @Test(expected = OnErrorFailedException.class)
+    public void testPluginExceptionWhileOnErrorThrows() {
+        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+            int calls;
+            @Override
+            public void handleError(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        
+        safe.onError(new TestException());
+    }
+    @Test(expected = OnErrorFailedException.class)
+    public void testPluginExceptionWhileOnErrorThrowsAndUnsubscribeThrows() {
+        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+            int calls;
+            @Override
+            public void handleError(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        safe.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                throw new RuntimeException();
+            }
+        }));
+        
+        safe.onError(new TestException());
+    }
+    @Test(expected = OnErrorFailedException.class)
+    public void testPluginExceptionWhenUnsubscribing2() {
+        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+            int calls;
+            @Override
+            public void handleError(Throwable e) {
+                if (++calls == 3) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);
+        safe.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                throw new RuntimeException();
+            }
+        }));
+        
+        safe.onError(new TestException());
+    }
+}

--- a/src/test/java/rx/observers/SubscribersTest.java
+++ b/src/test/java/rx/observers/SubscribersTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.*;
+import java.util.concurrent.atomic.*;
+
+import org.junit.Test;
+
+import rx.exceptions.*;
+import rx.functions.*;
+
+public class SubscribersTest {
+    @Test
+    public void testNotInstantiable() {
+        try {
+            Constructor<?> c = Subscribers.class.getDeclaredConstructor();
+            c.setAccessible(true);
+            Object instance = c.newInstance();
+            fail("Could instantiate Actions! " + instance);
+        } catch (NoSuchMethodException ex) {
+            ex.printStackTrace();
+        } catch (InvocationTargetException ex) {
+            ex.printStackTrace();
+        } catch (InstantiationException ex) {
+            ex.printStackTrace();
+        } catch (IllegalAccessException ex) {
+            ex.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testEmptyOnErrorNotImplemented() {
+        try {
+            Subscribers.empty().onError(new TestException());
+            fail("OnErrorNotImplementedException not thrown!");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                fail("TestException not wrapped, instead: " + ex.getCause());
+            }
+        }
+    }
+    @Test
+    public void testCreate1OnErrorNotImplemented() {
+        try {
+            Subscribers.create(Actions.empty()).onError(new TestException());
+            fail("OnErrorNotImplementedException not thrown!");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                fail("TestException not wrapped, instead: " + ex.getCause());
+            }
+        }
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate1Null() {
+        Subscribers.create(null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate2Null() {
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(null, throwAction);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate3Null() {
+        Subscribers.create(Actions.empty(), null);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate4Null() {
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(null, throwAction, Actions.empty());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate5Null() {
+        Subscribers.create(Actions.empty(), null, Actions.empty());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreate6Null() {
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(Actions.empty(), throwAction, null);
+    }
+    
+    @Test
+    public void testCreate1Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Action1<Integer> action = new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                value.set(t);
+            }
+        };
+        Subscribers.create(action).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    @Test
+    public void testCreate2Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Action1<Integer> action = new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                value.set(t);
+            }
+        };
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(action, throwAction).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testCreate3Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Action1<Integer> action = new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                value.set(t);
+            }
+        };
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(action, throwAction, Actions.empty()).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testError2() {
+        final AtomicReference<Throwable> value = new AtomicReference<Throwable>();
+        Action1<Throwable> action = new Action1<Throwable>() {
+            @Override
+            public void call(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Subscribers.create(Actions.empty(), action).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testError3() {
+        final AtomicReference<Throwable> value = new AtomicReference<Throwable>();
+        Action1<Throwable> action = new Action1<Throwable>() {
+            @Override
+            public void call(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Subscribers.create(Actions.empty(), action, Actions.empty()).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testCompleted() {
+        Action0 action = mock(Action0.class);
+        
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(Actions.empty(), throwAction, action).onCompleted();
+
+        verify(action).call();
+    }
+    @Test
+    public void testEmptyCompleted() {
+        Subscribers.create(Actions.empty()).onCompleted();
+        
+        Action1<Throwable> throwAction = Actions.empty();
+        Subscribers.create(Actions.empty(), throwAction).onCompleted();
+    }
+}

--- a/src/test/java/rx/observers/TestObserverTest.java
+++ b/src/test/java/rx/observers/TestObserverTest.java
@@ -15,20 +15,19 @@
  */
 package rx.observers;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
+import java.util.*;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.mockito.InOrder;
 
+import rx.Notification;
 import rx.Observable;
 import rx.Observer;
+import rx.exceptions.TestException;
 import rx.subjects.PublishSubject;
 
 public class TestObserverTest {
@@ -124,5 +123,109 @@ public class TestObserverTest {
     public void testErrorSwallowed() {
         Observable.error(new RuntimeException()).subscribe(new TestObserver<Object>());
     }
+    
+    @Test
+    public void testGetEvents() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onNext(1);
+        to.onNext(2);
+        
+        assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), 
+                Collections.emptyList(), 
+                Collections.emptyList()), to.getEvents());
+        
+        to.onCompleted();
+        
+        assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), Collections.emptyList(),
+                Collections.singletonList(Notification.createOnCompleted())), to.getEvents());
+        
+        TestException ex = new TestException();
+        TestObserver<Integer> to2 = new TestObserver<Integer>();
+        to2.onNext(1);
+        to2.onNext(2);
+        
+        assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), 
+                Collections.emptyList(), 
+                Collections.emptyList()), to2.getEvents());
+        
+        to2.onError(ex);
+        
+        assertEquals(Arrays.<Object>asList(
+                Arrays.asList(1, 2),
+                Collections.singletonList(ex),
+                Collections.emptyList()), 
+                    to2.getEvents());
+    }
 
+    @Test
+    public void testNullExpected() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onNext(1);
+
+        try {
+            to.assertReceivedOnNext(Arrays.asList((Integer)null));
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Null element check assertion didn't happen!");
+    }
+    
+    @Test
+    public void testNullActual() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onNext(null);
+
+        try {
+            to.assertReceivedOnNext(Arrays.asList(1));
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Null element check assertion didn't happen!");
+    }
+    
+    @Test
+    public void testTerminalErrorOnce() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onError(new TestException());
+        to.onError(new TestException());
+        
+        try {
+            to.assertTerminalEvent();
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Failed to report multiple onError terminal events!");
+    }
+    @Test
+    public void testTerminalCompletedOnce() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onCompleted();
+        to.onCompleted();
+        
+        try {
+            to.assertTerminalEvent();
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Failed to report multiple onError terminal events!");
+    }
+    
+    @Test
+    public void testTerminalOneKind() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onError(new TestException());
+        to.onCompleted();
+        
+        try {
+            to.assertTerminalEvent();
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Failed to report multiple kinds of events!");
+    }
 }


### PR DESCRIPTION
This includes a rewrite of `SerializedObserver` to have a more cleaner exception semantics.

The `TestSubscriberTest` can be improved further but I've run out of time for today.