### PR TITLE
No InterruptedException with synchronous BlockingObservable

### DIFF
--- a/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
@@ -93,6 +93,10 @@ public final class BlockingOperatorToIterator {
 
             private Notification<? extends T> take() {
                 try {
+                    Notification<? extends T> poll = notifications.poll();
+                    if (poll != null) {
+                        return poll;
+                    }
                     return notifications.take();
                 } catch (InterruptedException e) {
                     subscription.unsubscribe();

--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -123,17 +123,7 @@ public final class BlockingObservable<T> {
                 onNext.call(args);
             }
         });
-        // block until the subscription completes and then return
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
-            subscription.unsubscribe();
-            // set the interrupted flag again so callers can still get it
-            // for more information see https://github.com/ReactiveX/RxJava/pull/147#issuecomment-13624780
-            Thread.currentThread().interrupt();
-            // using Runtime so it is not checked
-            throw new RuntimeException("Interrupted while waiting for subscription to complete.", e);
-        }
+        awaitForComplete(latch, subscription);
 
         if (exceptionFromOnError.get() != null) {
             if (exceptionFromOnError.get() instanceof RuntimeException) {
@@ -456,14 +446,7 @@ public final class BlockingObservable<T> {
                 returnItem.set(item);
             }
         });
-
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
-            subscription.unsubscribe();
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while waiting for subscription to complete.", e);
-        }
+        awaitForComplete(latch, subscription);
 
         if (returnException.get() != null) {
             if (returnException.get() instanceof RuntimeException) {
@@ -474,5 +457,24 @@ public final class BlockingObservable<T> {
         }
 
         return returnItem.get();
+    }
+
+    private void awaitForComplete(CountDownLatch latch, Subscription subscription) {
+        if (latch.getCount() == 0) {
+            // Synchronous observable completes before awaiting for it.
+            // Skip await so InterruptedException will never be thrown.
+            return;
+        }
+        // block until the subscription completes and then return
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            subscription.unsubscribe();
+            // set the interrupted flag again so callers can still get it
+            // for more information see https://github.com/ReactiveX/RxJava/pull/147#issuecomment-13624780
+            Thread.currentThread().interrupt();
+            // using Runtime so it is not checked
+            throw new RuntimeException("Interrupted while waiting for subscription to complete.", e);
+        }
     }
 }

--- a/src/test/java/rx/internal/operators/BlockingOperatorNextTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorNextTest.java
@@ -15,11 +15,8 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static rx.internal.operators.BlockingOperatorNext.next;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -28,18 +25,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import rx.Observable;
 import rx.Subscriber;
 import rx.exceptions.TestException;
-import rx.internal.operators.BlockingOperatorNext;
 import rx.observables.BlockingObservable;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static rx.internal.operators.BlockingOperatorNext.next;
 
 public class BlockingOperatorNextTest {
 
@@ -82,6 +81,13 @@ public class BlockingOperatorNextTest {
         fireOnNextInNewThread(obs, "two");
         assertTrue(it.hasNext());
         assertEquals("two", it.next());
+
+        fireOnNextInNewThread(obs, "three");
+        try {
+            assertEquals("three", it.next());
+        } catch (NoSuchElementException e) {
+            fail("Calling next() without hasNext() should wait for next fire");
+        }
 
         obs.onCompleted();
         assertFalse(it.hasNext());


### PR DESCRIPTION
I'm using Observable for backport of Java 8's java.util.stream (i.e. [no more loops](http://www.deadcoderising.com/java-8-no-more-loops/)) for Android project.

```java
List<Foo> list2 = Observable.from(list)
        .map(...)
        .filter(...)
        .toList().toBlocking().single()
```

But it sometimes emits InterruptedException at BlockingObservable.
https://github.com/ReactiveX/RxJava/issues/1804#issuecomment-61396523

As the BlocingObservable is placed in map() of another observable with `subscribeOn(Schedulers.io())`, and it is unsubscribed from main thread, perhaps Future.cancel(true) is called on unsubscribing. (#1914)

This PR allows BlockingObsevable not to be interrupted when source observable emits synchronously, by checking current latch or queue state before awaiting for them.