### PR TITLE
Allow to use null as error for TestSubscriber.assertError()

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -404,20 +404,29 @@ public class TestSubscriber<T> extends Subscriber<T> {
      */
     @Experimental
     public void assertError(Throwable throwable) {
-        List<Throwable> err = testObserver.getOnErrorEvents();
-        if (err.size() == 0) {
+        final List<Throwable> errorEvents = testObserver.getOnErrorEvents();
+
+        if (errorEvents.isEmpty()) {
             throw new AssertionError("No errors");
-        } else
-        if (err.size() > 1) {
-            AssertionError ae = new AssertionError("Multiple errors: " + err.size());
-            ae.initCause(new CompositeException(err));
-            throw ae;
-        } else
-        if (!throwable.equals(err.get(0))) {
-            AssertionError ae = new AssertionError("Exceptions differ; expected: " + throwable + ", actual: " + err.get(0));
-            ae.initCause(err.get(0));
+        }
+
+        if (errorEvents.size() > 1) {
+            AssertionError ae = new AssertionError("Multiple errors: " + errorEvents.size());
+            ae.initCause(new CompositeException(errorEvents));
             throw ae;
         }
+
+        final Throwable firstError = errorEvents.isEmpty()
+                ? null
+                : errorEvents.get(0);
+
+        if (throwable != firstError && !throwable.equals(firstError)) {
+            AssertionError ae = new AssertionError("Exceptions differ; expected: " + throwable + ", actual: " + firstError);
+            ae.initCause(firstError);
+            throw ae;
+        }
+
+        // assert passed
     }
 
     /**

--- a/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -24,7 +24,9 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Observer;
+import rx.Subscriber;
 import rx.functions.Action1;
+import rx.observers.TestSubscriber;
 import rx.subjects.PublishSubject;
 
 public class ExceptionsTest {
@@ -162,4 +164,19 @@ public class ExceptionsTest {
         }
     }
 
+    @Test
+    public void shouldAllowThrowingNullError() {
+        TestSubscriber<Object> testSubscriber = new TestSubscriber<Object>();
+
+        Observable
+                .create(new Observable.OnSubscribe<Object>() {
+                    @Override
+                    public void call(Subscriber<? super Object> subscriber) {
+                        subscriber.onError(null);
+                    }
+                })
+                .subscribe(testSubscriber);
+
+        testSubscriber.assertError((Throwable) null);
+    }
 }


### PR DESCRIPTION
Resolves #3125 via test, makes `TestSubscriber.assertError()` little bit faster via caching first error, and allows to use `TestSubscriber.assertError(null)`.