### PR TITLE
Switch to PrivateConstructorChecker for "testNotInstantiable" tests

### DIFF
--- a/src/test/java/rx/functions/ActionsTest.java
+++ b/src/test/java/rx/functions/ActionsTest.java
@@ -17,11 +17,11 @@ package rx.functions;
 
 import static org.junit.Assert.*;
 
-import java.lang.reflect.*;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
+import rx.internal.util.PrivateConstructorChecker;
 
 public class ActionsTest {
 
@@ -269,22 +269,13 @@ public class ActionsTest {
             assertEquals(i, value.get());
         }
     }
-    
+
     @Test
     public void testNotInstantiable() {
-        try {
-            Constructor<?> c = Actions.class.getDeclaredConstructor();
-            c.setAccessible(true);
-            Object instance = c.newInstance();
-            fail("Could instantiate Actions! " + instance);
-        } catch (NoSuchMethodException ex) {
-            ex.printStackTrace();
-        } catch (InvocationTargetException ex) {
-            ex.printStackTrace();
-        } catch (InstantiationException ex) {
-            ex.printStackTrace();
-        } catch (IllegalAccessException ex) {
-            ex.printStackTrace();
-        }
+        PrivateConstructorChecker
+                .forClass(Actions.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("No instances!")
+                .check();
     }
 }

--- a/src/test/java/rx/functions/FunctionsTest.java
+++ b/src/test/java/rx/functions/FunctionsTest.java
@@ -17,29 +17,20 @@ package rx.functions;
 
 import static org.junit.Assert.*;
 
-import java.lang.reflect.*;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
+import rx.internal.util.PrivateConstructorChecker;
 
 public class FunctionsTest {
     @Test
     public void testNotInstantiable() {
-        try {
-            Constructor<?> c = Functions.class.getDeclaredConstructor();
-            c.setAccessible(true);
-            Object instance = c.newInstance();
-            fail("Could instantiate Actions! " + instance);
-        } catch (NoSuchMethodException ex) {
-            ex.printStackTrace();
-        } catch (InvocationTargetException ex) {
-            ex.printStackTrace();
-        } catch (InstantiationException ex) {
-            ex.printStackTrace();
-        } catch (IllegalAccessException ex) {
-            ex.printStackTrace();
-        }
+        PrivateConstructorChecker
+                .forClass(Functions.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("No instances!")
+                .check();
     }
     
     @Test(expected = RuntimeException.class)

--- a/src/test/java/rx/internal/util/PrivateConstructionCheckerTest.java
+++ b/src/test/java/rx/internal/util/PrivateConstructionCheckerTest.java
@@ -1,0 +1,243 @@
+package rx.internal.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PrivateConstructionCheckerTest {
+
+    @Test
+    public void builderShouldThrowExceptionIfNullWasPassedAsExpectedTypeOfException() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(Object.class)
+                    .expectedTypeOfException(null);
+
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("expectedTypeOfException can not be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void builderShouldThrowExceptionIfNullWasPassedAsExpectedExceptionMessage() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(Object.class)
+                    .expectedExceptionMessage(null);
+
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("expectedExceptionMessage can not be null", expected.getMessage());
+        }
+    }
+
+    static class ClassWithoutDefaultConstructor {
+        private ClassWithoutDefaultConstructor(String someParam) {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionIfClassHasNonDefaultConstructor() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithoutDefaultConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals(
+                    "Class has non-default constructor with some parameters",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    static class ClassWithPrivateConstructor {
+        private ClassWithPrivateConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldAssertThatConstructorIsPrivateAndDoesNotThrowExceptions() {
+        PrivateConstructorChecker
+                .forClass(ClassWithPrivateConstructor.class)
+                .check();
+    }
+
+    static class ClassWithDefaultProtectedConstructor {
+        ClassWithDefaultProtectedConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorHasDefaultModifier() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithDefaultProtectedConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+
+    static class ClassWithProtectedConstructor {
+        protected ClassWithProtectedConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorHasProtectedModifier() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithProtectedConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+
+    static class ClassWithPublicConstructor {
+        public ClassWithPublicConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorHasPublicModifier() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithPublicConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+
+    static class ClassWithConstructorThatThrowsException {
+        private ClassWithConstructorThatThrowsException() {
+            throw new IllegalStateException("test exception");
+        }
+    }
+
+    @Test
+    public void shouldCheckThatConstructorThrowsExceptionWithoutCheckingMessage() {
+        PrivateConstructorChecker
+                .forClass(ClassWithConstructorThatThrowsException.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .check();
+    }
+
+    @Test
+    public void shouldCheckThatConstructorThrowsExceptionWithExpectedMessage() {
+        PrivateConstructorChecker
+                .forClass(ClassWithConstructorThatThrowsException.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("test exception")
+                .check();
+    }
+
+    @Test
+    public void shouldCheckThatConstructorThrowsExceptionWithExpectedMessageButWithoutExpectedExceptionType() {
+        PrivateConstructorChecker
+                .forClass(ClassWithConstructorThatThrowsException.class)
+                .expectedExceptionMessage("test exception")
+                .check(); // without checking exception's type
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseTypeOfExpectedExceptionDoesNotMatch() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithConstructorThatThrowsException.class)
+                    .expectedTypeOfException(IllegalArgumentException.class) // Incorrect type
+                    .check();
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Expected exception of type = class java.lang.IllegalArgumentException, " +
+                            "but was exception of type = class java.lang.IllegalStateException",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseExpectedMessageDoesNotMatch() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithConstructorThatThrowsException.class)
+                    .expectedTypeOfException(IllegalStateException.class) // Correct type
+                    .expectedExceptionMessage("lol, not something that you've expected?") // Incorrect message
+                    .check();
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Expected exception message = 'lol, not something that you've expected?', " +
+                            "but was = 'test exception'",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorThrownUnexpectedException() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithConstructorThatThrowsException.class)
+                    .check(); // We don't expect exception, but it will be thrown
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("No exception was expected", expected.getMessage());
+        }
+    }
+
+    static class ClassWith2Constructors {
+        // This is good constructor for the checker
+        private ClassWith2Constructors() {
+
+        }
+
+        // This is bad constructor
+        private ClassWith2Constructors(String str) {
+
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseClassHasMoreThanOneConstructor() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWith2Constructors.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Class has more than one constructor", expected.getMessage());
+        }
+    }
+
+    static class ClassWithoutDeclaredConstructor {
+
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseClassDoesNotHaveDeclaredConstructors() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithoutDeclaredConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+}

--- a/src/test/java/rx/internal/util/PrivateConstructorChecker.java
+++ b/src/test/java/rx/internal/util/PrivateConstructorChecker.java
@@ -1,0 +1,154 @@
+package rx.internal.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+
+public class PrivateConstructorChecker<T> {
+
+    private final Class<T> clazz;
+
+    private final Class<? extends Throwable> expectedTypeOfException;
+
+    private final String expectedExceptionMessage;
+
+    private PrivateConstructorChecker(Class<T> clazz,
+                                      Class<? extends Throwable> expectedTypeOfException,
+                                      String expectedExceptionMessage) {
+        this.clazz = clazz;
+        this.expectedTypeOfException = expectedTypeOfException;
+        this.expectedExceptionMessage = expectedExceptionMessage;
+    }
+
+    public static class Builder<T> {
+
+        private final Class<T> clazz;
+
+        private Class<? extends Throwable> expectedTypeOfException;
+
+        private String expectedExceptionMessage;
+
+        Builder(Class<T> clazz) {
+            this.clazz = clazz;
+        }
+
+        /**
+         * Sets the expected type of exception that must be thrown by the constructor of required class.
+         * <p/>
+         * If you don't want to check exception message, you can set just type of the exception.
+         *
+         * @param expectedTypeOfException type of the exception that must be thrown by the constructor
+         *                                of required class, should not be {@code null}.
+         * @return builder.
+         */
+        public Builder<T> expectedTypeOfException(Class<? extends Throwable> expectedTypeOfException) {
+            if (expectedTypeOfException == null) {
+                throw new IllegalArgumentException("expectedTypeOfException can not be null");
+            }
+
+            this.expectedTypeOfException = expectedTypeOfException;
+            return this;
+        }
+
+        /**
+         * Sets the expected message of the exception that must be thrown by the constructor of required class.
+         * <p/>
+         * If you don't want to check the type of the exception, you can set just a message.
+         *
+         * @param expectedExceptionMessage message of the exception that must be thrown by the constructor
+         *                                 of required class, should not be {@code null}.
+         * @return builder.
+         */
+        public Builder<T> expectedExceptionMessage(String expectedExceptionMessage) {
+            if (expectedExceptionMessage == null) {
+                throw new IllegalArgumentException("expectedExceptionMessage can not be null");
+            }
+
+            this.expectedExceptionMessage = expectedExceptionMessage;
+            return this;
+        }
+
+        /**
+         * Runs the check which will assert that required class has one private constructor
+         * which throws or not throws exception.
+         */
+        public void check() {
+            new PrivateConstructorChecker<T>(
+                    clazz,
+                    expectedTypeOfException,
+                    expectedExceptionMessage
+            ).check();
+        }
+    }
+
+    /**
+     * Creates instance of {@link PrivateConstructorChecker.Builder}.
+     *
+     * @param clazz class that needs to be checked.
+     * @param <T>   type of the class.
+     * @return {@link PrivateConstructorChecker.Builder} which will prepare
+     * check of the passed class.
+     */
+    public static <T> Builder<T> forClass(Class<T> clazz) {
+        return new Builder<T>(clazz);
+    }
+
+    /**
+     * Runs the check which will assert that required class has one private constructor
+     * which throws or not throws exception.
+     */
+    public void check() {
+        final Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+
+        if (constructors.length > 1) {
+            throw new AssertionError("Class has more than one constructor");
+        }
+
+        final Constructor<?> constructor = constructors[0];
+
+        if (constructor.getParameterTypes().length > 0) {
+            throw new AssertionError("Class has non-default constructor with some parameters");
+        }
+
+        constructor.setAccessible(true);
+
+        if (!Modifier.isPrivate(constructor.getModifiers())) {
+            throw new AssertionError("Constructor must be private");
+        }
+
+        try {
+            constructor.newInstance();
+        } catch (InstantiationException e) {
+            throw new RuntimeException("Can not instantiate instance of " + clazz, e);
+        } catch (IllegalAccessException e) {
+            // Fixed by setAccessible(true)
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            final Throwable cause = e.getCause();
+
+            // It's okay case if we expect some exception from this constructor
+            if (expectedTypeOfException != null || expectedExceptionMessage != null) {
+                if (expectedTypeOfException != null && !expectedTypeOfException.equals(cause.getClass())) {
+                    throw new IllegalStateException("Expected exception of type = "
+                            + expectedTypeOfException + ", but was exception of type = "
+                            + e.getCause().getClass()
+                    );
+                }
+
+                if (expectedExceptionMessage != null && !expectedExceptionMessage.equals(cause.getMessage())) {
+                    throw new IllegalStateException("Expected exception message = '"
+                            + expectedExceptionMessage + "', but was = '"
+                            + cause.getMessage() + "'",
+                            e.getCause()
+                    );
+                }
+
+                // Everything is okay
+            } else {
+                throw new IllegalStateException("No exception was expected", e);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Looks like constructor of " + clazz + " is not default", e);
+        }
+    }
+}

--- a/src/test/java/rx/observers/ObserversTest.java
+++ b/src/test/java/rx/observers/ObserversTest.java
@@ -18,31 +18,22 @@ package rx.observers;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
 import rx.exceptions.*;
 import rx.functions.*;
+import rx.internal.util.PrivateConstructorChecker;
 
 public class ObserversTest {
     @Test
     public void testNotInstantiable() {
-        try {
-            Constructor<?> c = Observers.class.getDeclaredConstructor();
-            c.setAccessible(true);
-            Object instance = c.newInstance();
-            fail("Could instantiate Actions! " + instance);
-        } catch (NoSuchMethodException ex) {
-            ex.printStackTrace();
-        } catch (InvocationTargetException ex) {
-            ex.printStackTrace();
-        } catch (InstantiationException ex) {
-            ex.printStackTrace();
-        } catch (IllegalAccessException ex) {
-            ex.printStackTrace();
-        }
+        PrivateConstructorChecker
+                .forClass(Observers.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("No instances!")
+                .check();
     }
     
     @Test

--- a/src/test/java/rx/observers/SubscribersTest.java
+++ b/src/test/java/rx/observers/SubscribersTest.java
@@ -18,31 +18,22 @@ package rx.observers;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
 import rx.exceptions.*;
 import rx.functions.*;
+import rx.internal.util.PrivateConstructorChecker;
 
 public class SubscribersTest {
     @Test
     public void testNotInstantiable() {
-        try {
-            Constructor<?> c = Subscribers.class.getDeclaredConstructor();
-            c.setAccessible(true);
-            Object instance = c.newInstance();
-            fail("Could instantiate Actions! " + instance);
-        } catch (NoSuchMethodException ex) {
-            ex.printStackTrace();
-        } catch (InvocationTargetException ex) {
-            ex.printStackTrace();
-        } catch (InstantiationException ex) {
-            ex.printStackTrace();
-        } catch (IllegalAccessException ex) {
-            ex.printStackTrace();
-        }
+        PrivateConstructorChecker
+                .forClass(Subscribers.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("No instances!")
+                .check();
     }
     
     @Test


### PR DESCRIPTION
@akarnokd as I promised in #3112 I am adding nice class that allows to assert that:

* Class has **only one constructor without args and that it's private**.
* Constructor throws exception (optional) with some type and/or message.

Here is the repository: https://github.com/pushtorefresh/java-private-constructor-checker

Hope you'll find it nice & useful!

Previous solution didn't check that constructor is private, that class has only one constructor and it required a lot of boilerplate code!