### PR TITLE
Renaming rx.Subscriber#request(long) to requestFromProducer(long)

### DIFF
--- a/src/main/java/rx/Subscriber.java
+++ b/src/main/java/rx/Subscriber.java
@@ -137,7 +137,7 @@ public abstract class Subscriber<T> implements Observer<T>, Subscription {
      * @throws IllegalArgumentException
      *             if {@code n} is negative
      */
-    protected final void request(long n) {
+    protected final void requestFromProducer(long n) {
         if (n < 0) {
             throw new IllegalArgumentException("number requested cannot be negative: " + n);
         } 

--- a/src/main/java/rx/internal/operators/OnSubscribeAmb.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeAmb.java
@@ -275,11 +275,11 @@ public final class OnSubscribeAmb<T> implements OnSubscribe<T>{
             this.subscriber = subscriber;
             this.selection = selection;
             // initial request
-            request(requested);
+            requestFromProducer(requested);
         }
 
         private final void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -226,7 +226,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
             super(child);
             this.index = index;
             this.producer = producer;
-            request(initial);
+            requestFromProducer(initial);
         }
 
         public void requestUpTo(long n) {
@@ -234,7 +234,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
                 long r = emitted.get();
                 long u = Math.min(r, n);
                 if (emitted.compareAndSet(r, r - u)) {
-                    request(u);
+                    requestFromProducer(u);
                     break;
                 }
             } while (true);
@@ -256,7 +256,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
             emitted.incrementAndGet();
             boolean emitted = producer.onNext(index, t);
             if (!emitted) {
-                request(1);
+                requestFromProducer(1);
             }
         }
 
@@ -299,7 +299,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
         }
 
         public void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OnSubscribeSingle.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeSingle.java
@@ -45,7 +45,7 @@ public class OnSubscribeSingle<T> implements Single.OnSubscribe<T> {
             public void onStart() {
                 // We request 2 here since we need 1 for the single and 1 to check that the observable
                 // doesn't emit more than one item
-                request(2);
+                requestFromProducer(2);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorConcat.java
+++ b/src/main/java/rx/internal/operators/OperatorConcat.java
@@ -112,7 +112,7 @@ public final class OperatorConcat<T> implements Operator<T, Observable<? extends
         public void onStart() {
             // no need for more than 1 at a time since we concat 1 at a time, so we'll request 2 to start ...
             // 1 to be subscribed to, 1 in the queue, then we'll keep requesting 1 at a time after that
-            request(2);
+            requestFromProducer(2);
         }
 
         private void requestFromChild(long n) {
@@ -161,7 +161,7 @@ public final class OperatorConcat<T> implements Operator<T, Observable<? extends
             if (WIP.decrementAndGet(this) > 0) {
                 subscribeNext();
             }
-            request(1);
+            requestFromProducer(1);
         }
 
         void subscribeNext() {

--- a/src/main/java/rx/internal/operators/OperatorDebounceWithSelector.java
+++ b/src/main/java/rx/internal/operators/OperatorDebounceWithSelector.java
@@ -49,7 +49,7 @@ public final class OperatorDebounceWithSelector<T, U> implements Operator<T, T> 
             @Override
             public void onStart() {
                 // debounce wants to receive everything as a firehose without backpressure
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override

--- a/src/main/java/rx/internal/operators/OperatorDebounceWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorDebounceWithTime.java
@@ -65,7 +65,7 @@ public final class OperatorDebounceWithTime<T> implements Operator<T, T> {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorDistinct.java
+++ b/src/main/java/rx/internal/operators/OperatorDistinct.java
@@ -62,7 +62,7 @@ public final class OperatorDistinct<T, U> implements Operator<T, T> {
                 if (keyMemory.add(key)) {
                     child.onNext(t);
                 } else {
-                    request(1);
+                    requestFromProducer(1);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorDistinctUntilChanged.java
+++ b/src/main/java/rx/internal/operators/OperatorDistinctUntilChanged.java
@@ -63,7 +63,7 @@ public final class OperatorDistinctUntilChanged<T, U> implements Operator<T, T> 
                     if (!(currentKey == key || (key != null && key.equals(currentKey)))) {
                         child.onNext(t);
                     } else {
-                        request(1);
+                        requestFromProducer(1);
                     }
                 } else {
                     hasPrevious = true;

--- a/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
@@ -60,7 +60,7 @@ public class OperatorDoOnRequest<T> implements Operator<T, T> {
         }
 
         private void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OperatorFilter.java
+++ b/src/main/java/rx/internal/operators/OperatorFilter.java
@@ -54,7 +54,7 @@ public final class OperatorFilter<T> implements Operator<T, T> {
                         child.onNext(t);
                     } else {
                         // TODO consider a more complicated version that batches these
-                        request(1);
+                        requestFromProducer(1);
                     }
                 } catch (Throwable e) {
                     child.onError(OnErrorThrowable.addValueAsLastCause(e, t));

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -149,7 +149,7 @@ public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R
         @Override
         public void onStart() {
             REQUESTED.set(this, MAX_QUEUE_SIZE);
-            request(MAX_QUEUE_SIZE);
+            requestFromProducer(MAX_QUEUE_SIZE);
         }
 
         @Override
@@ -377,7 +377,7 @@ public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R
             if (REQUESTED.get(this) == 0 && terminated == 0) {
                 long toRequest = MAX_QUEUE_SIZE - BUFFERED_COUNT.get(this);
                 if (toRequest > 0 && REQUESTED.compareAndSet(this, 0, toRequest)) {
-                    request(toRequest);
+                    requestFromProducer(toRequest);
                 }
             }
         }

--- a/src/main/java/rx/internal/operators/OperatorMaterialize.java
+++ b/src/main/java/rx/internal/operators/OperatorMaterialize.java
@@ -87,12 +87,12 @@ public final class OperatorMaterialize<T> implements Operator<Notification<T>, T
 
         @Override
         public void onStart() {
-            request(0);
+            requestFromProducer(0);
         }
 
         void requestMore(long n) {
             BackpressureUtils.getAndAddRequest(REQUESTED, this, n);
-            request(n);
+            requestFromProducer(n);
             drain();
         }
 

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -183,7 +183,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             this.innerGuard = new Object();
             this.innerSubscribers = EMPTY;
             long r = Math.min(maxConcurrent, RxRingBuffer.SIZE);
-            request(r);
+            requestFromProducer(r);
         }
         
         Queue<Throwable> getOrCreateErrorQueue() {
@@ -403,7 +403,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
         }
 
         public void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
         
         /**
@@ -734,7 +734,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                     }
                     
                     if (replenishMain > 0) {
-                        request(replenishMain);
+                        requestFromProducer(replenishMain);
                     }
                     // if one or more inner completed, loop again to see if we can terminate the whole stream
                     if (innerCompleted) {
@@ -795,7 +795,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
         @Override
         public void onStart() {
             outstanding = RxRingBuffer.SIZE;
-            request(RxRingBuffer.SIZE);
+            requestFromProducer(RxRingBuffer.SIZE);
         }
         @Override
         public void onNext(T t) {
@@ -821,7 +821,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             outstanding = RxRingBuffer.SIZE;
             int k = RxRingBuffer.SIZE - r;
             if (k > 0) {
-                request(k);
+                requestFromProducer(k);
             }
         }
     }}

--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -126,7 +126,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
         @Override
         public void onStart() {
             // signal that this is an async operator capable of receiving this many
-            request(RxRingBuffer.SIZE);
+            requestFromProducer(RxRingBuffer.SIZE);
         }
 
         @Override
@@ -221,7 +221,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
                 }
             } while (COUNTER_UPDATER.decrementAndGet(this) > 0);
             if (emitted > 0) {
-                request(emitted);
+                requestFromProducer(emitted);
             }
         }
     }

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -90,7 +90,7 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
         }
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
@@ -63,7 +63,7 @@ public class OperatorOnBackpressureDrop<T> implements Operator<T, T> {
         return new Subscriber<T>(child) {
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureLatest.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureLatest.java
@@ -201,7 +201,7 @@ public final class OperatorOnBackpressureLatest<T> implements Operator<T, T> {
         @Override
         public void onStart() {
             // don't run until the child actually requested to avoid synchronous problems
-            request(0); 
+            requestFromProducer(0); 
         }
 
         @Override
@@ -219,7 +219,7 @@ public final class OperatorOnBackpressureLatest<T> implements Operator<T, T> {
             producer.onCompleted();
         }
         void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
     }
 }

--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -244,7 +244,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
         public void onStart() {
             // since subscribers may have different amount of requests, we try to 
             // optimize by buffering values up-front and replaying it on individual demand
-            request(RxRingBuffer.SIZE);
+            requestFromProducer(RxRingBuffer.SIZE);
         }
         @Override
         public void onNext(T t) {
@@ -526,7 +526,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
                                 return;
                             }
                             // otherwise, just ask for a new value
-                            request(1);
+                            requestFromProducer(1);
                             // and retry emitting to potential new child-subscribers
                             continue;
                         }
@@ -574,7 +574,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
                         
                         // if we did emit at least one element, request more to replenish the queue
                         if (d > 0) {
-                            request(d);
+                            requestFromProducer(d);
                         }
                         // if we have requests but not an empty queue after emission
                         // let's try again to see if more requests/child-subscribers are 

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -330,7 +330,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
             this.shouldConnect = new AtomicBoolean();
             // make sure the source doesn't produce values until the child subscribers
             // expressed their request amounts
-            this.request(0);
+            this.requestFromProducer(0);
         }
         /** Should be called after the constructor finished to setup nulling-out the current reference. */
         void init() {

--- a/src/main/java/rx/internal/operators/OperatorSampleWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorSampleWithTime.java
@@ -74,7 +74,7 @@ public final class OperatorSampleWithTime<T> implements Operator<T, T> {
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override

--- a/src/main/java/rx/internal/operators/OperatorSingle.java
+++ b/src/main/java/rx/internal/operators/OperatorSingle.java
@@ -100,7 +100,7 @@ public final class OperatorSingle<T> implements Operator<T, T> {
         }
 
         void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OperatorSkipLast.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipLast.java
@@ -68,7 +68,7 @@ public class OperatorSkipLast<T> implements Operator<T, T> {
                 if (deque.size() == count) {
                     subscriber.onNext(on.getValue(deque.removeFirst()));
                 } else {
-                    request(1);
+                    requestFromProducer(1);
                 }
                 deque.offerLast(on.next(value));
             }

--- a/src/main/java/rx/internal/operators/OperatorSkipUntil.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipUntil.java
@@ -72,7 +72,7 @@ public final class OperatorSkipUntil<T, U> implements Operator<T, T> {
                 if (gate.get()) {
                     s.onNext(t);
                 } else {
-                    request(1);
+                    requestFromProducer(1);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorSkipWhile.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipWhile.java
@@ -44,7 +44,7 @@ public final class OperatorSkipWhile<T> implements Operator<T, T> {
                         skipping = false;
                         child.onNext(t);
                     } else {
-                        request(1);
+                        requestFromProducer(1);
                     }
                 }
             }

--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -313,7 +313,7 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
             }
 
             public void requestMore(long n) {
-                request(n);
+                requestFromProducer(n);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorTakeLast.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLast.java
@@ -50,7 +50,7 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
             @Override
             public void onStart() {
                 // we do this to break the chain of the child subscriber being passed through
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorTakeLastTimed.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLastTimed.java
@@ -80,7 +80,7 @@ public final class OperatorTakeLastTimed<T> implements Operator<T, T> {
             @Override
             public void onStart() {
                 // we do this to break the chain of the child subscriber being passed through
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override

--- a/src/main/java/rx/internal/operators/OperatorTakeUntil.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeUntil.java
@@ -64,7 +64,7 @@ public final class OperatorTakeUntil<T, E> implements Operator<T, T> {
         final Subscriber<E> so = new Subscriber<E>() {
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override

--- a/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
@@ -73,7 +73,7 @@ public final class OperatorTakeUntilPredicate<T> implements Operator<T, T> {
             }
         }
         void downstreamRequest(long n) {
-            request(n);
+            requestFromProducer(n);
         }
     }
 

--- a/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
+++ b/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
@@ -41,7 +41,7 @@ public final class OperatorThrottleFirst<T> implements Operator<T, T> {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override

--- a/src/main/java/rx/internal/operators/OperatorToMap.java
+++ b/src/main/java/rx/internal/operators/OperatorToMap.java
@@ -81,7 +81,7 @@ public final class OperatorToMap<T, K, V> implements Operator<Map<K, V>, T> {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override

--- a/src/main/java/rx/internal/operators/OperatorToMultimap.java
+++ b/src/main/java/rx/internal/operators/OperatorToMultimap.java
@@ -108,7 +108,7 @@ public final class OperatorToMultimap<T, K, V> implements Operator<Map<K, Collec
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override

--- a/src/main/java/rx/internal/operators/OperatorToObservableList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableList.java
@@ -59,7 +59,7 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorToObservableSortedList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableSortedList.java
@@ -62,7 +62,7 @@ public final class OperatorToObservableSortedList<T> implements Operator<List<T>
             
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override

--- a/src/main/java/rx/internal/operators/OperatorWindowWithObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithObservable.java
@@ -76,7 +76,7 @@ public final class OperatorWindowWithObservable<T, U> implements Operator<Observ
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override
@@ -274,7 +274,7 @@ public final class OperatorWindowWithObservable<T, U> implements Operator<Observ
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override

--- a/src/main/java/rx/internal/operators/OperatorWindowWithObservableFactory.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithObservableFactory.java
@@ -82,7 +82,7 @@ public final class OperatorWindowWithObservableFactory<T, U> implements Operator
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override
@@ -293,7 +293,7 @@ public final class OperatorWindowWithObservableFactory<T, U> implements Operator
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override

--- a/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
@@ -100,7 +100,7 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
         }
         
         void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override
@@ -186,7 +186,7 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
         }
         
         void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OperatorWindowWithStartEndObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithStartEndObservable.java
@@ -55,7 +55,7 @@ public final class OperatorWindowWithStartEndObservable<T, U, V> implements Oper
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
             
             @Override
@@ -109,7 +109,7 @@ public final class OperatorWindowWithStartEndObservable<T, U, V> implements Oper
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override

--- a/src/main/java/rx/internal/operators/OperatorWindowWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithTime.java
@@ -132,7 +132,7 @@ public final class OperatorWindowWithTime<T> implements Operator<Observable<T>, 
         
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override
@@ -377,7 +377,7 @@ public final class OperatorWindowWithTime<T> implements Operator<Observable<T>, 
 
         @Override
         public void onStart() {
-            request(Long.MAX_VALUE);
+            requestFromProducer(Long.MAX_VALUE);
         }
         
         @Override

--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -305,11 +305,11 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
 
             @Override
             public void onStart() {
-                request(RxRingBuffer.SIZE);
+                requestFromProducer(RxRingBuffer.SIZE);
             }
             
             public void requestMore(long n) {
-                request(n);
+                requestFromProducer(n);
             }
 
             @Override

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -199,13 +199,13 @@ public class TestSubscriber<T> extends Subscriber<T> {
     }
     
     /**
-     * Allows calling the protected {@link #request(long)} from unit tests.
+     * Allows calling the protected {@link #requestFromProducer(long)} from unit tests.
      *
      * @param n the maximum number of items you want the Observable to emit to the Subscriber at this time, or
      *           {@code Long.MAX_VALUE} if you want the Observable to emit items at its own pace
      */
     public void requestMore(long n) {
-        request(n);
+        requestFromProducer(n);
     }
 
     /**

--- a/src/perf/java/rx/operators/OperatorPublishPerf.java
+++ b/src/perf/java/rx/operators/OperatorPublishPerf.java
@@ -50,7 +50,7 @@ public class OperatorPublishPerf {
         }
         @Override
         public void onStart() {
-            request(batchFrequency);
+            requestFromProducer(batchFrequency);
         }
         @Override
         public void onNext(Integer t) {
@@ -59,7 +59,7 @@ public class OperatorPublishPerf {
             }
             if (++received == batchFrequency) {
                 received = 0;
-                request(batchFrequency);
+                requestFromProducer(batchFrequency);
             }
         }
         @Override

--- a/src/perf/java/rx/operators/OperatorRangePerf.java
+++ b/src/perf/java/rx/operators/OperatorRangePerf.java
@@ -59,7 +59,7 @@ public class OperatorRangePerf {
 
                 @Override
                 public void onStart() {
-                    request(size);
+                    requestFromProducer(size);
                 }
                 
                 @Override

--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -341,7 +341,7 @@ public class BackpressureTests {
 
             @Override
             public void onStart() {
-                request(100);
+                requestFromProducer(100);
             }
 
             @Override
@@ -363,7 +363,7 @@ public class BackpressureTests {
                 }
                 if (received.get() == 100) {
                     batches.incrementAndGet();
-                    request(100);
+                    requestFromProducer(100);
                     received.set(0);
                 }
             }
@@ -387,7 +387,7 @@ public class BackpressureTests {
 
             @Override
             public void onStart() {
-                request(100);
+                requestFromProducer(100);
             }
 
             @Override
@@ -413,7 +413,7 @@ public class BackpressureTests {
                     batches.incrementAndGet();
                     received.set(0);
                     if (!done) {
-                        request(100);
+                        requestFromProducer(100);
                     }
                 }
                 if (done) {

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -440,7 +440,7 @@ public class SingleTest {
         TestSubscriber<String> ts = new TestSubscriber<String>() {
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
         };
 

--- a/src/test/java/rx/SubscriberTest.java
+++ b/src/test/java/rx/SubscriberTest.java
@@ -42,7 +42,7 @@ public class SubscriberTest {
     @Test
     public void testRequestFromFinalSubscribeWithRequestValue() {
         Subscriber<String> s = new TestSubscriber<String>();
-        s.request(10);
+        s.requestFromProducer(10);
         final AtomicLong r = new AtomicLong();
         s.setProducer(new Producer() {
 
@@ -101,7 +101,7 @@ public class SubscriberTest {
             }
 
         };
-        s.request(10);
+        s.requestFromProducer(10);
         Subscriber<? super String> ns = o.call(s);
 
         final AtomicLong r = new AtomicLong();
@@ -146,7 +146,7 @@ public class SubscriberTest {
             }
 
         };
-        s.request(10);
+        s.requestFromProducer(10);
         Subscriber<? super String> ns = o.call(s);
 
         final AtomicLong r = new AtomicLong();
@@ -201,12 +201,12 @@ public class SubscriberTest {
 
                 };
                 // we request 99 up to the parent
-                as.request(99);
+                as.requestFromProducer(99);
                 return as;
             }
 
         };
-        s.request(10);
+        s.requestFromProducer(10);
         Subscriber<? super String> ns = o.call(s);
 
         final AtomicLong r = new AtomicLong();
@@ -227,7 +227,7 @@ public class SubscriberTest {
     @Test
     public void testRequestToObservable() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.request(3);
+        ts.requestFromProducer(3);
         final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
@@ -250,7 +250,7 @@ public class SubscriberTest {
     @Test
     public void testRequestThroughMap() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.request(3);
+        ts.requestFromProducer(3);
         final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
@@ -280,7 +280,7 @@ public class SubscriberTest {
     @Test
     public void testRequestThroughTakeThatReducesRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.request(3);
+        ts.requestFromProducer(3);
         final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
@@ -303,7 +303,7 @@ public class SubscriberTest {
     @Test
     public void testRequestThroughTakeWhereRequestIsSmallerThanTake() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.request(3);
+        ts.requestFromProducer(3);
         final AtomicLong requested = new AtomicLong();
         Observable.create(new OnSubscribe<Integer>() {
 
@@ -331,7 +331,7 @@ public class SubscriberTest {
             @Override
             public void onStart() {
                 c.incrementAndGet();
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
@@ -346,7 +346,7 @@ public class SubscriberTest {
 
             @Override
             public void onNext(Integer t) {
-                request(1);
+                requestFromProducer(1);
             }
 
         });
@@ -362,7 +362,7 @@ public class SubscriberTest {
             @Override
             public void onStart() {
                 c.incrementAndGet();
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
@@ -377,7 +377,7 @@ public class SubscriberTest {
 
             @Override
             public void onNext(Integer t) {
-                request(1);
+                requestFromProducer(1);
             }
 
         });
@@ -397,7 +397,7 @@ public class SubscriberTest {
                     @Override
                     public void onStart() {
                         c.incrementAndGet();
-                        request(1);
+                        requestFromProducer(1);
                     }
 
                     @Override
@@ -413,7 +413,7 @@ public class SubscriberTest {
                     @Override
                     public void onNext(Integer t) {
                         child.onNext(t);
-                        request(1);
+                        requestFromProducer(1);
                     }
 
                 };
@@ -432,7 +432,7 @@ public class SubscriberTest {
 
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
             
             @Override
@@ -448,8 +448,8 @@ public class SubscriberTest {
 
             @Override
             public void onNext(Integer t) {
-                request(-1);
-                request(1);
+                requestFromProducer(-1);
+                requestFromProducer(1);
             }});
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         assertTrue(exception.get() instanceof IllegalArgumentException);
@@ -461,8 +461,8 @@ public class SubscriberTest {
         Observable.just(1,2,3,4,5).subscribe(new Subscriber<Integer>() {
             @Override
             public void onStart() {
-                request(3);
-                request(2);
+                requestFromProducer(3);
+                requestFromProducer(2);
             }
             
             @Override
@@ -488,8 +488,8 @@ public class SubscriberTest {
         Observable.just(1,2,3,4,5).subscribe(new Subscriber<Integer>() {
             @Override
             public void onStart() {
-                request(2);
-                request(Long.MAX_VALUE-1);
+                requestFromProducer(2);
+                requestFromProducer(Long.MAX_VALUE-1);
             }
             
             @Override

--- a/src/test/java/rx/internal/operators/OnBackpressureBlockTest.java
+++ b/src/test/java/rx/internal/operators/OnBackpressureBlockTest.java
@@ -63,7 +63,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         source.subscribe(o);
@@ -119,7 +119,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         source.subscribe(o);
@@ -146,7 +146,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         source.subscribe(o);
@@ -187,7 +187,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         source.subscribe(o);
@@ -219,7 +219,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         source.subscribe(o);
@@ -270,7 +270,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         Observable.<Integer>empty().onBackpressureBlock(2).subscribe(o);
@@ -285,7 +285,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
         };
         Observable.just(1).onBackpressureBlock(2).subscribe(o);
@@ -300,7 +300,7 @@ public class OnBackpressureBlockTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
             @Override
             public void onNext(Integer t) {
@@ -323,7 +323,7 @@ public class OnBackpressureBlockTest {
             boolean once = true;
             @Override
             public void onStart() {
-                request(0); // make sure it doesn't start in unlimited mode
+                requestFromProducer(0); // make sure it doesn't start in unlimited mode
             }
             @Override
             public void onNext(Integer t) {

--- a/src/test/java/rx/internal/operators/OnSubscribeAmbTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeAmbTest.java
@@ -257,7 +257,7 @@ public class OnSubscribeAmbTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }};
         Observable.amb(o1, o2).subscribe(ts);
         // before first emission request 20 more

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -866,7 +866,7 @@ public class OnSubscribeCombineLatestTest {
             
             @Override
             public void onStart() {
-                request(2);
+                requestFromProducer(2);
             }
 
             @Override
@@ -882,7 +882,7 @@ public class OnSubscribeCombineLatestTest {
             @Override
             public void onNext(Integer t) {
                 latch.countDown();
-                request(Long.MAX_VALUE-1);
+                requestFromProducer(Long.MAX_VALUE-1);
             }});
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -175,7 +175,7 @@ public class OnSubscribeFromIterableTest {
             
             @Override
             public void onStart() {
-                request(2);
+                requestFromProducer(2);
             }
 
             @Override
@@ -191,7 +191,7 @@ public class OnSubscribeFromIterableTest {
             @Override
             public void onNext(Integer t) {
                 latch.countDown();
-                request(Long.MAX_VALUE-1);
+                requestFromProducer(Long.MAX_VALUE-1);
             }});
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
@@ -203,7 +203,7 @@ public class OnSubscribeFromIterableTest {
 
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
             
             @Override

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -202,7 +202,7 @@ public class OnSubscribeRangeTest {
 
             @Override
             public void onStart() {
-                request(2);
+                requestFromProducer(2);
             }
             
             @Override
@@ -218,7 +218,7 @@ public class OnSubscribeRangeTest {
             @Override
             public void onNext(Integer t) {
                 count.incrementAndGet();
-                request(Long.MAX_VALUE - 1);
+                requestFromProducer(Long.MAX_VALUE - 1);
             }});
         assertEquals(n, count.get());
     }
@@ -230,7 +230,7 @@ public class OnSubscribeRangeTest {
 
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
             
             @Override

--- a/src/test/java/rx/internal/operators/OperatorBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorBufferTest.java
@@ -962,7 +962,7 @@ public class OperatorBufferTest {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE / 2 - 4);
+                requestFromProducer(Long.MAX_VALUE / 2 - 4);
             }
 
             @Override
@@ -975,7 +975,7 @@ public class OperatorBufferTest {
 
             @Override
             public void onNext(List<Integer> t) {
-                request(Long.MAX_VALUE / 2);
+                requestFromProducer(Long.MAX_VALUE / 2);
             }
 
         });

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -787,7 +787,7 @@ public class OperatorConcatTest {
 
             @Override
             public void onNext(Integer t) {
-                request(2);
+                requestFromProducer(2);
             }});
         
         assertTrue(completed.get());

--- a/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
@@ -56,7 +56,7 @@ public class OperatorDoOnRequestTest {
 
                     @Override
                     public void onStart() {
-                        request(3);
+                        requestFromProducer(3);
                     }
 
                     @Override
@@ -71,7 +71,7 @@ public class OperatorDoOnRequestTest {
 
                     @Override
                     public void onNext(Integer t) {
-                        request(t);
+                        requestFromProducer(t);
                     }
                 });
         assertEquals(Arrays.asList(3L,1L,2L,3L,4L,5L), requests);

--- a/src/test/java/rx/internal/operators/OperatorFilterTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFilterTest.java
@@ -87,7 +87,7 @@ public class OperatorFilterTest {
             public void onNext(String t) {
                 System.out.println("Received: " + t);
                 // request more each time we receive
-                request(1);
+                requestFromProducer(1);
             }
 
         };
@@ -133,7 +133,7 @@ public class OperatorFilterTest {
             public void onNext(Integer t) {
                 System.out.println("Received: " + t);
                 // request more each time we receive
-                request(1);
+                requestFromProducer(1);
             }
         };
         // this means it will only request 1 item and expect to receive more

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -1479,7 +1479,7 @@ public class OperatorGroupByTest {
                     
                     @Override
                     public void onStart() {
-                        request(2);
+                        requestFromProducer(2);
                     }
 
                     @Override
@@ -1497,7 +1497,7 @@ public class OperatorGroupByTest {
                     public void onNext(Integer t) {
                         System.out.println(t);
                         //provoke possible request overflow
-                        request(Long.MAX_VALUE-1);
+                        requestFromProducer(Long.MAX_VALUE-1);
                     }});
         assertTrue(completed.get());
     }

--- a/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
+++ b/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
@@ -106,7 +106,7 @@ public class OperatorIgnoreElementsTest {
 
                     @Override
                     public void onStart() {
-                        request(1);
+                        requestFromProducer(1);
                     }
 
                     @Override

--- a/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -259,7 +259,7 @@ public class OperatorMergeMaxConcurrentTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
             @Override
             public void onNext(Integer t) {

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -1176,7 +1176,7 @@ public class OperatorMergeTest {
             
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
@@ -1192,8 +1192,8 @@ public class OperatorMergeTest {
             @Override
             public void onNext(Integer t) {
                 latch.countDown();
-                request(2);
-                request(Long.MAX_VALUE-1);
+                requestFromProducer(2);
+                requestFromProducer(Long.MAX_VALUE-1);
             }});
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
@@ -1268,14 +1268,14 @@ public class OperatorMergeTest {
                 int remaining = req;
                 @Override
                 public void onStart() {
-                    request(req);
+                    requestFromProducer(req);
                 }
                 @Override
                 public void onNext(Integer t) {
                     super.onNext(t);
                     if (--remaining == 0) {
                         remaining = req;
-                        request(req);
+                        requestFromProducer(req);
                     }
                 }
             };
@@ -1289,14 +1289,14 @@ public class OperatorMergeTest {
                 int remaining = req;
                 @Override
                 public void onStart() {
-                    request(req);
+                    requestFromProducer(req);
                 }
                 @Override
                 public void onNext(Integer t) {
                     super.onNext(t);
                     if (--remaining == 0) {
                         remaining = req;
-                        request(req);
+                        requestFromProducer(req);
                     }
                 }
             };

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -738,7 +738,7 @@ public class OperatorObserveOnTest {
                     
                     @Override
                     public void onStart() {
-                        request(2);
+                        requestFromProducer(2);
                     }
 
                     @Override
@@ -755,9 +755,9 @@ public class OperatorObserveOnTest {
                     public void onNext(Integer t) {
                         count.incrementAndGet();
                         if (first) {
-                            request(Long.MAX_VALUE - 1);
-                            request(Long.MAX_VALUE - 1);
-                            request(10);
+                            requestFromProducer(Long.MAX_VALUE - 1);
+                            requestFromProducer(Long.MAX_VALUE - 1);
+                            requestFromProducer(10);
                             first = false;
                         }
                     }
@@ -784,7 +784,7 @@ public class OperatorObserveOnTest {
 
                     @Override
                     public void onStart() {
-                        request(1);
+                        requestFromProducer(1);
                     }
 
                     @Override

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
@@ -97,7 +97,7 @@ public class OperatorOnBackpressureDropTest {
 
             @Override
             public void onStart() {
-                request(10);
+                requestFromProducer(10);
             }
             
             @Override
@@ -113,7 +113,7 @@ public class OperatorOnBackpressureDropTest {
             public void onNext(Long t) {
                 count.incrementAndGet();
                 //cause overflow of requested if not handled properly in onBackpressureDrop operator
-                request(Long.MAX_VALUE-1);
+                requestFromProducer(Long.MAX_VALUE-1);
             }});
         assertEquals(n, count.get());
     }

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureLatestTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureLatestTest.java
@@ -54,7 +54,7 @@ public class OperatorOnBackpressureLatestTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(2);
+                requestFromProducer(2);
             }
         };
         
@@ -70,7 +70,7 @@ public class OperatorOnBackpressureLatestTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
         };
         
@@ -116,7 +116,7 @@ public class OperatorOnBackpressureLatestTest {
             final Random rnd = new Random();
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
             @Override
             public void onNext(Integer t) {
@@ -128,7 +128,7 @@ public class OperatorOnBackpressureLatestTest {
                         ex.printStackTrace();
                     }
                 }
-                request(1);
+                requestFromProducer(1);
             }
         };
         int m = 100000;

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -343,7 +343,7 @@ public class OperatorPublishTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
         };
         

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -168,7 +168,7 @@ public class OperatorScanTest {
 
                     @Override
                     public void onStart() {
-                        request(10);
+                        requestFromProducer(10);
                     }
 
                     @Override
@@ -209,7 +209,7 @@ public class OperatorScanTest {
 
                     @Override
                     public void onStart() {
-                        request(10);
+                        requestFromProducer(10);
                     }
 
                     @Override
@@ -348,12 +348,12 @@ public class OperatorScanTest {
 
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
             public void onNext(Integer integer) {
-                request(1);
+                requestFromProducer(1);
             }
         });
 

--- a/src/test/java/rx/internal/operators/OperatorSingleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSingleTest.java
@@ -142,7 +142,7 @@ public class OperatorSingleTest {
 
                     @Override
                     public void onStart() {
-                        request(1);
+                        requestFromProducer(1);
                     }
 
                     @Override
@@ -157,7 +157,7 @@ public class OperatorSingleTest {
 
                     @Override
                     public void onNext(Integer t) {
-                        request(2);
+                        requestFromProducer(2);
                     }
                 });
         assertEquals(Arrays.asList(2L), requests);
@@ -181,7 +181,7 @@ public class OperatorSingleTest {
 
                     @Override
                     public void onStart() {
-                        request(3);
+                        requestFromProducer(3);
                     }
 
                     @Override
@@ -219,7 +219,7 @@ public class OperatorSingleTest {
 
                     @Override
                     public void onStart() {
-                        request(1);
+                        requestFromProducer(1);
                     }
 
                     @Override
@@ -417,7 +417,7 @@ public class OperatorSingleTest {
 
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
@@ -432,7 +432,7 @@ public class OperatorSingleTest {
 
             @Override
             public void onNext(Integer integer) {
-                request(1);
+                requestFromProducer(1);
             }
         });
         observable.subscribe(subscriber);

--- a/src/test/java/rx/internal/operators/OperatorSwitchIfEmptyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchIfEmptyTest.java
@@ -139,7 +139,7 @@ public class OperatorSwitchIfEmptyTest {
 
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
         };
         Observable.<Integer>empty().switchIfEmpty(Observable.just(1, 2, 3)).subscribe(ts);
@@ -157,7 +157,7 @@ public class OperatorSwitchIfEmptyTest {
 
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
         };
         Observable.<Integer>empty().switchIfEmpty(Observable.just(1, 2, 3)).subscribe(ts);

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -498,7 +498,7 @@ public class OperatorSwitchTest {
             @Override
             public void onStart() {
                 requested = 3;
-                request(3);
+                requestFromProducer(3);
             }
 
             @Override
@@ -517,7 +517,7 @@ public class OperatorSwitchTest {
                 requested--;
                 if(requested == 0) {
                     requested = 3;
-                    request(3);
+                    requestFromProducer(3);
                 }
             }
         });

--- a/src/test/java/rx/internal/operators/OperatorTakeLastOneTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastOneTest.java
@@ -99,12 +99,12 @@ public class OperatorTakeLastOneTest {
         final List<T> list = new ArrayList<T>();
 
         public void requestMore(long n) {
-            request(n);
+            requestFromProducer(n);
         }
 
         @Override
         public void onStart() {
-            request(initialRequest);
+            requestFromProducer(initialRequest);
         }
 
         @Override

--- a/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
@@ -171,7 +171,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override
@@ -185,7 +185,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onNext(Integer integer) {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
         });
     }
@@ -197,7 +197,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
@@ -210,7 +210,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onNext(Integer integer) {
-                request(1);
+                requestFromProducer(1);
             }
         });
     }
@@ -222,7 +222,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
 
             @Override
@@ -236,7 +236,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onNext(Integer integer) {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
         });
     }
@@ -249,7 +249,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override
@@ -263,7 +263,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onNext(Integer integer) {
-                request(1);
+                requestFromProducer(1);
             }
         });
     }
@@ -275,7 +275,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onStart() {
-                request(Long.MAX_VALUE);
+                requestFromProducer(Long.MAX_VALUE);
             }
 
             @Override
@@ -303,7 +303,7 @@ public class OperatorTakeLastTest {
 
             @Override
             public void onStart() {
-                request(2);
+                requestFromProducer(2);
             }
             
             @Override
@@ -319,7 +319,7 @@ public class OperatorTakeLastTest {
             @Override
             public void onNext(Integer t) {
                 list.add(t);
-                request(Long.MAX_VALUE-1);
+                requestFromProducer(Long.MAX_VALUE-1);
             }});
         assertEquals(50, list.size());
     }

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -124,7 +124,7 @@ public class OperatorTakeUntilPredicateTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(5);
+                requestFromProducer(5);
             }
         };
         

--- a/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
@@ -231,7 +231,7 @@ public class OperatorTakeWhileTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(5);
+                requestFromProducer(5);
             }
         };
         

--- a/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
@@ -213,7 +213,7 @@ public class OperatorWindowWithSizeTest {
         source.subscribe(new Subscriber<Observable<Integer>>() {
             @Override
             public void onStart() {
-                request(1);
+                requestFromProducer(1);
             }
             @Override
             public void onNext(Observable<Integer> t) {

--- a/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
@@ -267,7 +267,7 @@ public class OperatorWithLatestFromTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onStart() {
-                request(0);
+                requestFromProducer(0);
             }
         };
         

--- a/src/test/java/rx/observables/AbstractOnSubscribeTest.java
+++ b/src/test/java/rx/observables/AbstractOnSubscribeTest.java
@@ -529,7 +529,7 @@ public class AbstractOnSubscribeTest {
 
             @Override
             public void onNext(Integer t) {
-                request(1);
+                requestFromProducer(1);
             }
         });
         if (exception.get()!=null) {


### PR DESCRIPTION
Right now its not possible to both extend `rx.Subscriber` and implement `rx.Producer`. See test below.

```java
public class Foo<T> extends Subscriber<T> implements Producer {

    @Override
    public void onCompleted() {
    }

    @Override
    public void onError(Throwable e) {
    }

    @Override
    public void onNext(T t) {
    }

    @Override
    public void request(long n) {
    }
}
```

Currently this blows up because `protected rx.Subscriber#request(long)` collides with `public rx.Producer#request(long)`. 