### PR TITLE
Range overhead reduction.

### DIFF
--- a/src/perf/java/rx/operators/OperatorRangePerf.java
+++ b/src/perf/java/rx/operators/OperatorRangePerf.java
@@ -17,18 +17,11 @@ package rx.operators;
 
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
-import rx.Observable;
-import rx.Subscriber;
+import rx.*;
+import rx.internal.operators.OnSubscribeRange;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -50,7 +43,7 @@ public class OperatorRangePerf {
 
         @Setup
         public void setup(final Blackhole bh) {
-            observable = Observable.range(0, size);
+            observable = Observable.create(new OnSubscribeRange(0, size));
             this.bh = bh;
         }
 
@@ -98,7 +91,7 @@ public class OperatorRangePerf {
 
         @Setup
         public void setup(final Blackhole bh) {
-            observable = Observable.range(0, size);
+            observable = Observable.create(new OnSubscribeRange(0, size));
             this.bh = bh;
 
         }

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -249,4 +249,23 @@ public class OnSubscribeRangeTest {
             }});
         assertTrue(completed.get());
     }
+    
+    @Test(timeout = 1000)
+    public void testNearMaxValueWithoutBackpressure() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);
+        
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
+    }
+    @Test(timeout = 1000)
+    public void testNearMaxValueWithBackpressure() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(3);
+        Observable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);
+        
+        ts.assertCompleted();
+        ts.assertNoErrors();
+        ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
+    }
 }


### PR DESCRIPTION
Applied some refactorings and local variable usage to reduce the overhead.

Few observations:
  - Having too many local variables may cause register spill, even on x64 which makes some `size` benchmark faster while other slower.
  - The observeOn benchmarks are quite hectic because of receiving thread migration caused by the round-robin worker assignment. It affects the benchmarks with 1 or 1000 elements in the stream.
  - Note that the previous `OperatorRangePerf` `size = 1` measured the speed of `just` due to the optimization of `range()`. The updated perf now instantiates the `OnSubscribeRange`.
  - Note that the `observeOn` benchmark with `size = 1` run the `just()` as well.

Benchmark comparison (i7 4770K, Windows 7 x64, Java 8u51)
![image](https://cloud.githubusercontent.com/assets/1269832/9153053/5f501902-3e42-11e5-85ea-8ff1f6725c08.png)
