### PR TITLE
Improved Scheduler.Worker memory leak detection

### DIFF
--- a/src/test/java/rx/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/rx/schedulers/CachedThreadSchedulerTest.java
@@ -16,18 +16,13 @@
 
 package rx.schedulers;
 
-import java.lang.management.*;
-import java.util.concurrent.*;
-
-import junit.framework.Assert;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import rx.Observable;
-import rx.Scheduler;
+import rx.*;
+import rx.Scheduler.Worker;
 import rx.functions.*;
-import rx.internal.schedulers.NewThreadWorker;
-import static org.junit.Assert.assertTrue;
 
 public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
@@ -74,49 +69,17 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     
     @Test(timeout = 30000)
     public void testCancelledTaskRetention() throws InterruptedException {
-        System.out.println("Wait before GC");
-        Thread.sleep(1000);
-        
-        System.out.println("GC");
-        System.gc();
-        
-        Thread.sleep(1000);
-
-        
-        MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
-        MemoryUsage memHeap = memoryMXBean.getHeapMemoryUsage();
-        long initial = memHeap.getUsed();
-        
-        System.out.printf("Starting: %.3f MB%n", initial / 1024.0 / 1024.0);
-        
-        Scheduler.Worker w = Schedulers.io().createWorker();
-        for (int i = 0; i < 750000; i++) {
-            if (i % 50000 == 0) {
-                System.out.println("  -> still scheduling: " + i);
-            }
-            w.schedule(Actions.empty(), 1, TimeUnit.DAYS);
+        Worker w = Schedulers.io().createWorker();
+        try {
+            ExecutorSchedulerTest.testCancelledRetention(w, false);
+        } finally {
+            w.unsubscribe();
         }
-        
-        memHeap = memoryMXBean.getHeapMemoryUsage();
-        long after = memHeap.getUsed();
-        System.out.printf("Peak: %.3f MB%n", after / 1024.0 / 1024.0);
-        
-        w.unsubscribe();
-        
-        System.out.println("Wait before second GC");
-        Thread.sleep(NewThreadWorker.PURGE_FREQUENCY + 2000);
-        
-        System.out.println("Second GC");
-        System.gc();
-        
-        Thread.sleep(1000);
-        
-        memHeap = memoryMXBean.getHeapMemoryUsage();
-        long finish = memHeap.getUsed();
-        System.out.printf("After: %.3f MB%n", finish / 1024.0 / 1024.0);
-        
-        if (finish > initial * 5) {
-            Assert.fail(String.format("Tasks retained: %.3f -> %.3f -> %.3f", initial / 1024 / 1024.0, after / 1024 / 1024.0, finish / 1024 / 1024d));
+        w = Schedulers.io().createWorker();
+        try {
+            ExecutorSchedulerTest.testCancelledRetention(w, true);
+        } finally {
+            w.unsubscribe();
         }
     }
 

--- a/src/test/java/rx/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/rx/schedulers/ComputationSchedulerTests.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.Scheduler;
+import rx.Scheduler.Worker;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func1;
@@ -150,5 +151,21 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     @Test
     public final void testHandledErrorIsNotDeliveredToThreadHandler() throws InterruptedException {
         SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
+    }
+    
+    @Test(timeout = 30000)
+    public void testCancelledTaskRetention() throws InterruptedException {
+        Worker w = Schedulers.computation().createWorker();
+        try {
+            ExecutorSchedulerTest.testCancelledRetention(w, false);
+        } finally {
+            w.unsubscribe();
+        }
+        w = Schedulers.computation().createWorker();
+        try {
+            ExecutorSchedulerTest.testCancelledRetention(w, true);
+        } finally {
+            w.unsubscribe();
+        }
     }
 }


### PR DESCRIPTION
The former Executor-based check instantiated the wrong worker. In addition, I've refactored the common parts, added check for periodic task retention (after the first round) and added the checks to computation scheduler test as well.