### PR TITLE
SafeSubscriber - report onCompleted unsubscribe error to RxJavaPlugin 

### DIFF
--- a/src/main/java/rx/exceptions/OnCompletedFailedException.java
+++ b/src/main/java/rx/exceptions/OnCompletedFailedException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.exceptions;
+
+public final class OnCompletedFailedException extends RuntimeException {
+
+    private static final long serialVersionUID = 8622579378868820554L;
+
+    public OnCompletedFailedException(Throwable throwable) {
+        super(throwable);
+    }
+    
+    public OnCompletedFailedException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/main/java/rx/exceptions/UnsubscribeFailedException.java
+++ b/src/main/java/rx/exceptions/UnsubscribeFailedException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.exceptions;
+
+public final class UnsubscribeFailedException extends RuntimeException {
+
+    private static final long serialVersionUID = 4594672310593167598L;
+
+    public UnsubscribeFailedException(Throwable throwable) {
+        super(throwable);
+    }
+    
+    public UnsubscribeFailedException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+    
+}

--- a/src/main/java/rx/internal/util/RxJavaPluginUtils.java
+++ b/src/main/java/rx/internal/util/RxJavaPluginUtils.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package rx.internal.util;
+
+import rx.plugins.RxJavaPlugins;
+
+public final class RxJavaPluginUtils {
+
+    public static void handleException(Throwable e) {
+        try {
+            RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+        } catch (Throwable pluginException) {
+            handlePluginException(pluginException);
+        }
+    }
+
+    private static void handlePluginException(Throwable pluginException) {
+        /*
+         * We don't want errors from the plugin to affect normal flow.
+         * Since the plugin should never throw this is a safety net
+         * and will complain loudly to System.err so it gets fixed.
+         */
+        System.err.println("RxJavaErrorHandler threw an Exception. It shouldn't. => " + pluginException.getMessage());
+        pluginException.printStackTrace();
+    }
+    
+}

--- a/src/test/java/rx/observers/SafeObserverTest.java
+++ b/src/test/java/rx/observers/SafeObserverTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
+import junit.framework.Assert;
 import rx.Subscriber;
 import rx.exceptions.*;
 import rx.functions.Action0;
@@ -65,19 +66,6 @@ public class SafeObserverTest {
             assertNull(onError.get());
             assertTrue(e instanceof SafeObserverTestException);
             assertEquals("onCompletedFail", e.getMessage());
-        }
-    }
-
-    @Test
-    public void onCompletedFailureSafe() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
-        try {
-            new SafeSubscriber<String>(OBSERVER_ONCOMPLETED_FAIL(onError)).onCompleted();
-            assertNotNull(onError.get());
-            assertTrue(onError.get() instanceof SafeObserverTestException);
-            assertEquals("onCompletedFail", onError.get().getMessage());
-        } catch (Exception e) {
-            fail("expects exception to be passed to onError");
         }
     }
 
@@ -184,8 +172,8 @@ public class SafeObserverTest {
             e.printStackTrace();
 
             assertTrue(o.isUnsubscribed());
-
-            assertTrue(e instanceof SafeObserverTestException);
+            assertTrue(e instanceof UnsubscribeFailedException);
+            assertTrue(e.getCause() instanceof SafeObserverTestException);
             assertEquals("failure from unsubscribe", e.getMessage());
             // expected since onError fails so SafeObserver can't help
         }
@@ -475,9 +463,12 @@ public class SafeObserverTest {
             }
         });
         
-        s.onCompleted();
-        
-        assertTrue("Error not received", error.get() instanceof TestException);
+        try {
+            s.onCompleted();
+            Assert.fail();
+        } catch (OnCompletedFailedException e) {
+           assertNull(error.get());
+        }
     }
     
     @Test


### PR DESCRIPTION
Discussed in #2464, when an observable emits `onCompleted` but `unsubscribe` in `SafeSubscriber` throws then the error should be reported to the `RxJavaPlugin` error handler and if that fails a stack trace is written to `System.err`.