### PR TITLE
Remove redundant variables

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorTimeoutBase.java
+++ b/src/main/java/rx/internal/operators/OperatorTimeoutBase.java
@@ -157,10 +157,9 @@ class OperatorTimeoutBase<T> implements Operator<T, T> {
         }
 
         public void onTimeout(long seqId) {
-            long expected = seqId;
             boolean timeoutWins = false;
             synchronized (gate) {
-                if (expected == actual && TERMINATED_UPDATER.getAndSet(this, 1) == 0) {
+                if (seqId == actual && TERMINATED_UPDATER.getAndSet(this, 1) == 0) {
                     timeoutWins = true;
                 }
             }

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -99,7 +99,6 @@ public class EventLoopsScheduler extends Scheduler {
 
         EventLoopWorker(PoolWorker poolWorker) {
             this.poolWorker = poolWorker;
-            
         }
 
         @Override
@@ -117,18 +116,14 @@ public class EventLoopsScheduler extends Scheduler {
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
-            ScheduledAction s = poolWorker.scheduleActual(action, 0, null, serial);
-            
-            return s;
+            return poolWorker.scheduleActual(action, 0, null, serial);
         }
         @Override
         public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
-            ScheduledAction s = poolWorker.scheduleActual(action, delayTime, unit, timed);
-            
-            return s;
+            return poolWorker.scheduleActual(action, delayTime, unit, timed);
         }
     }
     


### PR DESCRIPTION
Remove redundant variables from the following classes:

* OperatorTimeoutBase
* EventLoopsScheduler