### PR TITLE
Merge can now operate in horizontally unbounded mode.

### DIFF
--- a/src/main/java/rx/internal/util/atomic/AtomicReferenceArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/AtomicReferenceArrayQueue.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Original License: https://github.com/JCTools/JCTools/blob/master/LICENSE
+ * Original location: https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
+ */
+package rx.internal.util.atomic;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import rx.internal.util.unsafe.Pow2;
+
+abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> {
+    protected final AtomicReferenceArray<E> buffer;
+    protected final int mask;
+    public AtomicReferenceArrayQueue(int capacity) {
+        int actualCapacity = Pow2.roundToPowerOfTwo(capacity);
+        this.mask = actualCapacity - 1;
+        this.buffer = new AtomicReferenceArray<E>(actualCapacity);
+    }
+    @Override
+    public Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+    @Override
+    public void clear() {
+        // we have to test isEmpty because of the weaker poll() guarantee
+        while (poll() != null || !isEmpty())
+            ;
+    }
+    protected final int calcElementOffset(long index, int mask) {
+        return (int)index & mask;
+    }
+    protected final int calcElementOffset(long index) {
+        return (int)index & mask;
+    }
+    protected final E lvElement(AtomicReferenceArray<E> buffer, int offset) {
+        return buffer.get(offset);
+    }
+    protected final E lpElement(AtomicReferenceArray<E> buffer, int offset) {
+        return buffer.get(offset); // no weaker form available
+    }
+    protected final E lpElement(int offset) {
+        return buffer.get(offset); // no weaker form available
+    }
+    protected final void spElement(AtomicReferenceArray<E> buffer, int offset, E value) {
+        buffer.lazySet(offset, value);  // no weaker form available
+    }
+    protected final void spElement(int offset, E value) {
+        buffer.lazySet(offset, value);  // no weaker form available
+    }
+    protected final void soElement(AtomicReferenceArray<E> buffer, int offset, E value) {
+        buffer.lazySet(offset, value);
+    }
+    protected final void soElement(int offset, E value) {
+        buffer.lazySet(offset, value);
+    }
+    protected final void svElement(AtomicReferenceArray<E> buffer, int offset, E value) {
+        buffer.set(offset, value);
+    }
+    protected final E lvElement(int offset) {
+        return lvElement(buffer, offset);
+    }
+}

--- a/src/main/java/rx/internal/util/atomic/SpscAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscAtomicArrayQueue.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Original License: https://github.com/JCTools/JCTools/blob/master/LICENSE
+ * Original location: https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+ */
+package rx.internal.util.atomic;
+
+import java.util.concurrent.atomic.*;
+
+/**
+ * A Single-Producer-Single-Consumer queue backed by a pre-allocated buffer.
+ * <p>
+ * This implementation is a mashup of the <a href="http://sourceforge.net/projects/mc-fastflow/">Fast Flow</a>
+ * algorithm with an optimization of the offer method taken from the <a
+ * href="http://staff.ustc.edu.cn/~bhua/publications/IJPP_draft.pdf">BQueue</a> algorithm (a variation on Fast
+ * Flow), and adjusted to comply with Queue.offer semantics with regards to capacity.<br>
+ * For convenience the relevant papers are available in the resources folder:<br>
+ * <i>2010 - Pisa - SPSC Queues on Shared Cache Multi-Core Systems.pdf<br>
+ * 2012 - Junchang- BQueue- Efficient and Practical Queuing.pdf <br>
+ * </i> This implementation is wait free.
+ * 
+ * @param <E>
+ */
+public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> {
+    private static final Integer MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
+    final AtomicLong producerIndex;
+    protected long producerLookAhead;
+    final AtomicLong consumerIndex;
+    final int lookAheadStep;
+    public SpscAtomicArrayQueue(int capacity) {
+        super(capacity);
+        this.producerIndex = new AtomicLong();
+        this.consumerIndex = new AtomicLong();
+        lookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+    }
+
+    @Override
+    public boolean offer(E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final int mask = this.mask;
+        final long index = producerIndex.get();
+        final int offset = calcElementOffset(index, mask);
+        if (index >= producerLookAhead) {
+            int step = lookAheadStep;
+            if (null == lvElement(buffer, calcElementOffset(index + step, mask))) {// LoadLoad
+                producerLookAhead = index + step;
+            }
+            else if (null != lvElement(buffer, offset)){
+                return false;
+            }
+        }
+        soProducerIndex(index + 1); // ordered store -> atomic and ordered for size()
+        soElement(buffer, offset, e); // StoreStore
+        return true;
+    }
+
+    @Override
+    public E poll() {
+        final long index = consumerIndex.get();
+        final int offset = calcElementOffset(index);
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<E> lElementBuffer = buffer;
+        final E e = lvElement(lElementBuffer, offset);// LoadLoad
+        if (null == e) {
+            return null;
+        }
+        soConsumerIndex(index + 1); // ordered store -> atomic and ordered for size()
+        soElement(lElementBuffer, offset, null);// StoreStore
+        return e;
+    }
+
+    @Override
+    public E peek() {
+        return lvElement(calcElementOffset(consumerIndex.get()));
+    }
+
+    @Override
+    public int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and consumer
+         * indices, therefore protection is required to ensure size is within valid range. In the event of concurrent
+         * polls/offers to this method the size is OVER estimated as we read consumer index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+
+    private void soProducerIndex(long newIndex) {
+        producerIndex.lazySet(newIndex);
+    }
+
+    private void soConsumerIndex(long newIndex) {
+        consumerIndex.lazySet(newIndex);
+    }
+    
+    private long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+    private long lvProducerIndex() {
+        return producerIndex.get();
+    }
+}

--- a/src/main/java/rx/internal/util/atomic/SpscExactAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscExactAtomicArrayQueue.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Original License: https://github.com/JCTools/JCTools/blob/master/LICENSE
+ * Original location: https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+ */
+
+package rx.internal.util.atomic;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import rx.internal.util.unsafe.Pow2;
+
+/**
+ * A single-producer single-consumer bounded queue with exact capacity tracking.
+ * <p>This means that a queue of 10 will allow exactly 10 offers, however, the underlying storage is still power-of-2.
+ * <p>The implementation uses field updaters and thus should be platform-safe.
+ */
+public final class SpscExactAtomicArrayQueue<T> extends AtomicReferenceArray<T> implements Queue<T> {
+    /** */
+    private static final long serialVersionUID = 6210984603741293445L;
+    final int mask;
+    final int capacitySkip;
+    volatile long producerIndex;
+    volatile long consumerIndex;
+
+    @SuppressWarnings("rawtypes")
+    static final AtomicLongFieldUpdater<SpscExactAtomicArrayQueue> PRODUCER_INDEX =
+            AtomicLongFieldUpdater.newUpdater(SpscExactAtomicArrayQueue.class, "producerIndex");
+    @SuppressWarnings("rawtypes")
+    static final AtomicLongFieldUpdater<SpscExactAtomicArrayQueue> CONSUMER_INDEX =
+            AtomicLongFieldUpdater.newUpdater(SpscExactAtomicArrayQueue.class, "consumerIndex");
+    
+    public SpscExactAtomicArrayQueue(int capacity) {
+        super(Pow2.roundToPowerOfTwo(capacity));
+        int len = length();
+        this.mask = len - 1;
+        this.capacitySkip = len - capacity; 
+    }
+    
+    
+    @Override
+    public boolean offer(T value) {
+        if (value == null) {
+            throw new NullPointerException();
+        }
+        
+        long pi = producerIndex;
+        int m = mask;
+        
+        int fullCheck = (int)(pi + capacitySkip) & m;
+        if (get(fullCheck) != null) {
+            return false;
+        }
+        int offset = (int)pi & m;
+        PRODUCER_INDEX.lazySet(this, pi + 1);
+        lazySet(offset, value);
+        return true;
+    }
+    @Override
+    public T poll() {
+        long ci = consumerIndex;
+        int offset = (int)ci & mask;
+        T value = get(offset);
+        if (value == null) {
+            return null;
+        }
+        CONSUMER_INDEX.lazySet(this, ci + 1);
+        lazySet(offset, null);
+        return value;
+    }
+    @Override
+    public T peek() {
+        return get((int)consumerIndex & mask);
+    }
+    @Override
+    public void clear() {
+        while (poll() != null || !isEmpty());
+    }
+    @Override
+    public boolean isEmpty() {
+        return producerIndex == consumerIndex;
+    }
+    
+    @Override
+    public int size() {
+        long ci = consumerIndex;
+        for (;;) {
+            long pi = producerIndex;
+            long ci2 = consumerIndex;
+            if (ci == ci2) {
+                return (int)(pi - ci2);
+            }
+            ci = ci2;
+        }
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <E> E[] toArray(E[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean add(T e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T element() {
+        throw new UnsupportedOperationException();
+    }
+    
+}

--- a/src/main/java/rx/internal/util/atomic/SpscUnboundedAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscUnboundedAtomicArrayQueue.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Original License: https://github.com/JCTools/JCTools/blob/master/LICENSE
+ * Original location: https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
+ */
+
+package rx.internal.util.atomic;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import rx.internal.util.unsafe.Pow2;
+
+/**
+ * A single-producer single-consumer queue with unbounded capacity.
+ * <p>The implementation uses fixed, power-of-2 arrays to store elements and turns into a linked-list like
+ * structure if the production overshoots the consumption.
+ * <p>Note that the minimum capacity of the 'islands' are 8 due to how the look-ahead optimization works.
+ * <p>The implementation uses field updaters and thus should be platform-safe.
+ */
+public final class SpscUnboundedAtomicArrayQueue<T> implements Queue<T> {
+    static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
+    protected volatile long producerIndex;
+    @SuppressWarnings("rawtypes")
+    static final AtomicLongFieldUpdater<SpscUnboundedAtomicArrayQueue> PRODUCER_INDEX =
+            AtomicLongFieldUpdater.newUpdater(SpscUnboundedAtomicArrayQueue.class, "producerIndex");
+    protected int producerLookAheadStep;
+    protected long producerLookAhead;
+    protected int producerMask;
+    protected AtomicReferenceArray<Object> producerBuffer;
+    protected int consumerMask;
+    protected AtomicReferenceArray<Object> consumerBuffer;
+    protected volatile long consumerIndex;
+    @SuppressWarnings("rawtypes")
+    static final AtomicLongFieldUpdater<SpscUnboundedAtomicArrayQueue> CONSUMER_INDEX =
+            AtomicLongFieldUpdater.newUpdater(SpscUnboundedAtomicArrayQueue.class, "consumerIndex");
+    private static final Object HAS_NEXT = new Object();
+
+    public SpscUnboundedAtomicArrayQueue(final int bufferSize) {
+        int p2capacity = Pow2.roundToPowerOfTwo(Math.max(8, bufferSize)); // lookahead doesn't work with capacity < 8
+        int mask = p2capacity - 1;
+        AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<Object>(p2capacity + 1);
+        producerBuffer = buffer;
+        producerMask = mask;
+        adjustLookAheadStep(p2capacity);
+        consumerBuffer = buffer;
+        consumerMask = mask;
+        producerLookAhead = mask - 1; // we know it's all empty to start with
+        soProducerIndex(0L);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single producer thread use only.
+     */
+    @Override
+    public final boolean offer(final T e) {
+        if (e == null) {
+            throw new NullPointerException();
+        }
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<Object> buffer = producerBuffer;
+        final long index = lpProducerIndex();
+        final int mask = producerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        if (index < producerLookAhead) {
+            return writeToQueue(buffer, e, index, offset);
+        } else {
+            final int lookAheadStep = producerLookAheadStep;
+            // go around the buffer or resize if full (unless we hit max capacity)
+            int lookAheadElementOffset = calcWrappedOffset(index + lookAheadStep, mask);
+            if (null == lvElement(buffer, lookAheadElementOffset)) {// LoadLoad
+                producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
+                return writeToQueue(buffer, e, index, offset);
+            } else if (null != lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
+                return writeToQueue(buffer, e, index, offset);
+            } else {
+                resize(buffer, index, offset, e, mask); // add a buffer and link old to new
+                return true;
+            }
+        }
+    }
+
+    private boolean writeToQueue(final AtomicReferenceArray<Object> buffer, final T e, final long index, final int offset) {
+        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
+        soElement(buffer, offset, e);// StoreStore
+        return true;
+    }
+
+    private void resize(final AtomicReferenceArray<Object> oldBuffer, final long currIndex, final int offset, final T e,
+            final long mask) {
+        final int capacity = oldBuffer.length();
+        final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
+        producerBuffer = newBuffer;
+        producerLookAhead = currIndex + mask - 1;
+        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
+        soElement(newBuffer, offset, e);// StoreStore
+        soNext(oldBuffer, newBuffer);
+        soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is
+                                                                 // inserted
+    }
+
+    private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
+        soElement(curr, calcDirectOffset(curr.length() - 1), next);
+    }
+    @SuppressWarnings("unchecked")
+    private AtomicReferenceArray<Object> lvNext(AtomicReferenceArray<Object> curr) {
+        return (AtomicReferenceArray<Object>)lvElement(curr, calcDirectOffset(curr.length() - 1));
+    }
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public final T poll() {
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<Object> buffer = consumerBuffer;
+        final long index = lpConsumerIndex();
+        final int mask = consumerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        final Object e = lvElement(buffer, offset);// LoadLoad
+        boolean isNextBuffer = e == HAS_NEXT;
+        if (null != e && !isNextBuffer) {
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
+            soElement(buffer, offset, null);// StoreStore
+            return (T) e;
+        } else if (isNextBuffer) {
+            return newBufferPoll(lvNext(buffer), index, mask);
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private T newBufferPoll(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
+        consumerBuffer = nextBuffer;
+        final int offsetInNew = calcWrappedOffset(index, mask);
+        final T n = (T) lvElement(nextBuffer, offsetInNew);// LoadLoad
+        if (null == n) {
+            return null;
+        } else {
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
+            soElement(nextBuffer, offsetInNew, null);// StoreStore
+            return n;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public final T peek() {
+        final AtomicReferenceArray<Object> buffer = consumerBuffer;
+        final long index = lpConsumerIndex();
+        final int mask = consumerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        final Object e = lvElement(buffer, offset);// LoadLoad
+        if (e == HAS_NEXT) {
+            return newBufferPeek(lvNext(buffer), index, mask);
+        }
+
+        return (T) e;
+    }
+    
+    @Override
+    public void clear() {
+        while (poll() != null || !isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private T newBufferPeek(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
+        consumerBuffer = nextBuffer;
+        final int offsetInNew = calcWrappedOffset(index, mask);
+        return (T) lvElement(nextBuffer, offsetInNew);// LoadLoad
+    }
+
+    @Override
+    public final int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
+         * consumer indices, therefore protection is required to ensure size is within valid range. In the
+         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
+         * index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        return lvProducerIndex() == lvConsumerIndex();
+    }
+
+    private void adjustLookAheadStep(int capacity) {
+        producerLookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+    }
+
+    private long lvProducerIndex() {
+        return producerIndex;
+    }
+
+    private long lvConsumerIndex() {
+        return consumerIndex;
+    }
+
+    private long lpProducerIndex() {
+        return producerIndex;
+    }
+
+    private long lpConsumerIndex() {
+        return consumerIndex;
+    }
+
+    private void soProducerIndex(long v) {
+        PRODUCER_INDEX.lazySet(this, v);
+    }
+
+    private void soConsumerIndex(long v) {
+        CONSUMER_INDEX.lazySet(this, v);
+    }
+
+    private static final int calcWrappedOffset(long index, int mask) {
+        return calcDirectOffset((int)index & mask);
+    }
+    private static final int calcDirectOffset(int index) {
+        return index;
+    }
+    private static final void soElement(AtomicReferenceArray<Object> buffer, int offset, Object e) {
+        buffer.lazySet(offset, e);
+    }
+
+    private static final <E> Object lvElement(AtomicReferenceArray<Object> buffer, int offset) {
+        return buffer.get(offset);
+    }
+
+    @Override
+    public final Iterator<T> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <E> E[] toArray(E[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean add(T e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T element() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/perf/java/rx/operators/FlatMapPerf.java
+++ b/src/perf/java/rx/operators/FlatMapPerf.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2011-2015 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * Benchmark flatMap's optimizations.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*FlatMapPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*FlatMapPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlatMapPerf {
+    @Param({ "1", "1000", "1000000" })
+    public int times;
+
+    Observable<Integer> rxSource;
+    Observable<Integer> rxSource2;
+    
+    @Setup
+    public void setup() {
+        Observable<Integer> rxRange = Observable.range(0, times);
+        rxSource = rxRange.flatMap(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer t) {
+                return Observable.just(t);
+            }
+        });
+        rxSource2 = rxRange.flatMap(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer v) {
+                return Observable.range(v, 2);
+            }
+        });
+    }
+    
+    @Benchmark
+    public Object rxFlatMap() {
+        return rxSource.subscribe();
+    }
+    @Benchmark
+    public Object rxFlatMap2() {
+        return rxSource2.subscribe();
+    }
+}

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -716,7 +716,8 @@ public class OperatorMergeTest {
             }
         };
 
-        Observable.merge(o1).observeOn(Schedulers.computation()).take(RxRingBuffer.SIZE * 2).subscribe(testSubscriber);
+        int limit = RxRingBuffer.SIZE; // the default unbounded behavior makes this test fail 100% of the time: source is too fast
+        Observable.merge(o1, limit).observeOn(Schedulers.computation()).take(RxRingBuffer.SIZE * 2).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         if (testSubscriber.getOnErrorEvents().size() > 0) {
             testSubscriber.getOnErrorEvents().get(0).printStackTrace();
@@ -1302,5 +1303,35 @@ public class OperatorMergeTest {
             };
             runMerge(toHiddenScalar, ts);
         }
+    }
+    
+    @Test
+    public void testUnboundedDefaultConcurrency() {
+        List<Observable<Integer>> os = new ArrayList<Observable<Integer>>();
+        for(int i=0; i < 2000; i++) {
+            os.add(Observable.<Integer>never());
+        }
+        os.add(Observable.range(0, 100));       
+
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable.merge(os).take(1).subscribe(ts);
+        ts.awaitTerminalEvent(5000, TimeUnit.MILLISECONDS);
+        ts.assertValue(0);
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void testConcurrencyLimit() {
+        List<Observable<Integer>> os = new ArrayList<Observable<Integer>>();
+        for(int i=0; i < 2000; i++) {
+            os.add(Observable.<Integer>never());
+        }
+        os.add(Observable.range(0, 100));       
+
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable.merge(os, Integer.MAX_VALUE).take(1).subscribe(ts);
+        ts.awaitTerminalEvent(5000, TimeUnit.MILLISECONDS);
+        ts.assertValue(0);
+        ts.assertCompleted();
     }
 }

--- a/src/test/java/rx/internal/util/JCToolsQueueTests.java
+++ b/src/test/java/rx/internal/util/JCToolsQueueTests.java
@@ -460,4 +460,112 @@ public class JCToolsQueueTests {
         }
         UnsafeAccess.addressOf(Object.class, "field");
     }
+    
+    @Test
+    public void testSpscExactAtomicArrayQueue() {
+        for (int i = 1; i <= RxRingBuffer.SIZE * 2; i++) {
+            SpscExactAtomicArrayQueue<Integer> q = new SpscExactAtomicArrayQueue<Integer>(i);
+            
+            for (int j = 0; j < i; j++) {
+                assertTrue(q.offer(j));
+            }
+            
+            assertFalse(q.offer(i));
+            
+            for (int j = 0; j < i; j++) {
+                assertEquals((Integer)j, q.peek());
+                assertEquals((Integer)j, q.poll());
+            }
+            
+            for (int j = 0; j < RxRingBuffer.SIZE * 4; j++) {
+                assertTrue(q.offer(j));
+                assertEquals((Integer)j, q.peek());
+                assertEquals((Integer)j, q.poll());
+            }
+        }
+    }
+    
+    @Test
+    public void testUnboundedAtomicArrayQueue() {
+        for (int i = 1; i <= RxRingBuffer.SIZE * 2; i *= 2) {
+            SpscUnboundedAtomicArrayQueue<Integer> q = new SpscUnboundedAtomicArrayQueue<Integer>(i);
+            
+            for (int j = 0; j < i; j++) {
+                assertTrue(q.offer(j));
+            }
+            
+            assertTrue(q.offer(i));
+            
+            for (int j = 0; j < i; j++) {
+                assertEquals((Integer)j, q.peek());
+                assertEquals((Integer)j, q.poll());
+            }
+            
+            assertEquals((Integer)i, q.peek());
+            assertEquals((Integer)i, q.poll());
+            
+            for (int j = 0; j < RxRingBuffer.SIZE * 4; j++) {
+                assertTrue(q.offer(j));
+                assertEquals((Integer)j, q.peek());
+                assertEquals((Integer)j, q.poll());
+            }
+        }
+        
+    }
+
+    
+    @Test(expected = NullPointerException.class)
+    public void testSpscAtomicArrayQueueNull() {
+        SpscAtomicArrayQueue<Integer> q = new SpscAtomicArrayQueue<Integer>(16);
+        q.offer(null);
+    }
+    
+    @Test
+    public void testSpscAtomicArrayQueueOfferPoll() {
+        Queue<Integer> q = new SpscAtomicArrayQueue<Integer>(128);
+        
+        testOfferPoll(q);
+    }
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSpscAtomicArrayQueueIterator() {
+        SpscAtomicArrayQueue<Integer> q = new SpscAtomicArrayQueue<Integer>(16);
+        q.iterator();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSpscExactAtomicArrayQueueNull() {
+        SpscExactAtomicArrayQueue<Integer> q = new SpscExactAtomicArrayQueue<Integer>(10);
+        q.offer(null);
+    }
+    
+    @Test
+    public void testSpscExactAtomicArrayQueueOfferPoll() {
+        Queue<Integer> q = new SpscAtomicArrayQueue<Integer>(120);
+        
+        testOfferPoll(q);
+    }
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSpscExactAtomicArrayQueueIterator() {
+        SpscAtomicArrayQueue<Integer> q = new SpscAtomicArrayQueue<Integer>(10);
+        q.iterator();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSpscUnboundedAtomicArrayQueueNull() {
+        SpscUnboundedAtomicArrayQueue<Integer> q = new SpscUnboundedAtomicArrayQueue<Integer>(16);
+        q.offer(null);
+    }
+    
+    @Test
+    public void testSpscUnboundedAtomicArrayQueueOfferPoll() {
+        Queue<Integer> q = new SpscUnboundedAtomicArrayQueue<Integer>(128);
+        
+        testOfferPoll(q);
+    }
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSpscUnboundedAtomicArrayQueueIterator() {
+        SpscUnboundedAtomicArrayQueue<Integer> q = new SpscUnboundedAtomicArrayQueue<Integer>(16);
+        q.iterator();
+    }
+
 }


### PR DESCRIPTION
Resolves #3156 

Note that since the default merge operation is unbounded, this change could lead to an excessive memory usage when flatMapping fast sources. Note that the pre 1.0.13 version did this albeit on a slighty slower path.

The change also affects the scalar optimization as well. Pre 1.0.13 implicitly limited the concurrency level to RxRingBuffer.SIZE when scalars were received. This version now fills the queue up to the concurrency level.

For 2.0, I suggest having a bounded behavior by default and require the developer to specify Integer.MAX_VALUE to go for the unbounded behavior so he/she knows about the consequences.