### PR TITLE
RS dependency, some basic Observable/Observer methods.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
+    compile 'org.reactivestreams:reactive-streams:1.0.0'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -82,6 +82,6 @@ public class Observable<T> implements Publisher<T> {
         }
         Objects.requireNonNull(publisher);
         
-        return create(publisher::subscribe);
+        return create(s -> publisher.subscribe(s)); // javac fails to compile publisher::subscribe, Eclipse is just fine
     }
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -12,6 +12,76 @@
  */
 package io.reactivex;
 
-public class Observable {
 
+import java.util.Objects;
+import java.util.function.*;
+
+import org.reactivestreams.*;
+
+public class Observable<T> implements Publisher<T> {
+    final Consumer<Subscriber<? super T>> onSubscribe;
+    
+    private Observable(Consumer<Subscriber<? super T>> onSubscribe) {
+        this.onSubscribe = onSubscribe;
+    }
+    
+    public static <T> Observable<T> create(Consumer<Subscriber<? super T>> onSubscribe) {
+        // TODO plugin wrapping
+        return new Observable<>(onSubscribe);
+    }
+    
+    @Override
+    public final void subscribe(Subscriber<? super T> s) {
+        Objects.requireNonNull(s);
+        try {
+            onSubscribe.accept(s);
+        } catch (NullPointerException e) {
+            throw e;
+        } catch (Throwable e) {
+            // TODO throw if fatal
+            // TODO plugin error handler
+            // can't call onError because no way to know if a Subscription has been set or not
+            // can't call onSubscribe because the call might have set a Subscription already
+            e.printStackTrace();
+        }
+    }
+    
+    public final <R> Observable<R> lift(Function<Subscriber<? super R>, Subscriber<? super T>> lifter) {
+        return create(su -> {
+            try {
+                Subscriber<? super T> st = lifter.apply(su);
+                // TODO plugin wrapping
+                onSubscribe.accept(st);
+            } catch (NullPointerException e) {
+                throw e;
+            } catch (Throwable e) {
+                // TODO throw if fatal
+                // TODO plugin error handler
+                // can't call onError because no way to know if a Subscription has been set or not
+                // can't call onSubscribe because the call might have set a Subscription already
+                e.printStackTrace();
+            }
+        });
+    }
+    
+    // TODO generics
+    @SuppressWarnings("unchecked")
+    public final <R> Observable<R> compose(Function<? super Observable<T>, ? extends Observable<? extends R>> composer) {
+        return (Observable<R>)to(composer);
+    }
+    
+    // TODO generics
+    public final <R> R to(Function<? super Observable<T>, R> converter) {
+        return converter.apply(this);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Observable<T> fromPublisher(Publisher<? extends T> publisher) {
+        if (publisher instanceof Observable) {
+            return (Observable<T>)publisher;
+        }
+        Objects.requireNonNull(publisher);
+        
+        return create(publisher::subscribe);
+    }
 }

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import org.reactivestreams.*;
+
+public abstract class Observer<T> implements Subscriber<T> {
+    private Subscription s;
+    @Override
+    public final void onSubscribe(Subscription s) {
+        if (this.s != null) {
+            s.cancel();
+            // TODO plugin error handler
+            new IllegalStateException("Subscription already set!").printStackTrace();
+            return;
+        }
+        this.s = s;
+        onStart();
+    }
+    
+    protected final Subscription subscription() {
+        return s;
+    }
+    
+    protected final void request(long n) {
+        subscription().request(n);
+    }
+    
+    protected final void cancel() {
+        subscription().cancel();
+    }
+    /**
+     * Called once the subscription has been set on this observer; override this
+     * to perform initialization or issue an initial request.
+     * <p>
+     * The default implementation requests {@link Long#MAX_VALUE}.
+     */
+    protected void onStart() {
+        request(Long.MAX_VALUE);
+    }
+    
+}


### PR DESCRIPTION
  - Added compile dependency for reactive-streams.
  - Added some basic methods to Observable.

As long as the project defaults to 1.x, the create PR webpage will take a long time to render because it tries to compare a small branch 2.x against the huge 1.x branch with lots of 'deleted' content. A separate project would be much simpler to operate.