### PR TITLE
Refactored exception reporting of most operators.

### DIFF
--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -15,10 +15,9 @@
  */
 package rx.exceptions;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
+import rx.Observer;
 import rx.annotations.Experimental;
 
 /**
@@ -177,5 +176,29 @@ public final class Exceptions {
             throw new CompositeException(
                     "Multiple exceptions", exceptions);
         }
+    }
+    
+    /**
+     * Forwards a fatal exception or reports it along with the value
+     * caused it to the given Observer.
+     * @param t the exception
+     * @param o the observer to report to
+     * @param value the value that caused the exception
+     */
+    @Experimental
+    public static void throwOrReport(Throwable t, Observer<?> o, Object value) {
+        Exceptions.throwIfFatal(t);
+        o.onError(OnErrorThrowable.addValueAsLastCause(t, value));
+    }
+    /**
+     * Forwards a fatal exception or reports it to the given Observer.
+     * @param t the exception
+     * @param o the observer to report to
+     * @param value the value that caused the exception
+     */
+    @Experimental
+    public static void throwOrReport(Throwable t, Observer<?> o) {
+        Exceptions.throwIfFatal(t);
+        o.onError(t);
     }
 }

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -23,9 +23,9 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.exceptions.*;
 import rx.Producer;
 import rx.Subscriber;
-import rx.exceptions.MissingBackpressureException;
 import rx.functions.FuncN;
 import rx.internal.util.RxRingBuffer;
 
@@ -202,7 +202,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
                     } catch (MissingBackpressureException e) {
                         onError(e);
                     } catch (Throwable e) {
-                        onError(e);
+                        Exceptions.throwOrReport(e, child);
                     }
                 }
             }

--- a/src/main/java/rx/internal/operators/OnSubscribeDefer.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeDefer.java
@@ -18,6 +18,7 @@ package rx.internal.operators;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
+import rx.exceptions.Exceptions;
 import rx.functions.Func0;
 import rx.observers.Subscribers;
 
@@ -44,7 +45,7 @@ public final class OnSubscribeDefer<T> implements OnSubscribe<T> {
         try {
             o = observableFactory.call();
         } catch (Throwable t) {
-            s.onError(t);
+            Exceptions.throwOrReport(t, s);
             return;
         }
         o.unsafeSubscribe(Subscribers.wrap(s));

--- a/src/main/java/rx/internal/operators/OnSubscribeDelaySubscriptionWithSelector.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeDelaySubscriptionWithSelector.java
@@ -17,6 +17,7 @@ package rx.internal.operators;
 
 import rx.*;
 import rx.Observable.OnSubscribe;
+import rx.exceptions.Exceptions;
 import rx.functions.Func0;
 import rx.observers.Subscribers;
 
@@ -58,7 +59,7 @@ public final class OnSubscribeDelaySubscriptionWithSelector<T, U> implements OnS
 
             });
         } catch (Throwable e) {
-            child.onError(e);
+            Exceptions.throwOrReport(e, child);
         }
     }
 

--- a/src/main/java/rx/internal/operators/OnSubscribeGroupJoin.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeGroupJoin.java
@@ -15,24 +15,17 @@
  */
 package rx.internal.operators;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.functions.Func1;
-import rx.functions.Func2;
-import rx.observers.SerializedObserver;
-import rx.observers.SerializedSubscriber;
-import rx.subjects.PublishSubject;
-import rx.subjects.Subject;
-import rx.subscriptions.CompositeSubscription;
-import rx.subscriptions.RefCountSubscription;
+import rx.exceptions.Exceptions;
+import rx.functions.*;
+import rx.observers.*;
+import rx.subjects.*;
+import rx.subscriptions.*;
 
 /**
  * Corrrelates two sequences when they overlap and groups the results.
@@ -192,7 +185,7 @@ public final class OnSubscribeGroupJoin<T1, T2, D1, D2, R> implements OnSubscrib
                     
                     
                 } catch (Throwable t) {
-                    onError(t);
+                    Exceptions.throwOrReport(t, this);
                 }
             }
 
@@ -242,7 +235,7 @@ public final class OnSubscribeGroupJoin<T1, T2, D1, D2, R> implements OnSubscrib
                         o.onNext(args);
                     }
                 } catch (Throwable t) {
-                    onError(t);
+                    Exceptions.throwOrReport(t, this);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OnSubscribeJoin.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeJoin.java
@@ -15,20 +15,15 @@
  */
 package rx.internal.operators;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.functions.Func1;
-import rx.functions.Func2;
+import rx.exceptions.Exceptions;
+import rx.functions.*;
 import rx.observers.SerializedSubscriber;
-import rx.subscriptions.CompositeSubscription;
-import rx.subscriptions.SerialSubscription;
+import rx.subscriptions.*;
 
 /**
  * Correlates the elements of two sequences based on overlapping durations.
@@ -154,7 +149,7 @@ public final class OnSubscribeJoin<TLeft, TRight, TLeftDuration, TRightDuration,
                         subscriber.onNext(result);
                     }
                 } catch (Throwable t) {
-                    onError(t);
+                    Exceptions.throwOrReport(t, this);
                 }
             }
 
@@ -266,7 +261,7 @@ public final class OnSubscribeJoin<TLeft, TRight, TLeftDuration, TRightDuration,
                     }
                     
                 } catch (Throwable t) {
-                    onError(t);
+                    Exceptions.throwOrReport(t, this);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OnSubscribeTimerOnce.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeTimerOnce.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable.OnSubscribe;
 import rx.Scheduler;
 import rx.Scheduler.Worker;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Action0;
 
@@ -47,7 +48,7 @@ public final class OnSubscribeTimerOnce implements OnSubscribe<Long> {
                 try {
                     child.onNext(0L);
                 } catch (Throwable t) {
-                    child.onError(t);
+                    Exceptions.throwOrReport(t, child);
                     return;
                 }
                 child.onCompleted();

--- a/src/main/java/rx/internal/operators/OnSubscribeTimerPeriodically.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeTimerPeriodically.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable.OnSubscribe;
 import rx.Scheduler;
 import rx.Scheduler.Worker;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Action0;
 
@@ -51,9 +52,9 @@ public final class OnSubscribeTimerPeriodically implements OnSubscribe<Long> {
                     child.onNext(counter++);
                 } catch (Throwable e) {
                     try {
-                        child.onError(e);
-                    } finally {
                         worker.unsubscribe();
+                    } finally {
+                        Exceptions.throwOrReport(e, child);
                     }
                 }
             }

--- a/src/main/java/rx/internal/operators/OnSubscribeToObservableFuture.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeToObservableFuture.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable.OnSubscribe;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
@@ -83,7 +84,7 @@ public final class OnSubscribeToObservableFuture {
                     //refuse to emit onError if already unsubscribed
                     return;
                 }
-                subscriber.onError(e);
+                Exceptions.throwOrReport(e, subscriber);
             }
         }
     }

--- a/src/main/java/rx/internal/operators/OnSubscribeUsing.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeUsing.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.exceptions.CompositeException;
+import rx.exceptions.*;
 import rx.functions.*;
 import rx.observers.Subscribers;
 
@@ -72,6 +72,8 @@ public final class OnSubscribeUsing<T, Resource> implements OnSubscribe<T> {
                 observable.unsafeSubscribe(Subscribers.wrap(subscriber));
             } catch (Throwable e) {
                 Throwable disposeError = disposeEagerlyIfRequested(disposeOnceOnly);
+                Exceptions.throwIfFatal(e);
+                Exceptions.throwIfFatal(disposeError);
                 if (disposeError != null)
                     subscriber.onError(new CompositeException(Arrays.asList(e, disposeError)));
                 else
@@ -80,7 +82,7 @@ public final class OnSubscribeUsing<T, Resource> implements OnSubscribe<T> {
             }
         } catch (Throwable e) {
             // then propagate error
-            subscriber.onError(e);
+            Exceptions.throwOrReport(e, subscriber);
         }
     }
 

--- a/src/main/java/rx/internal/operators/OperatorAll.java
+++ b/src/main/java/rx/internal/operators/OperatorAll.java
@@ -18,7 +18,6 @@ package rx.internal.operators;
 import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 import rx.internal.producers.SingleDelayedProducer;
 
@@ -47,8 +46,7 @@ public final class OperatorAll<T> implements Operator<Boolean, T> {
                 try {
                     result = predicate.call(t);
                 } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    Exceptions.throwOrReport(e, this, t);
                     return;
                 }
                 if (!result && !done) {

--- a/src/main/java/rx/internal/operators/OperatorAny.java
+++ b/src/main/java/rx/internal/operators/OperatorAny.java
@@ -16,11 +16,9 @@
 package rx.internal.operators;
 
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.Operator;
-import rx.Subscriber;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 import rx.internal.producers.SingleDelayedProducer;
 
@@ -51,8 +49,7 @@ public final class OperatorAny<T> implements Operator<Boolean, T> {
                 try {
                     result = predicate.call(t);
                 } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    Exceptions.throwOrReport(e, this, t);
                     return;
                 }
                 if (result && !done) {

--- a/src/main/java/rx/internal/operators/OperatorBufferWithSingleObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferWithSingleObservable.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.Observer;
 import rx.Subscriber;
 import rx.functions.Func0;
@@ -79,7 +80,7 @@ public final class OperatorBufferWithSingleObservable<T, TClosing> implements Op
         try {
             closing = bufferClosingSelector.call();
         } catch (Throwable t) {
-            child.onError(t);
+            Exceptions.throwOrReport(t, child);
             return Subscribers.empty();
         }
         final BufferingSubscriber bsub = new BufferingSubscriber(new SerializedSubscriber<List<T>>(child));
@@ -157,7 +158,7 @@ public final class OperatorBufferWithSingleObservable<T, TClosing> implements Op
                 }
                 child.onNext(toEmit);
             } catch (Throwable t) {
-                child.onError(t);
+                Exceptions.throwOrReport(t, child);
                 return;
             }
             child.onCompleted();
@@ -183,7 +184,7 @@ public final class OperatorBufferWithSingleObservable<T, TClosing> implements Op
                     }
                     done = true;
                 }
-                child.onError(t);
+                Exceptions.throwOrReport(t, child);
             }
         }
     }

--- a/src/main/java/rx/internal/operators/OperatorBufferWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferWithSize.java
@@ -24,6 +24,7 @@ import rx.Observable;
 import rx.Observable.Operator;
 import rx.Producer;
 import rx.Subscriber;
+import rx.exceptions.Exceptions;
 
 /**
  * This operation takes
@@ -118,7 +119,7 @@ public final class OperatorBufferWithSize<T> implements Operator<List<T>, T> {
                         try {
                             child.onNext(oldBuffer);
                         } catch (Throwable t) {
-                            onError(t);
+                            Exceptions.throwOrReport(t, this);
                             return;
                         }
                     }
@@ -218,7 +219,7 @@ public final class OperatorBufferWithSize<T> implements Operator<List<T>, T> {
                         try {
                             child.onNext(chunk);
                         } catch (Throwable t) {
-                            onError(t);
+                            Exceptions.throwOrReport(t, this);
                             return;
                         }
                     }

--- a/src/main/java/rx/internal/operators/OperatorBufferWithStartEndObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferWithStartEndObservable.java
@@ -21,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.Observer;
 import rx.Subscriber;
 import rx.functions.Func1;
@@ -145,7 +146,7 @@ public final class OperatorBufferWithStartEndObservable<T, TOpening, TClosing> i
                     child.onNext(chunk);
                 }
             } catch (Throwable t) {
-                child.onError(t);
+                Exceptions.throwOrReport(t, child);
                 return;
             }
             child.onCompleted();
@@ -163,7 +164,7 @@ public final class OperatorBufferWithStartEndObservable<T, TOpening, TClosing> i
             try {
                 cobs = bufferClosing.call(v);
             } catch (Throwable t) {
-                onError(t);
+                Exceptions.throwOrReport(t, this);
                 return;
             }
             Subscriber<TClosing> closeSubscriber = new Subscriber<TClosing>() {

--- a/src/main/java/rx/internal/operators/OperatorBufferWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferWithTime.java
@@ -25,6 +25,7 @@ import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Worker;
 import rx.Subscriber;
+import rx.exceptions.Exceptions;
 import rx.functions.Action0;
 import rx.observers.SerializedSubscriber;
 
@@ -159,7 +160,7 @@ public final class OperatorBufferWithTime<T> implements Operator<List<T>, T> {
                     child.onNext(chunk);
                 }
             } catch (Throwable t) {
-                child.onError(t);
+                Exceptions.throwOrReport(t, child);
                 return;
             }
             child.onCompleted();
@@ -208,7 +209,7 @@ public final class OperatorBufferWithTime<T> implements Operator<List<T>, T> {
                 try {
                     child.onNext(chunkToEmit);
                 } catch (Throwable t) {
-                    onError(t);
+                    Exceptions.throwOrReport(t, this);
                 }
             }
         }
@@ -273,7 +274,7 @@ public final class OperatorBufferWithTime<T> implements Operator<List<T>, T> {
                 }
                 child.onNext(toEmit);
             } catch (Throwable t) {
-                child.onError(t);
+                Exceptions.throwOrReport(t, child);
                 return;
             }
             child.onCompleted();
@@ -299,7 +300,7 @@ public final class OperatorBufferWithTime<T> implements Operator<List<T>, T> {
             try {
                 child.onNext(toEmit);
             } catch (Throwable t) {
-                onError(t);
+                Exceptions.throwOrReport(t, this);
             }
         }
     }

--- a/src/main/java/rx/internal/operators/OperatorCast.java
+++ b/src/main/java/rx/internal/operators/OperatorCast.java
@@ -16,8 +16,8 @@
 package rx.internal.operators;
 
 import rx.Observable.Operator;
+import rx.exceptions.*;
 import rx.Subscriber;
-import rx.exceptions.OnErrorThrowable;
 
 /**
  * Converts the elements of an observable sequence to the specified type.
@@ -49,7 +49,7 @@ public class OperatorCast<T, R> implements Operator<R, T> {
                 try {
                     o.onNext(castClass.cast(t));
                 } catch (Throwable e) {
-                    onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    Exceptions.throwOrReport(e, this, t);
                 }
             }
         };

--- a/src/main/java/rx/internal/operators/OperatorDebounceWithSelector.java
+++ b/src/main/java/rx/internal/operators/OperatorDebounceWithSelector.java
@@ -17,6 +17,7 @@ package rx.internal.operators;
 
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Func1;
 import rx.internal.operators.OperatorDebounceWithTime.DebounceState;
@@ -59,7 +60,7 @@ public final class OperatorDebounceWithSelector<T, U> implements Operator<T, T> 
                 try {
                     debouncer = selector.call(t);
                 } catch (Throwable e) {
-                    onError(e);
+                    Exceptions.throwOrReport(e, this);
                     return;
                 }
                 

--- a/src/main/java/rx/internal/operators/OperatorDebounceWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorDebounceWithTime.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Worker;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.observers.SerializedSubscriber;
@@ -130,7 +131,7 @@ public final class OperatorDebounceWithTime<T> implements Operator<T, T> {
             try {
                 onNextAndComplete.onNext(localValue);
             } catch (Throwable e) {
-                onError.onError(e);
+                Exceptions.throwOrReport(e, onError, localValue);
                 return;
             }
 
@@ -166,7 +167,7 @@ public final class OperatorDebounceWithTime<T> implements Operator<T, T> {
                 try {
                     onNextAndComplete.onNext(localValue);
                 } catch (Throwable e) {
-                    onError.onError(e);
+                    Exceptions.throwOrReport(e, onError, localValue);
                     return;
                 }
             }

--- a/src/main/java/rx/internal/operators/OperatorDelayWithSelector.java
+++ b/src/main/java/rx/internal/operators/OperatorDelayWithSelector.java
@@ -17,6 +17,7 @@ package rx.internal.operators;
 
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Func1;
 import rx.observers.SerializedSubscriber;
@@ -71,7 +72,7 @@ public final class OperatorDelayWithSelector<T, V> implements Operator<T, T> {
 
                     }));
                 } catch (Throwable e) {
-                    onError(e);
+                    Exceptions.throwOrReport(e, this);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorDoOnEach.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnEach.java
@@ -15,11 +15,9 @@
  */
 package rx.internal.operators;
 
+import rx.*;
 import rx.Observable.Operator;
-import rx.Observer;
-import rx.Subscriber;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
 
 /**
  * Converts the elements of an observable sequence to the specified type.
@@ -45,7 +43,7 @@ public class OperatorDoOnEach<T> implements Operator<T, T> {
                 try {
                     doOnEachObserver.onCompleted();
                 } catch (Throwable e) {
-                    onError(e);
+                    Exceptions.throwOrReport(e, this);
                     return;
                 }
                 // Set `done` here so that the error in `doOnEachObserver.onCompleted()` can be noticed by observer
@@ -64,7 +62,7 @@ public class OperatorDoOnEach<T> implements Operator<T, T> {
                 try {
                     doOnEachObserver.onError(e);
                 } catch (Throwable e2) {
-                    observer.onError(e2);
+                    Exceptions.throwOrReport(e2, observer);
                     return;
                 }
                 observer.onError(e);
@@ -78,7 +76,7 @@ public class OperatorDoOnEach<T> implements Operator<T, T> {
                 try {
                     doOnEachObserver.onNext(value);
                 } catch (Throwable e) {
-                    onError(OnErrorThrowable.addValueAsLastCause(e, value));
+                    Exceptions.throwOrReport(e, this, value);
                     return;
                 }
                 observer.onNext(value);

--- a/src/main/java/rx/internal/operators/OperatorFilter.java
+++ b/src/main/java/rx/internal/operators/OperatorFilter.java
@@ -17,7 +17,7 @@ package rx.internal.operators;
 
 import rx.Observable.Operator;
 import rx.Subscriber;
-import rx.exceptions.OnErrorThrowable;
+import rx.exceptions.*;
 import rx.functions.Func1;
 
 /**
@@ -57,7 +57,7 @@ public final class OperatorFilter<T> implements Operator<T, T> {
                         request(1);
                     }
                 } catch (Throwable e) {
-                    child.onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    Exceptions.throwOrReport(e, child, t);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -26,10 +26,10 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observable.Operator;
+import rx.exceptions.*;
 import rx.Observer;
 import rx.Producer;
 import rx.Subscriber;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.observables.GroupedObservable;
@@ -226,7 +226,7 @@ public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R
                     emitItem(group, nl.next(t));
                 }
             } catch (Throwable e) {
-                onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                Exceptions.throwOrReport(e, this, t);
             }
         }
 
@@ -287,7 +287,7 @@ public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R
                             try {
                                 o.onNext(elementSelector.call(t));
                             } catch (Throwable e) {
-                                onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                                Exceptions.throwOrReport(e, this, t);
                             }
                         }
                     });

--- a/src/main/java/rx/internal/operators/OperatorMap.java
+++ b/src/main/java/rx/internal/operators/OperatorMap.java
@@ -18,7 +18,6 @@ package rx.internal.operators;
 import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
 /**
@@ -54,8 +53,7 @@ public final class OperatorMap<T, R> implements Operator<R, T> {
                 try {
                     o.onNext(transformer.call(t));
                 } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    Exceptions.throwOrReport(e, this, t);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorMapNotification.java
+++ b/src/main/java/rx/internal/operators/OperatorMapNotification.java
@@ -79,7 +79,7 @@ public final class OperatorMapNotification<T, R> implements Operator<R, T> {
             try {
                 emitter.offerAndComplete(onCompleted.call());
             } catch (Throwable e) {
-                o.onError(e);
+                Exceptions.throwOrReport(e, o);
             }
         }
 
@@ -88,7 +88,7 @@ public final class OperatorMapNotification<T, R> implements Operator<R, T> {
             try {
                 emitter.offerAndComplete(onError.call(e));
             } catch (Throwable e2) {
-                o.onError(e);
+                Exceptions.throwOrReport(e2, o);
             }
         }
 
@@ -97,7 +97,7 @@ public final class OperatorMapNotification<T, R> implements Operator<R, T> {
             try {
                 emitter.offer(onNext.call(t));
             } catch (Throwable e) {
-                o.onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                Exceptions.throwOrReport(e, o, t);
             }
         }
     }

--- a/src/main/java/rx/internal/operators/OperatorMapPair.java
+++ b/src/main/java/rx/internal/operators/OperatorMapPair.java
@@ -17,8 +17,8 @@ package rx.internal.operators;
 
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.exceptions.*;
 import rx.Subscriber;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 import rx.functions.Func2;
 
@@ -85,7 +85,7 @@ public final class OperatorMapPair<T, U, R> implements Operator<Observable<? ext
                         }
                     }));
                 } catch (Throwable e) {
-                    o.onError(OnErrorThrowable.addValueAsLastCause(e, outer));
+                    Exceptions.throwOrReport(e, o, outer);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
@@ -99,7 +99,7 @@ public final class OperatorOnErrorResumeNextViaFunction<T> implements Operator<T
                     Observable<? extends T> resume = resumeFunction.call(e);
                     resume.unsafeSubscribe(next);
                 } catch (Throwable e2) {
-                    child.onError(e2);
+                    Exceptions.throwOrReport(e2, child);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorOnErrorReturn.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorReturn.java
@@ -78,6 +78,7 @@ public final class OperatorOnErrorReturn<T> implements Operator<T, T> {
                     T result = resultFunction.call(e);
                     child.onNext(result);
                 } catch (Throwable x) {
+                    Exceptions.throwIfFatal(x);
                     child.onError(new CompositeException(Arrays.asList(e, x)));
                     return;
                 }

--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -19,7 +19,7 @@ import java.util.Queue;
 import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.exceptions.MissingBackpressureException;
+import rx.exceptions.*;
 import rx.functions.*;
 import rx.internal.util.*;
 import rx.internal.util.unsafe.*;
@@ -561,7 +561,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
                                     } catch (Throwable t) {
                                         // we bounce back exceptions and kick out the child subscriber
                                         ip.unsubscribe();
-                                        ip.child.onError(t);
+                                        Exceptions.throwOrReport(t, ip.child, value);
                                         continue;
                                     }
                                     // indicate this child has received 1 element

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -63,8 +63,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
                     co = connectableFactory.call();
                     observable = selector.call(co);
                 } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    child.onError(e);
+                    Exceptions.throwOrReport(e, child);
                     return;
                 }
                 

--- a/src/main/java/rx/internal/operators/OperatorSampleWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorSampleWithTime.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import rx.Observable.Operator;
 import rx.Scheduler;
 import rx.Scheduler.Worker;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.observers.SerializedSubscriber;
@@ -103,7 +104,7 @@ public final class OperatorSampleWithTime<T> implements Operator<T, T> {
                     T v = (T)localValue;
                     subscriber.onNext(v);
                 } catch (Throwable e) {
-                    onError(e);
+                    Exceptions.throwOrReport(e, this);
                 }
             }
         }

--- a/src/main/java/rx/internal/operators/OperatorSkip.java
+++ b/src/main/java/rx/internal/operators/OperatorSkip.java
@@ -15,11 +15,7 @@
  */
 package rx.internal.operators;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import rx.Observable;
-import rx.Producer;
-import rx.Subscriber;
+import rx.*;
 
 /**
  * Returns an Observable that skips the first <code>num</code> items emitted by the source

--- a/src/main/java/rx/internal/operators/OperatorTakeLastOne.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLastOne.java
@@ -3,6 +3,7 @@ package rx.internal.operators;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.Producer;
 import rx.Subscriber;
 
@@ -150,7 +151,7 @@ public class OperatorTakeLastOne<T> implements Operator<T, T> {
                 try {
                     child.onNext(t);
                 } catch (Throwable e) {
-                    child.onError(e);
+                    Exceptions.throwOrReport(e, child);
                     return;
                 }
             }

--- a/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
@@ -15,11 +15,10 @@
  */
 package rx.internal.operators;
 
-import rx.Observable.Operator;
 import rx.*;
+import rx.Observable.Operator;
 import rx.annotations.Experimental;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
 /**
@@ -47,8 +46,7 @@ public final class OperatorTakeUntilPredicate<T> implements Operator<T, T> {
                 stop = stopPredicate.call(t);
             } catch (Throwable e) {
                 done = true;
-                Exceptions.throwIfFatal(e);
-                child.onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                Exceptions.throwOrReport(e, child, t);
                 unsubscribe();
                 return;
             }

--- a/src/main/java/rx/internal/operators/OperatorTakeWhile.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeWhile.java
@@ -18,11 +18,9 @@ package rx.internal.operators;
 import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.exceptions.Exceptions;
-import rx.exceptions.OnErrorThrowable;
-import rx.functions.Func1;
-import rx.functions.Func2;
+import rx.functions.*;
 
-/**
+/**O
  * Returns an Observable that emits items emitted by the source Observable as long as a specified
  * condition is true.
  * <p>
@@ -60,8 +58,7 @@ public final class OperatorTakeWhile<T> implements Operator<T, T> {
                     isSelected = predicate.call(t, counter++);
                 } catch (Throwable e) {
                     done = true;
-                    Exceptions.throwIfFatal(e);
-                    subscriber.onError(OnErrorThrowable.addValueAsLastCause(e, t));
+                    Exceptions.throwOrReport(e, subscriber, t);
                     unsubscribe();
                     return;
                 }

--- a/src/main/java/rx/internal/operators/OperatorTimeoutWithSelector.java
+++ b/src/main/java/rx/internal/operators/OperatorTimeoutWithSelector.java
@@ -49,8 +49,7 @@ public class OperatorTimeoutWithSelector<T, U, V> extends
                     try {
                         o = firstTimeoutSelector.call();
                     } catch (Throwable t) {
-                        Exceptions.throwIfFatal(t);
-                        timeoutSubscriber.onError(t);
+                        Exceptions.throwOrReport(t, timeoutSubscriber);
                         return Subscriptions.unsubscribed();
                     }
                     return o.unsafeSubscribe(new Subscriber<U>() {
@@ -85,8 +84,7 @@ public class OperatorTimeoutWithSelector<T, U, V> extends
                 try {
                     o = timeoutSelector.call(value);
                 } catch (Throwable t) {
-                    Exceptions.throwIfFatal(t);
-                    timeoutSubscriber.onError(t);
+                    Exceptions.throwOrReport(t, timeoutSubscriber);
                     return Subscriptions.unsubscribed();
                 }
                 return o.unsafeSubscribe(new Subscriber<V>() {

--- a/src/main/java/rx/internal/operators/OperatorToObservableList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableList.java
@@ -18,6 +18,7 @@ package rx.internal.operators;
 import java.util.*;
 
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.*;
 import rx.internal.producers.SingleDelayedProducer;
 
@@ -85,7 +86,7 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
                          */
                         result = new ArrayList<T>(list);
                     } catch (Throwable t) {
-                        onError(t);
+                        Exceptions.throwOrReport(t, this);
                         return;
                     }
                     list = null;

--- a/src/main/java/rx/internal/operators/OperatorToObservableSortedList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableSortedList.java
@@ -18,6 +18,7 @@ package rx.internal.operators;
 import java.util.*;
 
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.*;
 import rx.functions.Func2;
 import rx.internal.producers.SingleDelayedProducer;
@@ -75,7 +76,7 @@ public final class OperatorToObservableSortedList<T> implements Operator<List<T>
                         // sort the list before delivery
                         Collections.sort(a, sortFunction);
                     } catch (Throwable e) {
-                        onError(e);
+                        Exceptions.throwOrReport(e, this);
                         return;
                     }
                     producer.setValue(a);

--- a/src/main/java/rx/internal/operators/OperatorWithLatestFrom.java
+++ b/src/main/java/rx/internal/operators/OperatorWithLatestFrom.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import rx.*;
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.functions.Func2;
 import rx.observers.SerializedSubscriber;
 
@@ -58,7 +59,7 @@ public final class OperatorWithLatestFrom<T, U, R> implements Operator<R, T>  {
                         
                         s.onNext(result);
                     } catch (Throwable e) {
-                        onError(e);
+                        Exceptions.throwOrReport(e, this);
                         return;
                     }
                 }

--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -20,11 +20,10 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.exceptions.*;
 import rx.Observer;
 import rx.Producer;
 import rx.Subscriber;
-import rx.exceptions.MissingBackpressureException;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func2;
 import rx.functions.Func3;
 import rx.functions.Func4;
@@ -265,7 +264,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
                                 requested.decrementAndGet();
                                 emitted++;
                             } catch (Throwable e) {
-                                child.onError(OnErrorThrowable.addValueAsLastCause(e, vs));
+                                Exceptions.throwOrReport(e, child, vs);
                                 return;
                             }
                             // now remove them

--- a/src/main/java/rx/internal/operators/OperatorZipIterable.java
+++ b/src/main/java/rx/internal/operators/OperatorZipIterable.java
@@ -18,6 +18,7 @@ package rx.internal.operators;
 import java.util.Iterator;
 
 import rx.Observable.Operator;
+import rx.exceptions.Exceptions;
 import rx.Subscriber;
 import rx.functions.Func2;
 import rx.observers.Subscribers;
@@ -41,7 +42,8 @@ public final class OperatorZipIterable<T1, T2, R> implements Operator<R, T1> {
                 return Subscribers.empty();
             }
         } catch (Throwable e) {
-            subscriber.onError(e);
+            Exceptions.throwOrReport(e, subscriber);
+            return Subscribers.empty();
         }
         return new Subscriber<T1>(subscriber) {
             boolean once;
@@ -67,7 +69,7 @@ public final class OperatorZipIterable<T1, T2, R> implements Operator<R, T1> {
                         onCompleted();
                     }
                 } catch (Throwable e) {
-                    onError(e);
+                    Exceptions.throwOrReport(e, this);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/TakeLastQueueProducer.java
+++ b/src/main/java/rx/internal/operators/TakeLastQueueProducer.java
@@ -18,6 +18,7 @@ package rx.internal.operators;
 
 import rx.Producer;
 import rx.Subscriber;
+import rx.exceptions.Exceptions;
 
 import java.util.Deque;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -75,7 +76,7 @@ final class TakeLastQueueProducer<T> implements Producer {
                         notification.accept(subscriber, value);
                     }
                 } catch (Throwable e) {
-                    subscriber.onError(e);
+                    Exceptions.throwOrReport(e, subscriber);
                 } finally {
                     deque.clear();
                 }

--- a/src/main/java/rx/internal/producers/ProducerObserverArbiter.java
+++ b/src/main/java/rx/internal/producers/ProducerObserverArbiter.java
@@ -233,9 +233,7 @@ public final class ProducerObserverArbiter<T> implements Producer, Observer<T> {
                     try {
                         c.onNext(v);
                     } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        Throwable ex1 = OnErrorThrowable.addValueAsLastCause(ex, v);
-                        c.onError(ex1);
+                        Exceptions.throwOrReport(ex, c, v);
                         return;
                     }
                 }

--- a/src/main/java/rx/internal/producers/QueuedProducer.java
+++ b/src/main/java/rx/internal/producers/QueuedProducer.java
@@ -169,9 +169,7 @@ public final class QueuedProducer<T> extends AtomicLong implements Producer, Obs
                             c.onNext(t);
                         }
                     } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        Throwable ex1 = OnErrorThrowable.addValueAsLastCause(ex, v != NULL_SENTINEL ? v : null);
-                        c.onError(ex1);
+                        Exceptions.throwOrReport(ex, c, v != NULL_SENTINEL ? v : null);
                         return;
                     }
                     r--;

--- a/src/main/java/rx/internal/producers/QueuedValueProducer.java
+++ b/src/main/java/rx/internal/producers/QueuedValueProducer.java
@@ -117,9 +117,7 @@ public final class QueuedValueProducer<T> extends AtomicLong implements Producer
                             c.onNext(t);
                         }
                     } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        Throwable ex1 = OnErrorThrowable.addValueAsLastCause(ex, v != NULL_SENTINEL ? v : null);
-                        c.onError(ex1);
+                        Exceptions.throwOrReport(ex, c, v != NULL_SENTINEL ? v : null);
                         return;
                     }
                     if (c.isUnsubscribed()) {

--- a/src/main/java/rx/internal/producers/SingleDelayedProducer.java
+++ b/src/main/java/rx/internal/producers/SingleDelayedProducer.java
@@ -101,9 +101,7 @@ public final class SingleDelayedProducer<T> extends AtomicInteger implements Pro
         try {
             c.onNext(v);
         } catch (Throwable e) {
-            Exceptions.throwIfFatal(e);
-            Throwable e1 = OnErrorThrowable.addValueAsLastCause(e, v);
-            c.onError(e1);
+            Exceptions.throwOrReport(e, c, v);
             return;
         }
         if (c.isUnsubscribed()) {

--- a/src/main/java/rx/internal/producers/SingleProducer.java
+++ b/src/main/java/rx/internal/producers/SingleProducer.java
@@ -64,8 +64,7 @@ public final class SingleProducer<T> extends AtomicBoolean implements Producer {
             try {
                 c.onNext(v);
             } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                c.onError(OnErrorThrowable.addValueAsLastCause(e, v));
+                Exceptions.throwOrReport(e, c, v);
                 return;
             }
             // eagerly check for unsubscription

--- a/src/test/java/rx/internal/operators/OperatorFilterTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFilterTest.java
@@ -16,18 +16,16 @@
 package rx.internal.operators;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 
-import rx.Observable;
-import rx.Observer;
-import rx.functions.Func1;
+import rx.*;
+import rx.exceptions.*;
+import rx.functions.*;
 import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;
 
@@ -143,5 +141,30 @@ public class OperatorFilterTest {
 
         // this will wait forever unless OperatorTake handles the request(n) on filtered items
         latch.await();
+    }
+    
+    @Test
+    public void testFatalError() {
+        try {
+            Observable.just(1)
+            .filter(new Func1<Integer, Boolean>() {
+                @Override
+                public Boolean call(Integer t) {
+                    return true;
+                }
+            })
+            .first()
+            .subscribe(new Action1<Integer>() {
+                @Override
+                public void call(Integer t) {
+                    throw new TestException();
+                }
+            });
+            Assert.fail("No exception was thrown");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                Assert.fail("Failed to report the original exception, instead: " + ex.getCause());
+            }
+        }
     }
 }


### PR DESCRIPTION
Added two convenient methods to `Exceptions` which either throws a fatal exception or reports it with our without the causing value to an Observer.