### PR TITLE
Operators of skip (untimed), filter; fix to takeUntil

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/OperatorFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorFilter.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.function.Predicate;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * 
+ */
+public final class OperatorFilter<T> implements Operator<T, T> {
+    final Predicate<? super T> predicate;
+    public OperatorFilter(Predicate<? super T> predicate) {
+        this.predicate = predicate;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> s) {
+        return new FilterSubscriber<>(s, predicate);
+    }
+    
+    static final class FilterSubscriber<T> implements Subscriber<T> {
+        final Predicate<? super T> filter;
+        final Subscriber<? super T> actual;
+        Subscription subscription;
+        public FilterSubscriber(Subscriber<? super T> actual, Predicate<? super T> filter) {
+            this.actual = actual;
+            this.filter = filter;
+        }
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (subscription != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            subscription = s;
+            actual.onSubscribe(s);
+        }
+        @Override
+        public void onNext(T t) {
+            boolean b;
+            try {
+                b = filter.test(t);
+            } catch (Throwable e) {
+                subscription.cancel();
+                actual.onError(e);
+                return;
+            }
+            if (b) {
+                actual.onNext(t);
+            } else {
+                subscription.request(1);
+            }
+        }
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorSkip.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorSkip.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+
+/**
+ * 
+ */
+public final class OperatorSkip<T> implements Operator<T, T> {
+    final long n;
+    public OperatorSkip(long n) {
+        this.n = n;
+    }
+
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> s) {
+        return new SkipSubscriber<>(s, n);
+    }
+    
+    static final class SkipSubscriber<T> implements Subscriber<T> {
+        final Subscriber<? super T> actual;
+        long remaining;
+        public SkipSubscriber(Subscriber<? super T> actual, long n) {
+            this.actual = actual;
+            this.remaining = n;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            long n = remaining;
+            actual.onSubscribe(s);
+            s.request(n);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (remaining != 0L) {
+                remaining--;
+            } else {
+                actual.onNext(t);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+        
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorSkipLast.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.ArrayDeque;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class OperatorSkipLast<T> implements Operator<T, T> {
+    final int skip;
+    
+    public OperatorSkipLast(int skip) {
+        this.skip = skip;
+    }
+
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> s) {
+        return new SkipLastSubscriber<>(s, skip);
+    }
+    
+    static final class SkipLastSubscriber<T> extends ArrayDeque<T> implements Subscriber<T> {
+        /** */
+        private static final long serialVersionUID = -3807491841935125653L;
+        final Subscriber<? super T> actual;
+        final int skip;
+        
+        Subscription s;
+        
+        public SkipLastSubscriber(Subscriber<? super T> actual, int skip) {
+            super(skip);
+            this.actual = actual;
+            this.skip = skip;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(s);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (skip == size()) {
+                actual.onNext(poll());
+            } else {
+                s.request(1);
+            }
+            offer(t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorSkipWhile.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.function.Predicate;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class OperatorSkipWhile<T> implements Operator<T, T> {
+    final Predicate<? super T> predicate;
+    public OperatorSkipWhile(Predicate<? super T> predicate) {
+        this.predicate = predicate;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> s) {
+        return new SkipWhileSubscriber<>(s, predicate);
+    }
+    
+    static final class SkipWhileSubscriber<T> implements Subscriber<T> {
+        final Subscriber<? super T> actual;
+        final Predicate<? super T> predicate;
+        Subscription s;
+        boolean notSkipping;
+        public SkipWhileSubscriber(Subscriber<? super T> actual, Predicate<? super T> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(s);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (notSkipping) {
+                actual.onNext(t);
+            } else {
+                boolean b;
+                try {
+                    b = predicate.test(t);
+                } catch (Throwable e) {
+                    s.cancel();
+                    actual.onError(e);
+                    return;
+                }
+                if (b) {
+                    s.request(1);
+                } else {
+                    notSkipping = true;
+                    actual.onNext(t);
+                }
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}


### PR DESCRIPTION
In `takeUntil`, the other source may emit an `onError` before the main source sets a subscription. The fix makes sure if other is first, it sets an empty subscription before emitting the error (this is an RS specific thing, doesn't affect 1.x).