### PR TITLE
Operators observeOn, subscribeOn and unsubscribeOn

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorObserveOn.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.Scheduler;
+import io.reactivex.internal.queue.*;
+import io.reactivex.internal.schedulers.TrampolineScheduler;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class OperatorObserveOn<T> implements Operator<T, T> {
+    final Scheduler scheduler;
+    final boolean delayError;
+    final int bufferSize;
+    public OperatorObserveOn(Scheduler scheduler, boolean delayError, int bufferSize) {
+        this.scheduler = scheduler;
+        this.delayError = delayError;
+        this.bufferSize = bufferSize;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> t) {
+        if (scheduler instanceof TrampolineScheduler) {
+            return t;
+        }
+        
+        Scheduler.Worker w = scheduler.createWorker();
+        
+        return new ObserveOnSubscriber<>(t, w, delayError, bufferSize);
+    }
+    
+    /**
+     * Pads the base atomic integer used for wip counting.
+     */
+    static class Padding0 extends AtomicInteger {
+        /** */
+        private static final long serialVersionUID = 3172843496016154809L;
+        
+        volatile long p01, p02, p03, p04, p05, p06, p07;
+    }
+    
+    /**
+     * Contains the requested amount.
+     */
+    static class Padding1 extends Padding0 {
+        /** */
+        private static final long serialVersionUID = 7659422588548271214L;
+        
+        volatile long requested;
+        static final AtomicLongFieldUpdater<Padding1> REQUESTED =
+                AtomicLongFieldUpdater.newUpdater(Padding1.class, "requested");
+        
+    }
+    
+    /**
+     * Pads the requested amount away from the effectively constant fields
+     */
+    static class Padding2 extends Padding1 {
+        /** */
+        private static final long serialVersionUID = 227348361328175380L;
+        volatile long p11, p12, p13, p14, p15, p16, p17;
+    }
+    
+    static final class ObserveOnSubscriber<T> extends Padding2 implements Subscriber<T>, Subscription, Runnable {
+        /** */
+        private static final long serialVersionUID = 6576896619930983584L;
+        final Subscriber<? super T> actual;
+        final Scheduler.Worker worker;
+        final boolean delayError;
+        final int bufferSize;
+        final Queue<T> queue;
+        
+        Subscription s;
+        
+        Throwable error;
+        volatile boolean done;
+        
+        volatile boolean cancelled;
+        
+        public ObserveOnSubscriber(Subscriber<? super T> actual, Scheduler.Worker worker, boolean delayError, int bufferSize) {
+            this.actual = actual;
+            this.worker = worker;
+            this.delayError = delayError;
+            this.bufferSize = bufferSize;
+            Queue<T> q;
+            if (Pow2.isPowerOfTwo(bufferSize)) {
+                q = new SpscArrayQueue<>(bufferSize);
+            } else {
+                q = new SpscExactArrayQueue<>(bufferSize);
+            }
+            this.queue = q;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(this);
+            s.request(bufferSize);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (!queue.offer(t)) {
+                onError(new IllegalStateException("Queue full?!"));
+                return;
+            }
+            schedule();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            done = true;
+            schedule();
+        }
+        
+        @Override
+        public void onComplete() {
+            done = true;
+            schedule();
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                RxJavaPlugins.onError(new IllegalArgumentException("n > required but it was " + n));
+                return;
+            }
+            BackpressureHelper.add(REQUESTED, this, n);
+            schedule();
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                s.cancel();
+                worker.dispose();
+            }
+        }
+        
+        void schedule() {
+            if (getAndIncrement() == 0) {
+                worker.schedule(this);
+            }
+        }
+        
+        @Override
+        public void run() {
+            int missed = 1;
+            
+            final Queue<T> q = queue;
+            final Subscriber<? super T> a = actual;
+            
+            for (;;) {
+                if (checkTerminated(done, q.isEmpty(), a)) {
+                    return;
+                }
+                
+                long r = requested;
+                long e = 0L;
+                boolean unbounded = r == Long.MAX_VALUE;
+                
+                while (r != 0L) {
+                    boolean d = done;
+                    T v = q.poll();
+                    boolean empty = v == null;
+                    
+                    if (checkTerminated(d, empty, a)) {
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(v);
+                    
+                    r--;
+                    e++;
+                }
+                
+                if (e != 0L) {
+                    if (!unbounded) {
+                        REQUESTED.addAndGet(this, -e);
+                    }
+                    s.request(e);
+                }
+                
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a) {
+            if (cancelled) {
+                return true;
+            }
+            if (d) {
+                Throwable e = error;
+                if (delayError) {
+                    if (empty) {
+                        if (e != null) {
+                            a.onError(e);
+                        } else {
+                            a.onComplete();
+                        }
+                        worker.dispose();
+                        return true;
+                    }
+                } else {
+                    if (e != null) {
+                        a.onError(e);
+                        worker.dispose();
+                        return true;
+                    } else
+                    if (empty) {
+                        a.onComplete();
+                        worker.dispose();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorUnsubscribeOn.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.Scheduler;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class OperatorUnsubscribeOn<T> implements Operator<T, T> {
+    final Scheduler scheduler;
+    public OperatorUnsubscribeOn(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> t) {
+        return new UnsubscribeSubscriber<>(t, scheduler);
+    }
+    
+    static final class UnsubscribeSubscriber<T> extends AtomicBoolean implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = 1015244841293359600L;
+        
+        final Subscriber<? super T> actual;
+        final Scheduler scheduler;
+        
+        Subscription s;
+        
+        public UnsubscribeSubscriber(Subscriber<? super T> actual, Scheduler scheduler) {
+            this.actual = actual;
+            this.scheduler = scheduler;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(this);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            try {
+                actual.onError(t);
+            } finally {
+                cancel();
+            }
+        }
+        
+        @Override
+        public void onComplete() {
+            try {
+                actual.onComplete();
+            } finally {
+                cancel();
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+        
+        @Override
+        public void cancel() {
+            if (compareAndSet(false, true)) {
+                scheduler.scheduleDirect(s::cancel);
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/PublisherSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherSubscribeOn.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Scheduler;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class PublisherSubscribeOn<T> implements Publisher<T> {
+    final Publisher<? extends T> source;
+    final Scheduler scheduler;
+    final boolean requestOn;
+    
+    public PublisherSubscribeOn(Publisher<? extends T> source, Scheduler scheduler, boolean requestOn) {
+        this.source = source;
+        this.scheduler = scheduler;
+        this.requestOn = requestOn;
+    }
+    
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        /*
+         * TODO can't use the returned disposable because to dispose it,
+         * one must set a Subscription on s on the current thread, but
+         * it is expected that onSubscribe is run on the target scheduler.
+         */
+        if (requestOn) {
+            Scheduler.Worker w = scheduler.createWorker();
+            SubscribeOnSubscriber<T> sos = new SubscribeOnSubscriber<>(s, w);
+            w.schedule(() -> {
+                source.subscribe(sos);
+            });
+        } else {
+            scheduler.scheduleDirect(() -> {
+                source.subscribe(s);
+            });
+        }
+    }
+    
+    static final class SubscribeOnSubscriber<T> extends AtomicReference<Thread> implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = 8094547886072529208L;
+        final Subscriber<? super T> actual;
+        final Scheduler.Worker worker;
+        
+        Subscription s;
+        
+        public SubscribeOnSubscriber(Subscriber<? super T> actual, Scheduler.Worker worker) {
+            this.actual = actual;
+            this.worker = worker;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            lazySet(Thread.currentThread());
+            actual.onSubscribe(this);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            cancel();
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            cancel();
+            actual.onComplete();
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                RxJavaPlugins.onError(new IllegalArgumentException("n > required but it was " + n));
+                return;
+            }
+            if (Thread.currentThread() == get()) {
+                s.request(n);
+            } else {
+                worker.schedule(() -> {
+                    s.request(n);
+                });
+            }
+        }
+        
+        @Override
+        public void cancel() {
+            s.cancel();
+            worker.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Few considerations:

  - Added an option to specify if `subscribeOn` should also request on the same worker or not. If not, the consumer thread may freely grab the producer and thus reduce the inter-thread communication.
  - The scheduling of the subscription in `subscribeOn` now can't be cancelled because in RS, the indication of 'subscription' is to call `onSubscribe` on the proper thread. Since the `Subscriber` can't call cancel until it receives the subscription through `onSubscribe` the time it receives the subscription there is no point in cancelling the operation.
  - Added two parametrization option to `observeOn`: the ability to delay the error after all the `onNext` events and the ability to specify the buffer size. Since many get surprised by the 1.x behavior, this should help the situation and also makes it possible to avoid wrapping/materializing the sequence. The second ability should help with fine tuning a particular sequence independent to the other sequences.
  - I've padded away (since the `@Contended` annotation is not standard) the request and wip counters in `observeOn`. If unpadded, they bash each other constantly and I've experienced 15-20% throughput loss.