### PR TITLE
Lambda-based subscribe and lifecycle tracking methods

### DIFF
--- a/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class LambdaSubscriber<T> extends AtomicReference<Object> implements Subscriber<T>, Subscription, Disposable {
+    /** */
+    private static final long serialVersionUID = -7251123623727029452L;
+    final Consumer<? super T> onNext;
+    final Consumer<? super Throwable> onError;
+    final Runnable onComplete;
+    final Consumer<? super Subscription> onSubscribe;
+    
+    static final Object CANCELLED = new Object();
+    
+    public LambdaSubscriber(Consumer<? super T> onNext, Consumer<? super Throwable> onError, 
+            Runnable onComplete,
+            Consumer<? super Subscription> onSubscribe) {
+        super();
+        this.onNext = onNext;
+        this.onError = onError;
+        this.onComplete = onComplete;
+        this.onSubscribe = onSubscribe;
+    }
+    
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (compareAndSet(null, s)) {
+            onSubscribe.accept(this);
+        } else {
+            s.cancel();
+            if (get() != CANCELLED) {
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+            }
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        try {
+            onNext.accept(t);
+        } catch (Throwable e) {
+            onError(e);
+        }
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        cancel();
+        try {
+            onError.accept(t);
+        } catch (Throwable e) {
+            e.addSuppressed(t);
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        cancel();
+        try {
+            onComplete.run();
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    @Override
+    public void dispose() {
+        cancel();
+    }
+    
+    @Override
+    public void request(long n) {
+        Object o = get();
+        if (o != CANCELLED) {
+            ((Subscription)o).request(n);
+        }
+    }
+    
+    @Override
+    public void cancel() {
+        Object o = get();
+        if (o != CANCELLED) {
+            o = getAndSet(CANCELLED);
+            if (o != CANCELLED && o != null) {
+                ((Subscription)o).cancel();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/SubscriptionLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/SubscriptionLambdaSubscriber.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import java.util.function.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Subscription {
+    final Subscriber<? super T> actual;
+    final Consumer<? super Subscription> onSubscribe;
+    final LongConsumer onRequest;
+    final Runnable onCancel;
+    
+    Subscription s;
+    
+    public SubscriptionLambdaSubscriber(Subscriber<? super T> actual, 
+            Consumer<? super Subscription> onSubscribe,
+            LongConsumer onRequest,
+            Runnable onCancel) {
+        this.actual = actual;
+        this.onSubscribe = onSubscribe;
+        this.onCancel = onCancel;
+        this.onRequest = onRequest;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        // this way, multiple calls to onSubscribe can show up in tests that use doOnSubscribe to validate behavior
+        try {
+            onSubscribe.accept(s);
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+        if (this.s != null) {
+            s.cancel();
+            RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+            return;
+        }
+        this.s = s;
+        actual.onSubscribe(this);
+    }
+    
+    @Override
+    public void onNext(T t) {
+        actual.onNext(t);
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        actual.onError(t);
+    }
+    
+    @Override
+    public void onComplete() {
+        actual.onComplete();
+    }
+    
+    @Override
+    public void request(long n) {
+        try {
+            onRequest.accept(n);
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+        s.request(n);
+    }
+    
+    @Override
+    public void cancel() {
+        try {
+            onCancel.run();
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+        s.cancel();
+    }
+}

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -38,6 +38,8 @@ public final class Schedulers {
     
     static final Scheduler TRAMPOLINE;
     
+    static final Scheduler NEW_THREAD;
+    
     static {
         // TODO plugins and stuff
         SINGLE = RxJavaPlugins.initSingleScheduler(new SingleScheduler());
@@ -47,6 +49,8 @@ public final class Schedulers {
         IO = RxJavaPlugins.initIOScheduler(new IOScheduler());
         
         TRAMPOLINE = TrampolineScheduler.instance();
+        
+        NEW_THREAD = NewThreadScheduler.instance();
     }
     
     public static Scheduler computation() {
@@ -65,6 +69,10 @@ public final class Schedulers {
         return TRAMPOLINE;
     }
 
+    public static Scheduler newThread() {
+        return NEW_THREAD;
+    }
+    
     /*
      * TODO This is a deliberately single threaded scheduler.
      * I can see a few uses for such scheduler:


### PR DESCRIPTION
 + forEachWhile that allows stopping the stream from within the onNext callback by returning false.

The lambda subscribe()s return a Disposable so they can be asynchronously cancelled.