### PR TITLE
Operators onBackpressure(Drop|Buffer|Latest)

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -860,4 +860,36 @@ public class Observable<T> implements Publisher<T> {
         
         return create(new PublisherIntervalRangeSource(start, end, initialDelay, period, unit, scheduler));
     }
+    
+    public final Observable<T> onBackpressureDrop() {
+        return lift(OperatorOnBackpressureDrop.instance());
+    }
+    
+    public final Observable<T> onBackpressureDrop(Consumer<? super T> onDrop) {
+        return lift(new OperatorOnBackpressureDrop<>(onDrop));
+    }
+    
+    public final Observable<T> onBackpressureBuffer() {
+        return onBackpressureBuffer(bufferSize(), false, true);
+    }
+    
+    public final Observable<T> onBackpressureBuffer(int bufferSize) {
+        return onBackpressureBuffer(bufferSize, false, false);
+    }
+    
+    public final Observable<T> onBackpressureBuffer(boolean delayError) {
+        return onBackpressureBuffer(bufferSize(), true, true);
+    }
+    
+    public final Observable<T> onBackpressureBuffer(int bufferSize, boolean delayError) {
+        return onBackpressureBuffer(bufferSize, true, false);
+    }
+    
+    public final Observable<T> onBackpressureBuffer(int bufferSize, boolean delayError, boolean unbounded) {
+        return lift(new OperatorOnBackpressureBuffer<>(bufferSize, unbounded, delayError));
+    }
+    
+    public final Observable<T> onBackpressureLatest() {
+        return lift(OperatorOnBackpressureLatest.instance());
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorOnBackpressureBuffer.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.internal.queue.*;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
+    final int bufferSize;
+    final boolean unbounded;
+    final boolean delayError;
+    
+    public OperatorOnBackpressureBuffer(int bufferSize, boolean unbounded, boolean delayError) {
+        this.bufferSize = bufferSize;
+        this.unbounded = unbounded;
+        this.delayError = delayError;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> t) {
+        return new BackpressureBufferSubscriber<>(t, bufferSize, unbounded, delayError);
+    }
+    
+    static final class BackpressureBufferSubscriber<T> extends AtomicInteger implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = -2514538129242366402L;
+        final Subscriber<? super T> actual;
+        final Queue<T> queue;
+        final boolean delayError;
+        
+        Subscription s;
+        
+        volatile boolean cancelled;
+        
+        volatile boolean done;
+        Throwable error;
+        
+        volatile long requested;
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<BackpressureBufferSubscriber> REQUESTED =
+                AtomicLongFieldUpdater.newUpdater(BackpressureBufferSubscriber.class, "requested");
+        
+        public BackpressureBufferSubscriber(Subscriber<? super T> actual, int bufferSize, boolean unbounded, boolean delayError) {
+            this.actual = actual;
+            this.delayError = delayError;
+            
+            Queue<T> q;
+            
+            if (unbounded) {
+                q = new SpscLinkedArrayQueue<>(bufferSize);
+            } else {
+                if (Pow2.isPowerOfTwo(bufferSize)) {
+                    q = new SpscArrayQueue<>(bufferSize);
+                } else {
+                    q = new SpscExactArrayQueue<>(bufferSize);
+                }
+            }
+            
+            this.queue = q;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(this);
+            s.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (!queue.offer(t)) {
+                s.cancel();
+                onError(new IllegalStateException("Buffer is full?!"));
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                RxJavaPlugins.onError(new IllegalArgumentException("n > required but it was " + n));
+                return;
+            }
+            BackpressureHelper.add(REQUESTED, this, n);
+            drain();
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                
+                if (getAndIncrement() == 0) {
+                    queue.clear();
+                    s.cancel();
+                }
+            }
+        }
+        
+        void drain() {
+            if (getAndIncrement() == 0) {
+                int missed = 1;
+                final Queue<T> q = queue;
+                final Subscriber<? super T> a = actual;
+                for (;;) {
+                    
+                    if (checkTerminated(done, q.isEmpty(), a)) {
+                        return;
+                    }
+                    
+                    long r = requested;
+                    boolean unbounded = r == Long.MAX_VALUE;
+                    
+                    long e = 0;
+                    
+                    while (r != 0L) {
+                        boolean d = done;
+                        T v = q.poll();
+                        boolean empty = v == null;
+                        
+                        if (checkTerminated(d, empty, a)) {
+                            return;
+                        }
+                        
+                        if (empty) {
+                            break;
+                        }
+                        
+                        a.onNext(v);
+                        
+                        r--;
+                        e--;
+                    }
+                    
+                    if (e != 0L) {
+                        if (!unbounded) {
+                            REQUESTED.addAndGet(this, e);
+                        }
+                    }
+                    
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                }
+            }
+        }
+        
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a) {
+            if (cancelled) {
+                s.cancel();
+                queue.clear();
+                return true;
+            }
+            if (d) {
+                if (delayError) {
+                    if (empty) {
+                        Throwable e = error;
+                        if (e != null) {
+                            actual.onError(e);
+                        } else {
+                            actual.onComplete();
+                        }
+                        return true;
+                    }
+                } else {
+                    Throwable e = error;
+                    if (e != null) {
+                        queue.clear();
+                        actual.onError(e);
+                        return true;
+                    } else
+                    if (empty) {
+                        actual.onComplete();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorOnBackpressureDrop.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class OperatorOnBackpressureDrop<T> implements Operator<T, T> {
+    
+    private static final OperatorOnBackpressureDrop<Object> DEFAULT =
+            new OperatorOnBackpressureDrop<>(v -> { });
+    
+    @SuppressWarnings("unchecked")
+    public static <T> OperatorOnBackpressureDrop<T> instance() {
+        return (OperatorOnBackpressureDrop<T>)DEFAULT;
+    }
+    
+    private final Consumer<? super T> onDrop;
+    
+    public OperatorOnBackpressureDrop(Consumer<? super T> onDrop) {
+        this.onDrop = onDrop;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super T> t) {
+        return new BackpressureDropSubscriber<>(t, onDrop);
+    }
+    
+    static final class BackpressureDropSubscriber<T> extends AtomicLong implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = -6246093802440953054L;
+        
+        final Subscriber<? super T> actual;
+        final Consumer<? super T> onDrop;
+        
+        Subscription s;
+        
+        boolean done;
+        
+        public BackpressureDropSubscriber(Subscriber<? super T> actual, Consumer<? super T> onDrop) {
+            this.actual = actual;
+            this.onDrop = onDrop;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(this);
+            s.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            long r = get();
+            if (r != 0L) {
+                actual.onNext(t);
+                if (r != Long.MAX_VALUE) {
+                    decrementAndGet();
+                }
+            } else {
+                try {
+                    onDrop.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    actual.onError(e);
+                }
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                RxJavaPlugins.onError(new IllegalArgumentException("n > required but it was " + n));
+                return;
+            }
+            BackpressureHelper.add(this, n);
+        }
+        
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorOnBackpressureLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorOnBackpressureLatest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public enum OperatorOnBackpressureLatest implements Operator<Object, Object> {
+    INSTANCE;
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Operator<T, T> instance() {
+        return (Operator<T, T>)INSTANCE;
+    }
+    
+    @Override
+    public Subscriber<? super Object> apply(Subscriber<? super Object> t) {
+        return new BackpressureLatestSubscriber(t);
+    }
+    
+    static final class BackpressureLatestSubscriber extends AtomicInteger implements Subscriber<Object>, Subscription {
+        /** */
+        private static final long serialVersionUID = 163080509307634843L;
+
+        final Subscriber<? super Object> actual;
+        
+        Subscription s;
+        
+        volatile boolean done;
+        Throwable error;
+        
+        volatile boolean cancelled;
+        
+        // TODO contended padding?
+        volatile long requested;
+        static final AtomicLongFieldUpdater<BackpressureLatestSubscriber> REQUESTED =
+                AtomicLongFieldUpdater.newUpdater(BackpressureLatestSubscriber.class, "requested");
+        
+        // TODO contended padding?
+        volatile Object current;
+        static final AtomicReferenceFieldUpdater<BackpressureLatestSubscriber, Object> CURRENT =
+                AtomicReferenceFieldUpdater.newUpdater(BackpressureLatestSubscriber.class, Object.class, "current");
+
+        public BackpressureLatestSubscriber(Subscriber<? super Object> actual) {
+            this.actual = actual;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (this.s != null) {
+                s.cancel();
+                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(this);
+            s.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(Object t) {
+            CURRENT.lazySet(this, t);
+            drain();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                RxJavaPlugins.onError(new IllegalArgumentException("n > required but it was " + n));
+                return;
+            }
+            BackpressureHelper.add(REQUESTED, this, n);
+            drain();
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                
+                if (getAndIncrement() == 0) {
+                    CURRENT.lazySet(this, null);
+                    s.cancel();
+                }
+            }
+        }
+        
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            final Subscriber<? super Object> a = actual;
+            int missed = 1;
+            for (;;) {
+                
+                if (checkTerminated(done, current == null, a)) {
+                    return;
+                }
+                
+                long r = requested;
+                
+                if (r != 0L) {
+                    boolean d = done;
+                    Object v = CURRENT.getAndSet(this, null);
+                    boolean empty = v == null;
+                    
+                    if (checkTerminated(d, empty, a)) {
+                        return;
+                    }
+                    
+                    if (!empty) {
+                        a.onNext(v);
+                        
+                        if (r != Long.MAX_VALUE) {
+                            REQUESTED.decrementAndGet(this);
+                        }
+                    }
+                }
+                
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super Object> a) {
+            if (cancelled) {
+                CURRENT.lazySet(this, null);
+                s.cancel();
+                return true;
+            }
+            
+            if (d) {
+                Throwable e = error;
+                if (e != null) {
+                    CURRENT.lazySet(this, null);
+                    a.onError(e);
+                    return true;
+                } else
+                if (empty) {
+                    a.onComplete();
+                    return true;
+                }
+            }
+            
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
There won't be `onBackpressureBlock` although it can work with `subscribeOn(scheduler, false)` since that won't schedule the request behind the blocked emission.

Operator `onBackpressureBuffer` has now a `delayError` option; I'd like to give the developer the option on this one. Naturally, the default is false.