### PR TITLE
Operators first, last, multi-offer for SpscLinkedArrayQueue

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1497,4 +1497,20 @@ public class Observable<T> implements Publisher<T> {
     public final Observable<List<T>> takeLastBuffer(long time, TimeUnit unit, Scheduler scheduler) {
         return takeLast(time, unit, scheduler).toList();
     }
+    
+    public final Observable<T> first() {
+        return take(1).single();
+    }
+    
+    public final Observable<T> first(T defaultValue) {
+        return take(1).single(defaultValue);
+    }
+    
+    public final Observable<T> last() {
+        return takeLast(1).single();
+    }
+    
+    public final Observable<T> last(T defaultValue) {
+        return takeLast(1).single(defaultValue);
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/OperatorSkipLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorSkipLastTimed.java
@@ -13,17 +13,16 @@
 
 package io.reactivex.internal.operators;
 
-import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
 import io.reactivex.Observable.Operator;
+import io.reactivex.Scheduler;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
-import io.reactivex.Scheduler;
 
 public final class OperatorSkipLastTimed<T> implements Operator<T, T> {
     final long time;
@@ -88,12 +87,11 @@ public final class OperatorSkipLastTimed<T> implements Operator<T, T> {
         
         @Override
         public void onNext(T t) {
-            final Queue<Object> q = queue;
+            final SpscLinkedArrayQueue<Object> q = queue;
 
             long now = scheduler.now(unit);
             
-            q.offer(now);
-            q.offer(t);
+            q.offer(now, t);
 
             drain();
         }


### PR DESCRIPTION
The multi-offer helps with the timed skipLast. By offering two at once, the drain won't loop until the second value arrives.