### PR TITLE
Operator buffer with boundary and open-close, fixes to the timed

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1878,9 +1878,12 @@ public class Observable<T> implements Publisher<T> {
             Observable<? extends TOpening> bufferOpenings, 
             Function<? super TOpening, ? extends Publisher<? extends TClosing>> bufferClosingSelector,
             Supplier<U> bufferSupplier) {
-        // TODO
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(bufferOpenings);
+        Objects.requireNonNull(bufferClosingSelector);
+        Objects.requireNonNull(bufferSupplier);
+        return lift(new OperatorBufferBoundary<>(bufferOpenings, bufferClosingSelector, bufferSupplier));
     }
+    
     public final <B> Observable<List<T>> buffer(Observable<B> boundary) {
         /*
          * XXX: javac complains if this is not manually cast, Eclipse is fine
@@ -1888,9 +1891,10 @@ public class Observable<T> implements Publisher<T> {
         return buffer(boundary, (Supplier<List<T>>)ArrayList::new);
     }
 
-    public final <B, U extends Collection<? super T>> Observable<List<T>> buffer(Observable<B> boundary, Supplier<U> bufferSupplier) {
-        // TODO
-        throw new UnsupportedOperationException();
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(Observable<B> boundary, Supplier<U> bufferSupplier) {
+        Objects.requireNonNull(boundary);
+        Objects.requireNonNull(bufferSupplier);
+        return lift(new OperatorBufferExactBoundary<>(boundary, bufferSupplier));
     }
 
     public final <B> Observable<List<T>> buffer(Observable<B> boundary, int initialCapacity) {

--- a/src/main/java/io/reactivex/Try.java
+++ b/src/main/java/io/reactivex/Try.java
@@ -34,8 +34,8 @@ public final class Try<T> {
     /**
      * Constructs a Try instance by wrapping the given value.
      * 
-     * @param value
-     * @return
+     * @param value the value to wrap 
+     * @return the created Try instance
      */
     public static <T> Try<T> ofValue(T value) {
         // TODO ? Objects.requireNonNull(value);
@@ -47,17 +47,16 @@ public final class Try<T> {
      * 
      * <p>Null Throwables are replaced by NullPointerException instance in this Try.
      * 
-     * @param e
-     * @return
+     * @param e the exception to wrap
+     * @return the new Try instance holding the exception
      */
     public static <T> Try<T> ofError(Throwable e) {
-        // TODO ? Objects.requireNonNull(e);
         return new Try<>(null, e != null ? e : new NullPointerException());
     }
     
     /**
      * Returns the value or null if the value is actually null or if this Try holds an error instead.
-     * @return
+     * @return the value contained
      * @see #hasValue()
      */
     public T value() {
@@ -67,7 +66,7 @@ public final class Try<T> {
     /**
      * Returns the error or null if this Try holds a value instead.
      * 
-     * @return
+     * @return the Throwable contained or null
      * 
      */
     public Throwable error() {
@@ -76,7 +75,7 @@ public final class Try<T> {
     
     /**
      * Returns true if this Try holds an error.
-     * @return
+     * @return true if this Try holds an error
      */
     public boolean hasError() {
         return error != null;
@@ -84,7 +83,7 @@ public final class Try<T> {
     
     /**
      * Returns true if this Try holds a value.
-     * @return
+     * @return true if this Try holds a value
      */
     public boolean hasValue() {
         return error == null;

--- a/src/main/java/io/reactivex/internal/disposables/SetCompositeResource.java
+++ b/src/main/java/io/reactivex/internal/disposables/SetCompositeResource.java
@@ -84,7 +84,7 @@ public final class SetCompositeResource<T> implements CompositeResource<T>, Disp
      * Removes the given resource from this composite and calls the disposer if the resource
      * was indeed in the composite.
      * @param resource the resource to remove, not-null (not verified)
-     * @return
+     * @return true if the resource was removed, false otherwise
      */
     @Override
     public boolean remove(T resource) {

--- a/src/main/java/io/reactivex/internal/operators/OperatorBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorBufferBoundary.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SetCompositeResource;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.SerializedSubscriber;
+
+public final class OperatorBufferBoundary<T, U extends Collection<? super T>, Open, Close> implements Operator<U, T> {
+    final Supplier<U> bufferSupplier;
+    final Publisher<? extends Open> bufferOpen;
+    final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;
+
+    public OperatorBufferBoundary(Publisher<? extends Open> bufferOpen,
+            Function<? super Open, ? extends Publisher<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
+        this.bufferOpen = bufferOpen;
+        this.bufferClose = bufferClose;
+        this.bufferSupplier = bufferSupplier;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super U> t) {
+        return new BufferBoundarySubscriber<>(
+                new SerializedSubscriber<>(t),
+                bufferOpen, bufferClose, bufferSupplier
+                );
+    }
+    
+    static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, Open, Close>
+    extends QueueDrainSubscriber<T, U, U> implements Subscription, Disposable {
+        final Publisher<? extends Open> bufferOpen;
+        final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;
+        final Supplier<U> bufferSupplier;
+        final SetCompositeResource<Disposable> resources;
+        
+        Subscription s;
+        
+        final List<U> buffers;
+        
+        volatile int windows;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<BufferBoundarySubscriber> WINDOWS =
+                AtomicIntegerFieldUpdater.newUpdater(BufferBoundarySubscriber.class, "windows");
+
+        public BufferBoundarySubscriber(Subscriber<? super U> actual, 
+                Publisher<? extends Open> bufferOpen,
+                Function<? super Open, ? extends Publisher<? extends Close>> bufferClose,
+                Supplier<U> bufferSupplier) {
+            super(actual, new MpscLinkedQueue<>());
+            this.bufferOpen = bufferOpen;
+            this.bufferClose = bufferClose;
+            this.bufferSupplier = bufferSupplier;
+            this.buffers = new LinkedList<>();
+            this.resources = new SetCompositeResource<>(Disposable::dispose);
+        }
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            
+            BufferOpenSubscriber<T, U, Open, Close> bos = new BufferOpenSubscriber<>(this);
+            resources.add(bos);
+
+            actual.onSubscribe(this);
+            
+            WINDOWS.lazySet(this, 1);
+            bufferOpen.subscribe(bos);
+            
+            s.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            synchronized (t) {
+                for (U b : buffers) {
+                    b.add(t);
+                }
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            cancel();
+            cancelled = true;
+            synchronized (this) {
+                buffers.clear();
+            }
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            cancel();
+            List<U> list;
+            synchronized (this) {
+                list = new ArrayList<>(buffers);
+                buffers.clear();
+            }
+            
+            Queue<U> q = queue;
+            for (U u : list) {
+                q.offer(u);
+            }
+            done = true;
+            if (enter()) {
+                drainMaxLoop(q, actual, false, this);
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            requested(n);
+        }
+        
+        @Override
+        public void dispose() {
+            resources.dispose();
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                dispose();
+            }
+        }
+        
+        @Override
+        public boolean accept(Subscriber<? super U> a, U v) {
+            a.onNext(v);
+            return true;
+        }
+        
+        void open(Open window) {
+            if (cancelled) {
+                return;
+            }
+            
+            U b;
+            
+            try {
+                b = bufferSupplier.get();
+            } catch (Throwable e) {
+                onError(e);
+                return;
+            }
+            
+            if (b == null) {
+                onError(new NullPointerException("The buffer supplied is null"));
+                return;
+            }
+
+            Publisher<? extends Close> p;
+            
+            try {
+                p = bufferClose.apply(window);
+            } catch (Throwable e) {
+                onError(e);
+                return;
+            }
+            
+            if (p == null) {
+                onError(new NullPointerException("The buffer closing publisher is null"));
+                return;
+            }
+            
+            if (cancelled) {
+                return;
+            }
+
+            synchronized (this) {
+                if (cancelled) {
+                    return;
+                }
+                buffers.add(b);
+            }
+            
+            BufferCloseSubscriber<T, U, Open, Close> bcs = new BufferCloseSubscriber<>(b, this);
+            resources.add(bcs);
+            
+            WINDOWS.getAndIncrement(this);
+            
+            p.subscribe(bcs);
+        }
+        
+        void openFinished(Disposable d) {
+            if (resources.remove(d)) {
+                if (WIP.decrementAndGet(this) == 0) {
+                    onComplete();
+                }
+            }
+        }
+        
+        void close(U b, Disposable d) {
+            
+            boolean e;
+            synchronized (this) {
+                e = buffers.remove(b);
+            }
+            
+            if (e) {
+                fastpathOrderedEmitMax(b, false, this);
+            }
+            
+            if (resources.remove(d)) {
+                if (WIP.decrementAndGet(this) == 0) {
+                    onComplete();
+                }
+            }
+        }
+    }
+    
+    static final class BufferOpenSubscriber<T, U extends Collection<? super T>, Open, Close>
+    extends DisposableSubscriber<Open> {
+        final BufferBoundarySubscriber<T, U, Open, Close> parent;
+        
+        boolean done;
+        
+        public BufferOpenSubscriber(BufferBoundarySubscriber<T, U, Open, Close> parent) {
+            this.parent = parent;
+        }
+        @Override
+        public void onNext(Open t) {
+            if (done) {
+                return;
+            }
+            parent.open(t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            parent.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.openFinished(this);
+        }
+    }
+    
+    static final class BufferCloseSubscriber<T, U extends Collection<? super T>, Open, Close>
+    extends DisposableSubscriber<Close> {
+        final BufferBoundarySubscriber<T, U, Open, Close> parent;
+        final U value;
+        boolean done;
+        public BufferCloseSubscriber(U value, BufferBoundarySubscriber<T, U, Open, Close> parent) {
+            this.parent = parent;
+            this.value = value;
+        }
+        
+        @Override
+        public void onNext(Close t) {
+            onComplete();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            parent.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.close(value, this);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorBufferExactBoundary.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.subscribers.SerializedSubscriber;
+
+public final class OperatorBufferExactBoundary<T, U extends Collection<? super T>, B> implements Operator<U, T> {
+    final Publisher<B> boundary;
+    final Supplier<U> bufferSupplier;
+    
+    public OperatorBufferExactBoundary(Publisher<B> boundary, Supplier<U> bufferSupplier) {
+        this.boundary = boundary;
+        this.bufferSupplier = bufferSupplier;
+    }
+
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super U> t) {
+        return new BufferExactBondarySubscriber<>(new SerializedSubscriber<>(t), bufferSupplier, boundary);
+    }
+    
+    static final class BufferExactBondarySubscriber<T, U extends Collection<? super T>, B>
+    extends QueueDrainSubscriber<T, U, U> implements Subscriber<T>, Subscription, Disposable {
+        /** */
+        final Supplier<U> bufferSupplier;
+        final Publisher<B> boundary;
+        
+        Subscription s;
+        
+        Disposable other;
+        
+        U buffer;
+        
+        public BufferExactBondarySubscriber(Subscriber<? super U> actual, Supplier<U> bufferSupplier,
+                Publisher<B> boundary) {
+            super(actual, new MpscLinkedQueue<>());
+            this.bufferSupplier = bufferSupplier;
+            this.boundary = boundary;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            
+            U b;
+            
+            try {
+                b = bufferSupplier.get();
+            } catch (Throwable e) {
+                cancelled = true;
+                s.cancel();
+                EmptySubscription.error(e, actual);
+                return;
+            }
+            
+            if (b == null) {
+                cancelled = true;
+                s.cancel();
+                EmptySubscription.error(new NullPointerException("The buffer supplied is null"), actual);
+                return;
+            }
+            buffer = b;
+            
+            BufferBoundarySubscriber<T, U, B> bs = new BufferBoundarySubscriber<>(this);
+            other = bs;
+            
+            actual.onSubscribe(this);
+            
+            if (!cancelled) {
+                s.request(Long.MAX_VALUE);
+                
+                boundary.subscribe(bs);
+            }
+        }
+        
+        @Override
+        public void onNext(T t) {
+            synchronized (this) {
+                U b = buffer;
+                if (b == null) {
+                    return;
+                }
+                b.add(t);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            cancel();
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            U b;
+            synchronized (this) {
+                b = buffer;
+                if (b == null) {
+                    return;
+                }
+                buffer = null;
+            }
+            queue.offer(b);
+            done = true;
+            if (enter()) {
+                drainMaxLoop(queue, actual, false, this);
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            requested(n);
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                other.dispose();
+                s.cancel();
+                
+                if (enter()) {
+                    queue.clear();
+                }
+            }
+        }
+        
+        void next() {
+            
+            U next;
+            
+            try {
+                next = bufferSupplier.get();
+            } catch (Throwable e) {
+                cancel();
+                actual.onError(e);
+                return;
+            }
+            
+            if (next == null) {
+                cancel();
+                actual.onError(new NullPointerException("The buffer supplied is null"));
+                return;
+            }
+            
+            U b;
+            synchronized (this) {
+                b = buffer;
+                if (b == null) {
+                    return;
+                }
+                buffer = next;
+            }
+            
+            fastpathEmitMax(b, false, this);
+        }
+        
+        @Override
+        public void dispose() {
+            cancel();
+        }
+        
+        @Override
+        public boolean accept(Subscriber<? super U> a, U v) {
+            actual.onNext(v);
+            return true;
+        }
+        
+    }
+    
+    static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, B> extends DisposableSubscriber<B> {
+        final BufferExactBondarySubscriber<T, U, B> parent;
+        
+        public BufferBoundarySubscriber(BufferExactBondarySubscriber<T, U, B> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void onNext(B t) {
+            parent.next();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            parent.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            parent.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.QueueDrain;
+
+/**
+ * Abstract base class for subscribers that hold another subscriber, a queue
+ * and requires queue-drain behavior.
+ * 
+ * @param <T> the source type to which this subscriber will be subscribed
+ * @param <U> the value type in the queue
+ * @param <V> the value type the child subscriber accepts
+ */
+public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriberPad4 implements Subscriber<T>, QueueDrain<U, V> {
+    protected final Subscriber<? super V> actual;
+    protected final Queue<U> queue;
+    
+    protected volatile boolean cancelled;
+    
+    protected volatile boolean done;
+    protected Throwable error;
+    
+    public QueueDrainSubscriber(Subscriber<? super V> actual, Queue<U> queue) {
+        this.actual = actual;
+        this.queue = queue;
+    }
+    
+    @Override
+    public final boolean cancelled() {
+        return cancelled;
+    }
+    
+    @Override
+    public final boolean done() {
+        return done;
+    }
+    
+    @Override
+    public final boolean enter() {
+        return WIP.getAndIncrement(this) == 0;
+    }
+    
+    protected final void fastpathEmit(U value, boolean delayError) {
+        final Subscriber<? super V> s = actual;
+        final Queue<U> q = queue;
+        
+        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+            long r = requested;
+            if (r != 0L) {
+                if (accept(s, value)) {
+                    if (r != Long.MAX_VALUE) {
+                        produced(1);
+                    }
+                }
+                if (leave(-1) == 0) {
+                    return;
+                }
+            }
+            q.offer(value);
+        } else {
+            q.offer(value);
+            if (!enter()) {
+                return;
+            }
+        }
+        drainLoop(q, s, delayError);
+    }
+
+    protected final void fastpathEmitMax(U value, boolean delayError, Disposable dispose) {
+        final Subscriber<? super V> s = actual;
+        final Queue<U> q = queue;
+        
+        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+            long r = requested;
+            if (r != 0L) {
+                if (accept(s, value)) {
+                    if (r != Long.MAX_VALUE) {
+                        produced(1);
+                    }
+                }
+                if (leave(-1) == 0) {
+                    return;
+                }
+            } else {
+                dispose.dispose();
+                s.onError(new IllegalStateException("Could not emit buffer due to lack of requests"));
+                return;
+            }
+        } else {
+            q.offer(value);
+            if (!enter()) {
+                return;
+            }
+        }
+        drainMaxLoop(q, s, delayError, dispose);
+    }
+
+    protected final void fastpathOrderedEmitMax(U value, boolean delayError, Disposable dispose) {
+        final Subscriber<? super V> s = actual;
+        final Queue<U> q = queue;
+        
+        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+            long r = requested;
+            if (r != 0L) {
+                if (q.isEmpty()) {
+                    if (accept(s, value)) {
+                        if (r != Long.MAX_VALUE) {
+                            produced(1);
+                        }
+                    }
+                    if (leave(-1) == 0) {
+                        return;
+                    }
+                } else {
+                    q.offer(value);
+                }
+            } else {
+                cancelled = true;
+                dispose.dispose();
+                s.onError(new IllegalStateException("Could not emit buffer due to lack of requests"));
+                return;
+            }
+        } else {
+            q.offer(value);
+            if (!enter()) {
+                return;
+            }
+        }
+        drainMaxLoop(q, s, delayError, dispose);
+    }
+
+    /**
+     * Makes sure the fast-path emits in order.
+     * @param value
+     * @param delayError
+     */
+    protected final void fastpathOrderedEmit(U value, boolean delayError) {
+        final Subscriber<? super V> s = actual;
+        final Queue<U> q = queue;
+        
+        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+            if (q.isEmpty()) {
+                long r = requested;
+                if (r != 0L) {
+                    if (accept(s, value)) {
+                        if (r != Long.MAX_VALUE) {
+                            produced(1);
+                        }
+                    }
+                    if (leave(-1) == 0) {
+                        return;
+                    }
+                }
+            }
+            q.offer(value);
+        } else {
+            q.offer(value);
+            if (!enter()) {
+                return;
+            }
+        }
+        drainLoop(q, s, delayError);
+    }
+
+    @Override
+    public final Throwable error() {
+        return error;
+    }
+    
+    @Override
+    public final int leave(int m) {
+        return WIP.addAndGet(this, m);
+    }
+    
+    @Override
+    public final long requested() {
+        return requested;
+    }
+    
+    @Override
+    public final long produced(long n) {
+        return REQUESTED.addAndGet(this, n);
+    }
+    
+    public final void requested(long n) {
+        if (SubscriptionHelper.validateRequest(n)) {
+            return;
+        }
+        REQUESTED.addAndGet(this, n);
+    }
+}
+
+// -------------------------------------------------------------------
+// Padding superclasses
+//-------------------------------------------------------------------
+
+/** Pads the header away from other fields. */
+class QueueDrainSubscriberPad0 {
+    volatile long p1, p2, p3, p4, p5, p6, p7;
+    volatile long p8, p9, p10, p11, p12, p13, p14, p15;
+}
+
+/** The WIP counter. */
+class QueueDrainSubscriberWip extends QueueDrainSubscriberPad0 {
+    protected volatile int wip;
+    protected static final AtomicIntegerFieldUpdater<QueueDrainSubscriberWip> WIP =
+            AtomicIntegerFieldUpdater.newUpdater(QueueDrainSubscriberWip.class, "wip");
+}
+
+/** Pads away the wip from the other fields. */
+class QueueDrainSubscriberPad2 extends QueueDrainSubscriberWip {
+    volatile long p1a, p2a, p3a, p4a, p5a, p6a, p7a;
+    volatile long p8a, p9a, p10a, p11a, p12a, p13a, p14a, p15a;
+}
+
+/** Contains the requested field. */
+class QueueDrainSubscriberPad3 extends QueueDrainSubscriberPad2 {
+    protected volatile long requested;
+    protected static final AtomicLongFieldUpdater<QueueDrainSubscriberPad3> REQUESTED =
+            AtomicLongFieldUpdater.newUpdater(QueueDrainSubscriberPad3.class, "requested");
+}
+
+/** Pads away the requested from the other fields. */
+class QueueDrainSubscriberPad4 extends QueueDrainSubscriberPad3 {
+    volatile long q1, q2, q3, q4, q5, q6, q7;
+    volatile long q8, q9, q10, q11, q12, q13, q14, q15;
+}

--- a/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
@@ -37,6 +37,10 @@ public enum EmptySubscription implements Subscription {
     /**
      * Sets the empty subscription instance on the subscriber and then
      * calls onError with the supplied error.
+     * 
+     * <p>Make sure this is only called if the subscriber hasn't received a 
+     * subscription already (there is no way of telling this).
+     * 
      * @param e the error to deliver to the subscriber
      * @param s the target subscriber
      */
@@ -48,6 +52,10 @@ public enum EmptySubscription implements Subscription {
     /**
      * Sets the empty subscription instance on the subscriber and then
      * calls onComplete.
+     * 
+     * <p>Make sure this is only called if the subscriber hasn't received a 
+     * subscription already (there is no way of telling this).
+     * 
      * @param s the target subscriber
      */
     public static void complete(Subscriber<?> s) {

--- a/src/main/java/io/reactivex/internal/util/QueueDrain.java
+++ b/src/main/java/io/reactivex/internal/util/QueueDrain.java
@@ -1,0 +1,167 @@
+package io.reactivex.internal.util;
+
+import java.util.Queue;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.disposables.Disposable;
+
+public interface QueueDrain<T, U> {
+    
+    boolean cancelled();
+    
+    boolean done();
+    
+    Throwable error();
+    
+    boolean enter();
+    
+    long requested();
+    
+    long produced(long n);
+    
+    /**
+     * Adds m to the wip counter.
+     * @param m
+     * @return
+     */
+    int leave(int m);
+    
+    /**
+     * Accept the value and return true if forwarded.
+     * @param a
+     * @param v
+     * @return
+     */
+    boolean accept(Subscriber<? super U> a, T v);
+    
+    default void drainLoop(Queue<T> q, Subscriber<? super U> a, boolean delayError) {
+        
+        int missed = 1;
+        
+        for (;;) {
+            if (checkTerminated(done(), q.isEmpty(), a, delayError, q)) {
+                return;
+            }
+            
+            long r = requested();
+            boolean unbounded = r == Long.MAX_VALUE;
+            long e = 0L;
+            
+            while (e != r) {
+                boolean d = done();
+                T v = q.poll();
+                
+                boolean empty = v == null;
+                
+                if (checkTerminated(d, empty, a, delayError, q)) {
+                    return;
+                }
+                
+                if (empty) {
+                    break;
+                }
+                
+                if (accept(a, v)) {
+                    e++;
+                }
+            }
+            
+            if (e != 0L && !unbounded) {
+                produced(e);
+            }
+            
+            missed = leave(-missed);
+            if (missed == 0) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Drain the queue but give up with an error if there aren't enough requests.
+     * @param q
+     * @param a
+     * @param delayError
+     */
+    default void drainMaxLoop(Queue<T> q, Subscriber<? super U> a, boolean delayError, 
+            Disposable dispose) {
+        int missed = 1;
+        
+        for (;;) {
+            for (;;) {
+                boolean d = done();
+                T v = q.poll();
+                
+                boolean empty = v == null;
+                
+                if (checkTerminated(d, empty, a, delayError, q)) {
+                    if (dispose != null) {
+                        dispose.dispose();
+                    }
+                    return;
+                }
+                
+                if (empty) {
+                    break;
+                }
+
+                long r = requested();
+                if (r != 0L) {
+                    if (accept(a, v)) {
+                        if (r != Long.MAX_VALUE) {
+                            r = produced(1);
+                        }
+                    }
+                } else {
+                    q.clear();
+                    if (dispose != null) {
+                        dispose.dispose();
+                    }
+                    a.onError(new IllegalStateException("Could not emit value due to lack of requests."));
+                    return;
+                }
+            }
+            
+            missed = leave(-missed);
+            if (missed == 0) {
+                break;
+            }
+        }
+    }
+
+    default boolean checkTerminated(boolean d, boolean empty, 
+            Subscriber<?> s, boolean delayError, Queue<?> q) {
+        if (cancelled()) {
+            q.clear();
+            return true;
+        }
+        
+        if (d) {
+            if (delayError) {
+                if (empty) {
+                    Throwable err = error();
+                    if (err != null) {
+                        s.onError(err);
+                    } else {
+                        s.onComplete();
+                    }
+                    return true;
+                }
+            } else {
+                Throwable err = error();
+                if (err != null) {
+                    q.clear();
+                    s.onError(err);
+                    return true;
+                } else
+                if (empty) {
+                    s.onComplete();
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }
+}


### PR DESCRIPTION
variants. 

Added `QueueDrain` and `QueueDrainSubscriber` for common queue-drain
operations. Not applied outside the `buffer()`s as of now.