### PR TITLE
BehaviorSubject

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1041,7 +1041,7 @@ public class Observable<T> implements Publisher<T> {
         return flatMap(mapper, combiner, delayError, maxConcurrency, bufferSize());
     }
 
-    public <U, R> Observable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
         return flatMap(t -> {
             Observable<U> u = fromPublisher(mapper.apply(t));
             return u.map(w -> combiner.apply(t, w));

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -15,15 +15,13 @@ package io.reactivex;
 
 import org.reactivestreams.*;
 
-import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public abstract class Observer<T> implements Subscriber<T> {
     private Subscription s;
     @Override
     public final void onSubscribe(Subscription s) {
-        if (this.s != null) {
-            s.cancel();
-            RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+        if (SubscriptionHelper.validateSubscription(this.s, s)) {
             return;
         }
         this.s = s;


### PR DESCRIPTION
The continuous delivery guarantee and the no-duplication requirement makes it necessary to read/write an index and object values together. I've implemented this with another synchronized block. The alternatives are:

  - use an object of (index, value) and atomically set the reference (requires allocation on every value delivered.
  - this current nested-synchronized block (no deadlock)
  - use a reader-writer lock which works better when concurrent subscribers want to do their first emission at the same time.