### PR TITLE
Operator window with boundary (exact, selector, exact + supplier).

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2163,6 +2163,34 @@ public class Observable<T> implements Publisher<T> {
         }
         return lift(new OperatorWindowTimed<>(timespan, timespan, unit, scheduler, count, bufferSize, restart));
     }
+    
+    public final <B> Observable<Observable<T>> window(Publisher<B> boundary) {
+        return window(boundary, bufferSize());
+    }
+
+    public final <B> Observable<Observable<T>> window(Publisher<B> boundary, int bufferSize) {
+        return lift(new OperatorWindowBoundary<>(boundary, bufferSize));
+    }
+
+    public final <B> Observable<Observable<T>> window(Supplier<? extends Publisher<B>> boundary) {
+        return window(boundary, bufferSize());
+    }
+
+    public final <B> Observable<Observable<T>> window(Supplier<? extends Publisher<B>> boundary, int bufferSize) {
+        return lift(new OperatorWindowBoundarySupplier<>(boundary, bufferSize));
+    }
+    
+    public final <U, V> Observable<Observable<T>> window(
+            Publisher<U> windowOpen, 
+            Function<? super U, ? extends Publisher<V>> windowClose) {
+        return window(windowOpen, windowClose, bufferSize());
+    }
+
+    public final <U, V> Observable<Observable<T>> window(
+            Publisher<U> windowOpen, 
+            Function<? super U, ? extends Publisher<V>> windowClose, int bufferSize) {
+        return lift(new OperatorWindowBoundarySelector<>(windowOpen, windowClose, bufferSize));
+    }
 
     public final <U, R> Observable<R> withLatestFrom(Publisher<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(other);

--- a/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundary.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observable.Operator;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.UnicastSubject;
+import io.reactivex.subscribers.SerializedSubscriber;
+
+public final class OperatorWindowBoundary<T, B> implements Operator<Observable<T>, T> {
+    final Publisher<B> other;
+    final int bufferSize;
+    
+    public OperatorWindowBoundary(Publisher<B> other, int bufferSize) {
+        this.other = other;
+        this.bufferSize = bufferSize;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super Observable<T>> t) {
+        return new WindowBoundaryMainSubscriber<>(new SerializedSubscriber<>(t), other, bufferSize);
+    }
+    
+    static final class WindowBoundaryMainSubscriber<T, B> 
+    extends QueueDrainSubscriber<T, Object, Observable<T>> 
+    implements Subscription {
+        
+        final Publisher<B> other;
+        final int bufferSize;
+        
+        Subscription s;
+        
+        volatile Disposable boundary;
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<WindowBoundaryMainSubscriber, Disposable> BOUNDARY =
+                AtomicReferenceFieldUpdater.newUpdater(WindowBoundaryMainSubscriber.class, Disposable.class, "boundary");
+        
+        static final Disposable CANCELLED = () -> { };
+        
+        UnicastSubject<T> window;
+        
+        static final Object NEXT = new Object();
+        
+        volatile long windows;
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<WindowBoundaryMainSubscriber> WINDOWS =
+                AtomicLongFieldUpdater.newUpdater(WindowBoundaryMainSubscriber.class, "windows");
+        
+        public WindowBoundaryMainSubscriber(Subscriber<? super Observable<T>> actual, Publisher<B> other,
+                int bufferSize) {
+            super(actual, new MpscLinkedQueue<>());
+            this.other = other;
+            this.bufferSize = bufferSize;
+            WINDOWS.lazySet(this, 1);
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            
+            Subscriber<? super Observable<T>> a = actual;
+            a.onSubscribe(this);
+            
+            if (cancelled) {
+                return;
+            }
+            
+            UnicastSubject<T> w = UnicastSubject.create(bufferSize);
+            
+            long r = requested();
+            if (r != 0L) {
+                a.onNext(w);
+                if (r != Long.MAX_VALUE) {
+                    produced(1);
+                }
+            } else {
+                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests"));
+                return;
+            }
+            
+            WindowBoundaryInnerSubscriber<T, B> inner = new WindowBoundaryInnerSubscriber<>(this);
+            
+            if (BOUNDARY.compareAndSet(this, null, inner)) {
+                s.request(Long.MAX_VALUE);
+                other.subscribe(inner);
+            }
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (fastEnter()) {
+                UnicastSubject<T> w = window;
+                
+                w.onNext(t);
+                
+                if (leave(-1) == 0) {
+                    return;
+                }
+            } else {
+                queue.offer(NotificationLite.next(t));
+                if (!enter()) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(error);
+                return;
+            }
+            error = t;
+            done = true;
+            if (enter()) {
+                drainLoop();
+            }
+            
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                dispose();
+            }
+            
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            if (enter()) {
+                drainLoop();
+            }
+            
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                dispose();
+            }
+
+            actual.onComplete();
+            
+        }
+        
+        @Override
+        public void request(long n) {
+            requested(n);
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+            }
+        }
+        
+        void dispose() {
+            Disposable d = boundary;
+            if (d != CANCELLED) {
+                d = BOUNDARY.getAndSet(this, CANCELLED);
+                if (d != CANCELLED && d != null) {
+                    d.dispose();
+                }
+            }
+        }
+        
+        void drainLoop() {
+            final Queue<Object> q = queue;
+            final Subscriber<? super Observable<T>> a = actual;
+            int missed = 1;
+            UnicastSubject<T> w = window;
+            for (;;) {
+                
+                for (;;) {
+                    boolean d = done;
+                    
+                    Object o = q.poll();
+                    
+                    boolean empty = o == null;
+                    
+                    if (d && empty) {
+                        dispose();
+                        Throwable e = error;
+                        if (e != null) {
+                            w.onError(e);
+                        } else {
+                            w.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    if (o == NEXT) {
+                        w.onComplete();
+
+                        if (WINDOWS.decrementAndGet(this) == 0) {
+                            dispose();
+                            return;
+                        }
+
+                        if (cancelled) {
+                            continue;
+                        }
+                        
+                        w = UnicastSubject.create(bufferSize);
+                        
+                        long r = requested();
+                        if (r != 0L) {
+                            WINDOWS.getAndIncrement(this);
+                            
+                            a.onNext(w);
+                            if (r != Long.MAX_VALUE) {
+                                produced(1);
+                            }
+                        } else {
+                            // don't emit new windows 
+                            cancelled = true;
+                            a.onError(new IllegalStateException("Could not deliver new window due to lack of requests"));
+                            continue;
+                        }
+                        
+                        window = w;
+                        continue;
+                    }
+                    
+                    w.onNext(NotificationLite.getValue(o));
+                }
+                
+                missed = leave(-missed);
+                if (missed == 0) {
+                    return;
+                }
+            }
+        }
+        
+        void next() {
+            queue.offer(NEXT);
+            if (enter()) {
+                drainLoop();
+            }
+        }
+        
+        @Override
+        public boolean accept(Subscriber<? super Observable<T>> a, Object v) {
+            // not used by this operator
+            return false;
+        }
+    }
+    
+    static final class WindowBoundaryInnerSubscriber<T, B> extends DisposableSubscriber<B> {
+        final WindowBoundaryMainSubscriber<T, B> parent;
+        
+        boolean done;
+        
+        public WindowBoundaryInnerSubscriber(WindowBoundaryMainSubscriber<T, B> parent) {
+            this.parent = parent;
+        }
+        
+        @Override
+        public void onNext(B t) {
+            if (done) {
+                return;
+            }
+            parent.next();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            parent.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundarySelector.java
@@ -1,0 +1,429 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.Function;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observable.Operator;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SetCompositeResource;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.UnicastSubject;
+import io.reactivex.subscribers.SerializedSubscriber;
+
+public final class OperatorWindowBoundarySelector<T, B, V> implements Operator<Observable<T>, T> {
+    final Publisher<B> open;
+    final Function<? super B, ? extends Publisher<V>> close;
+    final int bufferSize;
+    
+    public OperatorWindowBoundarySelector(Publisher<B> open, Function<? super B, ? extends Publisher<V>> close,
+            int bufferSize) {
+        this.open = open;
+        this.close = close;
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super Observable<T>> t) {
+        return new WindowBoundaryMainSubscriber<>(
+                new SerializedSubscriber<>(t), 
+                open, close, bufferSize);
+    }
+    
+    static final class WindowBoundaryMainSubscriber<T, B, V>
+    extends QueueDrainSubscriber<T, Object, Observable<T>>
+    implements Subscription {
+        final Publisher<B> open;
+        final Function<? super B, ? extends Publisher<V>> close;
+        final int bufferSize;
+        final SetCompositeResource<Disposable> resources;
+
+        Subscription s;
+        
+        volatile Disposable boundary;
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<WindowBoundaryMainSubscriber, Disposable> BOUNDARY =
+                AtomicReferenceFieldUpdater.newUpdater(WindowBoundaryMainSubscriber.class, Disposable.class, "boundary");
+        
+        static final Disposable CANCELLED = () -> { };
+        
+        final List<UnicastSubject<T>> ws;
+        
+        volatile long windows;
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<WindowBoundaryMainSubscriber> WINDOWS =
+                AtomicLongFieldUpdater.newUpdater(WindowBoundaryMainSubscriber.class, "windows");
+
+        public WindowBoundaryMainSubscriber(Subscriber<? super Observable<T>> actual,
+                Publisher<B> open, Function<? super B, ? extends Publisher<V>> close, int bufferSize) {
+            super(actual, new MpscLinkedQueue<>());
+            this.open = open;
+            this.close = close;
+            this.bufferSize = bufferSize;
+            this.resources = new SetCompositeResource<>(Disposable::dispose);
+            this.ws = new ArrayList<>();
+            WINDOWS.lazySet(this, 1);
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            
+            this.s = s;
+            
+            actual.onSubscribe(this);
+            
+            if (cancelled) {
+                return;
+            }
+            
+            OperatorWindowBoundaryOpenSubscriber<T, B> os = new OperatorWindowBoundaryOpenSubscriber<>(this);
+            
+            if (BOUNDARY.compareAndSet(this, null, os)) {
+                WINDOWS.getAndIncrement(this);
+                s.request(Long.MAX_VALUE);
+                open.subscribe(os);
+            }
+            
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (fastEnter()) {
+                for (UnicastSubject<T> w : ws) {
+                    w.onNext(t);
+                }
+                if (leave(-1) == 0) {
+                    return;
+                }
+            } else {
+                queue.offer(NotificationLite.next(t));
+                if (!enter()) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            error = t;
+            done = true;
+            
+            if (enter()) {
+                drainLoop();
+            }
+            
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                resources.dispose();
+            }
+            
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            
+            if (enter()) {
+                drainLoop();
+            }
+            
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                resources.dispose();
+            }
+            
+            actual.onComplete();
+        }
+        
+        
+        
+        void complete() {
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                s.cancel();
+                resources.dispose();
+            }
+            
+            actual.onComplete();
+        }
+        
+        void error(Throwable t) {
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                s.cancel();
+                resources.dispose();
+            }
+            
+            actual.onError(t);
+        }
+        
+        @Override
+        public void request(long n) {
+            requested(n);
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+            }
+        }
+        
+        void dispose() {
+            resources.dispose();
+            Disposable d = boundary;
+            if (d != CANCELLED) {
+                d = BOUNDARY.getAndSet(this, CANCELLED);
+                if (d != CANCELLED && d != null) {
+                    d.dispose();
+                }
+            }
+        }
+        
+        void drainLoop() {
+            final Queue<Object> q = queue;
+            final Subscriber<? super Observable<T>> a = actual;
+            final List<UnicastSubject<T>> ws = this.ws;
+            int missed = 1;
+            
+            for (;;) {
+                
+                for (;;) {
+                    boolean d = done;
+                    Object o = q.poll();
+                    
+                    boolean empty = o == null;
+                    
+                    if (d && empty) {
+                        dispose();
+                        Throwable e = error;
+                        if (e != null) {
+                            for (UnicastSubject<T> w : ws) {
+                                w.onError(e);
+                            }
+                        } else {
+                            for (UnicastSubject<T> w : ws) {
+                                w.onComplete();
+                            }
+                        }
+                        ws.clear();
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    if (o instanceof WindowOperation) {
+                        @SuppressWarnings("unchecked")
+                        WindowOperation<T, B> wo = (WindowOperation<T, B>) o;
+                        
+                        UnicastSubject<T> w = wo.w;
+                        if (w != null) {
+                            if (ws.remove(wo.w)) {
+                                wo.w.onComplete();
+                                
+                                if (WINDOWS.decrementAndGet(this) == 0) {
+                                    dispose();
+                                    return;
+                                }
+                            }
+                            continue;
+                        }
+                        
+                        if (cancelled) {
+                            continue;
+                        }
+                        
+
+                        w = UnicastSubject.create(bufferSize);
+                        
+                        long r = requested();
+                        if (r != 0L) {
+                            ws.add(w);
+                            a.onNext(w);
+                            if (r != Long.MAX_VALUE) {
+                                produced(1);
+                            }
+                        } else {
+                            cancelled = true;
+                            a.onError(new IllegalStateException("Could not deliver new window due to lack of requests"));
+                            continue;
+                        }
+                        
+                        Publisher<V> p;
+                        
+                        try {
+                            p = close.apply(wo.open);
+                        } catch (Throwable e) {
+                            cancelled = true;
+                            a.onError(e);
+                            continue;
+                        }
+                        
+                        if (p == null) {
+                            cancelled = true;
+                            a.onError(new NullPointerException("The publisher supplied is null"));
+                            continue;
+                        }
+                        
+                        OperatorWindowBoundaryCloseSubscriber<T, V> cl = new OperatorWindowBoundaryCloseSubscriber<>(this, w);
+                        
+                        if (resources.add(cl)) {
+                            WINDOWS.getAndIncrement(this);
+                            
+                            p.subscribe(cl);
+                        }
+                        
+                        continue;
+                    }
+                    
+                    for (UnicastSubject<T> w : ws) {
+                        w.onNext(NotificationLite.getValue(o));
+                    }
+                }
+                
+                missed = leave(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        @Override
+        public boolean accept(Subscriber<? super Observable<T>> a, Object v) {
+            // not used by this operator
+            return false;
+        }
+        
+        void open(B b) {
+            queue.offer(new WindowOperation<>(null, b));
+            if (enter()) {
+                drainLoop();
+            }
+        }
+        
+        void close(OperatorWindowBoundaryCloseSubscriber<T, V> w) {
+            resources.delete(w);
+            queue.offer(new WindowOperation<>(w.w, null));
+            if (enter()) {
+                drainLoop();
+            }
+        }
+    }
+    
+    static final class WindowOperation<T, B> {
+        final UnicastSubject<T> w;
+        final B open;
+        public WindowOperation(UnicastSubject<T> w, B open) {
+            this.w = w;
+            this.open = open;
+        }
+    }
+    
+    static final class OperatorWindowBoundaryOpenSubscriber<T, B> extends DisposableSubscriber<B> {
+        final WindowBoundaryMainSubscriber<T, B, ?> parent;
+        
+        boolean done;
+
+        public OperatorWindowBoundaryOpenSubscriber(WindowBoundaryMainSubscriber<T, B, ?> parent) {
+            this.parent = parent;
+        }
+        
+        @Override
+        public void onNext(B t) {
+            if (done) {
+                return;
+            }
+            parent.open(t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            parent.error(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.onComplete();
+        }
+    }
+    
+    static final class OperatorWindowBoundaryCloseSubscriber<T, V> extends DisposableSubscriber<V> {
+        final WindowBoundaryMainSubscriber<T, ?, V> parent;
+        final UnicastSubject<T> w;
+        
+        boolean done;
+
+        public OperatorWindowBoundaryCloseSubscriber(WindowBoundaryMainSubscriber<T, ?, V> parent, UnicastSubject<T> w) {
+            this.parent = parent;
+            this.w = w;
+        }
+        
+        @Override
+        public void onNext(V t) {
+            if (done) {
+                return;
+            }
+            done = true;
+            cancel();
+            parent.close(this);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            parent.error(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.close(this);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundarySupplier.java
@@ -1,0 +1,353 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+import java.util.function.Supplier;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observable.Operator;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.UnicastSubject;
+import io.reactivex.subscribers.SerializedSubscriber;
+
+public final class OperatorWindowBoundarySupplier<T, B> implements Operator<Observable<T>, T> {
+    final Supplier<? extends Publisher<B>> other;
+    final int bufferSize;
+    
+    public OperatorWindowBoundarySupplier(Supplier<? extends Publisher<B>> other, int bufferSize) {
+        this.other = other;
+        this.bufferSize = bufferSize;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super Observable<T>> t) {
+        return new WindowBoundaryMainSubscriber<>(new SerializedSubscriber<>(t), other, bufferSize);
+    }
+    
+    static final class WindowBoundaryMainSubscriber<T, B> 
+    extends QueueDrainSubscriber<T, Object, Observable<T>> 
+    implements Subscription {
+        
+        final Supplier<? extends Publisher<B>> other;
+        final int bufferSize;
+        
+        Subscription s;
+        
+        volatile Disposable boundary;
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<WindowBoundaryMainSubscriber, Disposable> BOUNDARY =
+                AtomicReferenceFieldUpdater.newUpdater(WindowBoundaryMainSubscriber.class, Disposable.class, "boundary");
+        
+        static final Disposable CANCELLED = () -> { };
+        
+        UnicastSubject<T> window;
+        
+        static final Object NEXT = new Object();
+        
+        volatile long windows;
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<WindowBoundaryMainSubscriber> WINDOWS =
+                AtomicLongFieldUpdater.newUpdater(WindowBoundaryMainSubscriber.class, "windows");
+        
+        public WindowBoundaryMainSubscriber(Subscriber<? super Observable<T>> actual, Supplier<? extends Publisher<B>> other,
+                int bufferSize) {
+            super(actual, new MpscLinkedQueue<>());
+            this.other = other;
+            this.bufferSize = bufferSize;
+            WINDOWS.lazySet(this, 1);
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            
+            Subscriber<? super Observable<T>> a = actual;
+            a.onSubscribe(this);
+            
+            if (cancelled) {
+                return;
+            }
+            
+            Publisher<B> p;
+            
+            try {
+                p = other.get();
+            } catch (Throwable e) {
+                a.onError(e);
+                return;
+            }
+            
+            if (p == null) {
+                a.onError(new NullPointerException("The first window publisher supplied is null"));
+                return;
+            }
+            
+            UnicastSubject<T> w = UnicastSubject.create(bufferSize);
+            
+            long r = requested();
+            if (r != 0L) {
+                a.onNext(w);
+                if (r != Long.MAX_VALUE) {
+                    produced(1);
+                }
+            } else {
+                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests"));
+                return;
+            }
+            
+            WindowBoundaryInnerSubscriber<T, B> inner = new WindowBoundaryInnerSubscriber<>(this);
+            
+            if (BOUNDARY.compareAndSet(this, null, inner)) {
+                s.request(Long.MAX_VALUE);
+                p.subscribe(inner);
+            }
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (fastEnter()) {
+                UnicastSubject<T> w = window;
+                
+                w.onNext(t);
+                
+                if (leave(-1) == 0) {
+                    return;
+                }
+            } else {
+                queue.offer(NotificationLite.next(t));
+                if (!enter()) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(error);
+                return;
+            }
+            error = t;
+            done = true;
+            if (enter()) {
+                drainLoop();
+            }
+            
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                dispose();
+            }
+            
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            if (enter()) {
+                drainLoop();
+            }
+            
+            if (WINDOWS.decrementAndGet(this) == 0) {
+                dispose();
+            }
+
+            actual.onComplete();
+            
+        }
+        
+        @Override
+        public void request(long n) {
+            requested(n);
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+            }
+        }
+        
+        void dispose() {
+            Disposable d = boundary;
+            if (d != CANCELLED) {
+                d = BOUNDARY.getAndSet(this, CANCELLED);
+                if (d != CANCELLED && d != null) {
+                    d.dispose();
+                }
+            }
+        }
+        
+        void drainLoop() {
+            final Queue<Object> q = queue;
+            final Subscriber<? super Observable<T>> a = actual;
+            int missed = 1;
+            UnicastSubject<T> w = window;
+            for (;;) {
+                
+                for (;;) {
+                    boolean d = done;
+                    
+                    Object o = q.poll();
+                    boolean empty = o == null;
+                    
+                    if (d && empty) {
+                        dispose();
+                        Throwable e = error;
+                        if (e != null) {
+                            w.onError(e);
+                        } else {
+                            w.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    if (o == NEXT) {
+                        w.onComplete();
+
+                        if (WINDOWS.decrementAndGet(this) == 0) {
+                            dispose();
+                            return;
+                        }
+
+                        if (cancelled) {
+                            continue;
+                        }
+                        
+                        Publisher<B> p;
+
+                        try {
+                            p = other.get();
+                        } catch (Throwable e) {
+                            dispose();
+                            a.onError(e);
+                            return;
+                        }
+                        
+                        if (p == null) {
+                            dispose();
+                            a.onError(new NullPointerException("The publisher supplied is null"));
+                            return;
+                        }
+                        
+                        w = UnicastSubject.create(bufferSize);
+                        
+                        long r = requested();
+                        if (r != 0L) {
+                            WINDOWS.getAndIncrement(this);
+                            
+                            a.onNext(w);
+                            if (r != Long.MAX_VALUE) {
+                                produced(1);
+                            }
+                        } else {
+                            // don't emit new windows 
+                            cancelled = true;
+                            a.onError(new IllegalStateException("Could not deliver new window due to lack of requests"));
+                            continue;
+                        }
+                        
+                        window = w;
+                        
+                        WindowBoundaryInnerSubscriber<T, B> b = new WindowBoundaryInnerSubscriber<>(this);
+                        
+                        if (BOUNDARY.compareAndSet(this, boundary, b)) {
+                            p.subscribe(b);
+                        }
+                        
+                        continue;
+                    }
+                    
+                    w.onNext(NotificationLite.getValue(o));
+                }
+                
+                missed = leave(-missed);
+                if (missed == 0) {
+                    return;
+                }
+            }
+        }
+        
+        void next() {
+            queue.offer(NEXT);
+            if (enter()) {
+                drainLoop();
+            }
+        }
+        
+        @Override
+        public boolean accept(Subscriber<? super Observable<T>> a, Object v) {
+            // not used by this operator
+            return false;
+        }
+    }
+    
+    static final class WindowBoundaryInnerSubscriber<T, B> extends DisposableSubscriber<B> {
+        final WindowBoundaryMainSubscriber<T, B> parent;
+        
+        boolean done;
+        
+        public WindowBoundaryInnerSubscriber(WindowBoundaryMainSubscriber<T, B> parent) {
+            this.parent = parent;
+        }
+        
+        @Override
+        public void onNext(B t) {
+            if (done) {
+                return;
+            }
+            done = true;
+            cancel();
+            parent.next();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            parent.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.onComplete();
+        }
+    }
+}


### PR DESCRIPTION
I'm not 100% certain about the state management: when to let the main
source keep running and when to stop. I.e., the in the selector version,
if the other completes, it means no new window will be opened but the
active should keep receiving values until their closer fires. If all
such closers have fired, the main can be stopped.