### PR TITLE
UnicastSubject javadoc, support for onCancelled notification.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/PublisherGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherGenerate.java
@@ -123,6 +123,10 @@ public final class PublisherGenerate<T, S> implements Publisher<T> {
             
                 if (!unbounded) {
                     n = get();
+                    if (n == Long.MAX_VALUE) {
+                        continue;
+                    }
+                    n += e;
                     if (n != 0L) {
                         continue; // keep draining and delay the addAndGet as much as possible
                     }

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -22,66 +22,145 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
 
+/**
+ * Subject that allows only a single Subscriber to subscribe to it during its lifetime.
+ * 
+ * <p>This subject buffers notifications and replays them to the Subscriber as requested.
+ * 
+ * <p>This subject holds an unbounded internal buffer.
+ * 
+ * <p>If more than one Subscriber attempts to subscribe to this Subject, they
+ * will receive an IllegalStateException if this Subject hasn't terminated yet,
+ * or the Subscribers receive the terminal event (error or completion) if this
+ * Subject has terminated.
+ * 
+ * @param <T> the value type unicasted
+ */
 public final class UnicastSubject<T> extends Subject<T, T> {
     
+    /**
+     * Creates an UnicastSubject with an internal buffer capacity hint 16.
+     * @return an UnicastSubject instance
+     */
     public static <T> UnicastSubject<T> create() {
         return create(16);
     }
     
+    /**
+     * Creates an UnicastSubject with the given internal buffer capacity hint.
+     * @param capacityHint the hint to size the internal unbounded buffer
+     * @return an UnicastSubject instance
+     */
     public static <T> UnicastSubject<T> create(int capacityHint) {
-        State<T> state = new State<>(capacityHint);
+        return create(capacityHint, null);
+    }
+
+    /**
+     * Creates an UnicastSubject with the given internal buffer capacity hint and a callback for
+     * the case when the single Subscriber cancels its subscription.
+     * 
+     * <p>The callback, if not null, is called exactly once and
+     * non-overlapped with any active replay.
+     * 
+     * @param capacityHint the hint to size the internal unbounded buffer
+     * @param onCancelled the optional callback
+     * @return an UnicastSubject instance
+     */
+    public static <T> UnicastSubject<T> create(int capacityHint, Runnable onCancelled) {
+        State<T> state = new State<>(capacityHint, onCancelled);
         return new UnicastSubject<>(state);
     }
-    
+
+    /** The subject state. */
     final State<T> state;
+    /**
+     * Constructs the Observable base class.
+     * @param state the subject state
+     */
     protected UnicastSubject(State<T> state) {
         super(state);
         this.state = state;
     }
 
+    // TODO may need to have a direct WIP field to avoid clashing on the object header
+    /** Pads the WIP counter. */
     static abstract class StatePad0 extends AtomicInteger {
         /** */
         private static final long serialVersionUID = 7779228232971173701L;
-        volatile long p1, p2, p3, p4, p5, p6, p7;
+        /** Cache line padding 1. */
+        volatile long p1a, p2a, p3a, p4a, p5a, p6a, p7a;
+        /** Cache line padding 2. */
+        volatile long p8a, p9a, p10a, p11a, p12a, p13a, p14a, p15a;
     }
     
+    /** Contains the requested counter. */
     static abstract class StateRequested extends StatePad0 {
         /** */
         private static final long serialVersionUID = -2744070795149472578L;
-        
+        /** Holds the current requested amount. */
         volatile long requested;
+        /** Updater to the field requested. */
         static final AtomicLongFieldUpdater<StateRequested> REQUESTED =
                 AtomicLongFieldUpdater.newUpdater(StateRequested.class, "requested");
     }
     
+    /** Pads away the requested counter. */
     static abstract class StatePad1 extends StateRequested {
         /** */
         private static final long serialVersionUID = -446575186947206398L;
-        volatile long p0, p1, p2, p3, p4, p5, p6, p7;
+        /** Cache line padding 3. */
+        volatile long p1b, p2b, p3b, p4b, p5b, p6b, p7b;
+        /** Cache line padding 4. */
+        volatile long p8b, p9b, p10b, p11b, p12b, p13b, p14b, p15b;
     }
     
+    /** The state of the UnicastSubject. */
     static final class State<T> extends StatePad1 implements Publisher<T>, Subscription, Subscriber<T> {
         /** */
         private static final long serialVersionUID = 5058617037583835632L;
 
+        /** The queue that buffers the source events. */
         final Queue<T> queue;
         
+        /** The single subscriber. */
         volatile Subscriber<? super T> subscriber;
+        /** Updater to the field subscriber. */
         @SuppressWarnings("rawtypes")
         static final AtomicReferenceFieldUpdater<State, Subscriber> SUBSCRIBER =
                 AtomicReferenceFieldUpdater.newUpdater(State.class, Subscriber.class, "subscriber");
         
+        /** Indicates the single subscriber has cancelled. */
         volatile boolean cancelled;
         
+        /** Indicates the source has terminated. */
         volatile boolean done;
+        /** 
+         * The terminal error if not null. 
+         * Must be set before writing to done and read after done == true.
+         */
         Throwable error;
 
+        /** Set to 1 atomically for the first and only Subscriber. */
         volatile int once;
+        /** Updater to field once. */
         @SuppressWarnings("rawtypes")
         static final AtomicIntegerFieldUpdater<State> ONCE =
                 AtomicIntegerFieldUpdater.newUpdater(State.class, "once");
         
-        public State(int capacityHint) {
+        /** 
+         * Called when the Subscriber has called cancel.
+         * This allows early termination for those who emit into this
+         * subject so that they can stop immediately 
+         */
+        Runnable onCancelled;
+        
+        /**
+         * Constructs the state with the given capacity and optional cancellation callback.
+         * @param capacityHint the capacity hint for the internal buffer
+         * @param onCancelled the optional cancellation callback
+         */
+        public State(int capacityHint, Runnable onCancelled) {
+            this.onCancelled = onCancelled;
             queue = new SpscLinkedArrayQueue<>(capacityHint);
         }
         
@@ -124,9 +203,22 @@ public final class UnicastSubject<T> extends Subject<T, T> {
             }
         }
         
+        void notifyOnCancelled() {
+            Runnable r = onCancelled;
+            onCancelled = null;
+            if (r != null) {
+                r.run();
+            }
+        }
+        
+        /**
+         * Clears the subscriber and the queue.
+         * @param q the queue reference (avoid re-reading instance field).
+         */
         void clear(Queue<?> q) {
             SUBSCRIBER.lazySet(this, null);
             q.clear();
+            notifyOnCancelled();
         }
         
         @Override
@@ -143,6 +235,10 @@ public final class UnicastSubject<T> extends Subject<T, T> {
             if (done || cancelled) {
                 return;
             }
+            if (t == null) {
+                onError(new NullPointerException());
+                return;
+            }
             queue.offer(t);
             drain();
         }
@@ -151,6 +247,9 @@ public final class UnicastSubject<T> extends Subject<T, T> {
         public void onError(Throwable t) {
             if (done || cancelled) {
                 return;
+            }
+            if (t == null) {
+                t = new NullPointerException();
             }
             error = t;
             done = true;
@@ -179,8 +278,10 @@ public final class UnicastSubject<T> extends Subject<T, T> {
                 
                 if (cancelled) {
                     clear(q);
+                    notifyOnCancelled();
                     return;
                 }
+                
                 if (a != null) {
                     
                     boolean d = done;
@@ -201,6 +302,13 @@ public final class UnicastSubject<T> extends Subject<T, T> {
                     long e = 0L;
                     
                     while (r != 0L) {
+                        
+                        if (cancelled) {
+                            clear(q);
+                            notifyOnCancelled();
+                            return;
+                        }
+
                         d = done;
                         T v = queue.poll();
                         empty = v == null;


### PR DESCRIPTION
The cancellation notification will come in handy with window (and in
groupby). It helps with the case when the main source has been cancelled
but the individual windows/groups are still being consumed. If those get
cancelled by their single Subscribers, this notification will reach the
source and once all windows/groups get cancelled, the main source can be
cancelled.

Fix to generator production accounting.