### PR TITLE
Simplest concat test from 1.x

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -198,8 +198,68 @@ public class Observable<T> implements Publisher<T> {
         return fromIterable(sources).concatMap(v -> v, prefetch);
     }
 
+    public static <T> Observable<T> concat(Publisher<? extends T> p1, Publisher<? extends T> p2) {
+        return concatArray(p1, p2);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2,
+            Publisher<? extends T> p3) {
+        return concatArray(p1, p2, p3);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2,
+            Publisher<? extends T> p3, Publisher<? extends T> p4) {
+        return concatArray(p1, p2, p3, p4);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2, 
+            Publisher<? extends T> p3, Publisher<? extends T> p4,
+            Publisher<? extends T> p5
+    ) {
+        return concatArray(p1, p2, p3, p4, p5);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2, 
+            Publisher<? extends T> p3, Publisher<? extends T> p4,
+            Publisher<? extends T> p5, Publisher<? extends T> p6
+    ) {
+        return concatArray(p1, p2, p3, p4, p5, p6);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2,
+            Publisher<? extends T> p3, Publisher<? extends T> p4,
+            Publisher<? extends T> p5, Publisher<? extends T> p6,
+            Publisher<? extends T> p7
+    ) {
+        return concatArray(p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2, 
+            Publisher<? extends T> p3, Publisher<? extends T> p4,
+            Publisher<? extends T> p5, Publisher<? extends T> p6,
+            Publisher<? extends T> p7, Publisher<? extends T> p8
+    ) {
+        return concatArray(p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    public static <T> Observable<T> concat(
+            Publisher<? extends T> p1, Publisher<? extends T> p2, 
+            Publisher<? extends T> p3, Publisher<? extends T> p4,
+            Publisher<? extends T> p5, Publisher<? extends T> p6,
+            Publisher<? extends T> p7, Publisher<? extends T> p8,
+            Publisher<? extends T> p9
+    ) {
+        return concatArray(p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
     @SafeVarargs
-    public static <T> Observable<T> concat(int prefetch, Publisher<? extends T>... sources) {
+    public static <T> Observable<T> concatArray(int prefetch, Publisher<? extends T>... sources) {
         Objects.requireNonNull(sources);
         return fromArray(sources).concatMap(v -> v, prefetch);
     }
@@ -209,8 +269,12 @@ public class Observable<T> implements Publisher<T> {
         return fromIterable(sources).concatMap(v -> v);
     }
 
+    /**
+     *
+     * TODO named this way because of overload conflict with concat(Publisher&lt;Publisher&gt)
+     */
     @SafeVarargs
-    public static <T> Observable<T> concat(Publisher<? extends T>... sources) {
+    public static <T> Observable<T> concatArray(Publisher<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         } else
@@ -810,11 +874,11 @@ public class Observable<T> implements Publisher<T> {
         return fromPublisher(to(composer));
     }
 
-    public final Observable<T> concat(Publisher<? extends Publisher<? extends T>> sources) {
+    public static final <T> Observable<T> concat(Publisher<? extends Publisher<? extends T>> sources) {
         return concat(sources, bufferSize());
     }
 
-    public final Observable<T> concat(Publisher<? extends Publisher<? extends T>> sources, int bufferSize) {
+    public static final <T> Observable<T> concat(Publisher<? extends Publisher<? extends T>> sources, int bufferSize) {
         return fromPublisher(sources).concatMap(v -> v);
     }
 
@@ -1012,7 +1076,7 @@ public class Observable<T> implements Publisher<T> {
     }
 
     public final Observable<T> endWith(Iterable<? extends T> values) {
-        return concat(this, fromIterable(values));
+        return concatArray(this, fromIterable(values));
     }
 
     @SafeVarargs
@@ -1021,7 +1085,7 @@ public class Observable<T> implements Publisher<T> {
         if (fromArray == empty()) {
             return this;
         }
-        return concat(this, fromArray);
+        return concatArray(this, fromArray);
     }
 
     /**
@@ -1692,7 +1756,7 @@ public class Observable<T> implements Publisher<T> {
     }
 
     public final Observable<T> startWith(Iterable<? extends T> values) {
-        return concat(fromIterable(values), this);
+        return concatArray(fromIterable(values), this);
     }
 
     @SafeVarargs
@@ -1701,7 +1765,7 @@ public class Observable<T> implements Publisher<T> {
         if (fromArray == empty()) {
             return this;
         }
-        return concat(fromArray, this);
+        return concatArray(fromArray, this);
     }
 
     public final Disposable subscribe() {
@@ -1746,6 +1810,10 @@ public class Observable<T> implements Publisher<T> {
         try {
             s = RxJavaPlugins.onSubscribe(s);
 
+            if (s == null) {
+                throw new NullPointerException("Plugin returned null Subscriber");
+            }
+            
             onSubscribe.subscribe(s);
         } catch (NullPointerException e) {
             throw e;

--- a/src/test/java/io/reactivex/ConcatTests.java
+++ b/src/test/java/io/reactivex/ConcatTests.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.CovarianceTest.*;
+
+public class ConcatTests {
+
+    @Test
+    public void testConcatSimple() {
+        Observable<String> o1 = Observable.just("one", "two");
+        Observable<String> o2 = Observable.just("three", "four");
+
+        List<String> values = Observable.concat(o1, o2).toList().toBlocking().single();
+
+        assertEquals("one", values.get(0));
+        assertEquals("two", values.get(1));
+        assertEquals("three", values.get(2));
+        assertEquals("four", values.get(3));
+    }
+
+    @Test
+    public void testConcatWithObservableOfObservable() {
+        Observable<String> o1 = Observable.just("one", "two");
+        Observable<String> o2 = Observable.just("three", "four");
+        Observable<String> o3 = Observable.just("five", "six");
+
+        Observable<Observable<String>> os = Observable.just(o1, o2, o3);
+
+        List<String> values = Observable.concat(os).toList().toBlocking().single();
+
+        assertEquals("one", values.get(0));
+        assertEquals("two", values.get(1));
+        assertEquals("three", values.get(2));
+        assertEquals("four", values.get(3));
+        assertEquals("five", values.get(4));
+        assertEquals("six", values.get(5));
+    }
+
+    @Test
+    public void testConcatWithIterableOfObservable() {
+        Observable<String> o1 = Observable.just("one", "two");
+        Observable<String> o2 = Observable.just("three", "four");
+        Observable<String> o3 = Observable.just("five", "six");
+
+        Iterable<Observable<String>> is = Arrays.asList(o1, o2, o3);
+
+        List<String> values = Observable.concat(Observable.fromIterable(is)).toList().toBlocking().single();
+
+        assertEquals("one", values.get(0));
+        assertEquals("two", values.get(1));
+        assertEquals("three", values.get(2));
+        assertEquals("four", values.get(3));
+        assertEquals("five", values.get(4));
+        assertEquals("six", values.get(5));        
+    }
+
+    @Test
+    public void testConcatCovariance() {
+        HorrorMovie horrorMovie1 = new HorrorMovie();
+        Movie movie = new Movie();
+        Media media = new Media();
+        HorrorMovie horrorMovie2 = new HorrorMovie();
+        
+        Observable<Media> o1 = Observable.<Media> just(horrorMovie1, movie);
+        Observable<Media> o2 = Observable.just(media, horrorMovie2);
+
+        Observable<Observable<Media>> os = Observable.just(o1, o2);
+
+        List<Media> values = Observable.concat(os).toList().toBlocking().single();
+        
+        assertEquals(horrorMovie1, values.get(0));
+        assertEquals(movie, values.get(1));
+        assertEquals(media, values.get(2));
+        assertEquals(horrorMovie2, values.get(3));
+        assertEquals(4, values.size());
+    }
+
+    @Test
+    public void testConcatCovariance2() {
+        HorrorMovie horrorMovie1 = new HorrorMovie();
+        Movie movie = new Movie();
+        Media media1 = new Media();
+        Media media2 = new Media();
+        HorrorMovie horrorMovie2 = new HorrorMovie();
+        
+        Observable<Media> o1 = Observable.just(horrorMovie1, movie, media1);
+        Observable<Media> o2 = Observable.just(media2, horrorMovie2);
+
+        Observable<Observable<Media>> os = Observable.just(o1, o2);
+
+        List<Media> values = Observable.concat(os).toList().toBlocking().single();
+
+        assertEquals(horrorMovie1, values.get(0));
+        assertEquals(movie, values.get(1));
+        assertEquals(media1, values.get(2));
+        assertEquals(media2, values.get(3));
+        assertEquals(horrorMovie2, values.get(4));
+        assertEquals(5, values.size());
+    }
+
+    @Test
+    public void testConcatCovariance3() {
+        HorrorMovie horrorMovie1 = new HorrorMovie();
+        Movie movie = new Movie();
+        Media media = new Media();
+        HorrorMovie horrorMovie2 = new HorrorMovie();
+        
+        Observable<Movie> o1 = Observable.just(horrorMovie1, movie);
+        Observable<Media> o2 = Observable.just(media, horrorMovie2);
+
+        List<Media> values = Observable.concat(o1, o2).toList().toBlocking().single();
+
+        assertEquals(horrorMovie1, values.get(0));
+        assertEquals(movie, values.get(1));
+        assertEquals(media, values.get(2));
+        assertEquals(horrorMovie2, values.get(3));
+        assertEquals(4, values.size());
+    }
+
+    @Test
+    public void testConcatCovariance4() {
+        final HorrorMovie horrorMovie1 = new HorrorMovie();
+        final Movie movie = new Movie();
+        Media media = new Media();
+        HorrorMovie horrorMovie2 = new HorrorMovie();
+        
+        Observable<Movie> o1 = Observable.create(o -> {
+                o.onNext(horrorMovie1);
+                o.onNext(movie);
+                //                o.onNext(new Media()); // correctly doesn't compile
+                o.onComplete();
+        });
+
+        Observable<Media> o2 = Observable.just(media, horrorMovie2);
+
+        List<Media> values = Observable.concat(o1, o2).toList().toBlocking().single();
+
+        assertEquals(horrorMovie1, values.get(0));
+        assertEquals(movie, values.get(1));
+        assertEquals(media, values.get(2));
+        assertEquals(horrorMovie2, values.get(3));
+        assertEquals(4, values.size());
+    }
+}


### PR DESCRIPTION
I've also added convenience overloads to concat 2-9 sources because `concat(Publisher...)` causes overload resolution conflict with `concat(Publisher<Publisher>)`.