### PR TITLE
ErrorHandlingTests and EventStream

### DIFF
--- a/src/test/java/io/reactivex/ErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/ErrorHandlingTests.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.schedulers.Schedulers;
+
+public class ErrorHandlingTests {
+
+    /**
+     * Test that an error from a user provided Observer.onNext is handled and emitted to the onError
+     */
+    @Test
+    public void testOnNextError() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+        Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
+        Subscriber<Long> observer = new Observer<Long>() {
+
+            @Override
+            public void onComplete() {
+                System.out.println("completed");
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                System.out.println("error: " + e);
+                caughtError.set(e);
+                latch.countDown();
+            }
+
+            @Override
+            public void onNext(Long args) {
+                throw new RuntimeException("forced failure");
+            }
+        };
+        o.safeSubscribe(observer);
+
+        latch.await(2000, TimeUnit.MILLISECONDS);
+        assertNotNull(caughtError.get());
+    }
+
+    /**
+     * Test that an error from a user provided Observer.onNext is handled and emitted to the onError
+     * even when done across thread boundaries with observeOn
+     */
+    @Test
+    public void testOnNextErrorAcrossThread() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+        Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
+        Subscriber<Long> observer = new Observer<Long>() {
+
+            @Override
+            public void onComplete() {
+                System.out.println("completed");
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                System.out.println("error: " + e);
+                caughtError.set(e);
+                latch.countDown();
+            }
+
+            @Override
+            public void onNext(Long args) {
+                throw new RuntimeException("forced failure");
+            }
+        };
+        o.observeOn(Schedulers.newThread())
+        .safeSubscribe(observer);
+
+        latch.await(2000, TimeUnit.MILLISECONDS);
+        assertNotNull(caughtError.get());
+    }
+}

--- a/src/test/java/io/reactivex/EventStream.java
+++ b/src/test/java/io/reactivex/EventStream.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.*;
+
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Utility for retrieving a mock eventstream for testing.
+ */
+public final class EventStream {
+    private EventStream() {
+        throw new IllegalStateException("No instances!");
+    }
+    public static Observable<Event> getEventStream(final String type, final int numInstances) {
+        
+        return Observable.<Event>generate(s -> {
+            s.onNext(randomEvent(type, numInstances));
+            try {
+                // slow it down somewhat
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                s.onError(e);
+            }
+        }).subscribeOn(Schedulers.newThread());
+    }
+
+    public static Event randomEvent(String type, int numInstances) {
+        Map<String, Object> values = new LinkedHashMap<>();
+        values.put("count200", randomIntFrom0to(4000));
+        values.put("count4xx", randomIntFrom0to(300));
+        values.put("count5xx", randomIntFrom0to(500));
+        return new Event(type, "instance_" + randomIntFrom0to(numInstances), values);
+    }
+
+    private static int randomIntFrom0to(int max) {
+        // XORShift instead of Math.random http://javamex.com/tutorials/random_numbers/xorshift.shtml
+        long x = System.nanoTime();
+        x ^= (x << 21);
+        x ^= (x >>> 35);
+        x ^= (x << 4);
+        return Math.abs((int) x % max);
+    }
+
+    public static class Event {
+        public final String type;
+        public final String instanceId;
+        public final Map<String, Object> values;
+
+        /**
+         * @param type
+         * @param instanceId
+         * @param values
+         *            This does NOT deep-copy, so do not mutate this Map after passing it in.
+         */
+        public Event(String type, String instanceId, Map<String, Object> values) {
+            this.type = type;
+            this.instanceId = instanceId;
+            this.values = Collections.unmodifiableMap(values);
+        }
+    }
+}


### PR DESCRIPTION
I've changed them to use `safeSubscribe` because plain RS subscribers
are not expected to throw.