### PR TITLE
2.x: test for operators all, any, asObservable, fixes to all and any

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -755,7 +755,7 @@ public class Observable<T> implements Publisher<T> {
 
     public final Observable<Boolean> all(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate);
-        return lift(new OperatorAny<>(predicate));
+        return lift(new OperatorAll<>(predicate));
     }
 
     public final Observable<T> ambWith(Publisher<? extends T> other) {
@@ -1257,7 +1257,7 @@ public class Observable<T> implements Publisher<T> {
     }
 
     public final Observable<Boolean> isEmpty() {
-        return any(v -> true);
+        return all(v -> false);
     }
 
     public static final <T> Observable<T> just(T v1, T v2) {

--- a/src/main/java/io/reactivex/internal/operators/OperatorAny.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorAny.java
@@ -12,12 +12,13 @@
  */
 package io.reactivex.internal.operators;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.reactivestreams.*;
 
 import io.reactivex.Observable.Operator;
-import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public final class OperatorAny<T> implements Operator<Boolean, T> {
     final Predicate<? super T> predicate;
@@ -30,23 +31,29 @@ public final class OperatorAny<T> implements Operator<Boolean, T> {
         return new AnySubscriber<>(t, predicate);
     }
     
-    static final class AnySubscriber<T> implements Subscriber<T>, Subscription {
+    static final class AnySubscriber<T> extends AtomicInteger implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = -2311252482644620661L;
+        
         final Subscriber<? super Boolean> actual;
         final Predicate<? super T> predicate;
         
         Subscription s;
         
         boolean done;
-        
+
+        static final int NO_REQUEST_NO_VALUE = 0;
+        static final int NO_REQUEST_HAS_VALUE = 1;
+        static final int HAS_REQUEST_NO_VALUE = 2;
+        static final int HAS_REQUEST_HAS_VALUE = 3;
+
         public AnySubscriber(Subscriber<? super Boolean> actual, Predicate<? super T> predicate) {
             this.actual = actual;
             this.predicate = predicate;
         }
         @Override
         public void onSubscribe(Subscription s) {
-            if (this.s != null) {
-                s.cancel();
-                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
                 return;
             }
             this.s = s;
@@ -62,12 +69,14 @@ public final class OperatorAny<T> implements Operator<Boolean, T> {
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
+                lazySet(HAS_REQUEST_HAS_VALUE);
                 done = true;
                 s.cancel();
                 actual.onError(e);
                 return;
             }
             if (b) {
+                lazySet(HAS_REQUEST_HAS_VALUE);
                 done = true;
                 s.cancel();
                 actual.onNext(true);
@@ -87,18 +96,53 @@ public final class OperatorAny<T> implements Operator<Boolean, T> {
         public void onComplete() {
             if (!done) {
                 done = true;
-                actual.onNext(false);
-                actual.onComplete();
+                for (;;) {
+                    int state = get();
+                    if (state == NO_REQUEST_HAS_VALUE || state == HAS_REQUEST_HAS_VALUE) {
+                        break;
+                    }
+                    if (state == HAS_REQUEST_NO_VALUE) {
+                        if (compareAndSet(HAS_REQUEST_NO_VALUE, HAS_REQUEST_HAS_VALUE)) {
+                            actual.onNext(false);
+                            actual.onComplete();
+                        }
+                        break;
+                    }
+                    if (compareAndSet(NO_REQUEST_NO_VALUE, NO_REQUEST_HAS_VALUE)) {
+                        break;
+                    }
+                }
             }
         }
         
         @Override
         public void request(long n) {
-            s.request(n);
+            if (SubscriptionHelper.validateRequest(n)) {
+                return;
+            }
+            
+            for (;;) {
+                int state = get();
+                if (state == HAS_REQUEST_NO_VALUE || state == HAS_REQUEST_HAS_VALUE) {
+                    break;
+                }
+                if (state == NO_REQUEST_HAS_VALUE) {
+                    if (compareAndSet(state, HAS_REQUEST_HAS_VALUE)) {
+                        actual.onNext(false);
+                        actual.onComplete();
+                    }
+                    break;
+                }
+                if (compareAndSet(NO_REQUEST_NO_VALUE, HAS_REQUEST_NO_VALUE)) {
+                    s.request(Long.MAX_VALUE);
+                    break;
+                }
+            }
         }
         
         @Override
         public void cancel() {
+            lazySet(HAS_REQUEST_HAS_VALUE);
             s.cancel();
         }
     }

--- a/src/test/java/io/reactivex/ObservableTests.java
+++ b/src/test/java/io/reactivex/ObservableTests.java
@@ -697,9 +697,10 @@ public class ObservableTests {
     public void testContainsWithNull() {
         Observable<Boolean> observable = Observable.just("a", "b", null).contains(null);
 
-        @SuppressWarnings("unchecked")
-        Observer<Object> observer = mock(Observer.class);
+        Subscriber<Object> observer = TestHelper.mockSubscriber();
+
         observable.subscribe(observer);
+        
         verify(observer, times(1)).onNext(true);
         verify(observer, never()).onNext(false);
         verify(observer, never()).onError(
@@ -711,9 +712,10 @@ public class ObservableTests {
     public void testContainsWithEmptyObservable() {
         Observable<Boolean> observable = Observable.<String> empty().contains("a");
 
-        @SuppressWarnings("unchecked")
-        Observer<Object> observer = mock(Observer.class);
+        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        
         observable.subscribe(observer);
+        
         verify(observer, times(1)).onNext(false);
         verify(observer, never()).onNext(true);
         verify(observer, never()).onError(
@@ -725,9 +727,10 @@ public class ObservableTests {
     public void testIgnoreElements() {
         Observable<Integer> observable = Observable.just(1, 2, 3).ignoreElements();
 
-        @SuppressWarnings("unchecked")
-        Observer<Integer> observer = mock(Observer.class);
+        Subscriber<Object> observer = TestHelper.mockSubscriber();
+
         observable.subscribe(observer);
+        
         verify(observer, never()).onNext(any(Integer.class));
         verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onComplete();

--- a/src/test/java/io/reactivex/internal/operators/OperatorAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorAllTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorAllTest {
+
+    @Test
+    public void testAll() {
+        Observable<String> obs = Observable.just("one", "two", "six");
+
+        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+        
+        obs.all(s -> s.length() == 3)
+        .subscribe(observer);
+
+        verify(observer).onSubscribe(any());
+        verify(observer).onNext(true);
+        verify(observer).onComplete();
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void testNotAll() {
+        Observable<String> obs = Observable.just("one", "two", "three", "six");
+
+        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+
+        obs.all(s -> s.length() == 3)
+        .subscribe(observer);
+
+        verify(observer).onSubscribe(any());
+        verify(observer).onNext(false);
+        verify(observer).onComplete();
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void testEmpty() {
+        Observable<String> obs = Observable.empty();
+
+        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+
+        obs.all(s -> s.length() == 3)
+        .subscribe(observer);
+
+        verify(observer).onSubscribe(any());
+        verify(observer).onNext(true);
+        verify(observer).onComplete();
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void testError() {
+        Throwable error = new Throwable();
+        Observable<String> obs = Observable.error(error);
+
+        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+
+        obs.all(s -> s.length() == 3)
+        .subscribe(observer);
+
+        verify(observer).onSubscribe(any());
+        verify(observer).onError(error);
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void testFollowingFirst() {
+        Observable<Integer> o = Observable.fromArray(1, 3, 5, 6);
+        Observable<Boolean> allOdd = o.all(i -> i % 2 == 1);
+        
+        assertFalse(allOdd.toBlocking().first());
+    }
+    @Test(timeout = 5000)
+    public void testIssue1935NoUnsubscribeDownstream() {
+        Observable<Integer> source = Observable.just(1)
+            .all(t1 -> false)
+            .flatMap(t1 -> Observable.just(2).delay(500, TimeUnit.MILLISECONDS));
+        
+        assertEquals((Object)2, source.toBlocking().first());
+    }
+    
+    @Test
+    public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<>((Long)null);
+        Observable.empty().all(t1 -> false).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void testBackpressureIfOneRequestedOneShouldBeDelivered() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<>(1L);
+        
+        Observable.empty().all(t -> false).subscribe(ts);
+        
+        ts.assertTerminated();
+        ts.assertNoErrors();
+        ts.assertComplete();
+        
+        ts.assertValue(true);
+    }
+    
+    @Test
+    public void testPredicateThrowsExceptionAndValueInCauseMessage() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<>();
+        
+        final IllegalArgumentException ex = new IllegalArgumentException();
+        
+        Observable.just("Boo!").all(v -> {
+            throw ex;
+        })
+        .subscribe(ts);
+        
+        ts.assertTerminated();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(ex);
+        // FIXME need to decide about adding the value that probably caused the crash in some way
+//        assertTrue(ex.getCause().getMessage().contains("Boo!"));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorAnyTest.java
@@ -1,0 +1,221 @@
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorAnyTest {
+
+    @Test
+    public void testAnyWithTwoItems() {
+        Observable<Integer> w = Observable.just(1, 2);
+        Observable<Boolean> observable = w.any(v -> true);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testIsEmptyWithTwoItems() {
+        Observable<Integer> w = Observable.just(1, 2);
+        Observable<Boolean> observable = w.isEmpty();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithOneItem() {
+        Observable<Integer> w = Observable.just(1);
+        Observable<Boolean> observable = w.any(v -> true);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testIsEmptyWithOneItem() {
+        Observable<Integer> w = Observable.just(1);
+        Observable<Boolean> observable = w.isEmpty();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithEmpty() {
+        Observable<Integer> w = Observable.empty();
+        Observable<Boolean> observable = w.any(v -> true);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testIsEmptyWithEmpty() {
+        Observable<Integer> w = Observable.empty();
+        Observable<Boolean> observable = w.isEmpty();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithPredicate1() {
+        Observable<Integer> w = Observable.just(1, 2, 3);
+        Observable<Boolean> observable = w.any(t1 -> t1 < 2);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testExists1() {
+        Observable<Integer> w = Observable.just(1, 2, 3);
+        Observable<Boolean> observable = w.any(t1 -> t1 < 2);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithPredicate2() {
+        Observable<Integer> w = Observable.just(1, 2, 3);
+        Observable<Boolean> observable = w.any(t1 -> t1 < 1);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithEmptyAndPredicate() {
+        // If the source is empty, always output false.
+        Observable<Integer> w = Observable.empty();
+        Observable<Boolean> observable = w.any(t -> true);
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testWithFollowingFirst() {
+        Observable<Integer> o = Observable.fromArray(1, 3, 5, 6);
+        Observable<Boolean> anyEven = o.any(i -> i % 2 == 0);
+        
+        assertTrue(anyEven.toBlocking().first());
+    }
+    @Test(timeout = 5000)
+    public void testIssue1935NoUnsubscribeDownstream() {
+        Observable<Integer> source = Observable.just(1).isEmpty()
+            .flatMap(t1 -> Observable.just(2).delay(500, TimeUnit.MILLISECONDS));
+        
+        assertEquals((Object)2, source.toBlocking().first());
+    }
+    
+    @Test
+    public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<>((Long)null);
+        
+        Observable.just(1).any(t -> true)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void testBackpressureIfOneRequestedOneShouldBeDelivered() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<>(1L);
+        Observable.just(1).any(v -> true).subscribe(ts);
+        
+        ts.assertTerminated();
+        ts.assertNoErrors();
+        ts.assertComplete();
+        ts.assertValue(true);
+    }
+    
+    @Test
+    public void testPredicateThrowsExceptionAndValueInCauseMessage() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<>();
+        final IllegalArgumentException ex = new IllegalArgumentException();
+        
+        Observable.just("Boo!").any(v -> {
+            throw ex;
+        }).subscribe(ts);
+        
+        ts.assertTerminated();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(ex);
+        // FIXME value as last cause?
+//        assertTrue(ex.getCause().getMessage().contains("Boo!"));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorAsObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorAsObservableTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subjects.PublishSubject;
+
+public class OperatorAsObservableTest {
+    @Test
+    public void testHiding() {
+        PublishSubject<Integer> src = PublishSubject.create();
+        
+        Observable<Integer> dst = src.asObservable();
+        
+        assertFalse(dst instanceof PublishSubject);
+        
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        dst.subscribe(o);
+        
+        src.onNext(1);
+        src.onComplete();
+        
+        verify(o).onNext(1);
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    @Test
+    public void testHidingError() {
+        PublishSubject<Integer> src = PublishSubject.create();
+        
+        Observable<Integer> dst = src.asObservable();
+        
+        assertFalse(dst instanceof PublishSubject);
+        
+        @SuppressWarnings("unchecked")
+        Observer<Object> o = mock(Observer.class);
+        
+        dst.subscribe(o);
+        
+        src.onError(new TestException());
+        
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+        verify(o).onError(any(TestException.class));
+    }
+}


### PR DESCRIPTION
Bugfix: since they would emit a value on an empty source, they have to hold it until an actual request comes in.