### PR TITLE
2.x: added missing buffer overload (with boundary selector)

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -866,9 +866,14 @@ public class Observable<T> implements Publisher<T> {
     }
     
     public final <B> Observable<List<T>> buffer(Supplier<? extends Observable<B>> boundarySupplier) {
+        return buffer(boundarySupplier, ArrayList::new);
+        
+    }
+
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends Observable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundarySupplier);
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(bufferSupplier);
+        return lift(new OperatorBufferBoundarySupplier<>(boundarySupplier, bufferSupplier));
     }
 
     public final Observable<T> cache() {

--- a/src/main/java/io/reactivex/internal/operators/OperatorBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorBufferBoundarySupplier.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.SerializedSubscriber;
+
+public final class OperatorBufferBoundarySupplier<T, U extends Collection<? super T>, B> implements Operator<U, T> {
+    final Supplier<? extends Publisher<B>> boundarySupplier;
+    final Supplier<U> bufferSupplier;
+    
+    public OperatorBufferBoundarySupplier(Supplier<? extends Publisher<B>> boundarySupplier, Supplier<U> bufferSupplier) {
+        this.boundarySupplier = boundarySupplier;
+        this.bufferSupplier = bufferSupplier;
+    }
+
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super U> t) {
+        return new BufferBondarySupplierSubscriber<>(new SerializedSubscriber<>(t), bufferSupplier, boundarySupplier);
+    }
+    
+    static final class BufferBondarySupplierSubscriber<T, U extends Collection<? super T>, B>
+    extends QueueDrainSubscriber<T, U, U> implements Subscriber<T>, Subscription, Disposable {
+        /** */
+        final Supplier<U> bufferSupplier;
+        final Supplier<? extends Publisher<B>> boundarySupplier;
+        
+        Subscription s;
+        
+        volatile Disposable other;
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<BufferBondarySupplierSubscriber, Disposable> OTHER =
+                AtomicReferenceFieldUpdater.newUpdater(BufferBondarySupplierSubscriber.class, Disposable.class, "other");
+        
+        static final Disposable DISPOSED = () -> { };
+        
+        U buffer;
+        
+        public BufferBondarySupplierSubscriber(Subscriber<? super U> actual, Supplier<U> bufferSupplier,
+                Supplier<? extends Publisher<B>> boundarySupplier) {
+            super(actual, new MpscLinkedQueue<>());
+            this.bufferSupplier = bufferSupplier;
+            this.boundarySupplier = boundarySupplier;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            
+            Subscriber<? super U> actual = this.actual;
+            
+            U b;
+            
+            try {
+                b = bufferSupplier.get();
+            } catch (Throwable e) {
+                cancelled = true;
+                s.cancel();
+                EmptySubscription.error(e, actual);
+                return;
+            }
+            
+            if (b == null) {
+                cancelled = true;
+                s.cancel();
+                EmptySubscription.error(new NullPointerException("The buffer supplied is null"), actual);
+                return;
+            }
+            buffer = b;
+            
+            Publisher<B> boundary;
+            
+            try {
+                boundary = boundarySupplier.get();
+            } catch (Throwable ex) {
+                cancelled = true;
+                s.cancel();
+                EmptySubscription.error(ex, actual);
+                return;
+            }
+            
+            if (boundary == null) {
+                cancelled = true;
+                s.cancel();
+                EmptySubscription.error(new NullPointerException("The boundary publisher supplied is null"), actual);
+                return;
+            }
+            
+            BufferBoundarySubscriber<T, U, B> bs = new BufferBoundarySubscriber<>(this);
+            other = bs;
+            
+            actual.onSubscribe(this);
+            
+            if (!cancelled) {
+                s.request(Long.MAX_VALUE);
+                
+                boundary.subscribe(bs);
+            }
+        }
+        
+        @Override
+        public void onNext(T t) {
+            synchronized (this) {
+                U b = buffer;
+                if (b == null) {
+                    return;
+                }
+                b.add(t);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            cancel();
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            U b;
+            synchronized (this) {
+                b = buffer;
+                if (b == null) {
+                    return;
+                }
+                buffer = null;
+            }
+            queue.offer(b);
+            done = true;
+            if (enter()) {
+                drainMaxLoop(queue, actual, false, this);
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            requested(n);
+        }
+        
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                s.cancel();
+                disposeOther();
+                
+                if (enter()) {
+                    queue.clear();
+                }
+            }
+        }
+        
+        void disposeOther() {
+            Disposable d = other;
+            if (d != DISPOSED) {
+                d = OTHER.getAndSet(this, DISPOSED);
+                if (d != DISPOSED && d != null) {
+                    d.dispose();
+                }
+            }
+        }
+        
+        void next() {
+            
+            Disposable o = other;
+            
+            U next;
+            
+            try {
+                next = bufferSupplier.get();
+            } catch (Throwable e) {
+                cancel();
+                actual.onError(e);
+                return;
+            }
+            
+            if (next == null) {
+                cancel();
+                actual.onError(new NullPointerException("The buffer supplied is null"));
+                return;
+            }
+            
+            Publisher<B> boundary;
+            
+            try {
+                boundary = boundarySupplier.get();
+            } catch (Throwable ex) {
+                cancelled = true;
+                s.cancel();
+                actual.onError(ex);
+                return;
+            }
+            
+            if (boundary == null) {
+                cancelled = true;
+                s.cancel();
+                actual.onError(new NullPointerException("The boundary publisher supplied is null"));
+                return;
+            }
+            
+            BufferBoundarySubscriber<T, U, B> bs = new BufferBoundarySubscriber<>(this);
+            
+            if (!OTHER.compareAndSet(this, o, bs)) {
+                return;
+            }
+            
+            U b;
+            synchronized (this) {
+                b = buffer;
+                if (b == null) {
+                    return;
+                }
+                buffer = next;
+            }
+            
+            boundary.subscribe(bs);
+            
+            fastpathEmitMax(b, false, this);
+        }
+        
+        @Override
+        public void dispose() {
+            s.cancel();
+            disposeOther();
+        }
+        
+        @Override
+        public boolean accept(Subscriber<? super U> a, U v) {
+            actual.onNext(v);
+            return true;
+        }
+        
+    }
+    
+    static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, B> extends DisposableSubscriber<B> {
+        final BufferBondarySupplierSubscriber<T, U, B> parent;
+        
+        boolean once;
+        
+        public BufferBoundarySubscriber(BufferBondarySupplierSubscriber<T, U, B> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void onNext(B t) {
+            if (once) {
+                return;
+            }
+            once = true;
+            cancel();
+            parent.next();
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (once) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            once = true;
+            parent.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (once) {
+                return;
+            }
+            once = true;
+            parent.next();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/PublisherFutureSource.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherFutureSource.java
@@ -38,18 +38,10 @@ public final class PublisherFutureSource<T> implements Publisher<T> {
             T v;
             try {
                 v = unit != null ? future.get(timeout, unit) : future.get();
-            } catch (CancellationException ex) {
-                return; // FIXME not sure about this either
-            } catch (ExecutionException ex) {
-                Throwable cause = ex.getCause();
-                if (cause != null) {
-                    s.onError(cause);
-                } else {
+            } catch (Throwable ex) {
+                if (!sas.isComplete()) {
                     s.onError(ex);
                 }
-                return;
-            } catch (Throwable ex) {
-                s.onError(ex);
                 return;
             } finally {
                 future.cancel(true); // TODO ?? not sure about this

--- a/src/main/java/io/reactivex/internal/subscriptions/AsyncSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/AsyncSubscription.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.util.BackpressureHelper;
+
+/**
+ * A subscription implementation that arbitrates exactly one other Subscription and can
+ * hold a single disposable resource.
+ * 
+ * <p>All methods are thread-safe.
+ */
+public final class AsyncSubscription extends AtomicLong implements Subscription, Disposable {
+    /** */
+    private static final long serialVersionUID = 7028635084060361255L;
+    
+    volatile Subscription actual;
+    static final AtomicReferenceFieldUpdater<AsyncSubscription, Subscription> ACTUAL =
+            AtomicReferenceFieldUpdater.newUpdater(AsyncSubscription.class, Subscription.class, "actual");
+
+    volatile Disposable resource;
+    static final AtomicReferenceFieldUpdater<AsyncSubscription, Disposable> RESOURCE =
+            AtomicReferenceFieldUpdater.newUpdater(AsyncSubscription.class, Disposable.class, "resource");
+    
+    static final Subscription CANCELLED = new Subscription() {
+        @Override
+        public void request(long n) {
+            
+        }
+        @Override
+        public void cancel() {
+            
+        }
+        
+        @Override
+        public String toString() {
+            return "AsyncSubscription.CANCELLED";
+        }
+    };
+    
+    static final Disposable DISPOSED = new Disposable() {
+        @Override
+        public void dispose() { 
+            
+        }
+        
+        @Override
+        public String toString() {
+            return "AsyncSubscription.DISPOSED";
+        };
+    };
+    
+    public AsyncSubscription() {
+        
+    }
+    
+    public AsyncSubscription(Disposable resource) {
+        RESOURCE.lazySet(this, resource);
+    }
+    
+    @Override
+    public void request(long n) {
+        Subscription s = actual;
+        if (s != null) {
+            s.request(n);
+        } else {
+            if (SubscriptionHelper.validateRequest(n)) {
+                return;
+            }
+            BackpressureHelper.add(this, n);
+            s = actual;
+            if (s != null) {
+                long mr = getAndSet(0L);
+                if (mr != 0L) {
+                    s.request(mr);
+                }
+            }
+        }
+    }
+    
+    @Override
+    public void cancel() {
+        Subscription s = actual;
+        if (s != CANCELLED) {
+            s = ACTUAL.getAndSet(this, CANCELLED);
+            if (s != CANCELLED && s != null) {
+                s.cancel();
+            }
+        }
+        
+        Disposable d = resource;
+        if (d != DISPOSED) {
+            d = RESOURCE.getAndSet(this, DISPOSED);
+            if (d != CANCELLED && d != null) {
+                d.dispose();
+            }
+        }
+    }
+    
+    @Override
+    public void dispose() {
+        cancel();
+    }
+    
+    /**
+     * Sets a new resource and disposes the currently held resource.
+     * @param r the new resource to set
+     * @return false if this AyncSubscription has been cancelled/disposed
+     * @see #replaceResource(Disposable)
+     */
+    public boolean setResource(Disposable r) {
+        for (;;) {
+            Disposable d = resource;
+            if (d == DISPOSED) {
+                if (r != null) {
+                    r.dispose();
+                }
+                return false;
+            }
+            if (RESOURCE.compareAndSet(this, d, r)) {
+                if (d != null) {
+                    d.dispose();
+                }
+                return true;
+            }
+        }
+    }
+    
+    /**
+     * Replaces the currently held resource with the given new one without disposing the old.
+     * @param r the new resource to set
+     * @return false if this AsyncSubscription has been cancelled/disposed
+     */
+    public boolean replaceResource(Disposable r) {
+        for (;;) {
+            Disposable d = resource;
+            if (d == DISPOSED) {
+                if (r != null) {
+                    r.dispose();
+                }
+                return false;
+            }
+            if (RESOURCE.compareAndSet(this, d, r)) {
+                return true;
+            }
+        }
+    }
+    
+    /**
+     * Sets the given subscription if there isn't any subscription held.
+     * @param s the first and only subscription to set
+     * @return false if this AsyncSubscription has been cancelled/disposed
+     */
+    public boolean setSubscription(Subscription s) {
+        for (;;) {
+            Subscription a = actual;
+            if (a == CANCELLED) {
+                s.cancel();
+                return false;
+            }
+            if (a != null) {
+                s.cancel();
+                SubscriptionHelper.reportSubscriptionSet();
+                return true;
+            }
+            if (ACTUAL.compareAndSet(this, null, s)) {
+                long mr = getAndSet(0L);
+                if (mr != 0L) {
+                    s.request(mr);
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/BackpressureHelperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/BackpressureHelperTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/BlockingOperatorLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/BlockingOperatorLatestTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import java.util.*;

--- a/src/test/java/io/reactivex/internal/operators/BlockingOperatorMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/BlockingOperatorMostRecentTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/BlockingOperatorToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/BlockingOperatorToIteratorTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/OnSubscribeDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OnSubscribeDeferTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/reactivex/internal/operators/OperatorAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorAnyTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorBufferTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorBufferTest.java
@@ -221,7 +221,6 @@ public class OperatorBufferTest {
     }
 
     @Test
-    @Ignore("Until this buffer variant gets implemented")
     public void testObservableBasedCloser() {
         Observable<String> source = Observable.create(new Publisher<String>() {
             @Override

--- a/src/test/java/io/reactivex/internal/subscriptions/AsyncSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/AsyncSubscriptionTest.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.disposables.Disposable;
+
+public class AsyncSubscriptionTest {
+    @Test
+    public void testNoResource() {
+        AsyncSubscription as = new AsyncSubscription();
+        
+        Subscription s = mock(Subscription.class);
+        
+        assertTrue(as.setSubscription(s));
+        
+        as.request(1);
+        
+        as.cancel();
+        
+        verify(s).request(1);
+        verify(s).cancel();
+    }
+    
+    @Test
+    public void testRequestBeforeSet() {
+        AsyncSubscription as = new AsyncSubscription();
+        
+        Subscription s = mock(Subscription.class);
+        
+        as.request(1);
+
+        assertTrue(as.setSubscription(s));
+        
+        as.cancel();
+        
+        verify(s).request(1);
+        verify(s).cancel();
+    }
+    
+    @Test
+    public void testCancelBeforeSet() {
+        AsyncSubscription as = new AsyncSubscription();
+        
+        Subscription s = mock(Subscription.class);
+        
+        as.request(1);
+        as.cancel();
+
+        assertFalse(as.setSubscription(s));
+        
+        verify(s, never()).request(1);
+        verify(s).cancel();
+    }
+
+    @Test
+    public void testSingleSet() {
+        AsyncSubscription as = new AsyncSubscription();
+        
+        Subscription s = mock(Subscription.class);
+        
+        assertTrue(as.setSubscription(s));
+
+        Subscription s1 = mock(Subscription.class);
+
+        assertTrue(as.setSubscription(s1));
+        
+        assertSame(as.actual, s);
+        
+        verify(s1).cancel();
+    }
+
+    @Test
+    public void testInitialResource() {
+        Disposable r = mock(Disposable.class);
+        AsyncSubscription as = new AsyncSubscription(r);
+        
+        as.cancel();
+        
+        verify(r).dispose();
+    }
+    
+    @Test
+    public void testSetResource() {
+        AsyncSubscription as = new AsyncSubscription();
+
+        Disposable r = mock(Disposable.class);
+        
+        assertTrue(as.setResource(r));
+
+        as.cancel();
+        
+        verify(r).dispose();
+    }
+
+    @Test
+    public void testReplaceResource() {
+        AsyncSubscription as = new AsyncSubscription();
+
+        Disposable r = mock(Disposable.class);
+        
+        assertTrue(as.replaceResource(r));
+
+        as.cancel();
+        
+        verify(r).dispose();
+    }
+    
+    @Test
+    public void testSetResource2() {
+        AsyncSubscription as = new AsyncSubscription();
+
+        Disposable r = mock(Disposable.class);
+        
+        assertTrue(as.setResource(r));
+
+        Disposable r2 = mock(Disposable.class);
+        
+        assertTrue(as.setResource(r2));
+
+        as.cancel();
+        
+        verify(r).dispose();
+        verify(r2).dispose();
+    }
+    
+    @Test
+    public void testReplaceResource2() {
+        AsyncSubscription as = new AsyncSubscription();
+
+        Disposable r = mock(Disposable.class);
+        
+        assertTrue(as.replaceResource(r));
+
+        Disposable r2 = mock(Disposable.class);
+        
+        assertTrue(as.replaceResource(r2));
+
+        as.cancel();
+        
+        verify(r, never()).dispose();
+        verify(r2).dispose();
+    }
+    
+    @Test
+    public void testSetResourceAfterCancel() {
+        AsyncSubscription as = new AsyncSubscription();
+
+        as.cancel();
+        
+        Disposable r = mock(Disposable.class);
+        
+        assertFalse(as.setResource(r));
+
+        verify(r).dispose();
+    }
+
+    @Test
+    public void testReplaceResourceAfterCancel() {
+        AsyncSubscription as = new AsyncSubscription();
+        as.cancel();
+
+        Disposable r = mock(Disposable.class);
+        
+        assertFalse(as.replaceResource(r));
+        
+        verify(r).dispose();
+    }
+    
+    @Test
+    public void testCancelOnce() {
+        Disposable r = mock(Disposable.class);
+        AsyncSubscription as = new AsyncSubscription(r);
+        Subscription s = mock(Subscription.class);
+        
+        assertTrue(as.setSubscription(s));
+        
+        as.cancel();
+        as.cancel();
+        as.cancel();
+        
+        verify(s, never()).request(anyLong());
+        verify(s).cancel();
+        verify(r).dispose();
+    }
+}


### PR DESCRIPTION
+ added AsyncSubscription that allows setting the actual subscription
later and can hold a resource. It has less overhead than
SubscriptionArbiter due to single use.