### PR TITLE
2.x: Operator debounce and defaultIfEmpty, fix to debounce behavior

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/OperatorDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDebounceTest.java
@@ -1,0 +1,281 @@
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorDebounceTest {
+
+    private TestScheduler scheduler;
+    private Subscriber<String> observer;
+    private Scheduler.Worker innerScheduler;
+
+    @Before
+    public void before() {
+        scheduler = new TestScheduler();
+        observer = TestHelper.mockSubscriber();
+        innerScheduler = scheduler.createWorker();
+    }
+
+    @Test
+    public void testDebounceWithCompleted() {
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+                publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+                publishNext(observer, 900, "three");   // Should be skipped since onCompleted will arrive before the timeout expires.
+                publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
+            }
+        });
+
+        Observable<String> sampled = source.debounce(400, TimeUnit.MILLISECONDS, scheduler);
+        sampled.subscribe(observer);
+
+        scheduler.advanceTimeTo(0, TimeUnit.MILLISECONDS);
+        InOrder inOrder = inOrder(observer);
+        // must go to 800 since it must be 400 after when two is sent, which is at 400
+        scheduler.advanceTimeTo(800, TimeUnit.MILLISECONDS);
+        inOrder.verify(observer, times(1)).onNext("two");
+        scheduler.advanceTimeTo(1000, TimeUnit.MILLISECONDS);
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testDebounceNeverEmits() {
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                // all should be skipped since they are happening faster than the 200ms timeout
+                publishNext(observer, 100, "a");    // Should be skipped
+                publishNext(observer, 200, "b");    // Should be skipped
+                publishNext(observer, 300, "c");    // Should be skipped
+                publishNext(observer, 400, "d");    // Should be skipped
+                publishNext(observer, 500, "e");    // Should be skipped
+                publishNext(observer, 600, "f");    // Should be skipped
+                publishNext(observer, 700, "g");    // Should be skipped
+                publishNext(observer, 800, "h");    // Should be skipped
+                publishCompleted(observer, 900);     // Should be published as soon as the timeout expires.
+            }
+        });
+
+        Observable<String> sampled = source.debounce(200, TimeUnit.MILLISECONDS, scheduler);
+        sampled.subscribe(observer);
+
+        scheduler.advanceTimeTo(0, TimeUnit.MILLISECONDS);
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(0)).onNext(anyString());
+        scheduler.advanceTimeTo(1000, TimeUnit.MILLISECONDS);
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testDebounceWithError() {
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                Exception error = new TestException();
+                publishNext(observer, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
+                publishNext(observer, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.
+                publishError(observer, 700, error);   // Should be published as soon as the timeout expires.
+            }
+        });
+
+        Observable<String> sampled = source.debounce(400, TimeUnit.MILLISECONDS, scheduler);
+        sampled.subscribe(observer);
+
+        scheduler.advanceTimeTo(0, TimeUnit.MILLISECONDS);
+        InOrder inOrder = inOrder(observer);
+        // 100 + 400 means it triggers at 500
+        scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
+        inOrder.verify(observer).onNext("one");
+        scheduler.advanceTimeTo(701, TimeUnit.MILLISECONDS);
+        inOrder.verify(observer).onError(any(TestException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    private <T> void publishCompleted(final Subscriber<T> observer, long delay) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onComplete();
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private <T> void publishError(final Subscriber<T> observer, long delay, final Exception error) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onError(error);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private <T> void publishNext(final Subscriber<T> observer, final long delay, final T value) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onNext(value);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void debounceSelectorNormal1() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        final PublishSubject<Integer> debouncer = PublishSubject.create();
+        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return debouncer;
+            }
+        };
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(o);
+
+        source.debounce(debounceSel).subscribe(o);
+
+        source.onNext(1);
+        debouncer.onNext(1);
+
+        source.onNext(2);
+        source.onNext(3);
+        source.onNext(4);
+
+        debouncer.onNext(2);
+
+        source.onNext(5);
+        source.onComplete();
+
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(4);
+        inOrder.verify(o).onNext(5);
+        inOrder.verify(o).onComplete();
+
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void debounceSelectorFuncThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                throw new TestException();
+            }
+        };
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        source.debounce(debounceSel).subscribe(o);
+
+        source.onNext(1);
+
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+        verify(o).onError(any(TestException.class));
+    }
+
+    @Test
+    public void debounceSelectorObservableThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return Observable.error(new TestException());
+            }
+        };
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        source.debounce(debounceSel).subscribe(o);
+
+        source.onNext(1);
+
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+        verify(o).onError(any(TestException.class));
+    }
+    @Test
+    public void debounceTimedLastIsNotLost() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        source.debounce(100, TimeUnit.MILLISECONDS, scheduler).subscribe(o);
+        
+        source.onNext(1);
+        source.onComplete();
+        
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        verify(o).onNext(1);
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    @Test
+    public void debounceSelectorLastIsNotLost() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        final PublishSubject<Integer> debouncer = PublishSubject.create();
+
+        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return debouncer;
+            }
+        };
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        source.debounce(debounceSel).subscribe(o);
+        
+        source.onNext(1);
+        source.onComplete();
+
+        debouncer.onComplete();
+
+        verify(o).onNext(1);
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void debounceWithTimeBackpressure() throws InterruptedException {
+        TestScheduler scheduler = new TestScheduler();
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+        Observable.merge(
+                Observable.just(1),
+                Observable.just(2).delay(10, TimeUnit.MILLISECONDS, scheduler)
+        ).debounce(20, TimeUnit.MILLISECONDS, scheduler).take(1).subscribe(subscriber);
+
+        scheduler.advanceTimeBy(30, TimeUnit.MILLISECONDS);
+
+        subscriber.assertValue(2);
+        subscriber.assertTerminated();
+        subscriber.assertNoErrors();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDefaultIfEmptyTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorDefaultIfEmptyTest {
+
+    @Test
+    public void testDefaultIfEmpty() {
+        Observable<Integer> source = Observable.just(1, 2, 3);
+        Observable<Integer> observable = source.defaultIfEmpty(10);
+
+        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer, never()).onNext(10);
+        verify(observer).onNext(1);
+        verify(observer).onNext(2);
+        verify(observer).onNext(3);
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testDefaultIfEmptyWithEmpty() {
+        Observable<Integer> source = Observable.empty();
+        Observable<Integer> observable = source.defaultIfEmpty(10);
+
+        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+        
+        verify(observer).onNext(10);
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+    
+    @Test
+    @Ignore("Subscribers should not throw")
+    public void testEmptyButClientThrows() {
+        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        
+        Observable.<Integer>empty().defaultIfEmpty(1).subscribe(new Observer<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+        });
+        
+        verify(o).onError(any(TestException.class));
+        verify(o, never()).onNext(any(Integer.class));
+        verify(o, never()).onComplete();
+    }
+    
+    @Test
+    public void testBackpressureEmpty() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        Observable.<Integer>empty().defaultIfEmpty(1).subscribe(ts);
+        ts.assertNoValues();
+        ts.assertNotTerminated();
+        ts.request(1);
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void testBackpressureNonEmpty() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        Observable.just(1,2,3).defaultIfEmpty(1).subscribe(ts);
+        ts.assertNoValues();
+        ts.assertNotTerminated();
+        ts.request(2);
+        ts.assertValues(1, 2);
+        ts.request(1);
+        ts.assertValues(1, 2, 3);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+}


### PR DESCRIPTION
When debounce is completed, the last value encountered is emitted immediately.