### PR TITLE
2.x: operator test distinct, distinctUntilChanged and doOnEach

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1017,15 +1017,23 @@ public class Observable<T> implements Publisher<T> {
         return m.lift(OperatorDematerialize.instance());
     }
     public final Observable<T> distinct() {
-        return distinct(HashSet::new);
+        return distinct(v -> v, HashSet::new);
+    }
+    
+    public final <K> Observable<T> distinct(Function<? super T, K> keySelector) {
+        return distinct(keySelector, HashSet::new);
     }
 
-    public final Observable<T> distinct(Supplier<? extends Collection<? super T>> collectionSupplier) {
-        return lift(OperatorDistinct.withCollection(collectionSupplier));
+    public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
+        return lift(OperatorDistinct.withCollection(keySelector, collectionSupplier));
     }
 
     public final Observable<T> distinctUntilChanged() {
         return lift(OperatorDistinct.untilChanged());
+    }
+
+    public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
+        return lift(OperatorDistinct.untilChanged(keySelector));
     }
 
     public final Observable<T> doOnCancel(Runnable onCancel) {
@@ -1053,7 +1061,7 @@ public class Observable<T> implements Publisher<T> {
                 );
     }
 
-    public final Observable<T> doOnEach(Observer<? super T> observer) {
+    public final Observable<T> doOnEach(Subscriber<? super T> observer) {
         return doOnEach(observer::onNext, observer::onError, observer::onComplete, () -> { });
     }
 

--- a/src/test/java/io/reactivex/internal/operators/OperatorDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDistinctTest.java
@@ -1,0 +1,112 @@
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Function;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+
+public class OperatorDistinctTest {
+
+    Subscriber<String> w;
+
+    // nulls lead to exceptions
+    final Function<String, String> TO_UPPER_WITH_EXCEPTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            if (s.equals("x")) {
+                return "XX";
+            }
+            return s.toUpperCase();
+        }
+    };
+
+    @Before
+    public void before() {
+        w = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void testDistinctOfNone() {
+        Observable<String> src = Observable.empty();
+        src.distinct().subscribe(w);
+
+        verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+        verify(w, times(1)).onComplete();
+    }
+
+    @Test
+    public void testDistinctOfNoneWithKeySelector() {
+        Observable<String> src = Observable.empty();
+        src.distinct(TO_UPPER_WITH_EXCEPTION).subscribe(w);
+
+        verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+        verify(w, times(1)).onComplete();
+    }
+
+    @Test
+    public void testDistinctOfNormalSource() {
+        Observable<String> src = Observable.just("a", "b", "c", "c", "c", "b", "b", "a", "e");
+        src.distinct().subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onNext("c");
+        inOrder.verify(w, times(1)).onNext("e");
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testDistinctOfNormalSourceWithKeySelector() {
+        Observable<String> src = Observable.just("a", "B", "c", "C", "c", "B", "b", "a", "E");
+        src.distinct(TO_UPPER_WITH_EXCEPTION).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("B");
+        inOrder.verify(w, times(1)).onNext("c");
+        inOrder.verify(w, times(1)).onNext("E");
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("Null values no longer allowed")
+    public void testDistinctOfSourceWithNulls() {
+        Observable<String> src = Observable.just(null, "a", "a", null, null, "b", null);
+        src.distinct().subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext(null);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("Null values no longer allowed")
+    public void testDistinctOfSourceWithExceptionsFromKeySelector() {
+        Observable<String> src = Observable.just("a", "b", null, "c");
+        src.distinct(TO_UPPER_WITH_EXCEPTION).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onError(any(NullPointerException.class));
+        inOrder.verify(w, never()).onNext(anyString());
+        inOrder.verify(w, never()).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDistinctUntilChangedTest.java
@@ -1,0 +1,120 @@
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Function;
+
+import org.junit.*;
+import org.mockito.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+
+public class OperatorDistinctUntilChangedTest {
+
+    Subscriber<String> w;
+    Subscriber<String> w2;
+
+    // nulls lead to exceptions
+    final Function<String, String> TO_UPPER_WITH_EXCEPTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            if (s.equals("x")) {
+                return "xx";
+            }
+            return s.toUpperCase();
+        }
+    };
+
+    @Before
+    public void before() {
+        w = TestHelper.mockSubscriber();
+        w2 = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void testDistinctUntilChangedOfNone() {
+        Observable<String> src = Observable.empty();
+        src.distinctUntilChanged().subscribe(w);
+
+        verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+        verify(w, times(1)).onComplete();
+    }
+
+    @Test
+    public void testDistinctUntilChangedOfNoneWithKeySelector() {
+        Observable<String> src = Observable.empty();
+        src.distinctUntilChanged(TO_UPPER_WITH_EXCEPTION).subscribe(w);
+
+        verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+        verify(w, times(1)).onComplete();
+    }
+
+    @Test
+    public void testDistinctUntilChangedOfNormalSource() {
+        Observable<String> src = Observable.just("a", "b", "c", "c", "c", "b", "b", "a", "e");
+        src.distinctUntilChanged().subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onNext("c");
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("e");
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testDistinctUntilChangedOfNormalSourceWithKeySelector() {
+        Observable<String> src = Observable.just("a", "b", "c", "C", "c", "B", "b", "a", "e");
+        src.distinctUntilChanged(TO_UPPER_WITH_EXCEPTION).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onNext("c");
+        inOrder.verify(w, times(1)).onNext("B");
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("e");
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("Null values no longer allowed")
+    public void testDistinctUntilChangedOfSourceWithNulls() {
+        Observable<String> src = Observable.just(null, "a", "a", null, null, "b", null, null);
+        src.distinctUntilChanged().subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext(null);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext(null);
+        inOrder.verify(w, times(1)).onNext("b");
+        inOrder.verify(w, times(1)).onNext(null);
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onNext(anyString());
+        verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("Null values no longer allowed")
+    public void testDistinctUntilChangedOfSourceWithExceptionsFromKeySelector() {
+        Observable<String> src = Observable.just("a", "b", null, "c");
+        src.distinctUntilChanged(TO_UPPER_WITH_EXCEPTION).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext("a");
+        inOrder.verify(w, times(1)).onNext("b");
+        verify(w, times(1)).onError(any(NullPointerException.class));
+        inOrder.verify(w, never()).onNext(anyString());
+        inOrder.verify(w, never()).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDoOnEachTest.java
@@ -1,0 +1,181 @@
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+
+public class OperatorDoOnEachTest {
+
+    Subscriber<String> subscribedObserver;
+    Subscriber<String> sideEffectObserver;
+
+    @Before
+    public void before() {
+        subscribedObserver = TestHelper.mockSubscriber();
+        sideEffectObserver = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void testDoOnEach() {
+        Observable<String> base = Observable.just("a", "b", "c");
+        Observable<String> doOnEach = base.doOnEach(sideEffectObserver);
+
+        doOnEach.subscribe(subscribedObserver);
+
+        // ensure the leaf observer is still getting called
+        verify(subscribedObserver, never()).onError(any(Throwable.class));
+        verify(subscribedObserver, times(1)).onNext("a");
+        verify(subscribedObserver, times(1)).onNext("b");
+        verify(subscribedObserver, times(1)).onNext("c");
+        verify(subscribedObserver, times(1)).onComplete();
+
+        // ensure our injected observer is getting called
+        verify(sideEffectObserver, never()).onError(any(Throwable.class));
+        verify(sideEffectObserver, times(1)).onNext("a");
+        verify(sideEffectObserver, times(1)).onNext("b");
+        verify(sideEffectObserver, times(1)).onNext("c");
+        verify(sideEffectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testDoOnEachWithError() {
+        Observable<String> base = Observable.just("one", "fail", "two", "three", "fail");
+        Observable<String> errs = base.map(new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                if ("fail".equals(s)) {
+                    throw new RuntimeException("Forced Failure");
+                }
+                return s;
+            }
+        });
+
+        Observable<String> doOnEach = errs.doOnEach(sideEffectObserver);
+
+        doOnEach.subscribe(subscribedObserver);
+        verify(subscribedObserver, times(1)).onNext("one");
+        verify(subscribedObserver, never()).onNext("two");
+        verify(subscribedObserver, never()).onNext("three");
+        verify(subscribedObserver, never()).onComplete();
+        verify(subscribedObserver, times(1)).onError(any(Throwable.class));
+
+        verify(sideEffectObserver, times(1)).onNext("one");
+        verify(sideEffectObserver, never()).onNext("two");
+        verify(sideEffectObserver, never()).onNext("three");
+        verify(sideEffectObserver, never()).onComplete();
+        verify(sideEffectObserver, times(1)).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testDoOnEachWithErrorInCallback() {
+        Observable<String> base = Observable.just("one", "two", "fail", "three");
+        Observable<String> doOnEach = base.doOnNext(new Consumer<String>() {
+            @Override
+            public void accept(String s) {
+                if ("fail".equals(s)) {
+                    throw new RuntimeException("Forced Failure");
+                }
+            }
+        });
+
+        doOnEach.subscribe(subscribedObserver);
+        verify(subscribedObserver, times(1)).onNext("one");
+        verify(subscribedObserver, times(1)).onNext("two");
+        verify(subscribedObserver, never()).onNext("three");
+        verify(subscribedObserver, never()).onComplete();
+        verify(subscribedObserver, times(1)).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testIssue1451Case1() {
+        // https://github.com/Netflix/RxJava/issues/1451
+        final int expectedCount = 3;
+        final AtomicInteger count = new AtomicInteger();
+        for (int i=0; i < expectedCount; i++) {
+            Observable
+                    .just(Boolean.TRUE, Boolean.FALSE)
+                    .takeWhile(new Predicate<Boolean>() {
+                        @Override
+                        public boolean test(Boolean value) {
+                            return value;
+                        }
+                    })
+                    .toList()
+                    .doOnNext(new Consumer<List<Boolean>>() {
+                        @Override
+                        public void accept(List<Boolean> booleans) {
+                            count.incrementAndGet();
+                        }
+                    })
+                    .subscribe();
+        }
+        assertEquals(expectedCount, count.get());
+    }
+
+    @Test
+    public void testIssue1451Case2() {
+        // https://github.com/Netflix/RxJava/issues/1451
+        final int expectedCount = 3;
+        final AtomicInteger count = new AtomicInteger();
+        for (int i=0; i < expectedCount; i++) {
+            Observable
+                    .just(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
+                    .takeWhile(new Predicate<Boolean>() {
+                        @Override
+                        public boolean test(Boolean value) {
+                            return value;
+                        }
+                    })
+                    .toList()
+                    .doOnNext(new Consumer<List<Boolean>>() {
+                        @Override
+                        public void accept(List<Boolean> booleans) {
+                            count.incrementAndGet();
+                        }
+                    })
+                    .subscribe();
+        }
+        assertEquals(expectedCount, count.get());
+    }
+
+    // FIXME crashing publisher can't propagate to a subscriber
+//    @Test
+//    public void testFatalError() {
+//        try {
+//            Observable.just(1, 2, 3)
+//                    .flatMap(new Function<Integer, Observable<?>>() {
+//                        @Override
+//                        public Observable<?> apply(Integer integer) {
+//                            return Observable.create(new Publisher<Object>() {
+//                                @Override
+//                                public void subscribe(Subscriber<Object> o) {
+//                                    throw new NullPointerException("Test NPE");
+//                                }
+//                            });
+//                        }
+//                    })
+//                    .doOnNext(new Consumer<Object>() {
+//                        @Override
+//                        public void accept(Object o) {
+//                            System.out.println("Won't come here");
+//                        }
+//                    })
+//                    .subscribe();
+//            fail("should have thrown an exception");
+//        } catch (OnErrorNotImplementedException e) {
+//            assertTrue(e.getCause() instanceof NullPointerException);
+//            assertEquals(e.getCause().getMessage(), "Test NPE");
+//            System.out.println("Received exception: " + e);
+//        }
+//    }
+}


### PR DESCRIPTION
Note: several tests have been ignored due to non-conformance with RS

Added missing distinct and distinctUntilChanged overloads, fixed doOnEach not cancelling upstream if the callback crashes on the onNext path.