### PR TITLE
2.x: operator test flatMap, merge, mergeDelayError

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/OperatorMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorMapNotification.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable.Operator;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+
+public final class OperatorMapNotification<T, R> implements Operator<Publisher<? extends R>, T>{
+
+    final Function<? super T, ? extends Publisher<? extends R>> onNextMapper;
+    final Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper;
+    final Supplier<? extends Publisher<? extends R>> onCompleteSupplier;
+
+    public OperatorMapNotification(Function<? super T, ? extends Publisher<? extends R>> onNextMapper, 
+            Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper, 
+            Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
+        this.onNextMapper = onNextMapper;
+        this.onErrorMapper = onErrorMapper;
+        this.onCompleteSupplier = onCompleteSupplier;
+    }
+    
+    @Override
+    public Subscriber<? super T> apply(Subscriber<? super Publisher<? extends R>> t) {
+        return new MapNotificationSubscriber<>(t, onNextMapper, onErrorMapper, onCompleteSupplier);
+    }
+    
+    static final class MapNotificationSubscriber<T, R>
+    extends AtomicLong
+    implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = 2757120512858778108L;
+        
+        final Subscriber<? super Publisher<? extends R>> actual;
+        final Function<? super T, ? extends Publisher<? extends R>> onNextMapper;
+        final Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper;
+        final Supplier<? extends Publisher<? extends R>> onCompleteSupplier;
+        
+        Subscription s;
+        
+        Publisher<? extends R> value;
+        
+        volatile boolean done;
+
+        volatile int state;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<MapNotificationSubscriber> STATE =
+                AtomicIntegerFieldUpdater.newUpdater(MapNotificationSubscriber.class, "state");
+        
+        static final int NO_REQUEST_NO_VALUE = 0;
+        static final int NO_REQUEST_HAS_VALUE = 1;
+        static final int HAS_REQUEST_NO_VALUE = 2;
+        static final int HAS_REQUEST_HAS_VALUE = 3;
+
+        public MapNotificationSubscriber(Subscriber<? super Publisher<? extends R>> actual,
+                Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
+                Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper,
+                Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
+            this.actual = actual;
+            this.onNextMapper = onNextMapper;
+            this.onErrorMapper = onErrorMapper;
+            this.onCompleteSupplier = onCompleteSupplier;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(this);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            Publisher<? extends R> p;
+            
+            try {
+                p = onNextMapper.apply(t);
+            } catch (Throwable e) {
+                actual.onError(e);
+                return;
+            }
+            
+            if (p == null) {
+                actual.onError(new NullPointerException("The onNext publisher returned is null"));
+                return;
+            }
+            
+            actual.onNext(p);
+            
+            long r = get();
+            if (r != Long.MAX_VALUE) {
+                decrementAndGet();
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            Publisher<? extends R> p;
+            
+            try {
+                p = onErrorMapper.apply(t);
+            } catch (Throwable e) {
+                actual.onError(e);
+                return;
+            }
+
+            if (p == null) {
+                actual.onError(new NullPointerException("The onError publisher returned is null"));
+                return;
+            }
+
+            tryEmit(p);
+        }
+        
+        @Override
+        public void onComplete() {
+            Publisher<? extends R> p;
+            
+            try {
+                p = onCompleteSupplier.get();
+            } catch (Throwable e) {
+                actual.onError(e);
+                return;
+            }
+
+            if (p == null) {
+                actual.onError(new NullPointerException("The onComplete publisher returned is null"));
+                return;
+            }
+
+            tryEmit(p);
+        }
+        
+        
+        void tryEmit(Publisher<? extends R> p) {
+            long r = get();
+            if (r != 0L) {
+                actual.onNext(p);
+                actual.onComplete();
+            } else {
+                for (;;) {
+                    int s = state;
+                    if (s == HAS_REQUEST_NO_VALUE) {
+                        if (STATE.compareAndSet(this, HAS_REQUEST_NO_VALUE, HAS_REQUEST_HAS_VALUE)) {
+                            actual.onNext(p);
+                            actual.onComplete();
+                        }
+                        return;
+                    } else
+                    if (s == NO_REQUEST_NO_VALUE) {
+                        value = p;
+                        done = true;
+                        if (STATE.compareAndSet(this, NO_REQUEST_NO_VALUE, NO_REQUEST_HAS_VALUE)) {
+                            return;
+                        }
+                    } else
+                    if (s == NO_REQUEST_HAS_VALUE || s == HAS_REQUEST_HAS_VALUE) {
+                        return;
+                    }
+                }
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validateRequest(n)) {
+                return;
+            }
+            
+            BackpressureHelper.add(this, n);
+            if (done) {
+                for (;;) {
+                    int s = state;
+                    
+                    if (s == HAS_REQUEST_NO_VALUE || s == HAS_REQUEST_HAS_VALUE) {
+                        return;
+                    } else
+                    if (s == NO_REQUEST_HAS_VALUE) {
+                        if (STATE.compareAndSet(this, NO_REQUEST_HAS_VALUE, HAS_REQUEST_HAS_VALUE)) {
+                            Publisher<? extends R> p = value;
+                            value = null;
+                            actual.onNext(p);
+                            actual.onComplete();
+                        }
+                        return;
+                    } else
+                    if (STATE.compareAndSet(this, NO_REQUEST_NO_VALUE, HAS_REQUEST_NO_VALUE)) {
+                        return;
+                    }
+                }
+            } else {
+                s.request(n);
+            }
+        }
+        
+        @Override
+        public void cancel() {
+            STATE.lazySet(this, HAS_REQUEST_HAS_VALUE);
+            s.cancel();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/SubscriptionLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/SubscriptionLambdaSubscriber.java
@@ -17,6 +17,7 @@ import java.util.function.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Subscription {
@@ -43,11 +44,12 @@ public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Sub
         try {
             onSubscribe.accept(s);
         } catch (Throwable e) {
-            RxJavaPlugins.onError(e);
-        }
-        if (this.s != null) {
             s.cancel();
-            RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+            RxJavaPlugins.onError(e);
+            EmptySubscription.error(e, actual);
+            return;
+        }
+        if (SubscriptionHelper.validateSubscription(this.s, s)) {
             return;
         }
         this.s = s;

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/reactivex/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorConcatTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDebounceTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDelayTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDematerializeTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDistinctTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDistinctUntilChangedTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDoOnEachTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDoOnRequestTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDoOnSubscribeTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/OperatorDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDoOnUnsubscribeTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/OperatorFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorFlatMapTest.java
@@ -1,0 +1,540 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorFlatMapTest {
+    @Test
+    public void testNormal() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        final List<Integer> list = Arrays.asList(1, 2, 3);
+
+        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(Integer t1) {
+                return list;
+            }
+        };
+        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
+
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                return t1 | t2;
+            }
+        };
+
+        List<Integer> source = Arrays.asList(16, 32, 64);
+
+        Observable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(o);
+
+        for (Integer s : source) {
+            for (Integer v : list) {
+                verify(o).onNext(s | v);
+            }
+        }
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testCollectionFunctionThrows() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(Integer t1) {
+                throw new TestException();
+            }
+        };
+        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
+
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                return t1 | t2;
+            }
+        };
+
+        List<Integer> source = Arrays.asList(16, 32, 64);
+
+        Observable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(o);
+
+        verify(o, never()).onComplete();
+        verify(o, never()).onNext(any());
+        verify(o).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testResultFunctionThrows() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        final List<Integer> list = Arrays.asList(1, 2, 3);
+
+        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(Integer t1) {
+                return list;
+            }
+        };
+        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
+
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                throw new TestException();
+            }
+        };
+
+        List<Integer> source = Arrays.asList(16, 32, 64);
+
+        Observable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(o);
+
+        verify(o, never()).onComplete();
+        verify(o, never()).onNext(any());
+        verify(o).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testMergeError() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        Function<Integer, Observable<Integer>> func = new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return Observable.error(new TestException());
+            }
+        };
+        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
+
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                return t1 | t2;
+            }
+        };
+
+        List<Integer> source = Arrays.asList(16, 32, 64);
+
+        Observable.fromIterable(source).flatMap(func, resFunc).subscribe(o);
+
+        verify(o, never()).onComplete();
+        verify(o, never()).onNext(any());
+        verify(o).onError(any(TestException.class));
+    }
+
+    <T, R> Function<T, R> just(final R value) {
+        return new Function<T, R>() {
+
+            @Override
+            public R apply(T t1) {
+                return value;
+            }
+        };
+    }
+
+    <R> Supplier<R> just0(final R value) {
+        return new Supplier<R>() {
+
+            @Override
+            public R get() {
+                return value;
+            }
+        };
+    }
+
+    @Test
+    public void testFlatMapTransformsNormal() {
+        Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
+        Observable<Integer> onCompleted = Observable.fromIterable(Arrays.asList(4));
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        source.flatMap(just(onNext), just(onError), just0(onCompleted)).subscribe(o);
+
+        verify(o, times(3)).onNext(1);
+        verify(o, times(3)).onNext(2);
+        verify(o, times(3)).onNext(3);
+        verify(o).onNext(4);
+        verify(o).onComplete();
+
+        verify(o, never()).onNext(5);
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFlatMapTransformsException() {
+        Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
+        Observable<Integer> onCompleted = Observable.fromIterable(Arrays.asList(4));
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.concat(
+                Observable.fromIterable(Arrays.asList(10, 20, 30)),
+                Observable.<Integer> error(new RuntimeException("Forced failure!"))
+                );
+        
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        source.flatMap(just(onNext), just(onError), just0(onCompleted)).subscribe(o);
+
+        verify(o, times(3)).onNext(1);
+        verify(o, times(3)).onNext(2);
+        verify(o, times(3)).onNext(3);
+        verify(o).onNext(5);
+        verify(o).onComplete();
+        verify(o, never()).onNext(4);
+
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    <R> Supplier<R> funcThrow0(R r) {
+        return new Supplier<R>() {
+            @Override
+            public R get() {
+                throw new TestException();
+            }
+        };
+    }
+
+    <T, R> Function<T, R> funcThrow(T t, R r) {
+        return new Function<T, R>() {
+            @Override
+            public R apply(T t) {
+                throw new TestException();
+            }
+        };
+    }
+
+    @Test
+    public void testFlatMapTransformsOnNextFuncThrows() {
+        Observable<Integer> onCompleted = Observable.fromIterable(Arrays.asList(4));
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        source.flatMap(funcThrow(1, onError), just(onError), just0(onCompleted)).subscribe(o);
+
+        verify(o).onError(any(TestException.class));
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+    }
+
+    @Test
+    public void testFlatMapTransformsOnErrorFuncThrows() {
+        Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
+        Observable<Integer> onCompleted = Observable.fromIterable(Arrays.asList(4));
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.error(new TestException());
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        source.flatMap(just(onNext), funcThrow((Throwable) null, onError), just0(onCompleted)).subscribe(o);
+
+        verify(o).onError(any(TestException.class));
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+    }
+
+    @Test
+    public void testFlatMapTransformsOnCompletedFuncThrows() {
+        Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
+        Observable<Integer> onCompleted = Observable.fromIterable(Arrays.asList(4));
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.fromIterable(Arrays.<Integer> asList());
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        source.flatMap(just(onNext), just(onError), funcThrow0(onCompleted)).subscribe(o);
+
+        verify(o).onError(any(TestException.class));
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+    }
+
+    @Test
+    public void testFlatMapTransformsMergeException() {
+        Observable<Integer> onNext = Observable.error(new TestException());
+        Observable<Integer> onCompleted = Observable.fromIterable(Arrays.asList(4));
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        source.flatMap(just(onNext), just(onError), funcThrow0(onCompleted)).subscribe(o);
+
+        verify(o).onError(any(TestException.class));
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+    }
+
+    private static <T> Observable<T> composer(Observable<T> source, final AtomicInteger subscriptionCount, final int m) {
+        return source.doOnSubscribe(s -> {
+                int n = subscriptionCount.getAndIncrement();
+                if (n >= m) {
+                    Assert.fail("Too many subscriptions! " + (n + 1));
+                }
+        }).doOnComplete(() -> {
+                int n = subscriptionCount.decrementAndGet();
+                if (n < 0) {
+                    Assert.fail("Too many unsubscriptions! " + (n - 1));
+                }
+        });
+    }
+
+    @Test
+    public void testFlatMapMaxConcurrent() {
+        final int m = 4;
+        final AtomicInteger subscriptionCount = new AtomicInteger();
+        Observable<Integer> source = Observable.range(1, 10)
+        .flatMap(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
+                        .subscribeOn(Schedulers.computation());
+            }
+        }, m);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.subscribe(ts);
+        
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        Set<Integer> expected = new HashSet<>(Arrays.asList(
+                10, 11, 20, 21, 30, 31, 40, 41, 50, 51, 60, 61, 70, 71, 80, 81, 90, 91, 100, 101
+        ));
+        Assert.assertEquals(expected.size(), ts.valueCount());
+        Assert.assertTrue(expected.containsAll(ts.values()));
+    }
+    @Test
+    public void testFlatMapSelectorMaxConcurrent() {
+        final int m = 4;
+        final AtomicInteger subscriptionCount = new AtomicInteger();
+        Observable<Integer> source = Observable.range(1, 10)
+            .flatMap(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
+                        .subscribeOn(Schedulers.computation());
+            }
+        }, new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                return t1 * 1000 + t2;
+            }
+        }, m);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.subscribe(ts);
+        
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        Set<Integer> expected = new HashSet<>(Arrays.asList(
+                1010, 1011, 2020, 2021, 3030, 3031, 4040, 4041, 5050, 5051, 
+                6060, 6061, 7070, 7071, 8080, 8081, 9090, 9091, 10100, 10101
+        ));
+        Assert.assertEquals(expected.size(), ts.valueCount());
+        System.out.println("--> testFlatMapSelectorMaxConcurrent: " + ts.values());
+        Assert.assertTrue(expected.containsAll(ts.values()));
+    }
+    
+    @Test
+    public void testFlatMapTransformsMaxConcurrentNormalLoop() {
+        for (int i = 0; i < 1000; i++) {
+            if (i % 100 == 0) {
+                System.out.println("testFlatMapTransformsMaxConcurrentNormalLoop => " + i);
+            }
+            testFlatMapTransformsMaxConcurrentNormal();
+        }
+    }
+    
+    @Test
+    public void testFlatMapTransformsMaxConcurrentNormal() {
+        final int m = 2;
+        final AtomicInteger subscriptionCount = new AtomicInteger();
+        Observable<Integer> onNext = 
+                composer(
+                        Observable.fromIterable(Arrays.asList(1, 2, 3))
+                        .observeOn(Schedulers.computation())
+                        , 
+                subscriptionCount, m)
+                .subscribeOn(Schedulers.computation())
+                ;
+        
+        Observable<Integer> onCompleted = composer(Observable.fromIterable(Arrays.asList(4)), subscriptionCount, m)
+                .subscribeOn(Schedulers.computation());
+        
+        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+
+        Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        TestSubscriber<Object> ts = new TestSubscriber<>(o);
+
+        source.flatMap(just(onNext), just(onError), just0(onCompleted), m).subscribe(ts);
+        
+        ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
+        ts.assertNoErrors();
+        ts.assertTerminated();
+
+        verify(o, times(3)).onNext(1);
+        verify(o, times(3)).onNext(2);
+        verify(o, times(3)).onNext(3);
+        verify(o).onNext(4);
+        verify(o).onComplete();
+
+        verify(o, never()).onNext(5);
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    
+    @Ignore // don't care for any reordering
+    @Test(timeout = 10000)
+    public void flatMapRangeAsyncLoop() {
+        for (int i = 0; i < 2000; i++) {
+            if (i % 10 == 0) {
+                System.out.println("flatMapRangeAsyncLoop > " + i);
+            }
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            Observable.range(0, 1000)
+            .flatMap(new Function<Integer, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer t) {
+                    return Observable.just(t);
+                }
+            })
+            .observeOn(Schedulers.computation())
+            .subscribe(ts);
+
+            ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+            if (ts.completions() == 0) {
+                System.out.println(ts.valueCount());
+            }
+            ts.assertTerminated();
+            ts.assertNoErrors();
+            List<Integer> list = ts.values();
+            assertEquals(1000, list.size());
+            boolean f = false;
+            for (int j = 0; j < list.size(); j++) {
+                if (list.get(j) != j) {
+                    System.out.println(j + " " + list.get(j));
+                    f = true;
+                }
+            }
+            if (f) {
+                Assert.fail("Results are out of order!");
+            }
+        }
+    }
+    @Test(timeout = 30000)
+    public void flatMapRangeMixedAsyncLoop() {
+        for (int i = 0; i < 2000; i++) {
+            if (i % 10 == 0) {
+                System.out.println("flatMapRangeAsyncLoop > " + i);
+            }
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            Observable.range(0, 1000)
+            .flatMap(new Function<Integer, Observable<Integer>>() {
+                final Random rnd = new Random();
+                @Override
+                public Observable<Integer> apply(Integer t) {
+                    Observable<Integer> r = Observable.just(t);
+                    if (rnd.nextBoolean()) {
+                        r = r.asObservable();
+                    }
+                    return r;
+                }
+            })
+            .observeOn(Schedulers.computation())
+            .subscribe(ts);
+
+            ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+            if (ts.completions() == 0) {
+                System.out.println(ts.valueCount());
+            }
+            ts.assertTerminated();
+            ts.assertNoErrors();
+            List<Integer> list = ts.values();
+            if (list.size() < 1000) {
+                Set<Integer> set = new HashSet<>(list);
+                for (int j = 0; j < 1000; j++) {
+                    if (!set.contains(j)) {
+                        System.out.println(j + " missing");
+                    }
+                }
+            }
+            assertEquals(1000, list.size());
+        }
+    }
+    
+    @Test
+    public void flatMapIntPassthruAsync() {
+        for (int i = 0;i < 1000; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            
+            Observable.range(1, 1000).flatMap(new Function<Integer, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer t) {
+                    return Observable.just(1).subscribeOn(Schedulers.computation());
+                }
+            }).subscribe(ts);
+            
+            ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+            ts.assertNoErrors();
+            ts.assertComplete();
+            ts.assertValueCount(1000);
+        }
+    }
+    @Test
+    public void flatMapTwoNestedSync() {
+        for (final int n : new int[] { 1, 1000, 1000000 }) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+    
+            Observable.just(1, 2).flatMap(new Function<Integer, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer t) {
+                    return Observable.range(1, n);
+                }
+            }).subscribe(ts);
+            
+            System.out.println("flatMapTwoNestedSync >> @ " + n);
+            ts.assertNoErrors();
+            ts.assertComplete();
+            ts.assertValueCount(n * 2);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorMergeDelayErrorTest.java
@@ -1,0 +1,580 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.LongConsumer;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorMergeDelayErrorTest {
+
+    Subscriber<String> stringObserver;
+
+    @Before
+    public void before() {
+        stringObserver = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void testErrorDelayed1() {
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", "three"));
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(1)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(0)).onNext("five");
+        // despite not expecting it ... we don't do anything to prevent it if the source Observable keeps sending after onError
+        // inner observable errors are considered terminal for that source
+//        verify(stringObserver, times(1)).onNext("six");
+        // inner observable errors are considered terminal for that source
+    }
+
+    @Test
+    public void testErrorDelayed2() {
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));
+        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(1)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(0)).onNext("five");
+        // despite not expecting it ... we don't do anything to prevent it if the source Observable keeps sending after onError
+        // inner observable errors are considered terminal for that source
+//        verify(stringObserver, times(1)).onNext("six");
+        verify(stringObserver, times(1)).onNext("seven");
+        verify(stringObserver, times(1)).onNext("eight");
+        verify(stringObserver, times(1)).onNext("nine");
+    }
+
+    @Test
+    public void testErrorDelayed3() {
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", "five", "six"));
+        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));
+        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(1)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(1)).onNext("five");
+        verify(stringObserver, times(1)).onNext("six");
+        verify(stringObserver, times(1)).onNext("seven");
+        verify(stringObserver, times(1)).onNext("eight");
+        verify(stringObserver, times(1)).onNext("nine");
+    }
+
+    @Test
+    public void testErrorDelayed4() {
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", "five", "six"));
+        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight"));
+        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine", null));
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(1)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(1)).onNext("five");
+        verify(stringObserver, times(1)).onNext("six");
+        verify(stringObserver, times(1)).onNext("seven");
+        verify(stringObserver, times(1)).onNext("eight");
+        verify(stringObserver, times(1)).onNext("nine");
+    }
+
+    @Test
+    public void testErrorDelayed4WithThreading() {
+        final TestAsyncErrorObservable o1 = new TestAsyncErrorObservable("one", "two", "three");
+        final TestAsyncErrorObservable o2 = new TestAsyncErrorObservable("four", "five", "six");
+        final TestAsyncErrorObservable o3 = new TestAsyncErrorObservable("seven", "eight");
+        // throw the error at the very end so no onComplete will be called after it
+        final TestAsyncErrorObservable o4 = new TestAsyncErrorObservable("nine", null);
+
+        Observable<String> m = Observable.mergeDelayError(Observable.create(o1), Observable.create(o2), Observable.create(o3), Observable.create(o4));
+        m.subscribe(stringObserver);
+
+        try {
+            o1.t.join();
+            o2.t.join();
+            o3.t.join();
+            o4.t.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(1)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(1)).onNext("five");
+        verify(stringObserver, times(1)).onNext("six");
+        verify(stringObserver, times(1)).onNext("seven");
+        verify(stringObserver, times(1)).onNext("eight");
+        verify(stringObserver, times(1)).onNext("nine");
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testCompositeErrorDelayed1() {
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", null));
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(Throwable.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(0)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(0)).onNext("five");
+        // despite not expecting it ... we don't do anything to prevent it if the source Observable keeps sending after onError
+        // inner observable errors are considered terminal for that source
+//        verify(stringObserver, times(1)).onNext("six");
+    }
+
+    @Test
+    public void testCompositeErrorDelayed2() {
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", null));
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        CaptureObserver w = new CaptureObserver();
+        m.subscribe(w);
+
+        assertNotNull(w.e);
+        
+        assertEquals(1, w.e.getSuppressed().length);
+        
+//        if (w.e instanceof CompositeException) {
+//            assertEquals(2, ((CompositeException) w.e).getExceptions().size());
+//            w.e.printStackTrace();
+//        } else {
+//            fail("Expecting CompositeException");
+//        }
+
+    }
+
+    /**
+     * The unit tests below are from OperationMerge and should ensure the normal merge functionality is correct.
+     */
+
+    @Test
+    public void testMergeObservableOfObservables() {
+        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+
+        Observable<Observable<String>> observableOfObservables = Observable.create(new Publisher<Observable<String>>() {
+
+            @Override
+            public void subscribe(Subscriber<? super Observable<String>> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                // simulate what would happen in an observable
+                observer.onNext(o1);
+                observer.onNext(o2);
+                observer.onComplete();
+            }
+
+        });
+        Observable<String> m = Observable.mergeDelayError(observableOfObservables);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(1)).onComplete();
+        verify(stringObserver, times(2)).onNext("hello");
+    }
+
+    @Test
+    public void testMergeArray() {
+        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+
+        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testMergeList() {
+        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        List<Observable<String>> listOfObservables = new ArrayList<>();
+        listOfObservables.add(o1);
+        listOfObservables.add(o2);
+
+        Observable<String> m = Observable.mergeDelayError(Observable.fromIterable(listOfObservables));
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(1)).onComplete();
+        verify(stringObserver, times(2)).onNext("hello");
+    }
+
+    @Test
+    public void testMergeArrayWithThreading() {
+        final TestASynchronousObservable o1 = new TestASynchronousObservable();
+        final TestASynchronousObservable o2 = new TestASynchronousObservable();
+
+        Observable<String> m = Observable.mergeDelayError(Observable.create(o1), Observable.create(o2));
+        m.subscribe(stringObserver);
+
+        try {
+            o1.t.join();
+            o2.t.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringObserver, times(1)).onComplete();
+    }
+
+    @Test(timeout = 1000L)
+    public void testSynchronousError() {
+        final Observable<Observable<String>> o1 = Observable.error(new RuntimeException("unit test"));
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        Observable.mergeDelayError(o1).subscribe(new Observer<String>() {
+            @Override
+            public void onComplete() {
+                fail("Expected onError path");
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onNext(String s) {
+                fail("Expected onError path");
+            }
+        });
+
+        try {
+            latch.await();
+        } catch (InterruptedException ex) {
+            fail("interrupted");
+        }
+    }
+
+    private static class TestSynchronousObservable implements Publisher<String> {
+
+        @Override
+        public void subscribe(Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onNext("hello");
+            observer.onComplete();
+        }
+    }
+
+    private static class TestASynchronousObservable implements Publisher<String> {
+        Thread t;
+
+        @Override
+        public void subscribe(final Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            t = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    observer.onNext("hello");
+                    observer.onComplete();
+                }
+
+            });
+            t.start();
+        }
+    }
+
+    private static class TestErrorObservable implements Publisher<String> {
+
+        String[] valuesToReturn;
+
+        TestErrorObservable(String... values) {
+            valuesToReturn = values;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            boolean errorThrown = false;
+            for (String s : valuesToReturn) {
+                if (s == null) {
+                    System.out.println("throwing exception");
+                    observer.onError(new NullPointerException());
+                    errorThrown = true;
+                    // purposefully not returning here so it will continue calling onNext
+                    // so that we also test that we handle bad sequences like this
+                } else {
+                    observer.onNext(s);
+                }
+            }
+            if (!errorThrown) {
+                observer.onComplete();
+            }
+        }
+    }
+
+    private static class TestAsyncErrorObservable implements Publisher<String> {
+
+        String[] valuesToReturn;
+
+        TestAsyncErrorObservable(String... values) {
+            valuesToReturn = values;
+        }
+
+        Thread t;
+
+        @Override
+        public void subscribe(final Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            t = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    for (String s : valuesToReturn) {
+                        if (s == null) {
+                            System.out.println("throwing exception");
+                            try {
+                                Thread.sleep(100);
+                            } catch (Throwable e) {
+
+                            }
+                            observer.onError(new NullPointerException());
+                            return;
+                        } else {
+                            observer.onNext(s);
+                        }
+                    }
+                    System.out.println("subscription complete");
+                    observer.onComplete();
+                }
+
+            });
+            t.start();
+        }
+    }
+
+    private static class CaptureObserver extends Observer<String> {
+        volatile Throwable e;
+
+        @Override
+        public void onComplete() {
+
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            this.e = e;
+        }
+
+        @Override
+        public void onNext(String args) {
+
+        }
+
+    }
+    @Test
+    @Ignore("Subscribers should not throw")
+    public void testMergeSourceWhichDoesntPropagateExceptionBack() {
+        Observable<Integer> source = Observable.create(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> t1) {
+                t1.onSubscribe(EmptySubscription.INSTANCE);
+                try {
+                    t1.onNext(0);
+                } catch (Throwable swallow) {
+                    
+                }
+                t1.onNext(1);
+                t1.onComplete();
+            }
+        });
+        
+        Observable<Integer> result = Observable.mergeDelayError(source, Observable.just(2));
+        
+        final Subscriber<Integer> o = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(o);
+        
+        result.unsafeSubscribe(new Observer<Integer>() {
+            int calls;
+            @Override
+            public void onNext(Integer t) {
+                if (calls++ == 0) {
+                    throw new TestException();
+                }
+                o.onNext(t);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+            
+        });
+        
+        /*
+         * If the child onNext throws, why would we keep accepting values from
+         * other sources?
+         */
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o, never()).onNext(0);
+        inOrder.verify(o, never()).onNext(1);
+        inOrder.verify(o, never()).onNext(anyInt());
+        inOrder.verify(o).onError(any(TestException.class));
+        verify(o, never()).onComplete();
+    }
+
+    @Test
+    public void testErrorInParentObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        Observable.mergeDelayError(
+                Observable.just(Observable.just(1), Observable.just(2))
+                        .startWith(Observable.<Integer> error(new RuntimeException()))
+                ).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertTerminated();
+        ts.assertValues(1, 2);
+        assertEquals(1, ts.errorCount());
+
+    }
+
+    @Test
+    public void testErrorInParentObservableDelayed() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            final TestASynchronous1sDelayedObservable o1 = new TestASynchronous1sDelayedObservable();
+            final TestASynchronous1sDelayedObservable o2 = new TestASynchronous1sDelayedObservable();
+            Observable<Observable<String>> parentObservable = Observable.create(new Publisher<Observable<String>>() {
+                @Override
+                public void subscribe(Subscriber<? super Observable<String>> op) {
+                    op.onSubscribe(EmptySubscription.INSTANCE);
+                    op.onNext(Observable.create(o1));
+                    op.onNext(Observable.create(o2));
+                    op.onError(new NullPointerException("throwing exception in parent"));
+                }
+            });
+    
+            Subscriber<String> stringObserver = TestHelper.mockSubscriber();
+            
+            TestSubscriber<String> ts = new TestSubscriber<>(stringObserver);
+            Observable<String> m = Observable.mergeDelayError(parentObservable);
+            m.subscribe(ts);
+            System.out.println("testErrorInParentObservableDelayed | " + i);
+            ts.awaitTerminalEvent(2000, TimeUnit.MILLISECONDS);
+            ts.assertTerminated();
+    
+            verify(stringObserver, times(2)).onNext("hello");
+            verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+            verify(stringObserver, never()).onComplete();
+        }
+    }
+
+    private static class TestASynchronous1sDelayedObservable implements Publisher<String> {
+        Thread t;
+
+        @Override
+        public void subscribe(final Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            t = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        observer.onError(e);
+                    }
+                    observer.onNext("hello");
+                    observer.onComplete();
+                }
+
+            });
+            t.start();
+        }
+    }
+    @Test
+    public void testDelayErrorMaxConcurrent() {
+        final List<Long> requests = new ArrayList<>();
+        Observable<Integer> source = Observable.mergeDelayError(Observable.just(
+                Observable.just(1).asObservable(), 
+                Observable.<Integer>error(new TestException()))
+                .doOnRequest(new LongConsumer() {
+                    @Override
+                    public void accept(long t1) {
+                        requests.add(t1);
+                    }
+                }), 1);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertTerminated();
+        ts.assertError(TestException.class);
+        assertEquals(Arrays.asList(1L, 1L, 1L), requests);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorMergeMaxConcurrentTest {
+
+    Subscriber<String> stringObserver;
+
+    @Before
+    public void before() {
+        stringObserver = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void testWhenMaxConcurrentIsOne() {
+        for (int i = 0; i < 100; i++) {
+            List<Observable<String>> os = new ArrayList<>();
+            os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
+            os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
+            os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
+
+            List<String> expected = Arrays.asList("one", "two", "three", "four", "five", "one", "two", "three", "four", "five", "one", "two", "three", "four", "five");
+            Iterator<String> iter = Observable.merge(os, 1).toBlocking().iterator();
+            List<String> actual = new ArrayList<>();
+            while (iter.hasNext()) {
+                actual.add(iter.next());
+            }
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void testMaxConcurrent() {
+        for (int times = 0; times < 100; times++) {
+            int observableCount = 100;
+            // Test maxConcurrent from 2 to 12
+            int maxConcurrent = 2 + (times % 10);
+            AtomicInteger subscriptionCount = new AtomicInteger(0);
+
+            List<Observable<String>> os = new ArrayList<>();
+            List<SubscriptionCheckObservable> scos = new ArrayList<>();
+            for (int i = 0; i < observableCount; i++) {
+                SubscriptionCheckObservable sco = new SubscriptionCheckObservable(subscriptionCount, maxConcurrent);
+                scos.add(sco);
+                os.add(Observable.create(sco));
+            }
+
+            Iterator<String> iter = Observable.merge(os, maxConcurrent).toBlocking().iterator();
+            List<String> actual = new ArrayList<>();
+            while (iter.hasNext()) {
+                actual.add(iter.next());
+            }
+            //            System.out.println("actual: " + actual);
+            assertEquals(5 * observableCount, actual.size());
+            for (SubscriptionCheckObservable sco : scos) {
+                assertFalse(sco.failed);
+            }
+        }
+    }
+
+    private static class SubscriptionCheckObservable implements Publisher<String> {
+
+        private final AtomicInteger subscriptionCount;
+        private final int maxConcurrent;
+        volatile boolean failed = false;
+
+        SubscriptionCheckObservable(AtomicInteger subscriptionCount, int maxConcurrent) {
+            this.subscriptionCount = subscriptionCount;
+            this.maxConcurrent = maxConcurrent;
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super String> t1) {
+            t1.onSubscribe(EmptySubscription.INSTANCE);
+            new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (subscriptionCount.incrementAndGet() > maxConcurrent) {
+                        failed = true;
+                    }
+                    t1.onNext("one");
+                    t1.onNext("two");
+                    t1.onNext("three");
+                    t1.onNext("four");
+                    t1.onNext("five");
+                    // We could not decrement subscriptionCount in the unsubscribe method
+                    // as "unsubscribe" is not guaranteed to be called before the next "subscribe".
+                    subscriptionCount.decrementAndGet();
+                    t1.onComplete();
+                }
+
+            }).start();
+        }
+
+    }
+    
+    @Test
+    public void testMergeALotOfSourcesOneByOneSynchronously() {
+        int n = 10000;
+        List<Observable<Integer>> sourceList = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            sourceList.add(Observable.just(i));
+        }
+        Iterator<Integer> it = Observable.merge(Observable.fromIterable(sourceList), 1).toBlocking().iterator();
+        int j = 0;
+        while (it.hasNext()) {
+            assertEquals((Integer)j, it.next());
+            j++;
+        }
+        assertEquals(j, n);
+    }
+    @Test
+    public void testMergeALotOfSourcesOneByOneSynchronouslyTakeHalf() {
+        int n = 10000;
+        List<Observable<Integer>> sourceList = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            sourceList.add(Observable.just(i));
+        }
+        Iterator<Integer> it = Observable.merge(Observable.fromIterable(sourceList), 1).take(n / 2).toBlocking().iterator();
+        int j = 0;
+        while (it.hasNext()) {
+            assertEquals((Integer)j, it.next());
+            j++;
+        }
+        assertEquals(j, n / 2);
+    }
+    
+    @Test
+    public void testSimple() {
+        for (int i = 1; i < 100; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            List<Integer> result = new ArrayList<>(i);
+            for (int j = 1; j <= i; j++) {
+                sourceList.add(Observable.just(j));
+                result.add(j);
+            }
+            
+            Observable.merge(sourceList, i).subscribe(ts);
+        
+            ts.assertNoErrors();
+            ts.assertTerminated();
+            ts.assertValueSequence(result);
+        }
+    }
+    @Test
+    public void testSimpleOneLess() {
+        for (int i = 2; i < 100; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            List<Integer> result = new ArrayList<>(i);
+            for (int j = 1; j <= i; j++) {
+                sourceList.add(Observable.just(j));
+                result.add(j);
+            }
+            
+            Observable.merge(sourceList, i - 1).subscribe(ts);
+        
+            ts.assertNoErrors();
+            ts.assertTerminated();
+            ts.assertValueSequence(result);
+        }
+    }
+    @Test(timeout = 20000)
+    public void testSimpleAsyncLoop() {
+        for (int i = 0; i < 200; i++) {
+            testSimpleAsync();
+        }
+    }
+    @Test(timeout = 10000)
+    public void testSimpleAsync() {
+        for (int i = 1; i < 50; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            Set<Integer> expected = new HashSet<>(i);
+            for (int j = 1; j <= i; j++) {
+                sourceList.add(Observable.just(j).subscribeOn(Schedulers.io()));
+                expected.add(j);
+            }
+            
+            Observable.merge(sourceList, i).subscribe(ts);
+        
+            ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            ts.assertNoErrors();
+            Set<Integer> actual = new HashSet<>(ts.values());
+            
+            assertEquals(expected, actual);
+        }
+    }
+    @Test(timeout = 10000)
+    public void testSimpleOneLessAsyncLoop() {
+        for (int i = 0; i < 200; i++) {
+            testSimpleOneLessAsync();
+        }
+    }
+    @Test(timeout = 10000)
+    public void testSimpleOneLessAsync() {
+        long t = System.currentTimeMillis();
+        for (int i = 2; i < 50; i++) {
+            if (System.currentTimeMillis() - t > TimeUnit.SECONDS.toMillis(9)) {
+                break;
+            }
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            Set<Integer> expected = new HashSet<>(i);
+            for (int j = 1; j <= i; j++) {
+                sourceList.add(Observable.just(j).subscribeOn(Schedulers.io()));
+                expected.add(j);
+            }
+            
+            Observable.merge(sourceList, i - 1).subscribe(ts);
+        
+            ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            ts.assertNoErrors();
+            Set<Integer> actual = new HashSet<>(ts.values());
+            
+            assertEquals(expected, actual);
+        }
+    }
+    @Test(timeout = 5000)
+    public void testBackpressureHonored() throws Exception {
+        List<Observable<Integer>> sourceList = new ArrayList<>(3);
+        
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        
+        final CountDownLatch cdl = new CountDownLatch(5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cdl.countDown();
+            }
+        };
+        
+        Observable.merge(sourceList, 2).subscribe(ts);
+        
+        ts.request(5);
+        
+        cdl.await();
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(5);
+        ts.assertNotComplete();
+        
+        ts.dispose();
+    }
+    @Test(timeout = 5000)
+    public void testTake() throws Exception {
+        List<Observable<Integer>> sourceList = new ArrayList<>(3);
+        
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        Observable.merge(sourceList, 2).take(5).subscribe(ts);
+        
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        ts.assertValueCount(5);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorMergeTest.java
@@ -1,0 +1,1335 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.schedulers.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorMergeTest {
+
+    Subscriber<String> stringObserver;
+
+    @Before
+    public void before() {
+        stringObserver = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void testMergeObservableOfObservables() {
+        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+
+        Observable<Observable<String>> observableOfObservables = Observable.create(new Publisher<Observable<String>>() {
+
+            @Override
+            public void subscribe(Subscriber<? super Observable<String>> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                // simulate what would happen in an observable
+                observer.onNext(o1);
+                observer.onNext(o2);
+                observer.onComplete();
+            }
+
+        });
+        Observable<String> m = Observable.merge(observableOfObservables);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(1)).onComplete();
+        verify(stringObserver, times(2)).onNext("hello");
+    }
+
+    @Test
+    public void testMergeArray() {
+        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+
+        Observable<String> m = Observable.merge(o1, o2);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testMergeList() {
+        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        List<Observable<String>> listOfObservables = new ArrayList<>();
+        listOfObservables.add(o1);
+        listOfObservables.add(o2);
+
+        Observable<String> m = Observable.merge(listOfObservables);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(1)).onComplete();
+        verify(stringObserver, times(2)).onNext("hello");
+    }
+
+    @Test(timeout = 1000)
+    public void testUnSubscribeObservableOfObservables() throws InterruptedException {
+
+        final AtomicBoolean unsubscribed = new AtomicBoolean();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        Observable<Observable<Long>> source = Observable.create(new Publisher<Observable<Long>>() {
+
+            @Override
+            public void subscribe(final Subscriber<? super Observable<Long>> observer) {
+                // verbose on purpose so I can track the inside of it
+                final Subscription s = new Subscription() {
+
+                    @Override
+                    public void request(long n) {
+                        
+                    }
+                    
+                    @Override
+                    public void cancel() {
+                        System.out.println("*** unsubscribed");
+                        unsubscribed.set(true);
+                    }
+
+                };
+                observer.onSubscribe(s);
+
+                new Thread(new Runnable() {
+
+                    @Override
+                    public void run() {
+
+                        while (!unsubscribed.get()) {
+                            observer.onNext(Observable.just(1L, 2L));
+                        }
+                        System.out.println("Done looping after unsubscribe: " + unsubscribed.get());
+                        observer.onComplete();
+
+                        // mark that the thread is finished
+                        latch.countDown();
+                    }
+                }).start();
+            }
+
+        });
+
+        final AtomicInteger count = new AtomicInteger();
+        Observable.merge(source).take(6).toBlocking().forEach(new Consumer<Long>() {
+
+            @Override
+            public void accept(Long v) {
+                System.out.println("Value: " + v);
+                int c = count.incrementAndGet();
+                if (c > 6) {
+                    fail("Should be only 6");
+                }
+
+            }
+        });
+
+        latch.await(1000, TimeUnit.MILLISECONDS);
+
+        System.out.println("unsubscribed: " + unsubscribed.get());
+
+        assertTrue(unsubscribed.get());
+
+    }
+
+    @Test
+    public void testMergeArrayWithThreading() {
+        final TestASynchronousObservable o1 = new TestASynchronousObservable();
+        final TestASynchronousObservable o2 = new TestASynchronousObservable();
+
+        Observable<String> m = Observable.merge(Observable.create(o1), Observable.create(o2));
+        TestSubscriber<String> ts = new TestSubscriber<>(stringObserver);
+        m.subscribe(ts);
+
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+
+        verify(stringObserver, never()).onError(any(Throwable.class));
+        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSynchronizationOfMultipleSequences() throws Throwable {
+        final TestASynchronousObservable o1 = new TestASynchronousObservable();
+        final TestASynchronousObservable o2 = new TestASynchronousObservable();
+
+        // use this latch to cause onNext to wait until we're ready to let it go
+        final CountDownLatch endLatch = new CountDownLatch(1);
+
+        final AtomicInteger concurrentCounter = new AtomicInteger();
+        final AtomicInteger totalCounter = new AtomicInteger();
+
+        Observable<String> m = Observable.merge(Observable.create(o1), Observable.create(o2));
+        m.subscribe(new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException("failed", e);
+            }
+
+            @Override
+            public void onNext(String v) {
+                totalCounter.incrementAndGet();
+                concurrentCounter.incrementAndGet();
+                try {
+                    // wait here until we're done asserting
+                    endLatch.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    throw new RuntimeException("failed", e);
+                } finally {
+                    concurrentCounter.decrementAndGet();
+                }
+            }
+
+        });
+
+        // wait for both observables to send (one should be blocked)
+        o1.onNextBeingSent.await();
+        o2.onNextBeingSent.await();
+
+        // I can't think of a way to know for sure that both threads have or are trying to send onNext
+        // since I can't use a CountDownLatch for "after" onNext since I want to catch during it
+        // but I can't know for sure onNext is invoked
+        // so I'm unfortunately reverting to using a Thread.sleep to allow the process scheduler time
+        // to make sure after o1.onNextBeingSent and o2.onNextBeingSent are hit that the following
+        // onNext is invoked.
+
+        Thread.sleep(300);
+
+        try { // in try/finally so threads are released via latch countDown even if assertion fails
+            assertEquals(1, concurrentCounter.get());
+        } finally {
+            // release so it can finish
+            endLatch.countDown();
+        }
+
+        try {
+            o1.t.join();
+            o2.t.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertEquals(2, totalCounter.get());
+        assertEquals(0, concurrentCounter.get());
+    }
+
+    /**
+     * unit test from OperationMergeDelayError backported here to show how these use cases work with normal merge
+     */
+    @Test
+    public void testError1() {
+        // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
+
+        Observable<String> m = Observable.merge(o1, o2);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(0)).onNext("one");
+        verify(stringObserver, times(0)).onNext("two");
+        verify(stringObserver, times(0)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(0)).onNext("five");
+        verify(stringObserver, times(0)).onNext("six");
+    }
+
+    /**
+     * unit test from OperationMergeDelayError backported here to show how these use cases work with normal merge
+     */
+    @Test
+    public void testError2() {
+        // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
+        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
+        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));// we expect to lose all of these since o2 is done first and fails
+
+        Observable<String> m = Observable.merge(o1, o2, o3, o4);
+        m.subscribe(stringObserver);
+
+        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, never()).onComplete();
+        verify(stringObserver, times(1)).onNext("one");
+        verify(stringObserver, times(1)).onNext("two");
+        verify(stringObserver, times(1)).onNext("three");
+        verify(stringObserver, times(1)).onNext("four");
+        verify(stringObserver, times(0)).onNext("five");
+        verify(stringObserver, times(0)).onNext("six");
+        verify(stringObserver, times(0)).onNext("seven");
+        verify(stringObserver, times(0)).onNext("eight");
+        verify(stringObserver, times(0)).onNext("nine");
+    }
+
+    @Test
+    @Ignore("Subscribe should not throw")
+    public void testThrownErrorHandling() {
+        TestSubscriber<String> ts = new TestSubscriber<>();
+        Observable<String> o1 = Observable.create(new Publisher<String>() {
+
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                throw new RuntimeException("fail");
+            }
+
+        });
+
+        Observable.merge(o1, o1).subscribe(ts);
+        ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
+        ts.assertTerminated();
+        System.out.println("Error: " + ts.errors());
+    }
+
+    private static class TestSynchronousObservable implements Publisher<String> {
+
+        @Override
+        public void subscribe(Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onNext("hello");
+            observer.onComplete();
+        }
+    }
+
+    private static class TestASynchronousObservable implements Publisher<String> {
+        Thread t;
+        final CountDownLatch onNextBeingSent = new CountDownLatch(1);
+
+        @Override
+        public void subscribe(final Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            t = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    onNextBeingSent.countDown();
+                    try {
+                        observer.onNext("hello");
+                        // I can't use a countDownLatch to prove we are actually sending 'onNext'
+                        // since it will block if synchronized and I'll deadlock
+                        observer.onComplete();
+                    } catch (Exception e) {
+                        observer.onError(e);
+                    }
+                }
+
+            });
+            t.start();
+        }
+    }
+
+    private static class TestErrorObservable implements Publisher<String> {
+
+        String[] valuesToReturn;
+
+        TestErrorObservable(String... values) {
+            valuesToReturn = values;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            for (String s : valuesToReturn) {
+                if (s == null) {
+                    System.out.println("throwing exception");
+                    observer.onError(new NullPointerException());
+                } else {
+                    observer.onNext(s);
+                }
+            }
+            observer.onComplete();
+        }
+    }
+
+    @Test
+    public void testUnsubscribeAsObservablesComplete() {
+        TestScheduler scheduler1 = Schedulers.test();
+        AtomicBoolean os1 = new AtomicBoolean(false);
+        Observable<Long> o1 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
+
+        TestScheduler scheduler2 = Schedulers.test();
+        AtomicBoolean os2 = new AtomicBoolean(false);
+        Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
+
+        TestSubscriber<Long> ts = new TestSubscriber<>();
+        Observable.merge(o1, o2).subscribe(ts);
+
+        // we haven't incremented time so nothing should be received yet
+        ts.assertNoValues();
+
+        scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
+        scheduler2.advanceTimeBy(2, TimeUnit.SECONDS);
+
+        ts.assertValues(0L, 1L, 2L, 0L, 1L);
+        // not unsubscribed yet
+        assertFalse(os1.get());
+        assertFalse(os2.get());
+
+        // advance to the end at which point it should complete
+        scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
+
+        ts.assertValues(0L, 1L, 2L, 0L, 1L, 3L, 4L);
+        assertTrue(os1.get());
+        assertFalse(os2.get());
+
+        // both should be completed now
+        scheduler2.advanceTimeBy(3, TimeUnit.SECONDS);
+
+        ts.assertValues(0L, 1L, 2L, 0L, 1L, 3L, 4L, 2L, 3L, 4L);
+        assertTrue(os1.get());
+        assertTrue(os2.get());
+
+        ts.assertTerminated();
+    }
+
+    @Test
+    public void testEarlyUnsubscribe() {
+        for (int i = 0; i < 10; i++) {
+            TestScheduler scheduler1 = Schedulers.test();
+            AtomicBoolean os1 = new AtomicBoolean(false);
+            Observable<Long> o1 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
+
+            TestScheduler scheduler2 = Schedulers.test();
+            AtomicBoolean os2 = new AtomicBoolean(false);
+            Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
+
+            TestSubscriber<Long> ts = new TestSubscriber<>();
+            Observable.merge(o1, o2).subscribe(ts);
+
+            // we haven't incremented time so nothing should be received yet
+            ts.assertNoValues();
+
+            scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
+            scheduler2.advanceTimeBy(2, TimeUnit.SECONDS);
+
+            ts.assertValues(0L, 1L, 2L, 0L, 1L);
+            // not unsubscribed yet
+            assertFalse(os1.get());
+            assertFalse(os2.get());
+
+            // early unsubscribe
+            ts.dispose();
+
+            assertTrue(os1.get());
+            assertTrue(os2.get());
+
+            ts.assertValues(0L, 1L, 2L, 0L, 1L);
+            // FIXME not happening anymore
+//            ts.assertUnsubscribed();
+        }
+    }
+
+    private Observable<Long> createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
+        return Observable.create(new Publisher<Long>() {
+
+            @Override
+            public void subscribe(Subscriber<? super Long> child) {
+                Observable.interval(1, TimeUnit.SECONDS, scheduler)
+                .take(5)
+                .subscribe(new Subscriber<Long>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        child.onSubscribe(new Subscription() {
+                            @Override
+                            public void request(long n) {
+                                s.request(n);
+                            }
+                            
+                            @Override
+                            public void cancel() {
+                                unsubscribed.set(true);
+                                s.cancel();
+                            }
+                        });
+                    }
+                    
+                    @Override
+                    public void onNext(Long t) {
+                        child.onNext(t);
+                    }
+                    
+                    @Override
+                    public void onError(Throwable t) {
+                        unsubscribed.set(true);
+                        child.onError(t);
+                    }
+                    
+                    @Override
+                    public void onComplete() {
+                        unsubscribed.set(true);
+                        child.onComplete();
+                    }
+                    
+                });
+            }
+        });
+    }
+
+    @Test//(timeout = 10000)
+    public void testConcurrency() {
+        Observable<Integer> o = Observable.range(1, 10000).subscribeOn(Schedulers.newThread());
+
+        for (int i = 0; i < 10; i++) {
+            Observable<Integer> merge = Observable.merge(o.onBackpressureBuffer(), o.onBackpressureBuffer(), o.onBackpressureBuffer());
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            merge.subscribe(ts);
+
+            ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
+            ts.assertTerminated();
+            ts.assertNoErrors();
+            ts.assertComplete();
+            List<Integer> onNextEvents = ts.values();
+            assertEquals(30000, onNextEvents.size());
+            //            System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getOnCompletedEvents().size());
+        }
+    }
+
+    @Test
+    public void testConcurrencyWithSleeping() {
+
+        Observable<Integer> o = Observable.create(new Publisher<Integer>() {
+
+            @Override
+            public void subscribe(final Subscriber<? super Integer> s) {
+                Worker inner = Schedulers.newThread().createWorker();
+                AsyncSubscription as = new AsyncSubscription();
+                as.setSubscription(EmptySubscription.INSTANCE);
+                as.setResource(inner);
+                
+                s.onSubscribe(as);
+                
+                inner.schedule(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        try {
+                            for (int i = 0; i < 100; i++) {
+                                s.onNext(1);
+                                try {
+                                    Thread.sleep(1);
+                                } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                                }
+                            }
+                        } catch (Exception e) {
+                            s.onError(e);
+                        }
+                        s.onComplete();
+                    }
+
+                });
+            }
+        });
+
+        for (int i = 0; i < 10; i++) {
+            Observable<Integer> merge = Observable.merge(o, o, o);
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            merge.subscribe(ts);
+
+            ts.awaitTerminalEvent();
+            ts.assertComplete();
+            List<Integer> onNextEvents = ts.values();
+            assertEquals(300, onNextEvents.size());
+            //            System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getOnCompletedEvents().size());
+        }
+    }
+
+    @Test
+    public void testConcurrencyWithBrokenOnCompleteContract() {
+        Observable<Integer> o = Observable.create(new Publisher<Integer>() {
+
+            @Override
+            public void subscribe(final Subscriber<? super Integer> s) {
+                Worker inner = Schedulers.newThread().createWorker();
+                AsyncSubscription as = new AsyncSubscription();
+                as.setSubscription(EmptySubscription.INSTANCE);
+                as.setResource(inner);
+                
+                s.onSubscribe(as);
+                
+                inner.schedule(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        try {
+                            for (int i = 0; i < 10000; i++) {
+                                s.onNext(i);
+                            }
+                        } catch (Exception e) {
+                            s.onError(e);
+                        }
+                        s.onComplete();
+                        s.onComplete();
+                        s.onComplete();
+                    }
+
+                });
+            }
+        });
+
+        for (int i = 0; i < 10; i++) {
+            Observable<Integer> merge = Observable.merge(o.onBackpressureBuffer(), o.onBackpressureBuffer(), o.onBackpressureBuffer());
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            merge.subscribe(ts);
+
+            ts.awaitTerminalEvent();
+            ts.assertNoErrors();
+            ts.assertComplete();
+            List<Integer> onNextEvents = ts.values();
+            assertEquals(30000, onNextEvents.size());
+            //                System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getOnCompletedEvents().size());
+        }
+    }
+
+    @Test
+    public void testBackpressureUpstream() throws InterruptedException {
+        final AtomicInteger generated1 = new AtomicInteger();
+        Observable<Integer> o1 = createInfiniteObservable(generated1).subscribeOn(Schedulers.computation());
+        final AtomicInteger generated2 = new AtomicInteger();
+        Observable<Integer> o2 = createInfiniteObservable(generated2).subscribeOn(Schedulers.computation());
+
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                System.err.println("testSubscriber received => " + t + "  on thread " + Thread.currentThread());
+                super.onNext(t);
+            }
+        };
+
+        Observable.merge(o1.take(Observable.bufferSize() * 2), o2.take(Observable.bufferSize() * 2)).subscribe(testSubscriber);
+        testSubscriber.awaitTerminalEvent();
+        if (testSubscriber.errors().size() > 0) {
+            testSubscriber.errors().get(0).printStackTrace();
+        }
+        testSubscriber.assertNoErrors();
+        System.err.println(testSubscriber.values());
+        assertEquals(Observable.bufferSize() * 4, testSubscriber.values().size());
+        // it should be between the take num and requested batch size across the async boundary
+        System.out.println("Generated 1: " + generated1.get());
+        System.out.println("Generated 2: " + generated2.get());
+        assertTrue(generated1.get() >= Observable.bufferSize() * 2 && generated1.get() <= Observable.bufferSize() * 4);
+    }
+
+    @Test
+    public void testBackpressureUpstream2InLoop() throws InterruptedException {
+        for (int i = 0; i < 1000; i++) {
+            System.err.flush();
+            System.out.println("---");
+            System.out.flush();
+            testBackpressureUpstream2();
+        }
+    }
+    
+    @Test
+    public void testBackpressureUpstream2() throws InterruptedException {
+        final AtomicInteger generated1 = new AtomicInteger();
+        Observable<Integer> o1 = createInfiniteObservable(generated1).subscribeOn(Schedulers.computation());
+
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+            }
+        };
+
+        Observable.merge(o1.take(Observable.bufferSize() * 2), Observable.just(-99)).subscribe(testSubscriber);
+        testSubscriber.awaitTerminalEvent();
+        
+        List<Integer> onNextEvents = testSubscriber.values();
+        
+        System.out.println("Generated 1: " + generated1.get() + " / received: " + onNextEvents.size());
+        System.out.println(onNextEvents);
+
+        if (testSubscriber.errors().size() > 0) {
+            testSubscriber.errors().get(0).printStackTrace();
+        }
+        testSubscriber.assertNoErrors();
+        assertEquals(Observable.bufferSize() * 2 + 1, onNextEvents.size());
+        // it should be between the take num and requested batch size across the async boundary
+        assertTrue(generated1.get() >= Observable.bufferSize() * 2 && generated1.get() <= Observable.bufferSize() * 3);
+    }
+
+    /**
+     * This is the same as the upstreams ones, but now adds the downstream as well by using observeOn.
+     * 
+     * This requires merge to also obey the Product.request values coming from it's child subscriber.
+     */
+    @Test(timeout = 10000)
+    public void testBackpressureDownstreamWithConcurrentStreams() throws InterruptedException {
+        final AtomicInteger generated1 = new AtomicInteger();
+        Observable<Integer> o1 = createInfiniteObservable(generated1).subscribeOn(Schedulers.computation());
+        final AtomicInteger generated2 = new AtomicInteger();
+        Observable<Integer> o2 = createInfiniteObservable(generated2).subscribeOn(Schedulers.computation());
+
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                if (t < 100)
+                    try {
+                        // force a slow consumer
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                //                System.err.println("testSubscriber received => " + t + "  on thread " + Thread.currentThread());
+                super.onNext(t);
+            }
+        };
+
+        Observable.merge(o1.take(Observable.bufferSize() * 2), o2.take(Observable.bufferSize() * 2)).observeOn(Schedulers.computation()).subscribe(testSubscriber);
+        testSubscriber.awaitTerminalEvent();
+        if (testSubscriber.errors().size() > 0) {
+            testSubscriber.errors().get(0).printStackTrace();
+        }
+        testSubscriber.assertNoErrors();
+        System.err.println(testSubscriber.values());
+        assertEquals(Observable.bufferSize() * 4, testSubscriber.values().size());
+        // it should be between the take num and requested batch size across the async boundary
+        System.out.println("Generated 1: " + generated1.get());
+        System.out.println("Generated 2: " + generated2.get());
+        assertTrue(generated1.get() >= Observable.bufferSize() * 2 && generated1.get() <= Observable.bufferSize() * 4);
+    }
+
+    @Test
+    public void testBackpressureBothUpstreamAndDownstreamWithSynchronousScalarObservables() throws InterruptedException {
+        final AtomicInteger generated1 = new AtomicInteger();
+        Observable<Observable<Integer>> o1 = createInfiniteObservable(generated1)
+        .map(new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return Observable.just(t1);
+            }
+
+        });
+
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                if (t < 100)
+                    try {
+                        // force a slow consumer
+                        Thread.sleep(2);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                //                System.err.println("testSubscriber received => " + t + "  on thread " + Thread.currentThread());
+                super.onNext(t);
+            }
+        };
+
+        Observable.merge(o1).observeOn(Schedulers.computation()).take(Observable.bufferSize() * 2).subscribe(testSubscriber);
+        testSubscriber.awaitTerminalEvent();
+        if (testSubscriber.errors().size() > 0) {
+            testSubscriber.errors().get(0).printStackTrace();
+        }
+        testSubscriber.assertNoErrors();
+        System.out.println("Generated 1: " + generated1.get());
+        System.err.println(testSubscriber.values());
+        assertEquals(Observable.bufferSize() * 2, testSubscriber.values().size());
+        // it should be between the take num and requested batch size across the async boundary
+        assertTrue(generated1.get() >= Observable.bufferSize() * 2 && generated1.get() <= Observable.bufferSize() * 4);
+    }
+
+    /**
+     * Currently there is no solution to this ... we can't exert backpressure on the outer Observable if we
+     * can't know if the ones we've received so far are going to emit or not, otherwise we could starve the system.
+     * 
+     * For example, 10,000 Observables are being merged (bad use case to begin with, but ...) and it's only one of them
+     * that will ever emit. If backpressure only allowed the first 1,000 to be sent, we would hang and never receive an event.
+     * 
+     * Thus, we must allow all Observables to be sent. The ScalarSynchronousObservable use case is an exception to this since
+     * we can grab the value synchronously.
+     * 
+     * @throws InterruptedException
+     */
+    @Test(timeout = 5000)
+    public void testBackpressureBothUpstreamAndDownstreamWithRegularObservables() throws InterruptedException {
+        final AtomicInteger generated1 = new AtomicInteger();
+        Observable<Observable<Integer>> o1 = createInfiniteObservable(generated1).map(new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                return Observable.just(1, 2, 3);
+            }
+
+        });
+
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
+            int i = 0;
+
+            @Override
+            public void onNext(Integer t) {
+                if (i++ < 400)
+                    try {
+                        // force a slow consumer
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                //                System.err.println("testSubscriber received => " + t + "  on thread " + Thread.currentThread());
+                super.onNext(t);
+            }
+        };
+
+        Observable.merge(o1).observeOn(Schedulers.computation()).take(Observable.bufferSize() * 2).subscribe(testSubscriber);
+        testSubscriber.awaitTerminalEvent();
+        if (testSubscriber.errors().size() > 0) {
+            testSubscriber.errors().get(0).printStackTrace();
+        }
+        testSubscriber.assertNoErrors();
+        System.out.println("Generated 1: " + generated1.get());
+        System.err.println(testSubscriber.values());
+        System.out.println("done1 testBackpressureBothUpstreamAndDownstreamWithRegularObservables ");
+        assertEquals(Observable.bufferSize() * 2, testSubscriber.values().size());
+        System.out.println("done2 testBackpressureBothUpstreamAndDownstreamWithRegularObservables ");
+        // we can't restrict this ... see comment above
+        //        assertTrue(generated1.get() >= Observable.bufferSize() && generated1.get() <= Observable.bufferSize() * 4);
+    }
+
+    @Test
+    @Ignore("Null values not permitted")
+    public void mergeWithNullValues() {
+        System.out.println("mergeWithNullValues");
+        TestSubscriber<String> ts = new TestSubscriber<>();
+        Observable.merge(Observable.just(null, "one"), Observable.just("two", null)).subscribe(ts);
+        ts.assertTerminated();
+        ts.assertNoErrors();
+        ts.assertValues(null, "one", "two", null);
+    }
+
+    @Test
+    @Ignore("Null values are no longer permitted")
+    public void mergeWithTerminalEventAfterUnsubscribe() {
+        System.out.println("mergeWithTerminalEventAfterUnsubscribe");
+        TestSubscriber<String> ts = new TestSubscriber<>();
+        Observable<String> bad = Observable.create(new Publisher<String>() {
+
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                s.onNext("two");
+                // FIXME can't cancel downstream
+//                s.unsubscribe();
+//                s.onComplete();
+            }
+
+        });
+        Observable.merge(Observable.just(null, "one"), bad).subscribe(ts);
+        ts.assertNoErrors();
+        ts.assertValues(null, "one", "two");
+    }
+
+    @Test
+    @Ignore("Null values are not permitted")
+    public void mergingNullObservable() {
+        TestSubscriber<String> ts = new TestSubscriber<>();
+        Observable.merge(Observable.just("one"), null).subscribe(ts);
+        ts.assertNoErrors();
+        ts.assertValue("one");
+    }
+
+    @Test
+    public void merge1AsyncStreamOf1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNAsyncStreamsOfN(1, 1).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1, ts.values().size());
+    }
+
+    @Test
+    public void merge1AsyncStreamOf1000() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNAsyncStreamsOfN(1, 1000).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1000, ts.values().size());
+    }
+
+    @Test
+    public void merge10AsyncStreamOf1000() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNAsyncStreamsOfN(10, 1000).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(10000, ts.values().size());
+    }
+
+    @Test
+    public void merge1000AsyncStreamOf1000() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNAsyncStreamsOfN(1000, 1000).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1000000, ts.values().size());
+    }
+
+    @Test
+    public void merge2000AsyncStreamOf100() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNAsyncStreamsOfN(2000, 100).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(200000, ts.values().size());
+    }
+
+    @Test
+    public void merge100AsyncStreamOf1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNAsyncStreamsOfN(100, 1).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(100, ts.values().size());
+    }
+
+    private Observable<Integer> mergeNAsyncStreamsOfN(final int outerSize, final int innerSize) {
+        Observable<Observable<Integer>> os = Observable.range(1, outerSize)
+        .map(new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer i) {
+                return Observable.range(1, innerSize).subscribeOn(Schedulers.computation());
+            }
+
+        });
+        return Observable.merge(os);
+    }
+
+    @Test
+    public void merge1SyncStreamOf1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNSyncStreamsOfN(1, 1).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1, ts.values().size());
+    }
+
+    @Test
+    public void merge1SyncStreamOf1000000() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNSyncStreamsOfN(1, 1000000).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1000000, ts.values().size());
+    }
+
+    @Test
+    public void merge1000SyncStreamOf1000() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNSyncStreamsOfN(1000, 1000).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1000000, ts.values().size());
+    }
+
+    @Test
+    public void merge10000SyncStreamOf10() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNSyncStreamsOfN(10000, 10).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(100000, ts.values().size());
+    }
+
+    @Test
+    public void merge1000000SyncStreamOf1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        mergeNSyncStreamsOfN(1000000, 1).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(1000000, ts.values().size());
+    }
+
+    private Observable<Integer> mergeNSyncStreamsOfN(final int outerSize, final int innerSize) {
+        Observable<Observable<Integer>> os = Observable.range(1, outerSize)
+        .map(new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Integer i) {
+                return Observable.range(1, innerSize);
+            }
+
+        });
+        return Observable.merge(os);
+    }
+
+    private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
+        Observable<Integer> observable = Observable.fromIterable(new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+
+                    @Override
+                    public void remove() {
+                    }
+
+                    @Override
+                    public Integer next() {
+                        return generated.getAndIncrement();
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+                };
+            }
+        });
+        return observable;
+    }
+
+    @Test
+    public void mergeManyAsyncSingle() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        Observable<Observable<Integer>> os = Observable.range(1, 10000)
+        .map(new Function<Integer, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(final Integer i) {
+                return Observable.create(new Publisher<Integer>() {
+
+                    @Override
+                    public void subscribe(Subscriber<? super Integer> s) {
+                        s.onSubscribe(EmptySubscription.INSTANCE);
+                        if (i < 500) {
+                            try {
+                                Thread.sleep(1);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                        s.onNext(i);
+                        s.onComplete();
+                    }
+
+                }).subscribeOn(Schedulers.computation()).cache();
+            }
+
+        });
+        Observable.merge(os).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(10000, ts.values().size());
+    }
+
+    @Test
+    public void shouldCompleteAfterApplyingBackpressure_NormalPath() {
+        Observable<Integer> source = Observable.mergeDelayError(Observable.just(Observable.range(1, 2)));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>((Long)null);
+        source.subscribe(subscriber);
+        subscriber.request(3); // 1, 2, <complete> - with request(2) we get the 1 and 2 but not the <complete>
+        subscriber.assertValues(1, 2);
+        subscriber.assertTerminated();
+    }
+
+    @Test
+    public void shouldCompleteAfterApplyingBackpressure_FastPath() {
+        Observable<Integer> source = Observable.mergeDelayError(Observable.just(Observable.just(1)));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>((Long)null);
+        source.subscribe(subscriber);
+        subscriber.request(2); // 1, <complete> - should work as per .._NormalPath above
+        subscriber.assertValue(1);
+        subscriber.assertTerminated();
+    }
+
+    @Test
+    public void shouldNotCompleteIfThereArePendingScalarSynchronousEmissionsWhenTheLastInnerSubscriberCompletes() {
+        TestScheduler scheduler = Schedulers.test();
+        Observable<Long> source = Observable.mergeDelayError(Observable.just(1L), Observable.timer(1, TimeUnit.SECONDS, scheduler).skip(1));
+        TestSubscriber<Long> subscriber = new TestSubscriber<>((Long)null);
+        source.subscribe(subscriber);
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        subscriber.assertNoValues();
+        subscriber.assertNotComplete();
+        subscriber.request(1);
+        subscriber.assertValue(1L);
+// TODO: it should be acceptable to get a completion event without requests
+//        assertEquals(Collections.<Notification<Long>>emptyList(), subscriber.getOnCompletedEvents());
+//        subscriber.request(1);
+        subscriber.assertTerminated();
+    }
+
+    @Test
+    public void delayedErrorsShouldBeEmittedWhenCompleteAfterApplyingBackpressure_NormalPath() {
+        Throwable exception = new Throwable();
+        Observable<Integer> source = Observable.mergeDelayError(Observable.range(1, 2), Observable.<Integer>error(exception));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>((Long)null);
+        source.subscribe(subscriber);
+        subscriber.request(3); // 1, 2, <error>
+        subscriber.assertValues(1, 2);
+        subscriber.assertTerminated();
+        assertEquals(asList(exception), subscriber.errors());
+    }
+
+    @Test
+    public void delayedErrorsShouldBeEmittedWhenCompleteAfterApplyingBackpressure_FastPath() {
+        Throwable exception = new Throwable();
+        Observable<Integer> source = Observable.mergeDelayError(Observable.just(1), Observable.<Integer>error(exception));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>((Long)null);
+        source.subscribe(subscriber);
+        subscriber.request(2); // 1, <error>
+        subscriber.assertValue(1);
+        subscriber.assertTerminated();
+        assertEquals(asList(exception), subscriber.errors());
+    }
+
+    @Test
+    public void shouldNotCompleteWhileThereAreStillScalarSynchronousEmissionsInTheQueue() {
+        Observable<Integer> source = Observable.merge(Observable.just(1), Observable.just(2));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>(1L);
+        source.subscribe(subscriber);
+        subscriber.assertValue(1);
+        subscriber.request(1);
+        subscriber.assertValues(1, 2);
+    }
+
+    @Test
+    public void shouldNotReceivedDelayedErrorWhileThereAreStillScalarSynchronousEmissionsInTheQueue() {
+        Throwable exception = new Throwable();
+        Observable<Integer> source = Observable.mergeDelayError(Observable.just(1), Observable.just(2), Observable.<Integer>error(exception));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>((Long)null);
+        subscriber.request(1);
+        source.subscribe(subscriber);
+        subscriber.assertValue(1);
+        assertEquals(Collections.<Throwable>emptyList(), subscriber.errors());
+        subscriber.request(1);
+        subscriber.assertValues(1, 2);
+        assertEquals(asList(exception), subscriber.errors());
+    }
+
+    @Test
+    public void shouldNotReceivedDelayedErrorWhileThereAreStillNormalEmissionsInTheQueue() {
+        Throwable exception = new Throwable();
+        Observable<Integer> source = Observable.mergeDelayError(Observable.range(1, 2), Observable.range(3, 2), Observable.<Integer>error(exception));
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>((Long)null);
+        subscriber.request(3);
+        source.subscribe(subscriber);
+        subscriber.assertValues(1, 2, 3);
+        assertEquals(Collections.<Throwable>emptyList(), subscriber.errors());
+        subscriber.request(2);
+        subscriber.assertValues(1, 2, 3, 4);
+        assertEquals(asList(exception), subscriber.errors());
+    }
+    
+    @Test
+    public void testMergeKeepsRequesting() throws InterruptedException {
+        //for (int i = 0; i < 5000; i++) {
+            //System.out.println(i + ".......................................................................");
+            final CountDownLatch latch = new CountDownLatch(1);
+            final ConcurrentLinkedQueue<String> messages = new ConcurrentLinkedQueue<>();
+
+            Observable.range(1, 2)
+                    // produce many integers per second
+                    .flatMap(new Function<Integer, Observable<Integer>>() {
+                        @Override
+                        public Observable<Integer> apply(final Integer number) {
+                            return Observable.range(1, Integer.MAX_VALUE)
+                                    .doOnRequest(new LongConsumer() {
+
+                                        @Override
+                                        public void accept(long n) {
+                                            messages.add(">>>>>>>> A requested[" + number + "]: " + n);
+                                        }
+
+                                    })
+                                    // pause a bit
+                                    .doOnNext(pauseForMs(3))
+                                    // buffer on backpressure
+                                    .onBackpressureBuffer()
+                                    // do in parallel
+                                    .subscribeOn(Schedulers.computation())
+                                    .doOnRequest(new LongConsumer() {
+
+                                        @Override
+                                        public void accept(long n) {
+                                            messages.add(">>>>>>>> B requested[" + number + "]: " + n);
+                                        }
+
+                                    });
+                        }
+
+                    })
+                    // take a number bigger than 2* Observable.bufferSize() (used by OperatorMerge)
+                    .take(Observable.bufferSize() * 2 + 1)
+                    // log count
+                    .doOnNext(printCount())
+                    // release latch
+                    .doOnComplete(() -> {
+                            latch.countDown();
+                    }).subscribe();
+            boolean a = latch.await(2, TimeUnit.SECONDS);
+            if (!a) {
+                for (String s : messages) {
+                    System.out.println("DEBUG => " + s);
+                }
+            }
+            assertTrue(a);
+        //}
+    }
+    
+    @Test
+    public void testMergeRequestOverflow() throws InterruptedException {
+        //do a non-trivial merge so that future optimisations with EMPTY don't invalidate this test
+        Observable<Integer> o = Observable.fromIterable(Arrays.asList(1,2))
+                .mergeWith(Observable.fromIterable(Arrays.asList(3,4)));
+        final int expectedCount = 4;
+        final CountDownLatch latch = new CountDownLatch(expectedCount);
+        o.subscribeOn(Schedulers.computation()).subscribe(new Observer<Integer>() {
+            
+            @Override
+            public void onStart() {
+                request(1);
+            }
+
+            @Override
+            public void onComplete() {
+                //ignore
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                latch.countDown();
+                request(2);
+                request(Long.MAX_VALUE-1);
+            }});
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+    }
+
+    private static Consumer<Integer> printCount() {
+        return new Consumer<Integer>() {
+            long count;
+
+            @Override
+            public void accept(Integer t1) {
+                count++;
+                System.out.println("count=" + count);
+            }
+        };
+    }
+
+    private static Consumer<Integer> pauseForMs(final long time) {
+        return new Consumer<Integer>() {
+            @Override
+            public void accept(Integer s) {
+                try {
+                    Thread.sleep(time);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+    
+    Function<Integer, Observable<Integer>> toScalar = Observable::just;
+    
+    Function<Integer, Observable<Integer>> toHiddenScalar = t ->
+            Observable.just(t).asObservable();
+    ;
+    
+    void runMerge(Function<Integer, Observable<Integer>> func, TestSubscriber<Integer> ts) {
+        List<Integer> list = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            list.add(i);
+        }
+        Observable<Integer> source = Observable.fromIterable(list);
+        source.flatMap(func).subscribe(ts);
+        
+        if (ts.values().size() != 1000) {
+            System.out.println(ts.values());
+        }
+        
+        ts.assertTerminated();
+        ts.assertNoErrors();
+        ts.assertValueSequence(list);
+    }
+    
+    @Test
+    public void testFastMergeFullScalar() {
+        runMerge(toScalar, new TestSubscriber<Integer>());
+    }
+    @Test
+    public void testFastMergeHiddenScalar() {
+        runMerge(toHiddenScalar, new TestSubscriber<Integer>());
+    }
+    @Test
+    public void testSlowMergeFullScalar() {
+        for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>((long)req) {
+                int remaining = req;
+
+                @Override
+                public void onNext(Integer t) {
+                    super.onNext(t);
+                    if (--remaining == 0) {
+                        remaining = req;
+                        request(req);
+                    }
+                }
+            };
+            runMerge(toScalar, ts);
+        }
+    }
+    @Test
+    public void testSlowMergeHiddenScalar() {
+        for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>((long)req) {
+                int remaining = req;
+                @Override
+                public void onNext(Integer t) {
+                    super.onNext(t);
+                    if (--remaining == 0) {
+                        remaining = req;
+                        request(req);
+                    }
+                }
+            };
+            runMerge(toHiddenScalar, ts);
+        }
+    }
+}


### PR DESCRIPTION
+ added operator flatMap of notifications, fixed a bug in onBackpressureBuffer

Note also the few ignored tests because they either want to test against a null value or try to throw from RS methods.