### PR TITLE
2.x: operator tests: publish, reduce, repeat + fixes

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1953,12 +1953,12 @@ public class Observable<T> implements Publisher<T> {
         if (n < 0) {
             throw new IllegalArgumentException("n >= required but it was " + n);
         } else
-            if (n == 0) {
-                return ignoreElements();
-            } else
-                if (n == 1) {
-                    return lift(OperatorTakeLastOne.instance());
-                }
+        if (n == 0) {
+            return ignoreElements();
+        } else
+        if (n == 1) {
+            return lift(OperatorTakeLastOne.instance());
+        }
         return lift(new OperatorTakeLast<>(n));
     }
 
@@ -2252,6 +2252,14 @@ public class Observable<T> implements Publisher<T> {
 
             coll.add(value);
         });
+    }
+    
+    public final Single<T> toSingle() {
+        return Single.fromPublisher(this);
+    }
+    
+    public final NbpObservable<T> toNbpObservable() {
+        return NbpObservable.fromPublisher(this);
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes"})

--- a/src/main/java/io/reactivex/internal/disposables/SetCompositeResource.java
+++ b/src/main/java/io/reactivex/internal/disposables/SetCompositeResource.java
@@ -118,6 +118,18 @@ public final class SetCompositeResource<T> implements CompositeResource<T>, Disp
         }
     }
     
+    public int size() {
+        synchronized (this) {
+            OpenHashSet<T> a = set;
+            if (a == null) {
+                return 0;
+            }
+            int[] c = new int[1];
+            a.forEach(v -> c[0]++);
+            return c[0];
+        }
+    }
+    
     @Override
     public void dispose() {
         if (!disposed) {

--- a/src/main/java/io/reactivex/internal/operators/OperatorPublish.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorPublish.java
@@ -657,19 +657,10 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
          * will prevent the dispatch() to emit (too many) values to a terminated child subscriber.
          */
         static final long UNSUBSCRIBED = Long.MIN_VALUE;
-        /**
-         * Indicates this child has not yet requested any value. We pretend we don't
-         * see such child subscribers in dispatch() to allow other child subscribers who
-         * have requested to make progress. In a concurrent subscription scennario,
-         * one can't be sure when a subscription happens exactly so this virtual shift
-         * should not cause any problems.
-         */
-        static final long NOT_REQUESTED = Long.MIN_VALUE / 2;
         
         public InnerProducer(PublishSubscriber<T> parent, Subscriber<? super T> child) {
             this.parent = parent;
             this.child = child;
-            this.lazySet(NOT_REQUESTED);
         }
         
         @Override
@@ -694,7 +685,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
                 }
                 long u;
                 // if this child has not requested yet
-                if (r == NOT_REQUESTED) {
+                if (r == 0L) {
                     // let the new request value this (no overflow check needed)
                     u = n;
                 } else {
@@ -733,7 +724,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
                 long r = get();
                 // if no request has been made yet, we shouldn't have emitted to this child
                 // subscriber so there is a bug in this operator
-                if (r == NOT_REQUESTED) {
+                if (r == 0L) {
                     throw new IllegalStateException("Produced without request");
                 }
                 // if the child has unsubscribed, simply return and indicate this

--- a/src/main/java/io/reactivex/internal/operators/PublisherRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherRedo.java
@@ -115,6 +115,9 @@ public final class PublisherRedo<T> implements Publisher<T> {
                         if (WIP.getAndIncrement(this) == 0) {
                             int missed = 1;
                             for (;;) {
+                                if (arbiter.isCancelled()) {
+                                    return;
+                                }
                                 source.subscribe(this);
                             
                                 missed = WIP.addAndGet(this, -missed);

--- a/src/main/java/io/reactivex/internal/operators/PublisherRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherRepeat.java
@@ -32,7 +32,7 @@ public final class PublisherRepeat<T> implements Publisher<T> {
         SubscriptionArbiter sa = new SubscriptionArbiter();
         s.onSubscribe(sa);
         
-        RepeatSubscriber<T> rs = new RepeatSubscriber<>(s, count, sa, source);
+        RepeatSubscriber<T> rs = new RepeatSubscriber<>(s, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sa, source);
         rs.subscribeNext();
     }
     
@@ -86,6 +86,9 @@ public final class PublisherRepeat<T> implements Publisher<T> {
             if (getAndIncrement() == 0) {
                 int missed = 1;
                 for (;;) {
+                    if (sa.isCancelled()) {
+                        return;
+                    }
                     source.subscribe(this);
                     
                     missed = addAndGet(-missed);

--- a/src/main/java/io/reactivex/internal/operators/PublisherRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherRetryPredicate.java
@@ -106,6 +106,9 @@ public final class PublisherRetryPredicate<T> implements Publisher<T> {
             if (getAndIncrement() == 0) {
                 int missed = 1;
                 for (;;) {
+                    if (sa.isCancelled()) {
+                        return;
+                    }
                     source.subscribe(this);
                     
                     missed = addAndGet(-missed);

--- a/src/main/java/io/reactivex/internal/operators/PublisherSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherSubscribeOn.java
@@ -19,7 +19,6 @@ import org.reactivestreams.*;
 
 import io.reactivex.Scheduler;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.plugins.RxJavaPlugins;
 
 public final class PublisherSubscribeOn<T> implements Publisher<T> {
     final Publisher<? extends T> source;
@@ -67,9 +66,7 @@ public final class PublisherSubscribeOn<T> implements Publisher<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (this.s != null) {
-                s.cancel();
-                RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
                 return;
             }
             this.s = s;

--- a/src/main/java/io/reactivex/internal/schedulers/IOScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IOScheduler.java
@@ -177,6 +177,10 @@ public final class IOScheduler extends Scheduler implements SchedulerLifecycle {
     public Worker createWorker() {
         return new EventLoopWorker(pool.get());
     }
+    
+    public int size() {
+        return pool.get().allWorkers.size();
+    }
 
     private static final class EventLoopWorker extends Scheduler.Worker {
         private final SetCompositeResource<Disposable> tasks;
@@ -201,9 +205,11 @@ public final class IOScheduler extends Scheduler implements SchedulerLifecycle {
                 // releasing the pool should be the last action
                 // should prevent pool reuse in case there is a blocking
                 // action not responding to cancellation
-                threadWorker.scheduleDirect(() -> {
-                    pool.release(threadWorker);
-                }, 0, TimeUnit.MILLISECONDS);
+//                threadWorker.scheduleDirect(() -> {
+//                    pool.release(threadWorker);
+//                }, 0, TimeUnit.MILLISECONDS);
+
+                pool.release(threadWorker);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
@@ -144,6 +144,10 @@ public final class SubscriptionArbiter extends AtomicInteger implements Subscrip
         }, this::drain);
     }
     
+    public boolean isCancelled() {
+        return cancelled;
+    }
+    
     void drain() {
         long mr = MISSED_REQUESTED.getAndSet(this, 0L);
         long mp = MISSED_PRODUCED.getAndSet(this, 0L);

--- a/src/test/java/io/reactivex/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -24,6 +24,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Observable;
 import io.reactivex.TestHelper;
+import io.reactivex.internal.schedulers.IOScheduler;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -188,10 +189,16 @@ public class OperatorMergeMaxConcurrentTest {
             ts.assertValueSequence(result);
         }
     }
-    @Test(timeout = 20000)
+    @Test//(timeout = 20000)
     public void testSimpleAsyncLoop() {
+        IOScheduler ios = (IOScheduler)Schedulers.io();
+        int c = ios.size();
         for (int i = 0; i < 200; i++) {
             testSimpleAsync();
+            int c1 = ios.size();
+            if (c + 60 < c1) {
+                throw new AssertionError("Worker leak: " + c + " - " + c1);
+            }
         }
     }
     @Test(timeout = 10000)

--- a/src/test/java/io/reactivex/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorMergeTest.java
@@ -38,9 +38,35 @@ public class OperatorMergeTest {
 
     Subscriber<String> stringObserver;
 
+    int count;
+    
     @Before
     public void before() {
         stringObserver = TestHelper.mockSubscriber();
+        
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().startsWith("RxNewThread")) {
+                count++;
+            }
+        }
+    }
+    
+    @After
+    public void after() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().startsWith("RxNewThread")) {
+                --count;
+            }
+        }
+        if (count != 0) {
+            throw new IllegalStateException("NewThread leak!");
+        }
     }
 
     @Test
@@ -555,6 +581,7 @@ public class OperatorMergeTest {
                         } catch (Exception e) {
                             s.onError(e);
                         }
+                        as.dispose();
                         s.onComplete();
                     }
 
@@ -599,6 +626,7 @@ public class OperatorMergeTest {
                         } catch (Exception e) {
                             s.onError(e);
                         }
+                        as.dispose();
                         s.onComplete();
                         s.onComplete();
                         s.onComplete();

--- a/src/test/java/io/reactivex/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorPublishTest.java
@@ -1,0 +1,401 @@
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.schedulers.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorPublishTest {
+
+    @Test
+    public void testPublish() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        ConnectableObservable<String> o = Observable.create(new Publisher<String>() {
+
+            @Override
+            public void subscribe(final Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                new Thread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        counter.incrementAndGet();
+                        observer.onNext("one");
+                        observer.onComplete();
+                    }
+                }).start();
+            }
+        }).publish();
+
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        // subscribe once
+        o.subscribe(new Consumer<String>() {
+
+            @Override
+            public void accept(String v) {
+                assertEquals("one", v);
+                latch.countDown();
+            }
+        });
+
+        // subscribe again
+        o.subscribe(new Consumer<String>() {
+
+            @Override
+            public void accept(String v) {
+                assertEquals("one", v);
+                latch.countDown();
+            }
+        });
+
+        Disposable s = o.connect();
+        try {
+            if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
+                fail("subscriptions did not receive values");
+            }
+            assertEquals(1, counter.get());
+        } finally {
+            s.dispose();
+        }
+    }
+
+    @Test
+    public void testBackpressureFastSlow() {
+        ConnectableObservable<Integer> is = Observable.range(1, Observable.bufferSize() * 2).publish();
+        Observable<Integer> fast = is.observeOn(Schedulers.computation())
+        .doOnComplete(() -> System.out.println("^^^^^^^^^^^^^ completed FAST"));
+
+        Observable<Integer> slow = is.observeOn(Schedulers.computation()).map(new Function<Integer, Integer>() {
+            int c = 0;
+
+            @Override
+            public Integer apply(Integer i) {
+                if (c == 0) {
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                    }
+                }
+                c++;
+                return i;
+            }
+
+        }).doOnComplete(new Runnable() {
+
+            @Override
+            public void run() {
+                System.out.println("^^^^^^^^^^^^^ completed SLOW");
+            }
+
+        });
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        Observable.merge(fast, slow).subscribe(ts);
+        is.connect();
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals(Observable.bufferSize() * 4, ts.valueCount());
+    }
+
+    // use case from https://github.com/ReactiveX/RxJava/issues/1732
+    @Test
+    public void testTakeUntilWithPublishedStreamUsingSelector() {
+        final AtomicInteger emitted = new AtomicInteger();
+        Observable<Integer> xs = Observable.range(0, Observable.bufferSize() * 2).doOnNext(new Consumer<Integer>() {
+
+            @Override
+            public void accept(Integer t1) {
+                emitted.incrementAndGet();
+            }
+
+        });
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        xs.publish(new Function<Observable<Integer>, Observable<Integer>>() {
+
+            @Override
+            public Observable<Integer> apply(Observable<Integer> xs) {
+                return xs.takeUntil(xs.skipWhile(new Predicate<Integer>() {
+
+                    @Override
+                    public boolean test(Integer i) {
+                        return i <= 3;
+                    }
+
+                }));
+            }
+
+        }).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        ts.assertValues(0, 1, 2, 3);
+        assertEquals(5, emitted.get());
+        System.out.println(ts.values());
+    }
+
+    // use case from https://github.com/ReactiveX/RxJava/issues/1732
+    @Test
+    public void testTakeUntilWithPublishedStream() {
+        Observable<Integer> xs = Observable.range(0, Observable.bufferSize() * 2);
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ConnectableObservable<Integer> xsp = xs.publish();
+        xsp.takeUntil(xsp.skipWhile(new Predicate<Integer>() {
+
+            @Override
+            public boolean test(Integer i) {
+                return i <= 3;
+            }
+
+        })).subscribe(ts);
+        xsp.connect();
+        System.out.println(ts.values());
+    }
+
+    @Test(timeout = 10000)
+    public void testBackpressureTwoConsumers() {
+        final AtomicInteger sourceEmission = new AtomicInteger();
+        final AtomicBoolean sourceUnsubscribed = new AtomicBoolean();
+        final Observable<Integer> source = Observable.range(1, 100)
+                .doOnNext(new Consumer<Integer>() {
+                    @Override
+                    public void accept(Integer t1) {
+                        sourceEmission.incrementAndGet();
+                    }
+                })
+                .doOnCancel(new Runnable() {
+                    @Override
+                    public void run() {
+                        sourceUnsubscribed.set(true);
+                    }
+                }).share();
+        ;
+        
+        final AtomicBoolean child1Unsubscribed = new AtomicBoolean();
+        final AtomicBoolean child2Unsubscribed = new AtomicBoolean();
+
+        final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                if (valueCount() == 2) {
+                    source.doOnCancel(new Runnable() {
+                        @Override
+                        public void run() {
+                            child2Unsubscribed.set(true);
+                        }
+                    }).take(5).subscribe(ts2);
+                }
+                super.onNext(t);
+            }
+        };
+        
+        source.doOnCancel(new Runnable() {
+            @Override
+            public void run() {
+                child1Unsubscribed.set(true);
+            }
+        }).take(5)
+        .subscribe(ts1);
+        
+        ts1.awaitTerminalEvent();
+        ts2.awaitTerminalEvent();
+        
+        ts1.assertNoErrors();
+        ts2.assertNoErrors();
+        
+        assertTrue(sourceUnsubscribed.get());
+        assertTrue(child1Unsubscribed.get());
+        assertTrue(child2Unsubscribed.get());
+        
+        ts1.assertValues(1, 2, 3, 4, 5);
+        ts2.assertValues(4, 5, 6, 7, 8);
+        
+        assertEquals(8, sourceEmission.get());
+    }
+
+    @Test
+    public void testConnectWithNoSubscriber() {
+        TestScheduler scheduler = new TestScheduler();
+        ConnectableObservable<Long> co = Observable.interval(10, 10, TimeUnit.MILLISECONDS, scheduler).take(3).publish();
+        co.connect();
+        // Emit 0
+        scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
+        TestSubscriber<Long> subscriber = new TestSubscriber<>();
+        co.subscribe(subscriber);
+        // Emit 1 and 2
+        scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
+        subscriber.assertValues(1L, 2L);
+        subscriber.assertNoErrors();
+        subscriber.assertTerminated();
+    }
+    
+    @Test
+    public void testSubscribeAfterDisconnectThenConnect() {
+        ConnectableObservable<Integer> source = Observable.just(1).publish();
+
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+
+        source.subscribe(ts1);
+
+        Disposable s = source.connect();
+
+        ts1.assertValue(1);
+        ts1.assertNoErrors();
+        ts1.assertTerminated();
+
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+
+        source.subscribe(ts2);
+
+        Disposable s2 = source.connect();
+
+        ts2.assertValue(1);
+        ts2.assertNoErrors();
+        ts2.assertTerminated();
+
+        System.out.println(s);
+        System.out.println(s2);
+    }
+    
+    @Test
+    public void testNoSubscriberRetentionOnCompleted() {
+        OperatorPublish<Integer> source = (OperatorPublish<Integer>)Observable.just(1).publish();
+
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+
+        source.unsafeSubscribe(ts1);
+
+        ts1.assertNoValues();
+        ts1.assertNoErrors();
+        ts1.assertNotComplete();
+        
+        source.connect();
+
+        ts1.assertValue(1);
+        ts1.assertNoErrors();
+        ts1.assertTerminated();
+
+        assertNull(source.current.get());
+    }
+    
+    @Test
+    public void testNonNullConnection() {
+        ConnectableObservable<Object> source = Observable.never().publish();
+        
+        assertNotNull(source.connect());
+        assertNotNull(source.connect());
+    }
+    
+    @Test
+    public void testNoDisconnectSomeoneElse() {
+        ConnectableObservable<Object> source = Observable.never().publish();
+
+        Disposable s1 = source.connect();
+        Disposable s2 = source.connect();
+        
+        s1.dispose();
+        
+        Disposable s3 = source.connect();
+        
+        s2.dispose();
+        
+        assertTrue(checkPublishDisposed(s1));
+        assertTrue(checkPublishDisposed(s2));
+        assertFalse(checkPublishDisposed(s3));
+    }
+    
+    @SuppressWarnings("unchecked")
+    static boolean checkPublishDisposed(Disposable d) {
+        return ((OperatorPublish.PublishSubscriber<Object>)d).isDisposed();
+    }
+    
+    @Test
+    public void testZeroRequested() {
+        ConnectableObservable<Integer> source = Observable.just(1).publish();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        
+        source.subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        source.connect();
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(5);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertTerminated();
+    }
+    @Test
+    public void testConnectIsIdempotent() {
+        final AtomicInteger calls = new AtomicInteger();
+        Observable<Integer> source = Observable.create(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> t) {
+                t.onSubscribe(EmptySubscription.INSTANCE);
+                calls.getAndIncrement();
+            }
+        });
+        
+        ConnectableObservable<Integer> conn = source.publish();
+
+        assertEquals(0, calls.get());
+
+        conn.connect();
+        conn.connect();
+        
+        assertEquals(1, calls.get());
+        
+        conn.connect().dispose();
+        
+        conn.connect();
+        conn.connect();
+
+        assertEquals(2, calls.get());
+    }
+    @Test
+    public void testObserveOn() {
+        ConnectableObservable<Integer> co = Observable.range(0, 1000).publish();
+        Observable<Integer> obs = co.observeOn(Schedulers.computation());
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 1; j < 6; j++) {
+                List<TestSubscriber<Integer>> tss = new ArrayList<>();
+                for (int k = 1; k < j; k++) {
+                    TestSubscriber<Integer> ts = new TestSubscriber<>();
+                    tss.add(ts);
+                    obs.subscribe(ts);
+                }
+                
+                Disposable s = co.connect();
+                
+                for (TestSubscriber<Integer> ts : tss) {
+                    ts.awaitTerminalEvent(2, TimeUnit.SECONDS);
+                    ts.assertTerminated();
+                    ts.assertNoErrors();
+                    assertEquals(1000, ts.valueCount());
+                }
+                s.dispose();
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorReduceTest.java
@@ -1,0 +1,116 @@
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+
+public class OperatorReduceTest {
+    Subscriber<Object> observer;
+
+    @Before
+    public void before() {
+        observer = TestHelper.mockSubscriber();
+    }
+
+    BiFunction<Integer, Integer, Integer> sum = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer t1, Integer t2) {
+            return t1 + t2;
+        }
+    };
+
+    @Test
+    public void testAggregateAsIntSum() {
+
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5).reduce(0, sum)
+                .map(v -> v);
+
+        result.subscribe(observer);
+
+        verify(observer).onNext(1 + 2 + 3 + 4 + 5);
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testAggregateAsIntSumSourceThrows() {
+        Observable<Integer> result = Observable.concat(Observable.just(1, 2, 3, 4, 5),
+                Observable.<Integer> error(new TestException()))
+                .reduce(0, sum).map(v -> v);
+
+        result.subscribe(observer);
+
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testAggregateAsIntSumAccumulatorThrows() {
+        BiFunction<Integer, Integer, Integer> sumErr = new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                throw new TestException();
+            }
+        };
+
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
+                .reduce(0, sumErr).map(v -> v);
+
+        result.subscribe(observer);
+
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testAggregateAsIntSumResultSelectorThrows() {
+
+        Function<Integer, Integer> error = new Function<Integer, Integer>() {
+
+            @Override
+            public Integer apply(Integer t1) {
+                throw new TestException();
+            }
+        };
+
+        Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
+                .reduce(0, sum).map(error);
+
+        result.subscribe(observer);
+
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testBackpressureWithNoInitialValue() throws InterruptedException {
+        Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
+        Observable<Integer> reduced = source.reduce(sum);
+
+        Integer r = reduced.toBlocking().first();
+        assertEquals(21, r.intValue());
+    }
+
+    @Test
+    public void testBackpressureWithInitialValue() throws InterruptedException {
+        Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
+        Observable<Integer> reduced = source.reduce(0, sum);
+
+        Integer r = reduced.toBlocking().first();
+        assertEquals(21, r.intValue());
+    }
+
+
+
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorRepeatTest.java
@@ -1,0 +1,184 @@
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorRepeatTest {
+
+    @Test(timeout = 2000)
+    public void testRepetition() {
+        int NUM = 10;
+        final AtomicInteger count = new AtomicInteger();
+        int value = Observable.create(new Publisher<Integer>() {
+
+            @Override
+            public void subscribe(final Subscriber<? super Integer> o) {
+                o.onNext(count.incrementAndGet());
+                o.onComplete();
+            }
+        }).repeat().subscribeOn(Schedulers.computation())
+        .take(NUM).toBlocking().last();
+
+        assertEquals(NUM, value);
+    }
+
+    @Test(timeout = 2000)
+    public void testRepeatTake() {
+        Observable<Integer> xs = Observable.just(1, 2);
+        Object[] ys = xs.repeat().subscribeOn(Schedulers.newThread()).take(4).toList().toBlocking().last().toArray();
+        assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
+    }
+
+    @Test(timeout = 20000)
+    public void testNoStackOverFlow() {
+        Observable.just(1).repeat().subscribeOn(Schedulers.newThread()).take(100000).toBlocking().last();
+    }
+
+    @Test
+    public void testRepeatTakeWithSubscribeOn() throws InterruptedException {
+
+        final AtomicInteger counter = new AtomicInteger();
+        Observable<Integer> oi = Observable.create(new Publisher<Integer>() {
+
+            @Override
+            public void subscribe(Subscriber<? super Integer> sub) {
+                sub.onSubscribe(EmptySubscription.INSTANCE);
+                counter.incrementAndGet();
+                sub.onNext(1);
+                sub.onNext(2);
+                sub.onComplete();
+            }
+        }).subscribeOn(Schedulers.newThread());
+
+        Object[] ys = oi.repeat().subscribeOn(Schedulers.newThread()).map(new Function<Integer, Integer>() {
+
+            @Override
+            public Integer apply(Integer t1) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                return t1;
+            }
+
+        }).take(4).toList().toBlocking().last().toArray();
+
+        assertEquals(2, counter.get());
+        assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
+    }
+
+    @Test(timeout = 2000)
+    public void testRepeatAndTake() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        Observable.just(1).repeat().take(10).subscribe(o);
+        
+        verify(o, times(10)).onNext(1);
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test(timeout = 2000)
+    public void testRepeatLimited() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        Observable.just(1).repeat(10).subscribe(o);
+        
+        verify(o, times(10)).onNext(1);
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test(timeout = 2000)
+    public void testRepeatError() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        Observable.error(new TestException()).repeat(10).subscribe(o);
+        
+        verify(o).onError(any(TestException.class));
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+        
+    }
+
+    @Test(timeout = 2000)
+    public void testRepeatZero() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        Observable.just(1).repeat(0).subscribe(o);
+        
+        verify(o).onComplete();
+        verify(o, never()).onNext(any());
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test(timeout = 2000)
+    public void testRepeatOne() {
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+        
+        Observable.just(1).repeat(1).subscribe(o);
+        
+        verify(o).onComplete();
+        verify(o, times(1)).onNext(any());
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    
+    /** Issue #2587. */
+    @Test
+    public void testRepeatAndDistinctUnbounded() {
+        Observable<Integer> src = Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5))
+                .take(3)
+                .repeat(3)
+                .distinct();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        src.subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertTerminated();
+        ts.assertValues(1, 2, 3);
+    }
+    
+    /** Issue #2844: wrong target of request. */
+    @Test(timeout = 3000)
+    public void testRepeatRetarget() {
+        final List<Integer> concatBase = new ArrayList<>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        Observable.just(1, 2)
+        .repeat(5)
+        .concatMap(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer x) {
+                System.out.println("testRepeatRetarget -> " + x);
+                concatBase.add(x);
+                return Observable.<Integer>empty()
+                        .delay(200, TimeUnit.MILLISECONDS);
+            }
+        })
+        .subscribe(ts);
+
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        ts.assertNoValues();
+        
+        assertEquals(Arrays.asList(1, 2, 1, 2, 1, 2, 1, 2, 1, 2), concatBase);
+    }
+}


### PR DESCRIPTION
+ added toSingle and toNbpObservable to Observable
+ fixed bugs in many operators and in the IO scheduler's release logic