### PR TITLE
2.x: operator test: retry, retryWhen

### DIFF
--- a/src/main/java/io/reactivex/Try.java
+++ b/src/main/java/io/reactivex/Try.java
@@ -108,7 +108,7 @@ public final class Try<T> {
     @Override
     public String toString() {
         if (error != null) {
-            return "Try[" + error + "]";
+            return "Try[ " + error + " ]";
         }
         return "Try[" + value + "]";
     }

--- a/src/main/java/io/reactivex/internal/operators/OperatorMap.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorMap.java
@@ -72,6 +72,12 @@ public final class OperatorMap<T, U> implements Operator<U, T> {
                 actual.onError(e);
                 return;
             }
+            if (u == null) {
+                done = true;
+                subscription.cancel();
+                actual.onError(new NullPointerException("Value returned by the function is null"));
+                return;
+            }
             actual.onNext(u);
         }
         @Override

--- a/src/main/java/io/reactivex/internal/operators/PublisherLift.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherLift.java
@@ -80,6 +80,10 @@ public final class PublisherLift<R, T> implements Publisher<R> {
             // can't call onError because no way to know if a Subscription has been set or not
             // can't call onSubscribe because the call might have set a Subscription already
             RxJavaPlugins.onError(e);
+            
+            NullPointerException npe = new NullPointerException("Actually not, but can't throw other exceptions due to RS");
+            npe.initCause(e);
+            throw npe;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/PublisherRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherRetryBiPredicate.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.subscriptions.SubscriptionArbiter;
+
+public final class PublisherRetryBiPredicate<T> implements Publisher<T> {
+    final Publisher<? extends T> source;
+    final BiPredicate<? super Integer, ? super Throwable> predicate;
+    public PublisherRetryBiPredicate(
+            Publisher<? extends T> source, 
+            BiPredicate<? super Integer, ? super Throwable> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+    
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        s.onSubscribe(sa);
+        
+        RetryBiSubscriber<T> rs = new RetryBiSubscriber<>(s, predicate, sa, source);
+        rs.subscribeNext();
+    }
+    
+    static final class RetryBiSubscriber<T> extends AtomicInteger implements Subscriber<T> {
+        /** */
+        private static final long serialVersionUID = -7098360935104053232L;
+        
+        final Subscriber<? super T> actual;
+        final SubscriptionArbiter sa;
+        final Publisher<? extends T> source;
+        final BiPredicate<? super Integer, ? super Throwable> predicate;
+        int retries;
+        public RetryBiSubscriber(Subscriber<? super T> actual, 
+                BiPredicate<? super Integer, ? super Throwable> predicate, SubscriptionArbiter sa, Publisher<? extends T> source) {
+            this.actual = actual;
+            this.sa = sa;
+            this.source = source;
+            this.predicate = predicate;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            sa.setSubscription(s);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+            sa.produced(1L);
+        }
+        @Override
+        public void onError(Throwable t) {
+            boolean b;
+            try {
+                b = predicate.test(++retries, t);
+            } catch (Throwable e) {
+                e.addSuppressed(t);
+                actual.onError(e);
+                return;
+            }
+            if (!b) {
+                actual.onError(t);
+                return;
+            }
+            subscribeNext();
+        }
+        
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+        
+        /**
+         * Subscribes to the source again via trampolining.
+         */
+        void subscribeNext() {
+            if (getAndIncrement() == 0) {
+                int missed = 1;
+                for (;;) {
+                    if (sa.isCancelled()) {
+                        return;
+                    }
+                    source.subscribe(this);
+                    
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorRetryTest.java
@@ -1,0 +1,911 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+
+import org.junit.Test;
+import org.mockito.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.observables.GroupedObservable;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorRetryTest {
+
+    @Test
+    public void iterativeBackoff() {
+        Subscriber<String> consumer = TestHelper.mockSubscriber();
+        
+        Observable<String> producer = Observable.create(new Publisher<String>() {
+
+            private AtomicInteger count = new AtomicInteger(4);
+            long last = System.currentTimeMillis();
+
+            @Override
+            public void subscribe(Subscriber<? super String> t1) {
+                t1.onSubscribe(EmptySubscription.INSTANCE);
+                System.out.println(count.get() + " @ " + String.valueOf(last - System.currentTimeMillis()));
+                last = System.currentTimeMillis();
+                if (count.getAndDecrement() == 0) {
+                    t1.onNext("hello");
+                    t1.onComplete();
+                }
+                else 
+                    t1.onError(new RuntimeException());
+            }
+            
+        });
+        TestSubscriber<String> ts = new TestSubscriber<>(consumer);
+        producer.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
+
+            @Override
+            public Observable<?> apply(Observable<? extends Throwable> attempts) {
+                // Worker w = Schedulers.computation().createWorker();
+                return attempts
+                    .map(new Function<Throwable, Tuple>() {
+                        @Override
+                        public Tuple apply(Throwable n) {
+                            return new Tuple(new Long(1), n);
+                        }})
+                    .scan(new BiFunction<Tuple, Tuple, Tuple>(){
+                        @Override
+                        public Tuple apply(Tuple t, Tuple n) {
+                            return new Tuple(t.count + n.count, n.n);
+                        }})
+                    .flatMap(new Function<Tuple, Observable<Long>>() {
+                        @Override
+                        public Observable<Long> apply(Tuple t) {
+                            System.out.println("Retry # "+t.count);
+                            return t.count > 20 ? 
+                                Observable.<Long>error(t.n) :
+                                Observable.timer(t.count *1L, TimeUnit.MILLISECONDS);
+                    }});
+            }
+        }).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+
+        InOrder inOrder = inOrder(consumer);
+        inOrder.verify(consumer, never()).onError(any(Throwable.class));
+        inOrder.verify(consumer, times(1)).onNext("hello");
+        inOrder.verify(consumer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+
+    }
+
+    public static class Tuple {
+        Long count;
+        Throwable n;
+
+        Tuple(Long c, Throwable n) {
+            count = c;
+            this.n = n;
+        }
+    }
+
+    @Test
+    public void testRetryIndefinitely() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        int NUM_RETRIES = 20;
+        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        origin.retry().unsafeSubscribe(new TestSubscriber<>(observer));
+
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
+        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSchedulingNotificationHandler() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        int NUM_RETRIES = 2;
+        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        TestSubscriber<String> subscriber = new TestSubscriber<>(observer);
+        origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<? extends Throwable> t1) {
+                return t1.observeOn(Schedulers.computation()).map(new Function<Throwable, Integer>() {
+                    @Override
+                    public Integer apply(Throwable t1) {
+                        return 1;
+                    }
+                }).startWith(1);
+            }
+        })
+        .doOnError(Throwable::printStackTrace)
+        .subscribe(subscriber);
+
+        subscriber.awaitTerminalEvent();
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(1 + NUM_RETRIES)).onNext("beginningEveryTime");
+        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testOnNextFromNotificationHandler() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        int NUM_RETRIES = 2;
+        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
+            @Override
+            public Observable<?> apply(Observable<? extends Throwable> t1) {
+                return t1.map(new Function<Throwable, Integer>() {
+
+                    @Override
+                    public Integer apply(Throwable t1) {
+                        return 0;
+                    }
+                }).startWith(0);
+            }
+        }).subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
+        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testOnCompletedFromNotificationHandler() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Observable<String> origin = Observable.create(new FuncWithErrors(1));
+        TestSubscriber<String> subscriber = new TestSubscriber<>(observer);
+        origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
+            @Override
+            public Observable<?> apply(Observable<? extends Throwable> t1) {
+                return Observable.empty();
+            }
+        }).subscribe(subscriber);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onSubscribe((Subscription)notNull());
+        inOrder.verify(observer, never()).onNext("beginningEveryTime");
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, never()).onError(any(Exception.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testOnErrorFromNotificationHandler() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Observable<String> origin = Observable.create(new FuncWithErrors(2));
+        origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
+            @Override
+            public Observable<?> apply(Observable<? extends Throwable> t1) {
+                return Observable.error(new RuntimeException());
+            }
+        }).subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onSubscribe((Subscription)notNull());
+        inOrder.verify(observer, never()).onNext("beginningEveryTime");
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(IllegalStateException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleSubscriptionOnFirst() throws Exception {
+        final AtomicInteger inc = new AtomicInteger(0);
+        Publisher<Integer> onSubscribe = new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(EmptySubscription.INSTANCE);
+                final int emit = inc.incrementAndGet();
+                subscriber.onNext(emit);
+                subscriber.onComplete();
+            }
+        };
+
+        int first = Observable.create(onSubscribe)
+                .retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
+                    @Override
+                    public Observable<?> apply(Observable<? extends Throwable> attempt) {
+                        return attempt.zipWith(Observable.just(1), new BiFunction<Throwable, Integer, Void>() {
+                            @Override
+                            public Void apply(Throwable o, Integer integer) {
+                                return null;
+                            }
+                        });
+                    }
+                })
+                .toBlocking()
+                .first();
+
+        assertEquals("Observer did not receive the expected output", 1, first);
+        assertEquals("Subscribe was not called once", 1, inc.get());
+    }
+
+    @Test
+    public void testOriginFails() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Observable<String> origin = Observable.create(new FuncWithErrors(1));
+        origin.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void testRetryFail() {
+        int NUM_RETRIES = 1;
+        int NUM_FAILURES = 2;
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        origin.retry(NUM_RETRIES).subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        // should show 2 attempts (first time fail, second time (1st retry) fail)
+        inOrder.verify(observer, times(1 + NUM_RETRIES)).onNext("beginningEveryTime");
+        // should only retry once, fail again and emit onError
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        // no success
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testRetrySuccess() {
+        int NUM_FAILURES = 1;
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        origin.retry(3).subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(1 + NUM_FAILURES)).onNext("beginningEveryTime");
+        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testInfiniteRetry() {
+        int NUM_FAILURES = 20;
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        origin.retry().subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(1 + NUM_FAILURES)).onNext("beginningEveryTime");
+        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    /**
+     * Checks in a simple and synchronous way that retry resubscribes
+     * after error. This test fails against 0.16.1-0.17.4, hangs on 0.17.5 and
+     * passes in 0.17.6 thanks to fix for issue #1027.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRetrySubscribesAgainAfterError() {
+
+        // record emitted values with this action
+        Consumer<Integer> record = mock(Consumer.class);
+        InOrder inOrder = inOrder(record);
+
+        // always throw an exception with this action
+        Consumer<Integer> throwException = mock(Consumer.class);
+        doThrow(new RuntimeException()).when(throwException).accept(Mockito.anyInt());
+
+        // create a retrying observable based on a PublishSubject
+        PublishSubject<Integer> subject = PublishSubject.create();
+        subject
+        // record item
+        .doOnNext(record)
+        // throw a RuntimeException
+                .doOnNext(throwException)
+                // retry on error
+                .retry()
+                // subscribe and ignore
+                .subscribe();
+
+        inOrder.verifyNoMoreInteractions();
+
+        subject.onNext(1);
+        inOrder.verify(record).accept(1);
+
+        subject.onNext(2);
+        inOrder.verify(record).accept(2);
+
+        subject.onNext(3);
+        inOrder.verify(record).accept(3);
+
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    public static class FuncWithErrors implements Publisher<String> {
+
+        private final int numFailures;
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        FuncWithErrors(int count) {
+            this.numFailures = count;
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super String> o) {
+            o.onSubscribe(new Subscription() {
+                final AtomicLong req = new AtomicLong();
+                // 0 = not set, 1 = fast path, 2 = backpressure
+                final AtomicInteger path = new AtomicInteger(0);
+                volatile boolean done = false;
+                
+                @Override
+                public void request(long n) {
+                    if (n == Long.MAX_VALUE && path.compareAndSet(0, 1)) {
+                        o.onNext("beginningEveryTime");
+                        int i = count.getAndIncrement();
+                        if (i < numFailures) {
+                            o.onError(new RuntimeException("forced failure: " + (i + 1)));
+                        } else {
+                            o.onNext("onSuccessOnly");
+                            o.onComplete();
+                        }
+                        return;
+                    }
+                    if (n > 0 && req.getAndAdd(n) == 0 && (path.get() == 2 || path.compareAndSet(0, 2)) && !done) {
+                        int i = count.getAndIncrement();
+                        if (i < numFailures) {
+                            o.onNext("beginningEveryTime");
+                            o.onError(new RuntimeException("forced failure: " + (i + 1)));
+                            done = true;
+                        } else {
+                            do {
+                                if (i == numFailures) {
+                                    o.onNext("beginningEveryTime");
+                                } else
+                                if (i > numFailures) {
+                                    o.onNext("onSuccessOnly");
+                                    o.onComplete();
+                                    done = true;
+                                    break;
+                                }
+                                i = count.getAndIncrement();
+                            } while (req.decrementAndGet() > 0);
+                        }
+                    }
+                }
+                @Override
+                public void cancel() {
+                    // TODO Auto-generated method stub
+                    
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testUnsubscribeFromRetry() {
+        PublishSubject<Integer> subject = PublishSubject.create();
+        final AtomicInteger count = new AtomicInteger(0);
+        Disposable sub = subject.retry().subscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer n) {
+                count.incrementAndGet();
+            }
+        });
+        subject.onNext(1);
+        sub.dispose();
+        subject.onNext(2);
+        assertEquals(1, count.get());
+    }
+
+    @Test
+    public void testRetryAllowsSubscriptionAfterAllSubscriptionsUnsubscribed() throws InterruptedException {
+        final AtomicInteger subsCount = new AtomicInteger(0);
+        Publisher<String> onSubscribe = new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                subsCount.incrementAndGet();
+                s.onSubscribe(new Subscription() {
+
+                    @Override
+                    public void request(long n) {
+                        
+                    }
+                    
+                    @Override
+                    public void cancel() {
+                        subsCount.decrementAndGet();
+                    }
+                });
+                
+            }
+        };
+        Observable<String> stream = Observable.create(onSubscribe);
+        Observable<String> streamWithRetry = stream.retry();
+        Disposable sub = streamWithRetry.subscribe();
+        assertEquals(1, subsCount.get());
+        sub.dispose();
+        assertEquals(0, subsCount.get());
+        streamWithRetry.subscribe();
+        assertEquals(1, subsCount.get());
+    }
+
+    @Test
+    public void testSourceObservableCallsUnsubscribe() throws InterruptedException {
+        final AtomicInteger subsCount = new AtomicInteger(0);
+
+        final TestSubscriber<String> ts = new TestSubscriber<>();
+
+        Publisher<String> onSubscribe = new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                BooleanSubscription bs = new BooleanSubscription();
+                // if isUnsubscribed is true that means we have a bug such as
+                // https://github.com/ReactiveX/RxJava/issues/1024
+                if (!bs.isCancelled()) {
+                    subsCount.incrementAndGet();
+                    s.onError(new RuntimeException("failed"));
+                    // it unsubscribes the child directly
+                    // this simulates various error/completion scenarios that could occur
+                    // or just a source that proactively triggers cleanup
+                    // FIXME can't unsubscribe child
+//                    s.unsubscribe();
+                    bs.cancel();
+                } else {
+                    s.onError(new RuntimeException());
+                }
+            }
+        };
+
+        Observable.create(onSubscribe).retry(3).subscribe(ts);
+        assertEquals(4, subsCount.get()); // 1 + 3 retries
+    }
+
+    @Test
+    public void testSourceObservableRetry1() throws InterruptedException {
+        final AtomicInteger subsCount = new AtomicInteger(0);
+
+        final TestSubscriber<String> ts = new TestSubscriber<>();
+
+        Publisher<String> onSubscribe = new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                s.onSubscribe(EmptySubscription.INSTANCE);
+                subsCount.incrementAndGet();
+                s.onError(new RuntimeException("failed"));
+            }
+        };
+
+        Observable.create(onSubscribe).retry(1).subscribe(ts);
+        assertEquals(2, subsCount.get());
+    }
+
+    @Test
+    public void testSourceObservableRetry0() throws InterruptedException {
+        final AtomicInteger subsCount = new AtomicInteger(0);
+
+        final TestSubscriber<String> ts = new TestSubscriber<>();
+
+        Publisher<String> onSubscribe = new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                s.onSubscribe(EmptySubscription.INSTANCE);
+                subsCount.incrementAndGet();
+                s.onError(new RuntimeException("failed"));
+            }
+        };
+
+        Observable.create(onSubscribe).retry(0).subscribe(ts);
+        assertEquals(1, subsCount.get());
+    }
+
+    static final class SlowObservable implements Publisher<Long> {
+
+        final AtomicInteger efforts = new AtomicInteger(0);
+        final AtomicInteger active = new AtomicInteger(0), maxActive = new AtomicInteger(0);
+        final AtomicInteger nextBeforeFailure;
+
+        private final int emitDelay;
+
+        public SlowObservable(int emitDelay, int countNext) {
+            this.emitDelay = emitDelay;
+            this.nextBeforeFailure = new AtomicInteger(countNext);
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super Long> subscriber) {
+            final AtomicBoolean terminate = new AtomicBoolean(false);
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(long n) {
+                    // TODO Auto-generated method stub
+                    
+                }
+                
+                @Override
+                public void cancel() {
+                    terminate.set(true);
+                    active.decrementAndGet();
+                }
+            });
+            efforts.getAndIncrement();
+            active.getAndIncrement();
+            maxActive.set(Math.max(active.get(), maxActive.get()));
+            final Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    long nr = 0;
+                    try {
+                        while (!terminate.get()) {
+                            Thread.sleep(emitDelay);
+                            if (nextBeforeFailure.getAndDecrement() > 0) {
+                                subscriber.onNext(nr++);
+                            } else {
+                                subscriber.onError(new RuntimeException("expected-failed"));
+                            }
+                        }
+                    } catch (InterruptedException t) {
+                    }
+                }
+            };
+            thread.start();
+        }
+    }
+
+    /** Observer for listener on seperate thread */
+    static final class AsyncObserver<T> extends Observer<T> {
+
+        protected CountDownLatch latch = new CountDownLatch(1);
+
+        protected Subscriber<T> target;
+
+        /** Wrap existing Observer */
+        public AsyncObserver(Subscriber<T> target) {
+            this.target = target;
+        }
+
+        /** Wait */
+        public void await() {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                fail("Test interrupted");
+            }
+        }
+
+        // Observer implementation
+
+        @Override
+        public void onComplete() {
+            target.onComplete();
+            latch.countDown();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            target.onError(t);
+            latch.countDown();
+        }
+
+        @Override
+        public void onNext(T v) {
+            target.onNext(v);
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void testUnsubscribeAfterError() {
+
+        @SuppressWarnings("unchecked")
+        Observer<Long> observer = mock(Observer.class);
+
+        // Observable that always fails after 100ms
+        SlowObservable so = new SlowObservable(100, 0);
+        Observable<Long> o = Observable.create(so).retry(5);
+
+        AsyncObserver<Long> async = new AsyncObserver<>(observer);
+
+        o.subscribe(async);
+
+        async.await();
+
+        InOrder inOrder = inOrder(observer);
+        // Should fail once
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+
+        assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
+        assertEquals("Only 1 active subscription", 1, so.maxActive.get());
+    }
+
+    @Test(timeout = 10000)
+    public void testTimeoutWithRetry() {
+
+        @SuppressWarnings("unchecked")
+        Observer<Long> observer = mock(Observer.class);
+
+        // Observable that sends every 100ms (timeout fails instead)
+        SlowObservable so = new SlowObservable(100, 10);
+        Observable<Long> o = Observable.create(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
+
+        AsyncObserver<Long> async = new AsyncObserver<>(observer);
+
+        o.subscribe(async);
+
+        async.await();
+
+        InOrder inOrder = inOrder(observer);
+        // Should fail once
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+
+        assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
+    }
+    
+    @Test//(timeout = 15000)
+    public void testRetryWithBackpressure() throws InterruptedException {
+        final int NUM_LOOPS = 1;
+        for (int j=0;j<NUM_LOOPS;j++) {
+            final int NUM_RETRIES = Observable.bufferSize() * 2;
+            for (int i = 0; i < 400; i++) {
+                Subscriber<String> observer = TestHelper.mockSubscriber();
+                Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+                TestSubscriber<String> ts = new TestSubscriber<>(observer);
+                origin.retry().observeOn(Schedulers.computation()).unsafeSubscribe(ts);
+                ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+                
+                InOrder inOrder = inOrder(observer);
+                // should have no errors
+                verify(observer, never()).onError(any(Throwable.class));
+                // should show NUM_RETRIES attempts
+                inOrder.verify(observer, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
+                // should have a single success
+                inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+                // should have a single successful onCompleted
+                inOrder.verify(observer, times(1)).onComplete();
+                inOrder.verifyNoMoreInteractions();
+            }
+        }
+    }
+    
+    @Test//(timeout = 15000)
+    public void testRetryWithBackpressureParallel() throws InterruptedException {
+        final int NUM_LOOPS = 1;
+        final int NUM_RETRIES = Observable.bufferSize() * 2;
+        int ncpu = Runtime.getRuntime().availableProcessors();
+        ExecutorService exec = Executors.newFixedThreadPool(Math.max(ncpu / 2, 2));
+        try {
+            for (int r = 0; r < NUM_LOOPS; r++) {
+                if (r % 10 == 0) {
+                    System.out.println("testRetryWithBackpressureParallelLoop -> " + r);
+                }
+
+                final AtomicInteger timeouts = new AtomicInteger();
+                final Map<Integer, List<String>> data = new ConcurrentHashMap<>();
+
+                int m = 5000;
+                final CountDownLatch cdl = new CountDownLatch(m);
+                for (int i = 0; i < m; i++) {
+                    final int j = i;
+                    exec.execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            final AtomicInteger nexts = new AtomicInteger();
+                            try {
+                                Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+                                TestSubscriber<String> ts = new TestSubscriber<>();
+                                origin.retry()
+                                .observeOn(Schedulers.computation()).unsafeSubscribe(ts);
+                                ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+                                List<String> onNextEvents = new ArrayList<>(ts.values());
+                                if (onNextEvents.size() != NUM_RETRIES + 2) {
+                                    for (Throwable t : ts.errors()) {
+                                        onNextEvents.add(t.toString());
+                                    }
+                                    for (long err = ts.completions(); err != 0; err--) {
+                                        onNextEvents.add("onCompleted");
+                                    }
+                                    data.put(j, onNextEvents);
+                                }
+                            } catch (Throwable t) {
+                                timeouts.incrementAndGet();
+                                System.out.println(j + " | " + cdl.getCount() + " !!! " + nexts.get());
+                            }
+                            cdl.countDown();
+                        }
+                    });
+                }
+                cdl.await();
+                assertEquals(0, timeouts.get());
+                if (data.size() > 0) {
+                    fail("Data content mismatch: " + allSequenceFrequency(data));
+                }
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
+    static <T> StringBuilder allSequenceFrequency(Map<Integer, List<T>> its) {
+        StringBuilder b = new StringBuilder();
+        for (Map.Entry<Integer, List<T>> e : its.entrySet()) {
+            if (b.length() > 0) {
+                b.append(", ");
+            }
+            b.append(e.getKey()).append("={");
+            b.append(sequenceFrequency(e.getValue()));
+            b.append("}");
+        }
+        return b;
+    }
+    static <T> StringBuilder sequenceFrequency(Iterable<T> it) {
+        StringBuilder sb = new StringBuilder();
+
+        Object prev = null;
+        int cnt = 0;
+
+        for (Object curr : it) {
+            if (sb.length() > 0) {
+                if (!curr.equals(prev)) {
+                    if (cnt > 1) {
+                        sb.append(" x ").append(cnt);
+                        cnt = 1;
+                    }
+                    sb.append(", ");
+                    sb.append(curr);
+                } else {
+                    cnt++;
+                }
+            } else {
+                sb.append(curr);
+                cnt++;
+            }
+            prev = curr;
+        }
+        if (cnt > 1) {
+            sb.append(" x ").append(cnt);
+        }
+
+        return sb;
+    }
+    @Test//(timeout = 3000)
+    public void testIssue1900() throws InterruptedException {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        final int NUM_MSG = 1034;
+        final AtomicInteger count = new AtomicInteger();
+
+        Observable<String> origin = Observable.range(0, NUM_MSG)
+                .map(new Function<Integer, String>() {
+                    @Override
+                    public String apply(Integer t1) {
+                        return "msg: " + count.incrementAndGet();
+                    }
+                });
+        
+        origin.retry()
+        .groupBy(new Function<String, String>() {
+            @Override
+            public String apply(String t1) {
+                return t1;
+            }
+        })
+        .flatMap(new Function<GroupedObservable<String,String>, Observable<String>>() {
+            @Override
+            public Observable<String> apply(GroupedObservable<String, String> t1) {
+                return t1.take(1);
+            }
+        })
+        .unsafeSubscribe(new TestSubscriber<>(observer));
+        
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(NUM_MSG)).onNext(any(java.lang.String.class));
+        //        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        //inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+    @Test//(timeout = 3000)
+    public void testIssue1900SourceNotSupportingBackpressure() {
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        final int NUM_MSG = 1034;
+        final AtomicInteger count = new AtomicInteger();
+
+        Observable<String> origin = Observable.create(new Publisher<String>() {
+
+            @Override
+            public void subscribe(Subscriber<? super String> o) {
+                o.onSubscribe(EmptySubscription.INSTANCE);
+                for(int i=0; i<NUM_MSG; i++) {
+                    o.onNext("msg:" + count.incrementAndGet());
+                }   
+                o.onComplete();
+            }
+        });
+        
+        origin.retry()
+        .groupBy(new Function<String, String>() {
+            @Override
+            public String apply(String t1) {
+                return t1;
+            }
+        })
+        .flatMap(new Function<GroupedObservable<String,String>, Observable<String>>() {
+            @Override
+            public Observable<String> apply(GroupedObservable<String, String> t1) {
+                return t1.take(1);
+            }
+        })
+        .unsafeSubscribe(new TestSubscriber<>(observer));
+        
+        InOrder inOrder = inOrder(observer);
+        // should show 3 attempts
+        inOrder.verify(observer, times(NUM_MSG)).onNext(any(java.lang.String.class));
+        //        // should have no errors
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        // should have a single success
+        //inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        // should have a single successful onCompleted
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorRetryWithPredicateTest.java
@@ -1,0 +1,392 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorRetryWithPredicateTest {
+    BiPredicate<Integer, Throwable> retryTwice = new BiPredicate<Integer, Throwable>() {
+        @Override
+        public boolean test(Integer t1, Throwable t2) {
+            return t1 <= 2;
+        }
+    };
+    BiPredicate<Integer, Throwable> retry5 = new BiPredicate<Integer, Throwable>() {
+        @Override
+        public boolean test(Integer t1, Throwable t2) {
+            return t1 <= 5;
+        }
+    };
+    BiPredicate<Integer, Throwable> retryOnTestException = new BiPredicate<Integer, Throwable>() {
+        @Override
+        public boolean test(Integer t1, Throwable t2) {
+            return t2 instanceof IOException;
+        }
+    };
+    @Test
+    public void testWithNothingToRetry() {
+        Observable<Integer> source = Observable.range(0, 3);
+        
+        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(o);
+        
+        source.retry(retryTwice).subscribe(o);
+        
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    @Test
+    public void testRetryTwice() {
+        Observable<Integer> source = Observable.create(new Publisher<Integer>() {
+            int count;
+            @Override
+            public void subscribe(Subscriber<? super Integer> t1) {
+                t1.onSubscribe(EmptySubscription.INSTANCE);
+                count++;
+                t1.onNext(0);
+                t1.onNext(1);
+                if (count == 1) {
+                    t1.onError(new TestException());
+                    return;
+                }
+                t1.onNext(2);
+                t1.onNext(3);
+                t1.onComplete();
+            }
+        });
+        
+        @SuppressWarnings("unchecked")
+        Observer<Integer> o = mock(Observer.class);
+        InOrder inOrder = inOrder(o);
+        
+        source.retry(retryTwice).subscribe(o);
+
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o).onNext(3);
+        inOrder.verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+        
+    }
+    @Test
+    public void testRetryTwiceAndGiveUp() {
+        Observable<Integer> source = Observable.create(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> t1) {
+                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onNext(0);
+                t1.onNext(1);
+                t1.onError(new TestException());
+            }
+        });
+        
+        @SuppressWarnings("unchecked")
+        Observer<Integer> o = mock(Observer.class);
+        InOrder inOrder = inOrder(o);
+        
+        source.retry(retryTwice).subscribe(o);
+
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onError(any(TestException.class));
+        verify(o, never()).onComplete();
+        
+    }
+    @Test
+    public void testRetryOnSpecificException() {
+        Observable<Integer> source = Observable.create(new Publisher<Integer>() {
+            int count;
+            @Override
+            public void subscribe(Subscriber<? super Integer> t1) {
+                t1.onSubscribe(EmptySubscription.INSTANCE);
+                count++;
+                t1.onNext(0);
+                t1.onNext(1);
+                if (count == 1) {
+                    t1.onError(new IOException());
+                    return;
+                }
+                t1.onNext(2);
+                t1.onNext(3);
+                t1.onComplete();
+            }
+        });
+        
+        @SuppressWarnings("unchecked")
+        Observer<Integer> o = mock(Observer.class);
+        InOrder inOrder = inOrder(o);
+        
+        source.retry(retryOnTestException).subscribe(o);
+
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o).onNext(3);
+        inOrder.verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    @Test
+    public void testRetryOnSpecificExceptionAndNotOther() {
+        final IOException ioe = new IOException();
+        final TestException te = new TestException();
+        Observable<Integer> source = Observable.create(new Publisher<Integer>() {
+            int count;
+            @Override
+            public void subscribe(Subscriber<? super Integer> t1) {
+                t1.onSubscribe(EmptySubscription.INSTANCE);
+                count++;
+                t1.onNext(0);
+                t1.onNext(1);
+                if (count == 1) {
+                    t1.onError(ioe);
+                    return;
+                }
+                t1.onNext(2);
+                t1.onNext(3);
+                t1.onError(te);
+            }
+        });
+        
+        @SuppressWarnings("unchecked")
+        Observer<Integer> o = mock(Observer.class);
+        InOrder inOrder = inOrder(o);
+        
+        source.retry(retryOnTestException).subscribe(o);
+
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(0);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o).onNext(3);
+        inOrder.verify(o).onError(te);
+        verify(o, never()).onError(ioe);
+        verify(o, never()).onComplete();
+    }
+    
+    @Test
+    public void testUnsubscribeFromRetry() {
+        PublishSubject<Integer> subject = PublishSubject.create();
+        final AtomicInteger count = new AtomicInteger(0);
+        Disposable sub = subject.retry(retryTwice).subscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer n) {
+                count.incrementAndGet();
+            }
+        });
+        subject.onNext(1);
+        sub.dispose();
+        subject.onNext(2);
+        assertEquals(1, count.get());
+    }
+    
+    @Test(timeout = 10000)
+    public void testUnsubscribeAfterError() {
+
+        Subscriber<Long> observer = TestHelper.mockSubscriber();
+
+        // Observable that always fails after 100ms
+        OperatorRetryTest.SlowObservable so = new OperatorRetryTest.SlowObservable(100, 0);
+        Observable<Long> o = Observable
+                .create(so)
+                .retry(retry5);
+
+        OperatorRetryTest.AsyncObserver<Long> async = new OperatorRetryTest.AsyncObserver<>(observer);
+
+        o.subscribe(async);
+
+        async.await();
+
+        InOrder inOrder = inOrder(observer);
+        // Should fail once
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+
+        assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
+        assertEquals("Only 1 active subscription", 1, so.maxActive.get());
+    }
+
+    @Test(timeout = 10000)
+    public void testTimeoutWithRetry() {
+
+        Subscriber<Long> observer = TestHelper.mockSubscriber();
+
+        // Observable that sends every 100ms (timeout fails instead)
+        OperatorRetryTest.SlowObservable so = new OperatorRetryTest.SlowObservable(100, 10);
+        Observable<Long> o = Observable
+                .create(so)
+                .timeout(80, TimeUnit.MILLISECONDS)
+                .retry(retry5);
+
+        OperatorRetryTest.AsyncObserver<Long> async = new OperatorRetryTest.AsyncObserver<>(observer);
+
+        o.subscribe(async);
+
+        async.await();
+
+        InOrder inOrder = inOrder(observer);
+        // Should fail once
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+
+        assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
+    }
+    
+    @Test
+    public void testIssue2826() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        final RuntimeException e = new RuntimeException("You shall not pass");
+        final AtomicInteger c = new AtomicInteger();
+        Observable.just(1).map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1) {
+                c.incrementAndGet();
+                throw e;
+            }
+        }).retry(retry5).subscribe(ts);
+
+        ts.assertTerminated();
+        assertEquals(6, c.get());
+        assertEquals(Collections.singletonList(e), ts.errors());
+    }
+    @Test
+    public void testJustAndRetry() throws Exception {
+        final AtomicBoolean throwException = new AtomicBoolean(true);
+        int value = Observable.just(1).map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1) {
+                if (throwException.compareAndSet(true, false)) {
+                    throw new TestException();
+                }
+                return t1;
+            }
+        }).retry(1).toBlocking().single();
+
+        assertEquals(1, value);
+    }
+    
+    @Test
+    public void testIssue3008RetryWithPredicate() {
+        final List<Long> list = new CopyOnWriteArrayList<>();
+        final AtomicBoolean isFirst = new AtomicBoolean(true);
+        Observable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>(){
+            @Override
+            public Long apply(Long x) {
+                System.out.println("map " + x);
+                if (x == 2 && isFirst.getAndSet(false)) {
+                    throw new RuntimeException("retryable error");
+                }
+                return x;
+            }})
+        .retry(new BiPredicate<Integer, Throwable>() {
+            @Override
+            public boolean test(Integer t1, Throwable t2) {
+                return true;
+            }})
+        .forEach(new Consumer<Long>() {
+
+            @Override
+            public void accept(Long t) {
+                System.out.println(t);
+                list.add(t);
+            }});
+        assertEquals(Arrays.asList(1L,1L,2L,3L), list);
+    }
+    
+    @Test
+    public void testIssue3008RetryInfinite() {
+        final List<Long> list = new CopyOnWriteArrayList<>();
+        final AtomicBoolean isFirst = new AtomicBoolean(true);
+        Observable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>(){
+            @Override
+            public Long apply(Long x) {
+                System.out.println("map " + x);
+                if (x == 2 && isFirst.getAndSet(false)) {
+                    throw new RuntimeException("retryable error");
+                }
+                return x;
+            }})
+        .retry()
+        .forEach(new Consumer<Long>() {
+
+            @Override
+            public void accept(Long t) {
+                System.out.println(t);
+                list.add(t);
+            }});
+        assertEquals(Arrays.asList(1L,1L,2L,3L), list);
+    }
+    
+    @Test
+    public void testBackpressure() {
+        final List<Long> requests = new ArrayList<>();
+        
+        Observable<Integer> source = Observable
+                .just(1)
+                .concatWith(Observable.<Integer>error(new TestException()))
+                .doOnRequest(new LongConsumer() {
+                    @Override
+                    public void accept(long t) {
+                        requests.add(t);
+                    }
+                });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>(3L);
+        source
+        .retry(new BiPredicate<Integer, Throwable>() {
+            @Override
+            public boolean test(Integer t1, Throwable t2) {
+                return t1 < 4; // FIXME was 3 in 1.x for some reason
+            }
+        }).subscribe(ts);
+        
+        assertEquals(Arrays.asList(3L, 2L, 1L), requests);
+        ts.assertValues(1, 1, 1);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+    }
+}


### PR DESCRIPTION
+ retry with bipredicate
+ fixed map not checking the returned value for null
+ since RS doesn't allow throwing other than NPE, temporarily subscribe
and lift will throw NPE with the actual error as cause so we don't miss
an operator bug due to swallowed exceptions.