### PR TITLE
2.x: operator test: skip variants and bugfix

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1776,13 +1776,14 @@ public class Observable<T> implements Publisher<T> {
     }
     
     public final Observable<T> skip(long n) {
-        if (n < 0) {
-            throw new IllegalArgumentException("n >= 0 required but it was " + n);
-        } else
-            if (n == 0) {
-                return this;
-            }
-        return lift(new OperatorSkip<>(n));
+//        if (n < 0) {
+//            throw new IllegalArgumentException("n >= 0 required but it was " + n);
+//        } else
+        // FIXME negative skip allowed?!
+        if (n <= 0) {
+            return this;
+        }
+    return lift(new OperatorSkip<>(n));
     }
     
     public final Observable<T> skip(long time, TimeUnit unit, Scheduler scheduler) {
@@ -1792,7 +1793,7 @@ public class Observable<T> implements Publisher<T> {
     
     public final Observable<T> skipLast(int n) {
         if (n < 0) {
-            throw new IllegalArgumentException("n >= 0 required but it was " + n);
+            throw new IndexOutOfBoundsException("n >= 0 required but it was " + n);
         } else
             if (n == 0) {
                 return this;

--- a/src/main/java/io/reactivex/internal/operators/OperatorSkipLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorSkipLastTimed.java
@@ -160,6 +160,12 @@ public final class OperatorSkipLastTimed<T> implements Operator<T, T> {
                     Long ts = (Long)q.peek();
                     
                     boolean empty = ts == null;
+
+                    long now = scheduler.now(unit);
+                    
+                    if (!empty && ts > now - time) {
+                        empty = true;
+                    }
                     
                     if (checkTerminated(d, empty, a, delayError)) {
                         return;
@@ -169,9 +175,8 @@ public final class OperatorSkipLastTimed<T> implements Operator<T, T> {
                         break;
                     }
                     
-                    long now = scheduler.now(unit);
                     
-                    if (ts >= now - time) {
+                    if (ts > now - time) {
                         // not old enough
                         break;
                     }
@@ -198,7 +203,7 @@ public final class OperatorSkipLastTimed<T> implements Operator<T, T> {
                     }
                 }
                 
-                missed = getAndSet(-missed);
+                missed = addAndGet(-missed);
                 if (missed == 0) {
                     break;
                 }

--- a/src/test/java/io/reactivex/internal/operators/OperatorSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSampleTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/reactivex/internal/operators/OperatorScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorScanTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSequenceEqualTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.isA;

--- a/src/test/java/io/reactivex/internal/operators/OperatorSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSerializeTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSingleTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipLastTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorSkipLastTest {
+
+    @Test
+    public void testSkipLastEmpty() {
+        Observable<String> observable = Observable.<String> empty().skipLast(2);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipLast1() {
+        Observable<String> observable = Observable.fromIterable(Arrays.asList("one", "two", "three")).skipLast(2);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(observer);
+        observable.subscribe(observer);
+        inOrder.verify(observer, never()).onNext("two");
+        inOrder.verify(observer, never()).onNext("three");
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipLast2() {
+        Observable<String> observable = Observable.fromIterable(Arrays.asList("one", "two")).skipLast(2);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipLastWithZeroCount() {
+        Observable<String> w = Observable.just("one", "two");
+        Observable<String> observable = w.skipLast(0);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    @Ignore("Null values not allowed")
+    public void testSkipLastWithNull() {
+        Observable<String> observable = Observable.fromIterable(Arrays.asList("one", null, "two")).skipLast(1);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext(null);
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipLastWithBackpressure() {
+        Observable<Integer> o = Observable.range(0, Observable.bufferSize() * 2).skipLast(Observable.bufferSize() + 10);
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        o.observeOn(Schedulers.computation()).subscribe(ts);
+        ts.awaitTerminalEvent();
+        ts.assertNoErrors();
+        assertEquals((Observable.bufferSize()) - 10, ts.valueCount());
+
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSkipLastWithNegativeCount() {
+        Observable.just("one").skipLast(-1);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipLastTimedTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+
+public class OperatorSkipLastTimedTest {
+
+    @Test
+    public void testSkipLastTimed() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        // FIXME the timeunit now matters due to rounding
+        Observable<Integer> result = source.skipLast(1000, TimeUnit.MILLISECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+
+        source.onNext(4);
+        source.onNext(5);
+        source.onNext(6);
+
+        scheduler.advanceTimeBy(950, TimeUnit.MILLISECONDS);
+        source.onComplete();
+
+        InOrder inOrder = inOrder(o);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o).onNext(3);
+        inOrder.verify(o, never()).onNext(4);
+        inOrder.verify(o, never()).onNext(5);
+        inOrder.verify(o, never()).onNext(6);
+        inOrder.verify(o).onComplete();
+        inOrder.verifyNoMoreInteractions();
+
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipLastTimedErrorBeforeTime() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skipLast(1, TimeUnit.SECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+        source.onError(new TestException());
+
+        scheduler.advanceTimeBy(1050, TimeUnit.MILLISECONDS);
+
+        verify(o).onError(any(TestException.class));
+
+        verify(o, never()).onComplete();
+        verify(o, never()).onNext(any());
+    }
+
+    @Test
+    public void testSkipLastTimedCompleteBeforeTime() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skipLast(1, TimeUnit.SECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+
+        source.onComplete();
+
+        InOrder inOrder = inOrder(o);
+        inOrder.verify(o).onComplete();
+        inOrder.verifyNoMoreInteractions();
+
+        verify(o, never()).onNext(any());
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipLastTimedWhenAllElementsAreValid() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skipLast(1, TimeUnit.MILLISECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+
+        source.onComplete();
+
+        InOrder inOrder = inOrder(o);
+        inOrder.verify(o).onNext(1);
+        inOrder.verify(o).onNext(2);
+        inOrder.verify(o).onNext(3);
+        inOrder.verify(o).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorSkipTest {
+
+    @Test
+    public void testSkipNegativeElements() {
+
+        Observable<String> skip = Observable.just("one", "two", "three").skip(-99);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        skip.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipZeroElements() {
+
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(0));
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        skip.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipOneElement() {
+
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(1));
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        skip.subscribe(observer);
+        verify(observer, never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipTwoElements() {
+
+        Observable<String> skip = Observable.just("one", "two", "three").lift(new OperatorSkip<String>(2));
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        skip.subscribe(observer);
+        verify(observer, never()).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipEmptyStream() {
+
+        Observable<String> w = Observable.empty();
+        Observable<String> skip = w.lift(new OperatorSkip<String>(1));
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        skip.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipMultipleObservers() {
+
+        Observable<String> skip = Observable.just("one", "two", "three")
+                .skip(2);
+
+        Subscriber<String> observer1 = TestHelper.mockSubscriber();
+        skip.subscribe(observer1);
+
+        Subscriber<String> observer2 = TestHelper.mockSubscriber();
+        skip.subscribe(observer2);
+
+        verify(observer1, times(1)).onNext(any(String.class));
+        verify(observer1, never()).onError(any(Throwable.class));
+        verify(observer1, times(1)).onComplete();
+
+        verify(observer2, times(1)).onNext(any(String.class));
+        verify(observer2, never()).onError(any(Throwable.class));
+        verify(observer2, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipError() {
+
+        Exception e = new Exception();
+
+        Observable<String> ok = Observable.just("one");
+        Observable<String> error = Observable.error(e);
+
+        Observable<String> skip = Observable.concat(ok, error).lift(new OperatorSkip<String>(100));
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        skip.subscribe(observer);
+
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, times(1)).onError(e);
+        verify(observer, never()).onComplete();
+
+    }
+    
+    @Test
+    public void testBackpressureMultipleSmallAsyncRequests() throws InterruptedException {
+        final AtomicLong requests = new AtomicLong(0);
+        TestSubscriber<Long> ts = new TestSubscriber<>((Long)null);
+        Observable.interval(100, TimeUnit.MILLISECONDS)
+                .doOnRequest(new LongConsumer() {
+                    @Override
+                    public void accept(long n) {
+                        requests.addAndGet(n);
+                    }
+                }).skip(4).subscribe(ts);
+        Thread.sleep(100);
+        ts.request(1);
+        ts.request(1);
+        Thread.sleep(100);
+        ts.dispose();
+        // FIXME not assertable anymore
+//        ts.assertUnsubscribed();
+        ts.assertNoErrors();
+        assertEquals(6, requests.get());
+    }
+    
+    @Test
+    public void testRequestOverflowDoesNotOccur() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE-1);
+        Observable.range(1, 10).skip(5).subscribe(ts);
+        ts.assertTerminated();
+        ts.assertComplete();
+        ts.assertNoErrors();
+        assertEquals(Arrays.asList(6,7,8,9,10), ts.values());
+    }
+    
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipTimedTest.java
@@ -1,0 +1,147 @@
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+
+public class OperatorSkipTimedTest {
+
+    @Test
+    public void testSkipTimed() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        source.onNext(4);
+        source.onNext(5);
+        source.onNext(6);
+
+        source.onComplete();
+
+        InOrder inOrder = inOrder(o);
+
+        inOrder.verify(o, never()).onNext(1);
+        inOrder.verify(o, never()).onNext(2);
+        inOrder.verify(o, never()).onNext(3);
+        inOrder.verify(o).onNext(4);
+        inOrder.verify(o).onNext(5);
+        inOrder.verify(o).onNext(6);
+        inOrder.verify(o).onComplete();
+        inOrder.verifyNoMoreInteractions();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipTimedFinishBeforeTime() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+        source.onComplete();
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        InOrder inOrder = inOrder(o);
+
+        inOrder.verify(o).onComplete();
+        inOrder.verifyNoMoreInteractions();
+        verify(o, never()).onNext(any());
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipTimedErrorBeforeTime() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+        source.onError(new TestException());
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        InOrder inOrder = inOrder(o);
+
+        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verifyNoMoreInteractions();
+        verify(o, never()).onNext(any());
+        verify(o, never()).onComplete();
+    }
+
+    @Test
+    public void testSkipTimedErrorAfterTime() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
+
+        Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        result.subscribe(o);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        source.onNext(4);
+        source.onNext(5);
+        source.onNext(6);
+
+        source.onError(new TestException());
+
+        InOrder inOrder = inOrder(o);
+
+        inOrder.verify(o, never()).onNext(1);
+        inOrder.verify(o, never()).onNext(2);
+        inOrder.verify(o, never()).onNext(3);
+        inOrder.verify(o).onNext(4);
+        inOrder.verify(o).onNext(5);
+        inOrder.verify(o).onNext(6);
+        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verifyNoMoreInteractions();
+        verify(o, never()).onComplete();
+
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipUntilTest.java
@@ -1,0 +1,143 @@
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.subjects.PublishSubject;
+
+public class OperatorSkipUntilTest {
+    Subscriber<Object> observer;
+
+    @Before
+    public void before() {
+        observer = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void normal1() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        Observable<Integer> m = source.skipUntil(other);
+        m.subscribe(observer);
+
+        source.onNext(0);
+        source.onNext(1);
+
+        other.onNext(100);
+
+        source.onNext(2);
+        source.onNext(3);
+        source.onNext(4);
+        source.onComplete();
+
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onNext(4);
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void otherNeverFires() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> m = source.skipUntil(Observable.never());
+
+        m.subscribe(observer);
+
+        source.onNext(0);
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+        source.onNext(4);
+        source.onComplete();
+
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void otherEmpty() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        Observable<Integer> m = source.skipUntil(Observable.empty());
+
+        m.subscribe(observer);
+
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void otherFiresAndCompletes() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        Observable<Integer> m = source.skipUntil(other);
+        m.subscribe(observer);
+
+        source.onNext(0);
+        source.onNext(1);
+
+        other.onNext(100);
+        other.onComplete();
+
+        source.onNext(2);
+        source.onNext(3);
+        source.onNext(4);
+        source.onComplete();
+
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onNext(4);
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void sourceThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        Observable<Integer> m = source.skipUntil(other);
+        m.subscribe(observer);
+
+        source.onNext(0);
+        source.onNext(1);
+
+        other.onNext(100);
+        other.onComplete();
+
+        source.onNext(2);
+        source.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void otherThrowsImmediately() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        Observable<Integer> m = source.skipUntil(other);
+        m.subscribe(observer);
+
+        source.onNext(0);
+        source.onNext(1);
+
+        other.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, never()).onNext(any());
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipWhileTest.java
@@ -1,0 +1,120 @@
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+
+public class OperatorSkipWhileTest {
+
+    Subscriber<Integer> w = TestHelper.mockSubscriber();
+
+    private static final Predicate<Integer> LESS_THAN_FIVE = new Predicate<Integer>() {
+        @Override
+        public boolean test(Integer v) {
+            if (v == 42)
+                throw new RuntimeException("that's not the answer to everything!");
+            return v < 5;
+        }
+    };
+
+    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() {
+        int index = 0;
+        @Override
+        public boolean test(Integer value) {
+            return index++ < 3;
+        }
+    };
+
+    @Test
+    public void testSkipWithIndex() {
+        Observable<Integer> src = Observable.just(1, 2, 3, 4, 5);
+        src.skipWhile(INDEX_LESS_THAN_THREE).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext(4);
+        inOrder.verify(w, times(1)).onNext(5);
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipEmpty() {
+        Observable<Integer> src = Observable.empty();
+        src.skipWhile(LESS_THAN_FIVE).subscribe(w);
+        verify(w, never()).onNext(anyInt());
+        verify(w, never()).onError(any(Throwable.class));
+        verify(w, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipEverything() {
+        Observable<Integer> src = Observable.just(1, 2, 3, 4, 3, 2, 1);
+        src.skipWhile(LESS_THAN_FIVE).subscribe(w);
+        verify(w, never()).onNext(anyInt());
+        verify(w, never()).onError(any(Throwable.class));
+        verify(w, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSkipNothing() {
+        Observable<Integer> src = Observable.just(5, 3, 1);
+        src.skipWhile(LESS_THAN_FIVE).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext(5);
+        inOrder.verify(w, times(1)).onNext(3);
+        inOrder.verify(w, times(1)).onNext(1);
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipSome() {
+        Observable<Integer> src = Observable.just(1, 2, 3, 4, 5, 3, 1, 5);
+        src.skipWhile(LESS_THAN_FIVE).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, times(1)).onNext(5);
+        inOrder.verify(w, times(1)).onNext(3);
+        inOrder.verify(w, times(1)).onNext(1);
+        inOrder.verify(w, times(1)).onNext(5);
+        inOrder.verify(w, times(1)).onComplete();
+        inOrder.verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSkipError() {
+        Observable<Integer> src = Observable.just(1, 2, 42, 5, 3, 1);
+        src.skipWhile(LESS_THAN_FIVE).subscribe(w);
+
+        InOrder inOrder = inOrder(w);
+        inOrder.verify(w, never()).onNext(anyInt());
+        inOrder.verify(w, never()).onComplete();
+        inOrder.verify(w, times(1)).onError(any(RuntimeException.class));
+    }
+    
+    @Test
+    public void testSkipManySubscribers() {
+        Observable<Integer> src = Observable.range(1, 10).skipWhile(LESS_THAN_FIVE);
+        int n = 5;
+        for (int i = 0; i < n; i++) {
+            Subscriber<Object> o = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(o);
+            
+            src.subscribe(o);
+            
+            for (int j = 5; j < 10; j++) {
+                inOrder.verify(o).onNext(j);
+            } 
+            inOrder.verify(o).onComplete();
+            verify(o, never()).onError(any(Throwable.class));
+        }
+    }
+}


### PR DESCRIPTION
Note that since we know have time unit in schedulers, one must be
careful with the time unit of the timed skip operators. The timestamps
will be calculated via this unit and may not return the expected values. 

For example, a skipLast of 1 second will not skip the value 0.5 seconds
before completion because its timestamp is rounded down to the start of
the second. But if one uses 1000 milliseconds, the value will be
skipped.