### PR TITLE
2.x: operator tests: timestamp, toMap, toMultiMap, toList, toSortedList

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2186,11 +2186,6 @@ public class Observable<T> implements Publisher<T> {
         return lift(new OperatorToList<>(collectionSupplier));
     }
 
-    /**
-     *
-     * @deprecated is this in use?
-     */
-    @Deprecated
     public final <K> Observable<Map<K, T>> toMap(Function<? super T, ? extends K> keySelector) {
         return collect(HashMap::new, (m, t) -> {
             K key = keySelector.apply(t);
@@ -2198,11 +2193,6 @@ public class Observable<T> implements Publisher<T> {
         });
     }
     
-    /**
-     *
-     * @deprecated is this in use?
-     */
-    @Deprecated
     public final <K, V> Observable<Map<K, V>> toMap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
         return collect(HashMap::new, (m, t) -> {
             K key = keySelector.apply(t);
@@ -2211,11 +2201,6 @@ public class Observable<T> implements Publisher<T> {
         });
     }
     
-    /**
-     *
-     * @deprecated is this in use?
-     */
-    @Deprecated
     public final <K, V> Observable<Map<K, V>> toMap(Function<? super T, ? extends K> keySelector, 
             Function<? super T, ? extends V> valueSelector,
             Supplier<? extends Map<K, V>> mapSupplier) {
@@ -2226,39 +2211,34 @@ public class Observable<T> implements Publisher<T> {
         });
     }
 
-    /**
-     *
-     * @deprecated is this in use?
-     */
-    @Deprecated
     public final <K> Observable<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
-        return toMultimap(keySelector, v -> v, ArrayList::new);
+        return toMultimap(keySelector, v -> v, HashMap::new, k -> new ArrayList<>());
     }
     
-    /**
-     *
-     * @deprecated is this in use?
-     */
-    @Deprecated
     public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
-        return toMultimap(keySelector, valueSelector, ArrayList::new);
+        return toMultimap(keySelector, valueSelector, HashMap::new, k -> new ArrayList<>());
     }
     
-    /**
-     *
-     * @deprecated is this in use?
-     */
-    @Deprecated
+    public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(
+            Function<? super T, ? extends K> keySelector, 
+            Function<? super T, ? extends V> valueSelector,
+            Supplier<Map<K, Collection<V>>> mapSupplier
+            ) {
+        return toMultimap(keySelector, valueSelector, mapSupplier, k -> new ArrayList<>());
+    }
+    
     @SuppressWarnings("unchecked")
-    public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, 
+    public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(
+            Function<? super T, ? extends K> keySelector, 
             Function<? super T, ? extends V> valueSelector, 
-            Supplier<? extends Collection<? super V>> collectionSupplier) {
-        return collect(HashMap::new, (m, t) -> {
+            Supplier<? extends Map<K, Collection<V>>> mapSupplier,
+            Function<? super K, ? extends Collection<? super V>> collectionFactory) {
+        return collect(mapSupplier, (m, t) -> {
             K key = keySelector.apply(t);
 
             Collection<V> coll = m.get(key);
             if (coll == null) {
-                coll = (Collection<V>)collectionSupplier.get();
+                coll = (Collection<V>)collectionFactory.apply(key);
                 m.put(key, coll);
             }
 

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2212,11 +2212,16 @@ public class Observable<T> implements Publisher<T> {
     }
 
     public final <K> Observable<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
-        return toMultimap(keySelector, v -> v, HashMap::new, k -> new ArrayList<>());
+        Function<? super T, ? extends T> valueSelector = v -> v;
+        Supplier<Map<K, Collection<T>>> mapSupplier = HashMap::new;
+        Function<K, Collection<T>> collectionFactory = k -> new ArrayList<>();
+        return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
     
     public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
-        return toMultimap(keySelector, valueSelector, HashMap::new, k -> new ArrayList<>());
+        Supplier<Map<K, Collection<V>>> mapSupplier = HashMap::new;
+        Function<K, Collection<V>> collectionFactory = k -> new ArrayList<>();
+        return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
     
     public final <K, V> Observable<Map<K, Collection<V>>> toMultimap(

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipTimedTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipUntilTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/reactivex/internal/operators/OperatorSkipWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorSkipWhileTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators;
 
 import static org.mockito.Matchers.*;

--- a/src/test/java/io/reactivex/internal/operators/OperatorTimestampTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorTimestampTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.*;
+import io.reactivex.subjects.PublishSubject;
+
+public class OperatorTimestampTest {
+    Subscriber<Object> observer;
+
+    @Before
+    public void before() {
+        observer = TestHelper.mockSubscriber();
+    }
+
+    @Test
+    public void timestampWithScheduler() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+        Observable<Timed<Integer>> m = source.timestamp(scheduler);
+        m.subscribe(observer);
+
+        source.onNext(1);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+        source.onNext(2);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+        source.onNext(3);
+
+        InOrder inOrder = inOrder(observer);
+
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(2, 100, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(3, 200, TimeUnit.MILLISECONDS));
+
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void timestampWithScheduler2() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+        Observable<Timed<Integer>> m = source.timestamp(scheduler);
+        m.subscribe(observer);
+
+        source.onNext(1);
+        source.onNext(2);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+        source.onNext(3);
+
+        InOrder inOrder = inOrder(observer);
+
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(2, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(3, 200, TimeUnit.MILLISECONDS));
+
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorToMapTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+
+public class OperatorToMapTest {
+    Subscriber<Object> objectObserver;
+
+    @Before
+    public void before() {
+        objectObserver = TestHelper.mockSubscriber();
+    }
+
+    Function<String, Integer> lengthFunc = new Function<String, Integer>() {
+        @Override
+        public Integer apply(String t1) {
+            return t1.length();
+        }
+    };
+    Function<String, String> duplicate = new Function<String, String>() {
+        @Override
+        public String apply(String t1) {
+            return t1 + t1;
+        }
+    };
+
+    @Test
+    public void testToMap() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc);
+
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMapWithValueSelector() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate);
+
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "aa");
+        expected.put(2, "bbbb");
+        expected.put(3, "cccccc");
+        expected.put(4, "dddddddd");
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMapWithError() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                if ("bb".equals(t1)) {
+                    throw new RuntimeException("Forced Failure");
+                }
+                return t1.length();
+            }
+        };
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFuncErr);
+
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testToMapWithErrorInValueSelector() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Function<String, String> duplicateErr = new Function<String, String>() {
+            @Override
+            public String apply(String t1) {
+                if ("bb".equals(t1)) {
+                    throw new RuntimeException("Forced failure");
+                }
+                return t1 + t1;
+            }
+        };
+
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr);
+
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "aa");
+        expected.put(2, "bbbb");
+        expected.put(3, "cccccc");
+        expected.put(4, "dddddddd");
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testToMapWithFactory() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
+            @Override
+            public Map<Integer, String> get() {
+                return new LinkedHashMap<Integer, String>() {
+                    /** */
+                    private static final long serialVersionUID = -3296811238780863394L;
+
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
+                        return size() > 3;
+                    }
+                };
+            }
+        };
+
+        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                return t1.length();
+            }
+        };
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, v -> v, mapFactory);
+
+        Map<Integer, String> expected = new LinkedHashMap<>();
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMapWithErrorThrowingFactory() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
+            @Override
+            public Map<Integer, String> get() {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                return t1.length();
+            }
+        };
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, v -> v, mapFactory);
+
+        Map<Integer, String> expected = new LinkedHashMap<>();
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorToMultimapTest.java
@@ -227,9 +227,10 @@ public class OperatorToMultimapTest {
         };
 
         Function<String, String> identity = v -> v;
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = HashMap::new;
         
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, 
-                identity, HashMap::new, collectionFactory);
+                identity, mapSupplier, collectionFactory);
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));

--- a/src/test/java/io/reactivex/internal/operators/OperatorToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorToMultimapTest.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+
+public class OperatorToMultimapTest {
+    Subscriber<Object> objectObserver;
+
+    @Before
+    public void before() {
+        objectObserver = TestHelper.mockSubscriber();
+    }
+
+    Function<String, Integer> lengthFunc = t1 -> t1.length();
+    Function<String, String> duplicate = t1 -> t1 + t1;
+
+    @Test
+    public void testToMultimap() {
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
+
+        Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(1, Arrays.asList("a", "b"));
+        expected.put(2, Arrays.asList("cc", "dd"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithValueSelector() {
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
+
+        Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(1, Arrays.asList("aa", "bb"));
+        expected.put(2, Arrays.asList("cccc", "dddd"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithMapFactory() {
+        Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
+
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
+            @Override
+            public Map<Integer, Collection<String>> get() {
+                return new LinkedHashMap<Integer, Collection<String>>() {
+                    /** */
+                    private static final long serialVersionUID = -2084477070717362859L;
+
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<Integer, Collection<String>> eldest) {
+                        return size() > 2;
+                    }
+                };
+            }
+        };
+
+        Function<String, String> identity = v -> v;
+        
+        Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(
+                lengthFunc, identity,
+                mapFactory, ArrayList::new);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, Arrays.asList("eee", "fff"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithCollectionFactory() {
+        Observable<String> source = Observable.just("cc", "dd", "eee", "eee");
+
+        Function<Integer, Collection<String>> collectionFactory = t1 -> {
+            if (t1 == 2) {
+                return new ArrayList<>();
+            } else {
+                return new HashSet<>();
+            }
+        };
+
+        Function<String, String> identity = v -> v;
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = HashMap::new;
+        
+        Observable<Map<Integer, Collection<String>>> mapped = source
+                .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, new HashSet<>(Arrays.asList("eee")));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithError() {
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
+
+        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                if ("b".equals(t1)) {
+                    throw new RuntimeException("Forced Failure");
+                }
+                return t1.length();
+            }
+        };
+
+        Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(1, Arrays.asList("a", "b"));
+        expected.put(2, Arrays.asList("cc", "dd"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithErrorInValueSelector() {
+        Observable<String> source = Observable.just("a", "b", "cc", "dd");
+
+        Function<String, String> duplicateErr = new Function<String, String>() {
+            @Override
+            public String apply(String t1) {
+                if ("b".equals(t1)) {
+                    throw new RuntimeException("Forced failure");
+                }
+                return t1 + t1;
+            }
+        };
+
+        Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(1, Arrays.asList("aa", "bb"));
+        expected.put(2, Arrays.asList("cccc", "dddd"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithMapThrowingFactory() {
+        Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
+
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
+            @Override
+            public Map<Integer, Collection<String>> get() {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Observable<Map<Integer, Collection<String>>> mapped = source
+                .toMultimap(lengthFunc, v -> v, mapFactory);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, Arrays.asList("eee", "fff"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithThrowingCollectionFactory() {
+        Observable<String> source = Observable.just("cc", "cc", "eee", "eee");
+
+        Function<Integer, Collection<String>> collectionFactory = t1 -> {
+            if (t1 == 2) {
+                throw new RuntimeException("Forced failure");
+            } else {
+                return new HashSet<>();
+            }
+        };
+
+        Function<String, String> identity = v -> v;
+        
+        Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, 
+                identity, HashMap::new, collectionFactory);
+
+        Map<Integer, Collection<String>> expected = new HashMap<>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, Collections.singleton("eee"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorToObservableListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorToObservableListTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.*;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorToObservableListTest {
+
+    @Test
+    public void testList() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        Observable<List<String>> observable = w.toList();
+
+        Subscriber<List<String>> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList("one", "two", "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+    
+    @Test
+    public void testListViaObservable() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        Observable<List<String>> observable = w.toList();
+
+        Subscriber<List<String>> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList("one", "two", "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testListMultipleSubscribers() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        Observable<List<String>> observable = w.toList();
+
+        Subscriber<List<String>> o1 = TestHelper.mockSubscriber();
+        observable.subscribe(o1);
+
+        Subscriber<List<String>> o2 = TestHelper.mockSubscriber();
+        observable.subscribe(o2);
+
+        List<String> expected = Arrays.asList("one", "two", "three");
+
+        verify(o1, times(1)).onNext(expected);
+        verify(o1, Mockito.never()).onError(any(Throwable.class));
+        verify(o1, times(1)).onComplete();
+
+        verify(o2, times(1)).onNext(expected);
+        verify(o2, Mockito.never()).onError(any(Throwable.class));
+        verify(o2, times(1)).onComplete();
+    }
+
+    @Test
+    public void testListWithNullValue() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", null, "three"));
+        Observable<List<String>> observable = w.toList();
+
+        Subscriber<List<String>> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList("one", null, "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testListWithBlockingFirst() {
+        Observable<String> o = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        List<String> actual = o.toList().toBlocking().first();
+        Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
+    }
+    @Test
+    public void testBackpressureHonored() {
+        Observable<List<Integer>> w = Observable.just(1, 2, 3, 4, 5).toList();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>((Long)null);
+        
+        w.subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(1);
+        
+        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertNoErrors();
+        ts.assertComplete();
+
+        ts.request(1);
+
+        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    @Test(timeout = 2000)
+    @Ignore("PublishSubject no longer emits without requests so this test fails due to the race of onComplete and request")
+    public void testAsyncRequested() {
+        Scheduler.Worker w = Schedulers.newThread().createWorker();
+        try {
+            for (int i = 0; i < 1000; i++) {
+                if (i % 50 == 0) {
+                    System.out.println("testAsyncRequested -> " + i);
+                }
+                PublishSubject<Integer> source = PublishSubject.create();
+                Observable<List<Integer>> sorted = source.toList();
+
+                final CyclicBarrier cb = new CyclicBarrier(2);
+                final TestSubscriber<List<Integer>> ts = new TestSubscriber<>((Long)null);
+                sorted.subscribe(ts);
+                
+                w.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        await(cb);
+                        ts.request(1);
+                    }
+                });
+                source.onNext(1);
+                await(cb);
+                source.onComplete();
+                ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
+                ts.assertTerminated();
+                ts.assertNoErrors();
+                ts.assertValue(Arrays.asList(1));
+            }
+        } finally {
+            w.dispose();
+        }
+    }
+    static void await(CyclicBarrier cb) {
+        try {
+            cb.await();
+        } catch (InterruptedException ex) {
+            ex.printStackTrace();
+        } catch (BrokenBarrierException ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorToObservableSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorToObservableSortedListTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.*;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorToObservableSortedListTest {
+
+    @Test
+    public void testSortedList() {
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.toSortedList();
+
+        Subscriber<List<Integer>> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testSortedListWithCustomFunction() {
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.toSortedList(new Comparator<Integer>() {
+
+            @Override
+            public int compare(Integer t1, Integer t2) {
+                return t2 - t1;
+            }
+
+        });
+
+        Subscriber<List<Integer>> observer = TestHelper.mockSubscriber();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testWithFollowingFirst() {
+        Observable<Integer> o = Observable.just(1, 3, 2, 5, 4);
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), o.toSortedList().toBlocking().first());
+    }
+    @Test
+    public void testBackpressureHonored() {
+        Observable<List<Integer>> w = Observable.just(1, 3, 2, 5, 4).toSortedList();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>((Long)null);
+        
+        w.subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(1);
+        
+        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertNoErrors();
+        ts.assertComplete();
+
+        ts.request(1);
+
+        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    @Test(timeout = 2000)
+    @Ignore("PublishSubject no longer emits without requests so this test fails due to the race of onComplete and request")
+    public void testAsyncRequested() {
+        Scheduler.Worker w = Schedulers.newThread().createWorker();
+        try {
+            for (int i = 0; i < 1000; i++) {
+                if (i % 50 == 0) {
+                    System.out.println("testAsyncRequested -> " + i);
+                }
+                PublishSubject<Integer> source = PublishSubject.create();
+                Observable<List<Integer>> sorted = source.toSortedList();
+
+                final CyclicBarrier cb = new CyclicBarrier(2);
+                final TestSubscriber<List<Integer>> ts = new TestSubscriber<>((Long)null);
+                sorted.subscribe(ts);
+                w.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        await(cb);
+                        ts.request(1);
+                    }
+                });
+                source.onNext(1);
+                await(cb);
+                source.onComplete();
+                ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
+                ts.assertTerminated();
+                ts.assertNoErrors();
+                ts.assertValue(Arrays.asList(1));
+            }
+        } finally {
+            w.dispose();
+        }
+    }
+    static void await(CyclicBarrier cb) {
+        try {
+            cb.await();
+        } catch (InterruptedException ex) {
+            ex.printStackTrace();
+        } catch (BrokenBarrierException ex) {
+            ex.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
+ signature fix to toMultimap and removed deprecated markers.