### PR TITLE
2.x: operator tests unsubscribeOn, withLatestFrom, zip (partial)

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2407,11 +2407,7 @@ public class Observable<T> implements Publisher<T> {
     }
 
     public final <U, R> Observable<R> zipWith(Iterable<? extends U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
-        return zip(this, new PublisherIterableSource<>(other), zipper);
-    }
-
-    public final <U, R> Observable<R> zipWith(Iterable<? extends U> other,  BiFunction<? super T, ? super U, ? extends R> zipper, int bufferSize) {
-        return zip(this, new PublisherIterableSource<>(other), zipper, false, bufferSize);
+        return create(new PublisherZipIterable<>(this, other, zipper));
     }
 
     public final <U, R> Observable<R> zipWith(Publisher<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {

--- a/src/main/java/io/reactivex/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorObserveOn.java
@@ -167,10 +167,8 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
         public void cancel() {
             if (!cancelled) {
                 cancelled = true;
-                if (getAndIncrement() == 0) {
-                    s.cancel();
-                    worker.dispose();
-                }
+                s.cancel();
+                worker.dispose();
             }
         }
         

--- a/src/main/java/io/reactivex/internal/operators/OperatorWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorWithLatestFrom.java
@@ -121,8 +121,6 @@ public final class OperatorWithLatestFrom<T, U, R> implements Operator<R, T> {
                     return;
                 }
                 actual.onNext(r);
-            } else {
-                s.request(1);
             }
         }
         

--- a/src/main/java/io/reactivex/internal/operators/PublisherSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherSubscribeOn.java
@@ -81,14 +81,20 @@ public final class PublisherSubscribeOn<T> implements Publisher<T> {
         
         @Override
         public void onError(Throwable t) {
-            cancel();
-            actual.onError(t);
+            try {
+                actual.onError(t);
+            } finally {
+                worker.dispose();
+            }
         }
         
         @Override
         public void onComplete() {
-            cancel();
-            actual.onComplete();
+            try {
+                actual.onComplete();
+            } finally {
+                worker.dispose();
+            }
         }
         
         @Override

--- a/src/main/java/io/reactivex/internal/operators/PublisherZip.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherZip.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators;
 
-import java.util.*;
+import java.util.Queue;
 import java.util.concurrent.atomic.*;
 import java.util.function.Function;
 
@@ -161,9 +161,9 @@ public final class PublisherZip<T, R> implements Publisher<R> {
                 boolean unbounded = r == Long.MAX_VALUE;
                 long e = 0;
                 
-                outer:
                 while (r != 0) {
                     int i = 0;
+                    int emptyCount = 0;
                     for (ZipSubscriber<T, R> z : zs) {
                         boolean d = z.done;
                         T v = z.queue.peek();
@@ -174,13 +174,17 @@ public final class PublisherZip<T, R> implements Publisher<R> {
                         }
                         
                         if (empty) {
-                            break outer;
+                            emptyCount++;
+                            continue;
                         }
                         
                         os[i] = v;
                         i++;
                     }
                     
+                    if (emptyCount != 0) {
+                        break;
+                    }
                     // consume the row
                     for (ZipSubscriber<T, R> z : zs) {
                         z.queue.poll();

--- a/src/main/java/io/reactivex/internal/operators/PublisherZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherZipIterable.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import java.util.Iterator;
+import java.util.function.BiFunction;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class PublisherZipIterable<T, U, V> implements Publisher<V> {
+    final Publisher<? extends T> source;
+    final Iterable<U> other;
+    final BiFunction<? super T, ? super U, ? extends V> zipper;
+
+    public PublisherZipIterable(
+            Publisher<? extends T> source,
+            Iterable<U> other, BiFunction<? super T, ? super U, ? extends V> zipper) {
+        this.source = source;
+        this.other = other;
+        this.zipper = zipper;
+    }
+    
+    @Override
+    public void subscribe(Subscriber<? super V> t) {
+        Iterator<U> it;
+        
+        try {
+            it = other.iterator();
+        } catch (Throwable e) {
+            EmptySubscription.error(e, t);
+            return;
+        }
+        
+        if (it == null) {
+            EmptySubscription.error(new NullPointerException("The iterator returned by other is null"), t);
+            return;
+        }
+        
+        boolean b;
+        
+        try {
+            b = it.hasNext();
+        } catch (Throwable e) {
+            EmptySubscription.error(e, t);
+            return;
+        }
+        
+        if (!b) {
+            EmptySubscription.complete(t);
+            return;
+        }
+        
+        source.subscribe(new ZipIterableSubscriber<>(t, it, zipper));
+    }
+    
+    static final class ZipIterableSubscriber<T, U, V> implements Subscriber<T> {
+        final Subscriber<? super V> actual;
+        final Iterator<U> iterator;
+        final BiFunction<? super T, ? super U, ? extends V> zipper;
+        
+        Subscription s;
+        
+        boolean done;
+
+        public ZipIterableSubscriber(Subscriber<? super V> actual, Iterator<U> iterator,
+                BiFunction<? super T, ? super U, ? extends V> zipper) {
+            this.actual = actual;
+            this.iterator = iterator;
+            this.zipper = zipper;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                return;
+            }
+            this.s = s;
+            actual.onSubscribe(s);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+
+            U u;
+
+            try {
+                u = iterator.next();
+            } catch (Throwable e) {
+                error(e);
+                return;
+            }
+            
+            if (u == null) {
+                error(new NullPointerException("The iterator returned a null value"));
+                return;
+            }
+            
+            V v;
+            try {
+                v = zipper.apply(t, u);
+            } catch (Throwable e) {
+                error(new NullPointerException("The iterator returned a null value"));
+                return;
+            }
+            
+            if (v == null) {
+                error(new NullPointerException("The zipper function returned a null value"));
+                return;
+            }
+            
+            actual.onNext(v);
+            
+            boolean b;
+            
+            try {
+                b = iterator.hasNext();
+            } catch (Throwable e) {
+                error(e);
+                return;
+            }
+            
+            if (!b) {
+                done = true;
+                s.cancel();
+                actual.onComplete();
+            }
+        }
+        
+        void error(Throwable e) {
+            done = true;
+            s.cancel();
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+        
+    }
+}

--- a/src/main/java/io/reactivex/internal/schedulers/ScheduledRunnable.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ScheduledRunnable.java
@@ -67,6 +67,8 @@ public final class ScheduledRunnable extends AtomicReferenceArray<Object> implem
                     if (compareAndSet(FUTURE_INDEX, o, DONE)) {
                         break;
                     }
+                } else {
+                    break;
                 }
             }
         }

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -20,6 +20,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscribers.EmptySubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
 /**
@@ -199,8 +200,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
     
     @Override
     public void request(long n) {
-        if (n <= 0) {
-            errors.add(new IllegalArgumentException("n > 0 required but it was " + n));
+        if (SubscriptionHelper.validateRequest(n)) {
             return;
         }
         Subscription s = subscription;

--- a/src/test/java/io/reactivex/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorReplayTest.java
@@ -602,7 +602,7 @@ public class OperatorReplayTest {
 //        verify(spiedWorker, times(1)).isUnsubscribed();
         // FIXME publish calls cancel too
         verify(spiedWorker, times(2)).dispose();
-        verify(sourceUnsubscribed, times(2)).run();
+        verify(sourceUnsubscribed, times(1)).run();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);
@@ -668,7 +668,7 @@ public class OperatorReplayTest {
 //        verify(spiedWorker, times(1)).isUnsubscribed();
         // FIXME publish also calls cancel
         verify(spiedWorker, times(2)).dispose();
-        verify(sourceUnsubscribed, times(2)).run();
+        verify(sourceUnsubscribed, times(1)).run();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);

--- a/src/test/java/io/reactivex/internal/operators/OperatorToObservableListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorToObservableListTest.java
@@ -78,6 +78,7 @@ public class OperatorToObservableListTest {
     }
 
     @Test
+    @Ignore("Null values are not allowed")
     public void testListWithNullValue() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", null, "three"));
         Observable<List<String>> observable = w.toList();

--- a/src/test/java/io/reactivex/internal/operators/OperatorUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorUnsubscribeOnTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorUnsubscribeOnTest {
+
+    @Test
+    public void testUnsubscribeWhenSubscribeOnAndUnsubscribeOnAreOnSameThread() throws InterruptedException {
+        UIEventLoopScheduler UI_EVENT_LOOP = new UIEventLoopScheduler();
+        try {
+            final ThreadSubscription subscription = new ThreadSubscription();
+            final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
+            Observable<Integer> w = Observable.create(new Publisher<Integer>() {
+
+                @Override
+                public void subscribe(Subscriber<? super Integer> t1) {
+                    subscribeThread.set(Thread.currentThread());
+                    t1.onSubscribe(subscription);
+                    t1.onNext(1);
+                    t1.onNext(2);
+                    t1.onComplete();
+                }
+            });
+
+            TestSubscriber<Integer> observer = new TestSubscriber<>();
+            w.subscribeOn(UI_EVENT_LOOP).observeOn(Schedulers.computation()).unsubscribeOn(UI_EVENT_LOOP).subscribe(observer);
+
+            observer.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            observer.dispose();
+            
+            Thread unsubscribeThread = subscription.getThread();
+
+            assertNotNull(unsubscribeThread);
+            assertNotSame(Thread.currentThread(), unsubscribeThread);
+
+            assertNotNull(subscribeThread.get());
+            assertNotSame(Thread.currentThread(), subscribeThread.get());
+            // True for Schedulers.newThread()
+
+            System.out.println("unsubscribeThread: " + unsubscribeThread);
+            System.out.println("subscribeThread.get(): " + subscribeThread.get());
+            assertTrue(unsubscribeThread == UI_EVENT_LOOP.getThread());
+
+            observer.assertValues(1, 2);
+            observer.assertTerminated();
+        } finally {
+            UI_EVENT_LOOP.shutdown();
+        }
+    }
+
+    @Test
+    public void testUnsubscribeWhenSubscribeOnAndUnsubscribeOnAreOnDifferentThreads() throws InterruptedException {
+        UIEventLoopScheduler UI_EVENT_LOOP = new UIEventLoopScheduler();
+        try {
+            final ThreadSubscription subscription = new ThreadSubscription();
+            final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
+            Observable<Integer> w = Observable.create(new Publisher<Integer>() {
+
+                @Override
+                public void subscribe(Subscriber<? super Integer> t1) {
+                    subscribeThread.set(Thread.currentThread());
+                    t1.onSubscribe(subscription);
+                    t1.onNext(1);
+                    t1.onNext(2);
+                    t1.onComplete();
+                }
+            });
+
+            TestSubscriber<Integer> observer = new TestSubscriber<>();
+            w.subscribeOn(Schedulers.newThread()).observeOn(Schedulers.computation()).unsubscribeOn(UI_EVENT_LOOP).subscribe(observer);
+
+            observer.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            observer.dispose();
+            
+            Thread unsubscribeThread = subscription.getThread();
+
+            assertNotNull(unsubscribeThread);
+            assertNotSame(Thread.currentThread(), unsubscribeThread);
+
+            assertNotNull(subscribeThread.get());
+            assertNotSame(Thread.currentThread(), subscribeThread.get());
+            // True for Schedulers.newThread()
+
+            System.out.println("UI Thread: " + UI_EVENT_LOOP.getThread());
+            System.out.println("unsubscribeThread: " + unsubscribeThread);
+            System.out.println("subscribeThread.get(): " + subscribeThread.get());
+            assertSame(unsubscribeThread, UI_EVENT_LOOP.getThread());
+
+            observer.assertValues(1, 2);
+            observer.assertTerminated();
+        } finally {
+            UI_EVENT_LOOP.shutdown();
+        }
+    }
+
+    private static class ThreadSubscription implements Subscription {
+        private volatile Thread thread;
+
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void cancel() {
+            System.out.println("unsubscribe invoked: " + Thread.currentThread());
+            thread = Thread.currentThread();
+            latch.countDown();
+        }
+
+        public Thread getThread() throws InterruptedException {
+            latch.await();
+            return thread;
+        }
+        
+        @Override
+        public void request(long n) {
+            
+        }
+    }
+
+    public static class UIEventLoopScheduler extends Scheduler {
+
+        private final Scheduler eventLoop;
+        private volatile Thread t;
+
+        public UIEventLoopScheduler() {
+
+            eventLoop = Schedulers.single();
+
+            /*
+             * DON'T DO THIS IN PRODUCTION CODE
+             */
+            final CountDownLatch latch = new CountDownLatch(1);
+            eventLoop.scheduleDirect(new Runnable() {
+
+                @Override
+                public void run() {
+                    t = Thread.currentThread();
+                    latch.countDown();
+                }
+
+            });
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("failed to initialize and get inner thread");
+            }
+        }
+        
+        @Override
+        public Worker createWorker() {
+            return eventLoop.createWorker();
+        }
+
+        public Thread getThread() {
+            return t;
+        }
+
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorWithLatestFromTest.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.function.BiFunction;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorWithLatestFromTest {
+    static final BiFunction<Integer, Integer, Integer> COMBINER = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer t1, Integer t2) {
+            return (t1 << 8) + t2;
+        }
+    };
+    static final BiFunction<Integer, Integer, Integer> COMBINER_ERROR = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer t1, Integer t2) {
+            throw new TestException("Forced failure");
+        }
+    };
+    @Test
+    public void testSimple() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(o);
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        result.subscribe(o);
+        
+        source.onNext(1);
+        inOrder.verify(o, never()).onNext(anyInt());
+        
+        other.onNext(1);
+        inOrder.verify(o, never()).onNext(anyInt());
+        
+        source.onNext(2);
+        inOrder.verify(o).onNext((2 << 8) + 1);
+        
+        other.onNext(2);
+        inOrder.verify(o, never()).onNext(anyInt());
+        
+        other.onComplete();
+        inOrder.verify(o, never()).onComplete();
+        
+        source.onNext(3);
+        inOrder.verify(o).onNext((3 << 8) + 2);
+        
+        source.onComplete();
+        inOrder.verify(o).onComplete();
+        
+        verify(o, never()).onError(any(Throwable.class));
+    }
+    
+    @Test
+    public void testEmptySource() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.subscribe(ts);
+
+        assertTrue(source.hasSubscribers());
+        assertTrue(other.hasSubscribers());
+
+        other.onNext(1);
+        
+        source.onComplete();
+        
+        ts.assertNoErrors();
+        ts.assertTerminated();
+        ts.assertNoValues();
+        
+        assertFalse(source.hasSubscribers());
+        assertFalse(other.hasSubscribers());
+    }
+    
+    @Test
+    public void testEmptyOther() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.subscribe(ts);
+
+        assertTrue(source.hasSubscribers());
+        assertTrue(other.hasSubscribers());
+
+        source.onNext(1);
+        
+        source.onComplete();
+        
+        ts.assertNoErrors();
+        ts.assertTerminated();
+        ts.assertNoValues();
+        
+        assertFalse(source.hasSubscribers());
+        assertFalse(other.hasSubscribers());
+    }
+    
+    
+    @Test
+    public void testUnsubscription() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.subscribe(ts);
+
+        assertTrue(source.hasSubscribers());
+        assertTrue(other.hasSubscribers());
+
+        other.onNext(1);
+        source.onNext(1);
+        
+        ts.dispose();
+        
+        ts.assertValue((1 << 8) + 1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        assertFalse(source.hasSubscribers());
+        assertFalse(other.hasSubscribers());
+    }
+
+    @Test
+    public void testSourceThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.subscribe(ts);
+
+        assertTrue(source.hasSubscribers());
+        assertTrue(other.hasSubscribers());
+
+        other.onNext(1);
+        source.onNext(1);
+        
+        source.onError(new TestException());
+        
+        ts.assertTerminated();
+        ts.assertValue((1 << 8) + 1);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+        
+        assertFalse(source.hasSubscribers());
+        assertFalse(other.hasSubscribers());
+    }
+    @Test
+    public void testOtherThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.subscribe(ts);
+
+        assertTrue(source.hasSubscribers());
+        assertTrue(other.hasSubscribers());
+
+        other.onNext(1);
+        source.onNext(1);
+        
+        other.onError(new TestException());
+        
+        ts.assertTerminated();
+        ts.assertValue((1 << 8) + 1);
+        ts.assertNotComplete();
+        ts.assertError(TestException.class);
+        
+        assertFalse(source.hasSubscribers());
+        assertFalse(other.hasSubscribers());
+    }
+    
+    @Test
+    public void testFunctionThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER_ERROR);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.subscribe(ts);
+
+        assertTrue(source.hasSubscribers());
+        assertTrue(other.hasSubscribers());
+
+        other.onNext(1);
+        source.onNext(1);
+        
+        ts.assertTerminated();
+        ts.assertNotComplete();
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        
+        assertFalse(source.hasSubscribers());
+        assertFalse(other.hasSubscribers());
+    }
+    
+    @Test
+    public void testNoDownstreamUnsubscribe() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        result.unsafeSubscribe(ts);
+        
+        source.onComplete();
+        
+        assertFalse(ts.isCancelled());
+    }
+    
+    @Test
+    public void testBackpressure() {
+        Observable<Integer> source = Observable.range(1, 10);
+        PublishSubject<Integer> other = PublishSubject.create();
+        
+        Observable<Integer> result = source.withLatestFrom(other, COMBINER);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        
+        result.subscribe(ts);
+
+        assertTrue("Other has no observers!", other.hasSubscribers());
+        
+        ts.request(1);
+
+        assertTrue("Other has no observers!", other.hasSubscribers());
+
+        ts.assertNoValues();
+        
+        other.onNext(1);
+        
+        ts.request(1);
+        
+        ts.assertValue((2 << 8) + 1);
+        
+        ts.request(5);
+        ts.assertValues(
+                (2 << 8) + 1, (3 << 8) + 1, (4 << 8) + 1, (5 << 8) + 1, 
+                (6 << 8) + 1, (7 << 8) + 1 
+        );
+        
+        ts.dispose();
+        
+        assertFalse("Other has observers!", other.hasSubscribers());
+
+        ts.assertNoErrors();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorZipCompletionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorZipCompletionTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.mockito.Mockito.*;
+
+import java.util.function.BiFunction;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.subjects.PublishSubject;
+
+/**
+ * Systematically tests that when zipping an infinite and a finite Observable,
+ * the resulting Observable is finite.
+ * 
+ */
+public class OperatorZipCompletionTest {
+    BiFunction<String, String, String> concat2Strings;
+
+    PublishSubject<String> s1;
+    PublishSubject<String> s2;
+    Observable<String> zipped;
+
+    Subscriber<String> observer;
+    InOrder inOrder;
+
+    @Before
+    public void setUp() {
+        concat2Strings = new BiFunction<String, String, String>() {
+            @Override
+            public String apply(String t1, String t2) {
+                return t1 + "-" + t2;
+            }
+        };
+
+        s1 = PublishSubject.create();
+        s2 = PublishSubject.create();
+        zipped = Observable.zip(s1, s2, concat2Strings);
+
+        observer = TestHelper.mockSubscriber();
+        inOrder = inOrder(observer);
+
+        zipped.subscribe(observer);
+    }
+
+    @Test
+    public void testFirstCompletesThenSecondInfinite() {
+        s1.onNext("a");
+        s1.onNext("b");
+        s1.onComplete();
+        s2.onNext("1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
+        s2.onNext("2");
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSecondInfiniteThenFirstCompletes() {
+        s2.onNext("1");
+        s2.onNext("2");
+        s1.onNext("a");
+        inOrder.verify(observer, times(1)).onNext("a-1");
+        s1.onNext("b");
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        s1.onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSecondCompletesThenFirstInfinite() {
+        s2.onNext("1");
+        s2.onNext("2");
+        s2.onComplete();
+        s1.onNext("a");
+        inOrder.verify(observer, times(1)).onNext("a-1");
+        s1.onNext("b");
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testFirstInfiniteThenSecondCompletes() {
+        s1.onNext("a");
+        s1.onNext("b");
+        s2.onNext("1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
+        s2.onNext("2");
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        s2.onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorZipIterableTest.java
@@ -1,0 +1,359 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function3;
+import io.reactivex.subjects.PublishSubject;
+
+public class OperatorZipIterableTest {
+    BiFunction<String, String, String> concat2Strings;
+    PublishSubject<String> s1;
+    PublishSubject<String> s2;
+    Observable<String> zipped;
+
+    Subscriber<String> observer;
+    InOrder inOrder;
+
+    @Before
+    public void setUp() {
+        concat2Strings = new BiFunction<String, String, String>() {
+            @Override
+            public String apply(String t1, String t2) {
+                return t1 + "-" + t2;
+            }
+        };
+
+        s1 = PublishSubject.create();
+        s2 = PublishSubject.create();
+        zipped = Observable.zip(s1, s2, concat2Strings);
+
+        observer = TestHelper.mockSubscriber();
+        inOrder = inOrder(observer);
+
+        zipped.subscribe(observer);
+    }
+
+    BiFunction<Object, Object, String> zipr2 = new BiFunction<Object, Object, String>() {
+
+        @Override
+        public String apply(Object t1, Object t2) {
+            return "" + t1 + t2;
+        }
+
+    };
+    Function3<Object, Object, Object, String> zipr3 = new Function3<Object, Object, Object, String>() {
+
+        @Override
+        public String apply(Object t1, Object t2, Object t3) {
+            return "" + t1 + t2 + t3;
+        }
+
+    };
+
+    @Test
+    public void testZipIterableSameSize() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = Arrays.asList("1", "2", "3");
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onNext("two-");
+        r1.onNext("three-");
+        r1.onComplete();
+
+        io.verify(o).onNext("one-1");
+        io.verify(o).onNext("two-2");
+        io.verify(o).onNext("three-3");
+        io.verify(o).onComplete();
+
+        verify(o, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testZipIterableEmptyFirstSize() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = Arrays.asList("1", "2", "3");
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onComplete();
+
+        io.verify(o).onComplete();
+
+        verify(o, never()).onNext(any(String.class));
+        verify(o, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testZipIterableEmptySecond() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = Arrays.asList();
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onNext("two-");
+        r1.onNext("three-");
+        r1.onComplete();
+
+        io.verify(o).onComplete();
+
+        verify(o, never()).onNext(any(String.class));
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testZipIterableFirstShorter() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = Arrays.asList("1", "2", "3");
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onNext("two-");
+        r1.onComplete();
+
+        io.verify(o).onNext("one-1");
+        io.verify(o).onNext("two-2");
+        io.verify(o).onComplete();
+
+        verify(o, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testZipIterableSecondShorter() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = Arrays.asList("1", "2");
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onNext("two-");
+        r1.onNext("three-");
+        r1.onComplete();
+
+        io.verify(o).onNext("one-1");
+        io.verify(o).onNext("two-2");
+        io.verify(o).onComplete();
+
+        verify(o, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testZipIterableFirstThrows() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = Arrays.asList("1", "2", "3");
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onNext("two-");
+        r1.onError(new TestException());
+
+        io.verify(o).onNext("one-1");
+        io.verify(o).onNext("two-2");
+        io.verify(o).onError(any(TestException.class));
+
+        verify(o, never()).onComplete();
+
+    }
+
+    @Test
+    public void testZipIterableIteratorThrows() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = new Iterable<String>() {
+            @Override
+            public Iterator<String> iterator() {
+                throw new TestException();
+            }
+        };
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onNext("two-");
+        r1.onError(new TestException());
+
+        io.verify(o).onError(any(TestException.class));
+
+        verify(o, never()).onComplete();
+        verify(o, never()).onNext(any(String.class));
+
+    }
+
+    @Test
+    public void testZipIterableHasNextThrows() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = new Iterable<String>() {
+
+            @Override
+            public Iterator<String> iterator() {
+                return new Iterator<String>() {
+                    int count;
+
+                    @Override
+                    public boolean hasNext() {
+                        if (count == 0) {
+                            return true;
+                        }
+                        throw new TestException();
+                    }
+
+                    @Override
+                    public String next() {
+                        count++;
+                        return "1";
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException("Not supported yet.");
+                    }
+
+                };
+            }
+
+        };
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onNext("one-");
+        r1.onError(new TestException());
+
+        io.verify(o).onNext("one-1");
+        io.verify(o).onError(any(TestException.class));
+
+        verify(o, never()).onComplete();
+
+    }
+
+    @Test
+    public void testZipIterableNextThrows() {
+        PublishSubject<String> r1 = PublishSubject.create();
+        /* define a Subscriber to receive aggregated events */
+        Subscriber<String> o = TestHelper.mockSubscriber();
+        InOrder io = inOrder(o);
+
+        Iterable<String> r2 = new Iterable<String>() {
+
+            @Override
+            public Iterator<String> iterator() {
+                return new Iterator<String>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public String next() {
+                        throw new TestException();
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException("Not supported yet.");
+                    }
+
+                };
+            }
+
+        };
+
+        r1.zipWith(r2, zipr2).subscribe(o);
+
+        r1.onError(new TestException());
+
+        io.verify(o).onError(any(TestException.class));
+
+        verify(o, never()).onNext(any(String.class));
+        verify(o, never()).onComplete();
+
+    }
+    
+    Consumer<String> printer = System.out::println;
+
+    static final class SquareStr implements Function<Integer, String> {
+        final AtomicInteger counter = new AtomicInteger();
+        @Override
+        public String apply(Integer t1) {
+            counter.incrementAndGet();
+            System.out.println("Omg I'm calculating so hard: " + t1 + "*" + t1 + "=" + (t1*t1));
+            return " " + (t1*t1);
+        }
+    }
+
+    @Test 
+    public void testTake2() {
+        Observable<Integer> o = Observable.just(1, 2, 3, 4, 5);
+        Iterable<String> it = Arrays.asList("a", "b", "c", "d", "e");
+        
+        SquareStr squareStr = new SquareStr();
+        
+        o.map(squareStr).zipWith(it, concat2Strings).take(2).subscribe(printer);
+        
+        assertEquals(2, squareStr.counter.get());
+    }
+}


### PR DESCRIPTION
+ fixed cancellation behavior of observeOn, subscribeOn and
unsubscribeOn (when and what to call cancel on)
+ fixed infinite loop in ScheduledRunnable
+ fixed zip not quitting eagerly if one of the sources was shorter
+ added specific ZipIterable because zip-iterable tests expect it to be
not prefetching any of the sources (the plain zip does prefetch)
+ made the fromIterable more resilient to Iterable/Iterator crashes and
added null-value checks