### PR TITLE
2.x: operator test: window variants

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2358,10 +2358,12 @@ public class Observable<T> implements Publisher<T> {
 
     public final Observable<Observable<T>> window(long timespan, TimeUnit unit, 
             Scheduler scheduler, long count, boolean restart) {
-        return window(timespan, unit, scheduler, count, restart);
+        return window(timespan, unit, scheduler, count, restart, bufferSize());
     }
 
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit, Scheduler scheduler, long count, boolean restart, int bufferSize) {
+    public final Observable<Observable<T>> window(
+            long timespan, TimeUnit unit, Scheduler scheduler, 
+            long count, boolean restart, int bufferSize) {
         validateBufferSize(bufferSize);
         Objects.requireNonNull(scheduler);
         Objects.requireNonNull(unit);

--- a/src/main/java/io/reactivex/internal/operators/OperatorConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorConcatMap.java
@@ -119,7 +119,7 @@ public final class OperatorConcatMap<T, U> implements Operator<U, T> {
         void innerComplete() {
             if (decrementAndGet() != 0) {
                 drain();
-            } else
+            }
             if (!done) {
                 s.request(1);
             }

--- a/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorWindowBoundary.java
@@ -103,9 +103,12 @@ public final class OperatorWindowBoundary<T, B> implements Operator<Observable<T
                 return;
             }
             
+            window = w;
+            
             WindowBoundaryInnerSubscriber<T, B> inner = new WindowBoundaryInnerSubscriber<>(this);
             
             if (BOUNDARY.compareAndSet(this, null, inner)) {
+                WINDOWS.getAndIncrement(this);
                 s.request(Long.MAX_VALUE);
                 other.subscribe(inner);
             }

--- a/src/main/java/io/reactivex/internal/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/DisposableSubscriber.java
@@ -47,7 +47,7 @@ public abstract class DisposableSubscriber<T> implements Subscriber<T>, Disposab
     public final void onSubscribe(Subscription s) {
         if (!S.compareAndSet(this, null, s)) {
             s.cancel();
-            if (s != CANCELLED) {
+            if (this.s != CANCELLED) {
                 SubscriptionHelper.reportSubscriptionSet();
             }
             return;

--- a/src/test/java/io/reactivex/internal/operators/OperatorWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorWindowWithObservableTest.java
@@ -1,0 +1,458 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorWindowWithObservableTest {
+
+    @Test
+    public void testWindowViaObservableNormal1() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> boundary = PublishSubject.create();
+
+        final Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        final List<Subscriber<Object>> values = new ArrayList<>();
+
+        Subscriber<Observable<Integer>> wo = new Observer<Observable<Integer>>() {
+            @Override
+            public void onNext(Observable<Integer> args) {
+                final Subscriber<Object> mo = TestHelper.mockSubscriber();
+                values.add(mo);
+
+                args.subscribe(mo);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+        };
+
+        source.window(boundary).subscribe(wo);
+
+        int n = 30;
+        for (int i = 0; i < n; i++) {
+            source.onNext(i);
+            if (i % 3 == 2 && i < n - 1) {
+                boundary.onNext(i / 3);
+            }
+        }
+        source.onComplete();
+
+
+        verify(o, never()).onError(any(Throwable.class));
+
+        assertEquals(n / 3, values.size());
+        
+        int j = 0;
+        for (Subscriber<Object> mo : values) {
+            verify(mo, never()).onError(any(Throwable.class));
+            for (int i = 0; i < 3; i++) {
+                verify(mo).onNext(j + i);
+            }
+            verify(mo).onComplete();
+            j += 3;
+        }
+
+        verify(o).onComplete();
+    }
+
+    @Test
+    public void testWindowViaObservableBoundaryCompletes() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> boundary = PublishSubject.create();
+
+        final Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        final List<Subscriber<Object>> values = new ArrayList<>();
+
+        Subscriber<Observable<Integer>> wo = new Observer<Observable<Integer>>() {
+            @Override
+            public void onNext(Observable<Integer> args) {
+                final Subscriber<Object> mo = TestHelper.mockSubscriber();
+                values.add(mo);
+
+                args.subscribe(mo);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+        };
+
+        source.window(boundary).subscribe(wo);
+
+        int n = 30;
+        for (int i = 0; i < n; i++) {
+            source.onNext(i);
+            if (i % 3 == 2 && i < n - 1) {
+                boundary.onNext(i / 3);
+            }
+        }
+        boundary.onComplete();
+
+        assertEquals(n / 3, values.size());
+
+        int j = 0;
+        for (Subscriber<Object> mo : values) {
+            for (int i = 0; i < 3; i++) {
+                verify(mo).onNext(j + i);
+            }
+            verify(mo).onComplete();
+            verify(mo, never()).onError(any(Throwable.class));
+            j += 3;
+        }
+
+        verify(o).onComplete();
+        verify(o, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testWindowViaObservableBoundaryThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> boundary = PublishSubject.create();
+
+        final Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        final List<Subscriber<Object>> values = new ArrayList<>();
+
+        Subscriber<Observable<Integer>> wo = new Observer<Observable<Integer>>() {
+            @Override
+            public void onNext(Observable<Integer> args) {
+                final Subscriber<Object> mo = TestHelper.mockSubscriber();
+                values.add(mo);
+
+                args.subscribe(mo);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+        };
+
+        source.window(boundary).subscribe(wo);
+
+        source.onNext(0);
+        source.onNext(1);
+        source.onNext(2);
+
+        boundary.onError(new TestException());
+
+        assertEquals(1, values.size());
+
+        Subscriber<Object> mo = values.get(0);
+
+        verify(mo).onNext(0);
+        verify(mo).onNext(1);
+        verify(mo).onNext(2);
+        verify(mo).onError(any(TestException.class));
+
+        verify(o, never()).onComplete();
+        verify(o).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testWindowViaObservableSourceThrows() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> boundary = PublishSubject.create();
+
+        final Subscriber<Object> o = TestHelper.mockSubscriber();
+
+        final List<Subscriber<Object>> values = new ArrayList<>();
+
+        Subscriber<Observable<Integer>> wo = new Observer<Observable<Integer>>() {
+            @Override
+            public void onNext(Observable<Integer> args) {
+                final Subscriber<Object> mo = TestHelper.mockSubscriber();
+                values.add(mo);
+
+                args.subscribe(mo);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+        };
+
+        source.window(boundary).subscribe(wo);
+
+        source.onNext(0);
+        source.onNext(1);
+        source.onNext(2);
+
+        source.onError(new TestException());
+
+        assertEquals(1, values.size());
+
+        Subscriber<Object> mo = values.get(0);
+
+        verify(mo).onNext(0);
+        verify(mo).onNext(1);
+        verify(mo).onNext(2);
+        verify(mo).onError(any(TestException.class));
+
+        verify(o, never()).onComplete();
+        verify(o).onError(any(TestException.class));
+    }
+
+    @Test
+    public void testWindowNoDuplication() {
+        final PublishSubject<Integer> source = PublishSubject.create();
+        final TestSubscriber<Integer> tsw = new TestSubscriber<Integer>() {
+            boolean once;
+            @Override
+            public void onNext(Integer t) {
+                if (!once) {
+                    once = true;
+                    source.onNext(2);
+                }
+                super.onNext(t);
+            }
+        };
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<Observable<Integer>>() {
+            @Override
+            public void onNext(Observable<Integer> t) {
+                t.subscribe(tsw);
+                super.onNext(t);
+            }
+        };
+        source.window(new Supplier<Observable<Object>>() {
+            @Override
+            public Observable<Object> get() {
+                return Observable.never();
+            }
+        }).subscribe(ts);
+
+        source.onNext(1);
+        source.onComplete();
+
+        ts.assertValueCount(1);
+        tsw.assertValues(1, 2);
+    }
+    
+    @Test
+    public void testWindowViaObservableNoUnsubscribe() {
+        Observable<Integer> source = Observable.range(1, 10);
+        Supplier<Observable<String>> boundary = new Supplier<Observable<String>>() {
+            @Override
+            public Observable<String> get() {
+                return Observable.empty();
+            }
+        };
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        source.window(boundary).unsafeSubscribe(ts);
+        
+        assertFalse(ts.isCancelled());
+    }
+    
+    @Test
+    public void testBoundaryUnsubscribedOnMainCompletion() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        final PublishSubject<Integer> boundary = PublishSubject.create();
+        Supplier<Observable<Integer>> boundaryFunc = new Supplier<Observable<Integer>>() {
+            @Override
+            public Observable<Integer> get() {
+                return boundary;
+            }
+        };
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        source.window(boundaryFunc).subscribe(ts);
+        
+        assertTrue(source.hasSubscribers());
+        assertTrue(boundary.hasSubscribers());
+        
+        source.onComplete();
+
+        assertFalse(source.hasSubscribers());
+        assertFalse(boundary.hasSubscribers());
+        
+        ts.assertComplete();
+        ts.assertNoErrors();
+        ts.assertValueCount(1);
+    }
+    @Test
+    public void testMainUnsubscribedOnBoundaryCompletion() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        final PublishSubject<Integer> boundary = PublishSubject.create();
+        Supplier<Observable<Integer>> boundaryFunc = new Supplier<Observable<Integer>>() {
+            @Override
+            public Observable<Integer> get() {
+                return boundary;
+            }
+        };
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        source.window(boundaryFunc).subscribe(ts);
+        
+        assertTrue(source.hasSubscribers());
+        assertTrue(boundary.hasSubscribers());
+        
+        boundary.onComplete();
+
+        // FIXME source still active because the open window
+        assertTrue(source.hasSubscribers());
+        assertFalse(boundary.hasSubscribers());
+        
+        ts.assertComplete();
+        ts.assertNoErrors();
+        ts.assertValueCount(1);
+    }
+    
+    @Test
+    public void testChildUnsubscribed() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        final PublishSubject<Integer> boundary = PublishSubject.create();
+        Supplier<Observable<Integer>> boundaryFunc = new Supplier<Observable<Integer>>() {
+            @Override
+            public Observable<Integer> get() {
+                return boundary;
+            }
+        };
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        source.window(boundaryFunc).subscribe(ts);
+        
+        assertTrue(source.hasSubscribers());
+        assertTrue(boundary.hasSubscribers());
+
+        ts.dispose();
+
+        // FIXME source has subscribers because the open window
+        assertTrue(source.hasSubscribers());
+        // FIXME boundary has subscribers because the open window
+        assertTrue(boundary.hasSubscribers());
+        
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+        ts.assertValueCount(1);
+    }
+    @Test
+    public void testInnerBackpressure() {
+        Observable<Integer> source = Observable.range(1, 10);
+        final PublishSubject<Integer> boundary = PublishSubject.create();
+        Supplier<Observable<Integer>> boundaryFunc = new Supplier<Observable<Integer>>() {
+            @Override
+            public Observable<Integer> get() {
+                return boundary;
+            }
+        };
+        
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(1L);
+        final TestSubscriber<Observable<Integer>> ts1 = new TestSubscriber<Observable<Integer>>(1L) {
+            @Override
+            public void onNext(Observable<Integer> t) {
+                super.onNext(t);
+                t.subscribe(ts);
+            }
+        };
+        source.window(boundaryFunc)
+        .subscribe(ts1);
+        
+        ts1.assertNoErrors();
+        ts1.assertComplete();
+        ts1.assertValueCount(1);
+        
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        ts.assertValues(1);
+        
+        ts.request(11);
+        
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void newBoundaryCalledAfterWindowClosed() {
+        final AtomicInteger calls = new AtomicInteger();
+        PublishSubject<Integer> source = PublishSubject.create();
+        final PublishSubject<Integer> boundary = PublishSubject.create();
+        Supplier<Observable<Integer>> boundaryFunc = new Supplier<Observable<Integer>>() {
+            @Override
+            public Observable<Integer> get() {
+                calls.getAndIncrement();
+                return boundary;
+            }
+        };
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        source.window(boundaryFunc).subscribe(ts);
+        
+        source.onNext(1);
+        boundary.onNext(1);
+        assertTrue(boundary.hasSubscribers());
+
+        source.onNext(2);
+        boundary.onNext(2);
+        assertTrue(boundary.hasSubscribers());
+
+        source.onNext(3);
+        boundary.onNext(3);
+        assertTrue(boundary.hasSubscribers());
+        
+        source.onNext(4);
+        source.onComplete();
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(4);
+        ts.assertComplete();
+
+        assertFalse(source.hasSubscribers());
+        assertFalse(boundary.hasSubscribers());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorWindowWithSizeTest.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorWindowWithSizeTest {
+
+    private static <T> List<List<T>> toLists(Observable<Observable<T>> observables) {
+
+        final List<List<T>> lists = new ArrayList<>();
+        Observable.concat(observables.map(new Function<Observable<T>, Observable<List<T>>>() {
+            @Override
+            public Observable<List<T>> apply(Observable<T> xs) {
+                return xs.toList();
+            }
+        }))
+                .toBlocking()
+                .forEach(new Consumer<List<T>>() {
+                    @Override
+                    public void accept(List<T> xs) {
+                        lists.add(xs);
+                    }
+                });
+        return lists;
+    }
+
+    @Test
+    public void testNonOverlappingWindows() {
+        Observable<String> subject = Observable.just("one", "two", "three", "four", "five");
+        Observable<Observable<String>> windowed = subject.window(3);
+
+        List<List<String>> windows = toLists(windowed);
+
+        assertEquals(2, windows.size());
+        assertEquals(list("one", "two", "three"), windows.get(0));
+        assertEquals(list("four", "five"), windows.get(1));
+    }
+
+    @Test
+    public void testSkipAndCountGaplessWindows() {
+        Observable<String> subject = Observable.just("one", "two", "three", "four", "five");
+        Observable<Observable<String>> windowed = subject.window(3, 3);
+
+        List<List<String>> windows = toLists(windowed);
+
+        assertEquals(2, windows.size());
+        assertEquals(list("one", "two", "three"), windows.get(0));
+        assertEquals(list("four", "five"), windows.get(1));
+    }
+
+    @Test
+    public void testOverlappingWindows() {
+        Observable<String> subject = Observable.fromArray(new String[] { "zero", "one", "two", "three", "four", "five" });
+        Observable<Observable<String>> windowed = subject.window(3, 1);
+
+        List<List<String>> windows = toLists(windowed);
+
+        assertEquals(6, windows.size());
+        assertEquals(list("zero", "one", "two"), windows.get(0));
+        assertEquals(list("one", "two", "three"), windows.get(1));
+        assertEquals(list("two", "three", "four"), windows.get(2));
+        assertEquals(list("three", "four", "five"), windows.get(3));
+        assertEquals(list("four", "five"), windows.get(4));
+        assertEquals(list("five"), windows.get(5));
+    }
+
+    @Test
+    public void testSkipAndCountWindowsWithGaps() {
+        Observable<String> subject = Observable.just("one", "two", "three", "four", "five");
+        Observable<Observable<String>> windowed = subject.window(2, 3);
+
+        List<List<String>> windows = toLists(windowed);
+
+        assertEquals(2, windows.size());
+        assertEquals(list("one", "two"), windows.get(0));
+        assertEquals(list("four", "five"), windows.get(1));
+    }
+
+    @Test
+    public void testWindowUnsubscribeNonOverlapping() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        final AtomicInteger count = new AtomicInteger();
+        Observable.merge(Observable.range(1, 10000).doOnNext(new Consumer<Integer>() {
+
+            @Override
+            public void accept(Integer t1) {
+                count.incrementAndGet();
+            }
+
+        }).window(5).take(2)).subscribe(ts);
+        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts.assertTerminated();
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        //        System.out.println(ts.getOnNextEvents());
+        assertEquals(10, count.get());
+    }
+
+    @Test
+    public void testWindowUnsubscribeNonOverlappingAsyncSource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        final AtomicInteger count = new AtomicInteger();
+        Observable.merge(Observable.range(1, 100000)
+                .doOnNext(new Consumer<Integer>() {
+
+                    @Override
+                    public void accept(Integer t1) {
+                        count.incrementAndGet();
+                    }
+
+                })
+                .observeOn(Schedulers.computation())
+                .window(5)
+                .take(2))
+                .subscribe(ts);
+        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts.assertTerminated();
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        // make sure we don't emit all values ... the unsubscribe should propagate
+        assertTrue(count.get() < 100000);
+    }
+
+    @Test
+    public void testWindowUnsubscribeOverlapping() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        final AtomicInteger count = new AtomicInteger();
+        Observable.merge(Observable.range(1, 10000).doOnNext(new Consumer<Integer>() {
+
+            @Override
+            public void accept(Integer t1) {
+                count.incrementAndGet();
+            }
+
+        }).window(5, 4).take(2)).subscribe(ts);
+        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts.assertTerminated();
+        //        System.out.println(ts.getOnNextEvents());
+        ts.assertValues(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
+        assertEquals(9, count.get());
+    }
+
+    @Test
+    public void testWindowUnsubscribeOverlappingAsyncSource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        final AtomicInteger count = new AtomicInteger();
+        Observable.merge(Observable.range(1, 100000)
+                .doOnNext(new Consumer<Integer>() {
+
+                    @Override
+                    public void accept(Integer t1) {
+                        count.incrementAndGet();
+                    }
+
+                })
+                .observeOn(Schedulers.computation())
+                .window(5, 4)
+                .take(2))
+                .subscribe(ts);
+        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        ts.assertTerminated();
+        ts.assertValues(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
+        // make sure we don't emit all values ... the unsubscribe should propagate
+        assertTrue(count.get() < 100000);
+    }
+
+    private List<String> list(String... args) {
+        List<String> list = new ArrayList<>();
+        for (String arg : args) {
+            list.add(arg);
+        }
+        return list;
+    }
+    
+    @Test
+    public void testBackpressureOuter() {
+        Observable<Observable<Integer>> source = Observable.range(1, 10).window(3);
+        
+        final List<Integer> list = new ArrayList<>();
+        
+        final Subscriber<Integer> o = TestHelper.mockSubscriber();
+        
+        source.subscribe(new Observer<Observable<Integer>>() {
+            @Override
+            public void onStart() {
+                request(1);
+            }
+            @Override
+            public void onNext(Observable<Integer> t) {
+                t.subscribe(new Observer<Integer>() {
+                    @Override
+                    public void onNext(Integer t) {
+                        list.add(t);
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        o.onError(e);
+                    }
+                    @Override
+                    public void onComplete() {
+                        o.onComplete();
+                    }
+                });
+            }
+            @Override
+            public void onError(Throwable e) {
+                o.onError(e);
+            }
+            @Override
+            public void onComplete() {
+                o.onComplete();
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3), list);
+        
+        verify(o, never()).onError(any(Throwable.class));
+        verify(o, times(1)).onComplete(); // 1 inner
+    }
+
+    public static Observable<Integer> hotStream() {
+        return Observable.create(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> s) {
+                BooleanSubscription bs = new BooleanSubscription();
+                s.onSubscribe(bs);
+                while (!bs.isCancelled()) {
+                    // burst some number of items
+                    for (int i = 0; i < Math.random() * 20; i++) {
+                        s.onNext(i);
+                    }
+                    try {
+                        // sleep for a random amount of time
+                        // NOTE: Only using Thread.sleep here as an artificial demo.
+                        Thread.sleep((long) (Math.random() * 200));
+                    } catch (Exception e) {
+                        // do nothing
+                    }
+                }
+                System.out.println("Hot done.");
+            }
+        }).subscribeOn(Schedulers.newThread()); // use newThread since we are using sleep to block
+    }
+    
+    @Test
+    public void testTakeFlatMapCompletes() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        final int indicator = 999999999;
+        
+        hotStream()
+        .window(10)
+        .take(2)
+        .flatMap(new Function<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> w) {
+                return w.startWith(indicator);
+            }
+        }).subscribe(ts);
+        
+        ts.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        ts.assertComplete();
+        ts.assertValueCount(22);
+    }
+    
+    @Test
+    public void testBackpressureOuterInexact() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>((Long)null);
+        
+        Observable.range(1, 5).window(2, 1)
+        .map(new Function<Observable<Integer>, Observable<List<Integer>>>() {
+            @Override
+            public Observable<List<Integer>> apply(Observable<Integer> t) {
+                return t.toList();
+            }
+        }).concatMap(v -> v)
+        .subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        
+        ts.request(2);
+
+        ts.assertValues(Arrays.asList(1, 2), Arrays.asList(2, 3));
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        ts.request(5);
+
+        System.out.println(ts.values());
+        
+        ts.assertValues(Arrays.asList(1, 2), Arrays.asList(2, 3),
+                Arrays.asList(3, 4), Arrays.asList(4, 5), Arrays.asList(5));
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorWindowWithStartEndObservableTest.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Scheduler;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class OperatorWindowWithStartEndObservableTest {
+
+    private TestScheduler scheduler;
+    private Scheduler.Worker innerScheduler;
+
+    @Before
+    public void before() {
+        scheduler = new TestScheduler();
+        innerScheduler = scheduler.createWorker();
+    }
+
+    @Test
+    public void testObservableBasedOpenerAndCloser() {
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
+
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                push(observer, "one", 10);
+                push(observer, "two", 60);
+                push(observer, "three", 110);
+                push(observer, "four", 160);
+                push(observer, "five", 210);
+                complete(observer, 500);
+            }
+        });
+
+        Observable<Object> openings = Observable.create(new Publisher<Object>() {
+            @Override
+            public void subscribe(Subscriber<? super Object> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                push(observer, new Object(), 50);
+                push(observer, new Object(), 200);
+                complete(observer, 250);
+            }
+        });
+
+        Function<Object, Observable<Object>> closer = new Function<Object, Observable<Object>>() {
+            @Override
+            public Observable<Object> apply(Object opening) {
+                return Observable.create(new Publisher<Object>() {
+                    @Override
+                    public void subscribe(Subscriber<? super Object> observer) {
+                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        push(observer, new Object(), 100);
+                        complete(observer, 101);
+                    }
+                });
+            }
+        };
+
+        Observable<Observable<String>> windowed = source.window(openings, closer);
+        windowed.subscribe(observeWindow(list, lists));
+
+        scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
+        assertEquals(2, lists.size());
+        assertEquals(lists.get(0), list("two", "three"));
+        assertEquals(lists.get(1), list("five"));
+    }
+
+    @Test
+    public void testObservableBasedCloser() {
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
+
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                push(observer, "one", 10);
+                push(observer, "two", 60);
+                push(observer, "three", 110);
+                push(observer, "four", 160);
+                push(observer, "five", 210);
+                complete(observer, 250);
+            }
+        });
+
+        Supplier<Observable<Object>> closer = new Supplier<Observable<Object>>() {
+            int calls;
+            @Override
+            public Observable<Object> get() {
+                return Observable.create(new Publisher<Object>() {
+                    @Override
+                    public void subscribe(Subscriber<? super Object> observer) {
+                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        int c = calls++;
+                        if (c == 0) {
+                            push(observer, new Object(), 100);
+                        } else
+                        if (c == 1) {
+                            push(observer, new Object(), 100);
+                        } else {
+                            complete(observer, 101);
+                        }
+                    }
+                });
+            }
+        };
+
+        Observable<Observable<String>> windowed = source.window(closer);
+        windowed.subscribe(observeWindow(list, lists));
+
+        scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
+        assertEquals(3, lists.size());
+        assertEquals(lists.get(0), list("one", "two"));
+        assertEquals(lists.get(1), list("three", "four"));
+        assertEquals(lists.get(2), list("five"));
+    }
+
+    private List<String> list(String... args) {
+        List<String> list = new ArrayList<>();
+        for (String arg : args) {
+            list.add(arg);
+        }
+        return list;
+    }
+
+    private <T> void push(final Subscriber<T> observer, final T value, int delay) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onNext(value);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private void complete(final Subscriber<?> observer, int delay) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onComplete();
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private Consumer<Observable<String>> observeWindow(final List<String> list, final List<List<String>> lists) {
+        return new Consumer<Observable<String>>() {
+            @Override
+            public void accept(Observable<String> stringObservable) {
+                stringObservable.subscribe(new Observer<String>() {
+                    @Override
+                    public void onComplete() {
+                        lists.add(new ArrayList<>(list));
+                        list.clear();
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        fail(e.getMessage());
+                    }
+
+                    @Override
+                    public void onNext(String args) {
+                        list.add(args);
+                    }
+                });
+            }
+        };
+    }
+    
+    @Test
+    public void testNoUnsubscribeAndNoLeak() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        PublishSubject<Integer> open = PublishSubject.create();
+        final PublishSubject<Integer> close = PublishSubject.create();
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        
+        source.window(open, new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                return close;
+            }
+        }).unsafeSubscribe(ts);
+        
+        open.onNext(1);
+        source.onNext(1);
+        
+        assertTrue(open.hasSubscribers());
+        assertTrue(close.hasSubscribers());
+
+        close.onNext(1);
+        
+        assertFalse(close.hasSubscribers());
+        
+        source.onComplete();
+        
+        ts.assertComplete();
+        ts.assertNoErrors();
+        ts.assertValueCount(1);
+        
+        assertFalse(ts.isCancelled());
+        assertFalse(open.hasSubscribers());
+        assertFalse(close.hasSubscribers());
+    }
+    
+    @Test
+    public void testUnsubscribeAll() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        PublishSubject<Integer> open = PublishSubject.create();
+        final PublishSubject<Integer> close = PublishSubject.create();
+        
+        TestSubscriber<Observable<Integer>> ts = new TestSubscriber<>();
+        
+        source.window(open, new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                return close;
+            }
+        }).unsafeSubscribe(ts);
+        
+        open.onNext(1);
+        
+        assertTrue(open.hasSubscribers());
+        assertTrue(close.hasSubscribers());
+
+        ts.dispose();
+        
+        // FIXME subject has subscribers because of the open window
+        assertTrue(open.hasSubscribers());
+        // FIXME subject has subscribers because of the open window
+        assertTrue(close.hasSubscribers());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorWindowWithTimeTest.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Scheduler;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
+
+
+public class OperatorWindowWithTimeTest {
+
+    private TestScheduler scheduler;
+    private Scheduler.Worker innerScheduler;
+
+    @Before
+    public void before() {
+        scheduler = new TestScheduler();
+        innerScheduler = scheduler.createWorker();
+    }
+
+    @Test
+    public void testTimedAndCount() {
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
+
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                push(observer, "one", 10);
+                push(observer, "two", 90);
+                push(observer, "three", 110);
+                push(observer, "four", 190);
+                push(observer, "five", 210);
+                complete(observer, 250);
+            }
+        });
+
+        Observable<Observable<String>> windowed = source.window(100, TimeUnit.MILLISECONDS, scheduler, 2);
+        windowed.subscribe(observeWindow(list, lists));
+
+        scheduler.advanceTimeTo(100, TimeUnit.MILLISECONDS);
+        assertEquals(1, lists.size());
+        assertEquals(lists.get(0), list("one", "two"));
+
+        scheduler.advanceTimeTo(200, TimeUnit.MILLISECONDS);
+        assertEquals(2, lists.size());
+        assertEquals(lists.get(1), list("three", "four"));
+
+        scheduler.advanceTimeTo(300, TimeUnit.MILLISECONDS);
+        assertEquals(3, lists.size());
+        assertEquals(lists.get(2), list("five"));
+    }
+
+    @Test
+    public void testTimed() {
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
+
+        Observable<String> source = Observable.create(new Publisher<String>() {
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(EmptySubscription.INSTANCE);
+                push(observer, "one", 98);
+                push(observer, "two", 99);
+                push(observer, "three", 99); // FIXME happens after the window is open
+                push(observer, "four", 101);
+                push(observer, "five", 102);
+                complete(observer, 150);
+            }
+        });
+
+        Observable<Observable<String>> windowed = source.window(100, TimeUnit.MILLISECONDS, scheduler);
+        windowed.subscribe(observeWindow(list, lists));
+
+        scheduler.advanceTimeTo(101, TimeUnit.MILLISECONDS);
+        assertEquals(1, lists.size());
+        assertEquals(lists.get(0), list("one", "two", "three"));
+
+        scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
+        assertEquals(2, lists.size());
+        assertEquals(lists.get(1), list("four", "five"));
+    }
+
+    private List<String> list(String... args) {
+        List<String> list = new ArrayList<>();
+        for (String arg : args) {
+            list.add(arg);
+        }
+        return list;
+    }
+
+    private <T> void push(final Subscriber<T> observer, final T value, int delay) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onNext(value);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private void complete(final Subscriber<?> observer, int delay) {
+        innerScheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                observer.onComplete();
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private <T> Consumer<Observable<T>> observeWindow(final List<T> list, final List<List<T>> lists) {
+        return new Consumer<Observable<T>>() {
+            @Override
+            public void accept(Observable<T> stringObservable) {
+                stringObservable.subscribe(new Observer<T>() {
+                    @Override
+                    public void onComplete() {
+                        lists.add(new ArrayList<>(list));
+                        list.clear();
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        fail(e.getMessage());
+                    }
+
+                    @Override
+                    public void onNext(T args) {
+                        list.add(args);
+                    }
+                });
+            }
+        };
+    }
+    @Test
+    public void testExactWindowSize() {
+        Observable<Observable<Integer>> source = Observable.range(1, 10)
+                .window(1, TimeUnit.MINUTES, scheduler, 3);
+        
+        final List<Integer> list = new ArrayList<>();
+        final List<List<Integer>> lists = new ArrayList<>();
+        
+        source.subscribe(observeWindow(list, lists));
+        
+        assertEquals(4, lists.size());
+        assertEquals(3, lists.get(0).size());
+        assertEquals(Arrays.asList(1, 2, 3), lists.get(0));
+        assertEquals(3, lists.get(1).size());
+        assertEquals(Arrays.asList(4, 5, 6), lists.get(1));
+        assertEquals(3, lists.get(2).size());
+        assertEquals(Arrays.asList(7, 8, 9), lists.get(2));
+        assertEquals(1, lists.get(3).size());
+        assertEquals(Arrays.asList(10), lists.get(3));
+    }
+    
+    @Test
+    public void testTakeFlatMapCompletes() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        AtomicInteger wip = new AtomicInteger();
+        
+        final int indicator = 999999999;
+        
+        OperatorWindowWithSizeTest.hotStream()
+        .window(300, TimeUnit.MILLISECONDS)
+        .take(10)
+        .doOnComplete(() -> System.out.println("Main done!"))
+        .flatMap(new Function<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> w) {
+                return w.startWith(indicator)
+                        .doOnComplete(() -> System.out.println("inner done: " + wip.incrementAndGet()))
+                        ;
+            }
+        })
+        .doOnNext(System.out::println)
+        .subscribe(ts);
+        
+        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        ts.assertComplete();
+        Assert.assertTrue(ts.valueCount() != 0);
+    }
+    
+}


### PR DESCRIPTION
I had to adjust some test slightly due to the a new behavior: if one
cancels a source which is windowed, as long as the windows are active,
the source has to stay active. However, there are more subtle
possibilities that need new tests.