### PR TITLE
2.x: subscribers/observers tests

### DIFF
--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+import java.util.*;
+
+public final class CompositeException extends RuntimeException {
+    /** */
+    private static final long serialVersionUID = 2004635183691362481L;
+
+    public CompositeException() {
+        super();
+    }
+
+    public CompositeException(String message) {
+        super(message);
+    }
+
+    public List<Throwable> getExceptions() {
+        Throwable cause = getCause();
+        Throwable[] suppressed = getSuppressed();
+        List<Throwable> list = new ArrayList<>(cause != null 
+                ? 1 + suppressed.length : suppressed.length);
+        if (cause != null) {
+            list.add(cause);
+        }
+        for (Throwable t : suppressed) {
+            list.add(t);
+        }
+        
+        return list;
+    }
+}

--- a/src/main/java/io/reactivex/exceptions/OnCompleteFailedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnCompleteFailedException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+public final class OnCompleteFailedException extends RuntimeException {
+    /** */
+    private static final long serialVersionUID = -6179993283427447098L;
+
+    public OnCompleteFailedException(Throwable cause) {
+        super(cause);
+    }
+    
+}

--- a/src/main/java/io/reactivex/exceptions/OnErrorFailedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorFailedException.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+public final class OnErrorFailedException extends RuntimeException {
+    /** */
+    private static final long serialVersionUID = 2656125445290831911L;
+
+    public OnErrorFailedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+public final class OnErrorNotImplementedException extends RuntimeException {
+    /** */
+    private static final long serialVersionUID = -3698670655303683299L;
+
+    public OnErrorNotImplementedException() {
+        super();
+    }
+
+    public OnErrorNotImplementedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OnErrorNotImplementedException(String message) {
+        super(message);
+    }
+
+    public OnErrorNotImplementedException(Throwable cause) {
+        super(cause);
+    }
+    
+}

--- a/src/main/java/io/reactivex/exceptions/UnsubscribeFailedException.java
+++ b/src/main/java/io/reactivex/exceptions/UnsubscribeFailedException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+public final class UnsubscribeFailedException extends RuntimeException {
+    /** */
+    private static final long serialVersionUID = 8947024194181365640L;
+
+    public UnsubscribeFailedException(Throwable cause) {
+        super(cause);
+    }
+    
+}

--- a/src/main/java/io/reactivex/internal/operators/OperatorDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorDoOnEach.java
@@ -51,6 +51,8 @@ public final class OperatorDoOnEach<T> implements Operator<T, T> {
         
         Subscription s;
         
+        boolean done;
+        
         public DoOnEachSubscriber(
                 Subscriber<? super T> actual,
                 Consumer<? super T> onNext, 
@@ -75,6 +77,9 @@ public final class OperatorDoOnEach<T> implements Operator<T, T> {
         
         @Override
         public void onNext(T t) {
+            if (done) {
+                return;
+            }
             try {
                 onNext.accept(t);
             } catch (Throwable e) {
@@ -88,6 +93,11 @@ public final class OperatorDoOnEach<T> implements Operator<T, T> {
         
         @Override
         public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
             try {
                 onError.accept(t);
             } catch (Throwable e) {
@@ -104,6 +114,10 @@ public final class OperatorDoOnEach<T> implements Operator<T, T> {
         
         @Override
         public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
             try {
                 onComplete.run();
             } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/subscribers/CancelledSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/CancelledSubscriber.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * A subscriber cancels the subscription sent to it 
+ * A subscriber that cancels the subscription sent to it 
  * and ignores all events (onError is forwarded to RxJavaPlugins though).
  */
 public enum CancelledSubscriber implements Subscriber<Object> {

--- a/src/main/java/io/reactivex/subscribers/Observers.java
+++ b/src/main/java/io/reactivex/subscribers/Observers.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.reactivex.Observer;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Utility class to create Observers from lambdas.
+ */
+public final class Observers {
+    /** Utility class with factory methods only. */
+    private Observers() {
+        throw new IllegalStateException("No instances!");
+    }
+    
+    public static <T> Observer<T> empty() {
+        return new Observer<T>() {
+            @Override
+            public void onNext(T t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                RxJavaPlugins.onError(t);
+            }
+            
+            @Override
+            public void onComplete() {
+                
+            }
+        };
+    }
+    
+    public static <T> AsyncObserver<T> emptyAsync() {
+        return new AsyncObserver<T>() {
+            @Override
+            public void onNext(T t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                RxJavaPlugins.onError(t);
+            }
+            
+            @Override
+            public void onComplete() {
+                
+            }
+        };
+    }
+    
+    public static <T> Observer<T> create(Consumer<? super T> onNext) {
+        return create(onNext, RxJavaPlugins::onError, () -> { }, () -> { });
+    }
+
+    public static <T> Observer<T> create(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError) {
+        return create(onNext, onError, () -> { }, () -> { });
+    }
+
+    public static <T> Observer<T> create(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete) {
+        return create(onNext, onError, onComplete, () -> { });
+    }
+
+    public static <T> Observer<T> create(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete, Runnable onStart) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new Observer<T>() {
+            boolean done;
+            @Override
+            protected void onStart() {
+                super.onStart();
+                try {
+                    onStart.run();
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+    
+    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext) {
+        return createAsync(onNext, RxJavaPlugins::onError, () -> { }, () -> { });
+    }
+
+    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError) {
+        return createAsync(onNext, onError, () -> { }, () -> { });
+    }
+
+    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete) {
+        return createAsync(onNext, onError, onComplete, () -> { });
+    }
+    
+    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete, Runnable onStart) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new AsyncObserver<T>() {
+            boolean done;
+            @Override
+            protected void onStart() {
+                try {
+                    onStart.run();
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
@@ -175,4 +175,8 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
             RxJavaPlugins.onError(e);
         }
     }
+    
+    /* test */ Subscriber<? super T> actual() {
+        return actual;
+    }
 }

--- a/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
@@ -65,6 +65,11 @@ public final class SerializedSubscriber<T> implements Subscriber<T> {
         if (done) {
             return;
         }
+        if (t == null) {
+            subscription.cancel();
+            onError(new NullPointerException());
+            return;
+        }
         synchronized (this) {
             if (done) {
                 return;

--- a/src/main/java/io/reactivex/subscribers/Subscribers.java
+++ b/src/main/java/io/reactivex/subscribers/Subscribers.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Utility class to construct various resource-holding and disposable Subscribers from lambdas.
+ */
+public final class Subscribers {
+    /** Utility class. */
+    private Subscribers() {
+        throw new IllegalStateException("No instances!");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Subscriber<T> empty() {
+        return (Subscriber<T>)EmptySubscriber.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Subscriber<T> cancelled() {
+        return (Subscriber<T>)CancelledSubscriber.INSTANCE;
+    }
+
+    public static <T> DisposableSubscriber<T> emptyDisposable() {
+        return new DisposableSubscriber<T>() {
+            @Override
+            public void onNext(T t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                
+            }
+            
+            @Override
+            public void onComplete() {
+                
+            }
+        };
+    }
+
+    public static <T> DisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext
+    ) {
+        return createDisposable(onNext, RxJavaPlugins::onError, () -> { }, () -> { });
+    }
+
+    public static <T> DisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError
+    ) {
+        return createDisposable(onNext, onError, () -> { }, () -> { });
+    }
+
+    public static <T> DisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete
+    ) {
+        return createDisposable(onNext, onError, onComplete, () -> { });
+    }
+    
+    public static <T> DisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete,
+            Runnable onStart
+    ) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new DisposableSubscriber<T>() {
+            boolean done;
+            @Override
+            protected void onStart() {
+                super.onStart();
+                try {
+                    onStart.run();
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+
+    public static <T> Subscriber<T> create(
+            Consumer<? super T> onNext
+    ) {
+        return create(onNext, RxJavaPlugins::onError, () -> { }, s -> { });
+    }
+
+    public static <T> Subscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError
+    ) {
+        return create(onNext, onError, () -> { }, s -> { });
+    }
+
+    public static <T> Subscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete
+    ) {
+        return create(onNext, onError, onComplete, s -> { });
+    }
+    
+    public static <T> Subscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete,
+            Consumer<? super Subscription> onStart
+    ) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new Subscriber<T>() {
+            boolean done;
+            
+            Subscription s;
+            @Override
+            public void onSubscribe(Subscription s) {
+                if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                    return;
+                }
+                this.s = s;
+                try {
+                    onStart.accept(s);
+                } catch (Throwable e) {
+                    done = true;
+                    s.cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    s.cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.Notification;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscribers.EmptySubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -609,6 +610,18 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
         if (done.getCount() != 0) {
             fail("", "Subscriber still running!", errors);
         }
+        long c = completions;
+        if (c > 1) {
+            fail("", "Terminated with multiple completions: " + c, errors);
+        }
+        int s = errors.size();
+        if (s > 1) {
+            fail("", "Terminated with multiple errors: " + s, errors);
+        }
+        
+        if (c != 0 && s != 0) {
+            fail("", "Terminated with multiple completions and errors: " + c, errors);
+        }
     }
     
     /**
@@ -701,5 +714,29 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
         } else {
             fail(prefix, "Multiple errors", errors);
         }
+    }
+    
+    /**
+     * Returns a list of 3 other lists: the first inner list contains the plain
+     * values received; the second list contains the potential errors
+     * and the final list contains the potential completions as Notifications.
+     * 
+     * @return a list of (values, errors, completion-notifications)
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public List<List<Object>> getEvents() {
+        List<List<Object>> result = new ArrayList<>();
+        
+        result.add((List)values());
+        
+        result.add((List)errors());
+        
+        List<Object> completeList = new ArrayList<>();
+        for (long i = 0; i < completions; i++) {
+            completeList.add(Notification.complete());
+        }
+        result.add(completeList);
+        
+        return result;
     }
 }

--- a/src/test/java/io/reactivex/subscribers/ObserversTest.java
+++ b/src/test/java/io/reactivex/subscribers/ObserversTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.Consumer;
+
+import org.junit.Test;
+
+import io.reactivex.exceptions.TestException;
+
+public class ObserversTest {
+    @Test
+    public void testNotInstantiable() {
+        try {
+            Constructor<?> c = Observers.class.getDeclaredConstructor();
+            c.setAccessible(true);
+            Object instance = c.newInstance();
+            fail("Could instantiate Actions! " + instance);
+        } catch (NoSuchMethodException ex) {
+            ex.printStackTrace();
+        } catch (InvocationTargetException ex) {
+            ex.printStackTrace();
+        } catch (InstantiationException ex) {
+            ex.printStackTrace();
+        } catch (IllegalAccessException ex) {
+            ex.printStackTrace();
+        }
+    }
+    
+    // FIXME RS subscribers can't throw
+//    @Test
+//    public void testEmptyOnErrorNotImplemented() {
+//        try {
+//            Observers.empty().onError(new TestException());
+//            fail("OnErrorNotImplementedException not thrown!");
+//        } catch (OnErrorNotImplementedException ex) {
+//            if (!(ex.getCause() instanceof TestException)) {
+//                fail("TestException not wrapped, instead: " + ex.getCause());
+//            }
+//        }
+//    }
+
+    // FIXME RS subscribers can't throw
+//    @Test
+//    public void testCreate1OnErrorNotImplemented() {
+//        try {
+//            Observers.create(() -> { }).onError(new TestException());
+//            fail("OnErrorNotImplementedException not thrown!");
+//        } catch (OnErrorNotImplementedException ex) {
+//            if (!(ex.getCause() instanceof TestException)) {
+//                fail("TestException not wrapped, instead: " + ex.getCause());
+//            }
+//        }
+//    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testCreate1Null() {
+        Observers.create(null);
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate2Null() {
+        Consumer<Throwable> throwAction = e -> { };
+        Observers.create(null, throwAction);
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate3Null() {
+        Observers.create(v -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testCreate4Null() {
+        Consumer<Throwable> throwAction = v -> { };
+        Observers.create(null, throwAction, () -> { });
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate5Null() {
+        Observers.create(v -> { }, null, () -> { });
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate6Null() {
+        Consumer<Throwable> throwAction = v -> { };
+        Observers.create(v -> { }, throwAction, null);
+    }
+    
+    @Test
+    public void testCreate1Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Consumer<Integer> action = new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                value.set(t);
+            }
+        };
+        Observers.create(action).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    @Test
+    public void testCreate2Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Consumer<Integer> action = new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                value.set(t);
+            }
+        };
+        Consumer<Throwable> throwAction = v -> { };
+        Observers.create(action, throwAction).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testCreate3Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Consumer<Integer> action = new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                value.set(t);
+            }
+        };
+        Consumer<Throwable> throwAction = v -> { };
+        Observers.create(action, throwAction, () -> { }).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testError2() {
+        final AtomicReference<Throwable> value = new AtomicReference<>();
+        Consumer<Throwable> action = new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Observers.create(v -> { }, action).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testError3() {
+        final AtomicReference<Throwable> value = new AtomicReference<>();
+        Consumer<Throwable> action = new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Observers.create(v -> { }, action, () -> { }).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testCompleted() {
+        Runnable action = mock(Runnable.class);
+        
+        Consumer<Throwable> throwAction = v -> { };
+        Observers.create(v -> { }, throwAction, action).onComplete();
+
+        verify(action).run();
+    }
+    
+    @Test
+    public void testEmptyCompleted() {
+        Observers.create(v -> { }).onComplete();
+        
+        Consumer<Throwable> throwAction = v -> { };
+        Observers.create(v -> { }, throwAction).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeObserverTest.java
@@ -1,0 +1,522 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Observer;
+import io.reactivex.exceptions.*;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+
+public class SafeObserverTest {
+
+    @Test
+    public void onNextFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<>();
+        try {
+            OBSERVER_ONNEXT_FAIL(onError).onNext("one");
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertNull(onError.get());
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onNextFail", e.getMessage());
+        }
+    }
+
+    @Test
+    public void onNextFailureSafe() {
+        AtomicReference<Throwable> onError = new AtomicReference<>();
+        try {
+            SafeSubscriber<String> safeSubscriber = new SafeSubscriber<>(OBSERVER_ONNEXT_FAIL(onError));
+            safeSubscriber.onSubscribe(EmptySubscription.INSTANCE);
+            safeSubscriber.onNext("one");
+            assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeObserverTestException);
+            assertEquals("onNextFail", onError.get().getMessage());
+        } catch (Exception e) {
+            fail("expects exception to be passed to onError");
+        }
+    }
+
+    @Test
+    public void onCompletedFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<>();
+        try {
+            OBSERVER_ONCOMPLETED_FAIL(onError).onComplete();
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertNull(onError.get());
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onCompletedFail", e.getMessage());
+        }
+    }
+
+    @Test
+    public void onErrorFailure() {
+        try {
+            OBSERVER_ONERROR_FAIL().onError(new SafeObserverTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onErrorFailureSafe() {
+        try {
+            new SafeSubscriber<>(OBSERVER_ONERROR_FAIL()).onError(new SafeObserverTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Observer.onError", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(2, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeObserverTestException);
+            assertEquals("error!", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e4.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onErrorNotImplementedFailureSafe() {
+        try {
+            new SafeSubscriber<>(OBSERVER_ONERROR_NOTIMPLEMENTED()).onError(new SafeObserverTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof OnErrorNotImplementedException);
+            assertTrue(e.getCause() instanceof SafeObserverTestException);
+            assertEquals("error!", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void onNextOnErrorFailure() {
+        try {
+            OBSERVER_ONNEXT_ONERROR_FAIL().onNext("one");
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof SafeObserverTestException);
+            assertEquals("onNextFail", e.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onNextOnErrorFailureSafe() {
+        try {
+            new SafeSubscriber<>(OBSERVER_ONNEXT_ONERROR_FAIL()).onNext("one");
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Observer.onError", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(2, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeObserverTestException);
+            assertEquals("onNextFail", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e4.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onCompleteSuccessWithUnsubscribeFailure() {
+        Subscriber<String> o = OBSERVER_SUCCESS();
+        try {
+            o.onSubscribe(new Subscription() {
+
+                @Override
+                public void cancel() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+                
+                @Override
+                public void request(long n) {
+                    
+                }
+            });
+            new SafeSubscriber<>(o).onComplete();
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+            assertTrue(e instanceof UnsubscribeFailedException);
+            assertTrue(e.getCause() instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e.getMessage());
+            // expected since onError fails so SafeObserver can't help
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onErrorSuccessWithUnsubscribeFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<>();
+        Subscriber<String> o = OBSERVER_SUCCESS(onError);
+        try {
+            o.onSubscribe(new Subscription() {
+
+                @Override
+                public void cancel() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+                
+                @Override
+                public void request(long n) {
+                    
+                }
+            });
+            new SafeSubscriber<>(o).onError(new SafeObserverTestException("failed"));
+            fail("we expect the unsubscribe failure to cause an exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+
+            // we still expect onError to have received something before unsubscribe blew up
+            assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeObserverTestException);
+            assertEquals("failed", onError.get().getMessage());
+
+            // now assert the exception that was thrown
+            OnErrorFailedException onErrorFailedException = (OnErrorFailedException) e;
+            assertTrue(onErrorFailedException.getCause() instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onErrorFailureWithUnsubscribeFailure() {
+        Subscriber<String> o = OBSERVER_ONERROR_FAIL();
+        try {
+            o.onSubscribe(new Subscription() {
+
+                @Override
+                public void cancel() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+                
+                @Override
+                public void request(long n) {
+                    
+                }
+            });
+            new SafeSubscriber<>(o).onError(new SafeObserverTestException("onError failure"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+
+            // assertions for what is expected for the actual failure propagated to onError which then fails
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Observer.onError and during unsubscription.", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(3, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeObserverTestException);
+            assertEquals("onError failure", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeObserverTestException);
+            assertEquals("onErrorFail", e4.getMessage());
+
+            Throwable e5 = innerExceptions.get(2);
+            assertTrue(e5 instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e5.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void onErrorNotImplementedFailureWithUnsubscribeFailure() {
+        Subscriber<String> o = OBSERVER_ONERROR_NOTIMPLEMENTED();
+        try {
+            o.onSubscribe(new Subscription() {
+
+                @Override
+                public void cancel() {
+                    // break contract by throwing exception
+                    throw new SafeObserverTestException("failure from unsubscribe");
+                }
+                
+                @Override
+                public void request(long n) {
+                    
+                }
+            });
+            new SafeSubscriber<>(o).onError(new SafeObserverTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+
+            // assertions for what is expected for the actual failure propagated to onError which then fails
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Observer.onError not implemented and error while unsubscribing.", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(2, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeObserverTestException);
+            assertEquals("error!", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeObserverTestException);
+            assertEquals("failure from unsubscribe", e4.getMessage());
+        }
+    }
+
+    private static Subscriber<String> OBSERVER_SUCCESS() {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+        };
+
+    }
+
+    private static Subscriber<String> OBSERVER_SUCCESS(final AtomicReference<Throwable> onError) {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+        };
+
+    }
+
+    private static Subscriber<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+                throw new SafeObserverTestException("onNextFail");
+            }
+        };
+
+    }
+
+    private static Subscriber<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new SafeObserverTestException("onErrorFail");
+            }
+
+            @Override
+            public void onNext(String args) {
+                throw new SafeObserverTestException("onNextFail");
+            }
+
+        };
+    }
+
+    private static Subscriber<String> OBSERVER_ONERROR_FAIL() {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new SafeObserverTestException("onErrorFail");
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    private static Subscriber<String> OBSERVER_ONERROR_NOTIMPLEMENTED() {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new OnErrorNotImplementedException(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    private static Subscriber<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
+        return new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+                throw new SafeObserverTestException("onCompletedFail");
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    @SuppressWarnings("serial")
+    private static class SafeObserverTestException extends RuntimeException {
+        public SafeObserverTestException(String message) {
+            super(message);
+        }
+    }
+    
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void testOnCompletedThrows() {
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        SafeSubscriber<Integer> s = new SafeSubscriber<>(new Observer<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                
+            }
+            @Override
+            public void onError(Throwable e) {
+                error.set(e);
+            }
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
+        
+        try {
+            s.onComplete();
+            Assert.fail();
+        } catch (OnCompleteFailedException e) {
+           assertNull(error.get());
+        }
+    }
+    
+    @Test
+    public void testActual() {
+        Subscriber<Integer> actual = new Observer<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+            }
+            @Override
+            public void onError(Throwable e) {
+            }
+            @Override
+            public void onComplete() {
+            }
+        };
+        SafeSubscriber<Integer> s = new SafeSubscriber<>(actual);
+        
+        assertSame(actual, s.actual());
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberWithPluginTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberWithPluginTest.java
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.junit.*;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.exceptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import static org.junit.Assert.*;
+
+public class SafeSubscriberWithPluginTest {
+    private final class SubscriptionCancelThrows implements Subscription {
+        @Override
+        public void cancel() {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void request(long n) {
+            
+        }
+    }
+
+    @Before
+    @After
+    public void resetBefore() {
+        RxJavaPlugins.reset();
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void testOnCompletedThrows() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        try {
+            safe.onComplete();
+            Assert.fail();
+        } catch (OnCompleteFailedException e) {
+            // FIXME no longer assertable
+            // assertTrue(safe.isUnsubscribed());
+        }
+    }
+    
+    @Test
+    public void testOnCompletedThrows2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onComplete() {
+                throw new OnErrorNotImplementedException(new TestException());
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        
+        try {
+            safe.onComplete();
+        } catch (OnErrorNotImplementedException ex) {
+            // expected
+        }
+        
+        // FIXME no longer assertable
+        // assertTrue(safe.isUnsubscribed());
+    }
+    
+    @Test(expected = OnCompleteFailedException.class)
+    @Ignore("Subscribers can't throw")
+    public void testPluginException() {
+        RxJavaPlugins.setErrorHandler(e -> {
+            throw new RuntimeException();
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        
+        safe.onComplete();
+    }
+    
+    @Test(expected = OnErrorFailedException.class)
+    @Ignore("Subscribers can't throw")
+    public void testPluginExceptionWhileOnErrorUnsubscribeThrows() {
+        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+            int calls;
+            @Override
+            public void accept(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        safe.onSubscribe(new SubscriptionCancelThrows());
+        
+        safe.onError(new TestException());
+    }
+    
+    @Test(expected = RuntimeException.class)
+    @Ignore("Subscribers can't throw")
+    public void testPluginExceptionWhileOnErrorThrowsNotImplAndUnsubscribeThrows() {
+        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+            int calls;
+            @Override
+            public void accept(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new OnErrorNotImplementedException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        safe.onSubscribe(new SubscriptionCancelThrows());
+        
+        safe.onError(new TestException());
+    }
+    
+    @Test(expected = OnErrorFailedException.class)
+    @Ignore("Subscribers can't throw")
+    public void testPluginExceptionWhileOnErrorThrows() {
+        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+            int calls;
+            @Override
+            public void accept(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        
+        safe.onError(new TestException());
+    }
+    @Test(expected = OnErrorFailedException.class)
+    @Ignore("Subscribers can't throw")
+    public void testPluginExceptionWhileOnErrorThrowsAndUnsubscribeThrows() {
+        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+            int calls;
+            @Override
+            public void accept(Throwable e) {
+                if (++calls == 2) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        safe.onSubscribe(new SubscriptionCancelThrows());
+        
+        safe.onError(new TestException());
+    }
+    @Test(expected = OnErrorFailedException.class)
+    @Ignore("Subscribers can't throw")
+    public void testPluginExceptionWhenUnsubscribing2() {
+        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+            int calls;
+            @Override
+            public void accept(Throwable e) {
+                if (++calls == 3) {
+                    throw new RuntimeException();
+                }
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        safe.onSubscribe(new SubscriptionCancelThrows());
+        
+        safe.onError(new TestException());
+    }
+    
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void testPluginErrorHandlerReceivesExceptionWhenUnsubscribeAfterCompletionThrows() {
+        final AtomicInteger calls = new AtomicInteger();
+        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) {
+                calls.incrementAndGet();
+            }
+        });
+        
+        final AtomicInteger errors = new AtomicInteger();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                errors.incrementAndGet();
+            }
+        };
+        final RuntimeException ex = new RuntimeException();
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        safe.onSubscribe(new Subscription() {
+            @Override
+            public void cancel() {
+                throw ex;
+            }
+            
+            @Override
+            public void request(long n) {
+                
+            }
+        });
+        
+        try {
+            safe.onComplete();
+            Assert.fail();
+        } catch(UnsubscribeFailedException e) {
+            assertEquals(1, calls.get());
+            assertEquals(0, errors.get());
+        }
+    }
+
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void testPluginErrorHandlerReceivesExceptionFromFailingUnsubscribeAfterCompletionThrows() {
+        final AtomicInteger calls = new AtomicInteger();
+        RxJavaPlugins.setErrorHandler(e -> {
+                calls.incrementAndGet();
+        });
+        
+        final AtomicInteger errors = new AtomicInteger();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            
+            @Override 
+            public void onComplete() {
+                throw new RuntimeException();
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                errors.incrementAndGet();
+            }
+        };
+        SafeSubscriber<Integer> safe = new SafeSubscriber<>(ts);
+        safe.onSubscribe(new SubscriptionCancelThrows());
+        
+        try {
+            safe.onComplete();
+            Assert.fail();
+        } catch(UnsubscribeFailedException e) {
+            assertEquals(2, calls.get());
+            assertEquals(0, errors.get());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
@@ -1,0 +1,967 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class SerializedObserverTest {
+
+    Subscriber<String> observer;
+
+    @Before
+    public void before() {
+        observer = TestHelper.mockSubscriber();
+    }
+
+    private Subscriber<String> serializedSubscriber(Subscriber<String> o) {
+        return new SerializedSubscriber<>(o);
+    }
+
+    @Test
+    public void testSingleThreadedBasic() {
+        TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
+        Observable<String> w = Observable.create(onSubscribe);
+
+        Subscriber<String> aw = serializedSubscriber(observer);
+
+        w.subscribe(aw);
+        onSubscribe.waitToFinish();
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        // non-deterministic because unsubscribe happens after 'waitToFinish' releases
+        // so commenting out for now as this is not a critical thing to test here
+        //            verify(s, times(1)).unsubscribe();
+    }
+
+    @Test
+    public void testMultiThreadedBasic() {
+        TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three");
+        Observable<String> w = Observable.create(onSubscribe);
+
+        BusySubscriber busySubscriber = new BusySubscriber();
+        Subscriber<String> aw = serializedSubscriber(busySubscriber);
+
+        w.subscribe(aw);
+        onSubscribe.waitToFinish();
+
+        assertEquals(3, busySubscriber.onNextCount.get());
+        assertFalse(busySubscriber.onError);
+        assertTrue(busySubscriber.onCompleted);
+        // non-deterministic because unsubscribe happens after 'waitToFinish' releases
+        // so commenting out for now as this is not a critical thing to test here
+        //            verify(s, times(1)).unsubscribe();
+
+        // we can have concurrency ...
+        assertTrue(onSubscribe.maxConcurrentThreads.get() > 1);
+        // ... but the onNext execution should be single threaded
+        assertEquals(1, busySubscriber.maxConcurrentThreads.get());
+    }
+
+    @Test(timeout = 1000)
+    public void testMultiThreadedWithNPE() throws InterruptedException {
+        TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
+        Observable<String> w = Observable.create(onSubscribe);
+
+        BusySubscriber busySubscriber = new BusySubscriber();
+        Subscriber<String> aw = serializedSubscriber(busySubscriber);
+
+        w.subscribe(aw);
+        onSubscribe.waitToFinish();
+        busySubscriber.terminalEvent.await();
+
+        System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get() + "  Subscriber maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
+
+        // we can't know how many onNext calls will occur since they each run on a separate thread
+        // that depends on thread scheduling so 0, 1, 2 and 3 are all valid options
+        // assertEquals(3, busySubscriber.onNextCount.get());
+        assertTrue(busySubscriber.onNextCount.get() < 4);
+        assertTrue(busySubscriber.onError);
+        // no onCompleted because onError was invoked
+        assertFalse(busySubscriber.onCompleted);
+        // non-deterministic because unsubscribe happens after 'waitToFinish' releases
+        // so commenting out for now as this is not a critical thing to test here
+        //verify(s, times(1)).unsubscribe();
+
+        // we can have concurrency ...
+        assertTrue(onSubscribe.maxConcurrentThreads.get() > 1);
+        // ... but the onNext execution should be single threaded
+        assertEquals(1, busySubscriber.maxConcurrentThreads.get());
+    }
+
+    @Test
+    public void testMultiThreadedWithNPEinMiddle() {
+        int n = 10;
+        for (int i = 0; i < n; i++) {
+            TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, 
+                    "four", "five", "six", "seven", "eight", "nine");
+            Observable<String> w = Observable.create(onSubscribe);
+
+            BusySubscriber busySubscriber = new BusySubscriber();
+            Subscriber<String> aw = serializedSubscriber(busySubscriber);
+
+            w.subscribe(aw);
+            onSubscribe.waitToFinish();
+
+            System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get() + "  Subscriber maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
+
+            // we can have concurrency ...
+            assertTrue(onSubscribe.maxConcurrentThreads.get() > 1);
+            // ... but the onNext execution should be single threaded
+            assertEquals(1, busySubscriber.maxConcurrentThreads.get());
+
+            // this should not be the full number of items since the error should stop it before it completes all 9
+            System.out.println("onNext count: " + busySubscriber.onNextCount.get());
+            assertFalse(busySubscriber.onCompleted);
+            assertTrue(busySubscriber.onError);
+            assertTrue(busySubscriber.onNextCount.get() < 9);
+            // no onCompleted because onError was invoked
+            // non-deterministic because unsubscribe happens after 'waitToFinish' releases
+            // so commenting out for now as this is not a critical thing to test here
+            // verify(s, times(1)).unsubscribe();
+        }
+    }
+
+    /**
+     * A non-realistic use case that tries to expose thread-safety issues by throwing lots of out-of-order
+     * events on many threads.
+     */
+    @Test
+    public void runOutOfOrderConcurrencyTest() {
+        ExecutorService tp = Executors.newFixedThreadPool(20);
+        try {
+            TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
+            // we need Synchronized + SafeSubscriber to handle synchronization plus life-cycle
+            Subscriber<String> w = serializedSubscriber(new SafeSubscriber<>(tw));
+
+            Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
+            Future<?> f2 = tp.submit(new OnNextThread(w, 5000));
+            Future<?> f3 = tp.submit(new OnNextThread(w, 75000));
+            Future<?> f4 = tp.submit(new OnNextThread(w, 13500));
+            Future<?> f5 = tp.submit(new OnNextThread(w, 22000));
+            Future<?> f6 = tp.submit(new OnNextThread(w, 15000));
+            Future<?> f7 = tp.submit(new OnNextThread(w, 7500));
+            Future<?> f8 = tp.submit(new OnNextThread(w, 23500));
+
+            Future<?> f10 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onCompleted, f1, f2, f3, f4));
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+            Future<?> f11 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onCompleted, f4, f6, f7));
+            Future<?> f12 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onCompleted, f4, f6, f7));
+            Future<?> f13 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onCompleted, f4, f6, f7));
+            Future<?> f14 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onCompleted, f4, f6, f7));
+            // // the next 4 onError events should wait on same as f10
+            Future<?> f15 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+            Future<?> f16 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+            Future<?> f17 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+            Future<?> f18 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+
+            waitOnThreads(f1, f2, f3, f4, f5, f6, f7, f8, f10, f11, f12, f13, f14, f15, f16, f17, f18);
+            @SuppressWarnings("unused")
+            int numNextEvents = tw.assertEvents(null); // no check of type since we don't want to test barging results here, just interleaving behavior
+            //            System.out.println("Number of events executed: " + numNextEvents);
+        } catch (Throwable e) {
+            fail("Concurrency test failed: " + e.getMessage());
+            e.printStackTrace();
+        } finally {
+            tp.shutdown();
+            try {
+                tp.awaitTermination(5000, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Test
+    public void runConcurrencyTest() {
+        ExecutorService tp = Executors.newFixedThreadPool(20);
+        try {
+            TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
+            // we need Synchronized + SafeSubscriber to handle synchronization plus life-cycle
+            Subscriber<String> w = serializedSubscriber(new SafeSubscriber<>(tw));
+            w.onSubscribe(EmptySubscription.INSTANCE);
+
+            Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
+            Future<?> f2 = tp.submit(new OnNextThread(w, 5000));
+            Future<?> f3 = tp.submit(new OnNextThread(w, 75000));
+            Future<?> f4 = tp.submit(new OnNextThread(w, 13500));
+            Future<?> f5 = tp.submit(new OnNextThread(w, 22000));
+            Future<?> f6 = tp.submit(new OnNextThread(w, 15000));
+            Future<?> f7 = tp.submit(new OnNextThread(w, 7500));
+            Future<?> f8 = tp.submit(new OnNextThread(w, 23500));
+
+            // 12000 + 5000 + 75000 + 13500 + 22000 + 15000 + 7500 + 23500 = 173500
+
+            Future<?> f10 = tp.submit(new CompletionThread(w, TestConcurrencySubscriberEvent.onCompleted, f1, f2, f3, f4, f5, f6, f7, f8));
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+
+            waitOnThreads(f1, f2, f3, f4, f5, f6, f7, f8, f10);
+            int numNextEvents = tw.assertEvents(null); // no check of type since we don't want to test barging results here, just interleaving behavior
+            assertEquals(173500, numNextEvents);
+            // System.out.println("Number of events executed: " + numNextEvents);
+        } catch (Throwable e) {
+            fail("Concurrency test failed: " + e.getMessage());
+            e.printStackTrace();
+        } finally {
+            tp.shutdown();
+            try {
+                tp.awaitTermination(25000, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Test that a notification does not get delayed in the queue waiting for the next event to push it through.
+     * 
+     * @throws InterruptedException
+     */
+    @Ignore
+    // this is non-deterministic ... haven't figured out what's wrong with the test yet (benjchristensen: July 2014)
+    @Test
+    public void testNotificationDelay() throws InterruptedException {
+        ExecutorService tp1 = Executors.newFixedThreadPool(1);
+        ExecutorService tp2 = Executors.newFixedThreadPool(1);
+        try {
+            int n = 10;
+            for (int i = 0; i < n; i++) {
+                final CountDownLatch firstOnNext = new CountDownLatch(1);
+                final CountDownLatch onNextCount = new CountDownLatch(2);
+                final CountDownLatch latch = new CountDownLatch(1);
+                final CountDownLatch running = new CountDownLatch(2);
+
+                TestSubscriber<String> to = new TestSubscriber<>(new Observer<String>() {
+
+                    @Override
+                    public void onComplete() {
+
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+
+                    }
+
+                    @Override
+                    public void onNext(String t) {
+                        firstOnNext.countDown();
+                        // force it to take time when delivering so the second one is enqueued
+                        try {
+                            latch.await();
+                        } catch (InterruptedException e) {
+                        }
+                    }
+
+                });
+                Subscriber<String> o = serializedSubscriber(to);
+
+                Future<?> f1 = tp1.submit(new OnNextThread(o, 1, onNextCount, running));
+                Future<?> f2 = tp2.submit(new OnNextThread(o, 1, onNextCount, running));
+
+                running.await(); // let one of the OnNextThread actually run before proceeding
+                
+                firstOnNext.await();
+
+                Thread t1 = to.lastThread();
+                System.out.println("first onNext on thread: " + t1);
+
+                latch.countDown();
+
+                waitOnThreads(f1, f2);
+                // not completed yet
+
+                assertEquals(2, to.valueCount());
+
+                Thread t2 = to.lastThread();
+                System.out.println("second onNext on thread: " + t2);
+
+                assertSame(t1, t2);
+
+                System.out.println(to.values());
+                o.onComplete();
+                System.out.println(to.values());
+            }
+        } finally {
+            tp1.shutdown();
+            tp2.shutdown();
+        }
+    }
+
+    /**
+     * Demonstrates thread starvation problem.
+     * 
+     * No solution on this for now. Trade-off in this direction as per https://github.com/ReactiveX/RxJava/issues/998#issuecomment-38959474
+     * Probably need backpressure for this to work
+     * 
+     * When using SynchronizedSubscriber we get this output:
+     * 
+     * p1: 18 p2: 68 => should be close to each other unless we have thread starvation
+     * 
+     * When using SerializedSubscriber we get:
+     * 
+     * p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation
+     * 
+     * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
+     * The real issue in this example is the async buffer-bloat, so we need backpressure.
+     * 
+     * 
+     * @throws InterruptedException
+     */
+    @Ignore
+    @Test
+    public void testThreadStarvation() throws InterruptedException {
+
+        TestSubscriber<String> to = new TestSubscriber<>(new Observer<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(String t) {
+                // force it to take time when delivering
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                }
+            }
+
+        });
+        Subscriber<String> o = serializedSubscriber(to);
+
+        AtomicInteger p1 = new AtomicInteger();
+        AtomicInteger p2 = new AtomicInteger();
+
+        o.onSubscribe(EmptySubscription.INSTANCE);
+        AsyncObserver<String> as1 = Observers.createAsync(o::onNext);
+        AsyncObserver<String> as2 = Observers.createAsync(o::onNext);
+        
+        infinite(p1).subscribe(as1);
+        infinite(p2).subscribe(as2);
+
+        Thread.sleep(100);
+
+        System.out.println("p1: " + p1.get() + " p2: " + p2.get() + " => should be close to each other unless we have thread starvation");
+        assertEquals(p1.get(), p2.get(), 10000); // fairly distributed within 10000 of each other
+
+        as1.dispose();
+        as2.dispose();
+    }
+
+    private static void waitOnThreads(Future<?>... futures) {
+        for (Future<?> f : futures) {
+            try {
+                f.get(20, TimeUnit.SECONDS);
+            } catch (Throwable e) {
+                System.err.println("Failed while waiting on future.");
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static Observable<String> infinite(final AtomicInteger produced) {
+        return Observable.create(new Publisher<String>() {
+
+            @Override
+            public void subscribe(Subscriber<? super String> s) {
+                BooleanSubscription bs = new BooleanSubscription();
+                s.onSubscribe(bs);
+                while (!bs.isCancelled()) {
+                    s.onNext("onNext");
+                    produced.incrementAndGet();
+                }
+            }
+
+        }).subscribeOn(Schedulers.newThread());
+    }
+
+    /**
+     * A thread that will pass data to onNext
+     */
+    public static class OnNextThread implements Runnable {
+
+        private final CountDownLatch latch;
+        private final Subscriber<String> observer;
+        private final int numStringsToSend;
+        final AtomicInteger produced;
+        private final CountDownLatch running;
+
+        OnNextThread(Subscriber<String> observer, int numStringsToSend, CountDownLatch latch, CountDownLatch running) {
+            this(observer, numStringsToSend, new AtomicInteger(), latch, running);
+        }
+
+        OnNextThread(Subscriber<String> observer, int numStringsToSend, AtomicInteger produced) {
+            this(observer, numStringsToSend, produced, null, null);
+        }
+
+        OnNextThread(Subscriber<String> observer, int numStringsToSend, AtomicInteger produced, CountDownLatch latch, CountDownLatch running) {
+            this.observer = observer;
+            this.numStringsToSend = numStringsToSend;
+            this.produced = produced;
+            this.latch = latch;
+            this.running = running;
+        }
+
+        OnNextThread(Subscriber<String> observer, int numStringsToSend) {
+            this(observer, numStringsToSend, new AtomicInteger());
+        }
+
+        @Override
+        public void run() {
+            if (running != null) {
+                running.countDown();
+            }
+            for (int i = 0; i < numStringsToSend; i++) {
+                observer.onNext(Thread.currentThread().getId() + "-" + i);
+                if (latch != null) {
+                    latch.countDown();
+                }
+                produced.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     * A thread that will call onError or onNext
+     */
+    public static class CompletionThread implements Runnable {
+
+        private final Subscriber<String> observer;
+        private final TestConcurrencySubscriberEvent event;
+        private final Future<?>[] waitOnThese;
+
+        CompletionThread(Subscriber<String> Subscriber, TestConcurrencySubscriberEvent event, Future<?>... waitOnThese) {
+            this.observer = Subscriber;
+            this.event = event;
+            this.waitOnThese = waitOnThese;
+        }
+
+        @Override
+        public void run() {
+            /* if we have 'waitOnThese' futures, we'll wait on them before proceeding */
+            if (waitOnThese != null) {
+                for (Future<?> f : waitOnThese) {
+                    try {
+                        f.get();
+                    } catch (Throwable e) {
+                        System.err.println("Error while waiting on future in CompletionThread");
+                    }
+                }
+            }
+
+            /* send the event */
+            if (event == TestConcurrencySubscriberEvent.onError) {
+                observer.onError(new RuntimeException("mocked exception"));
+            } else if (event == TestConcurrencySubscriberEvent.onCompleted) {
+                observer.onComplete();
+
+            } else {
+                throw new IllegalArgumentException("Expecting either onError or onCompleted");
+            }
+        }
+    }
+
+    private static enum TestConcurrencySubscriberEvent {
+        onCompleted, onError, onNext
+    }
+
+    private static class TestConcurrencySubscriber extends Observer<String> {
+
+        /**
+         * used to store the order and number of events received
+         */
+        private final LinkedBlockingQueue<TestConcurrencySubscriberEvent> events = new LinkedBlockingQueue<>();
+        private final int waitTime;
+
+        @SuppressWarnings("unused")
+        public TestConcurrencySubscriber(int waitTimeInNext) {
+            this.waitTime = waitTimeInNext;
+        }
+
+        public TestConcurrencySubscriber() {
+            this.waitTime = 0;
+        }
+
+        @Override
+        public void onComplete() {
+            events.add(TestConcurrencySubscriberEvent.onCompleted);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            events.add(TestConcurrencySubscriberEvent.onError);
+        }
+
+        @Override
+        public void onNext(String args) {
+            events.add(TestConcurrencySubscriberEvent.onNext);
+            // do some artificial work to make the thread scheduling/timing vary
+            int s = 0;
+            for (int i = 0; i < 20; i++) {
+                s += s * i;
+            }
+
+            if (waitTime > 0) {
+                try {
+                    Thread.sleep(waitTime);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+
+        /**
+         * Assert the order of events is correct and return the number of onNext executions.
+         * 
+         * @param expectedEndingEvent
+         * @return int count of onNext calls
+         * @throws IllegalStateException
+         *             If order of events was invalid.
+         */
+        public int assertEvents(TestConcurrencySubscriberEvent expectedEndingEvent) throws IllegalStateException {
+            int nextCount = 0;
+            boolean finished = false;
+            for (TestConcurrencySubscriberEvent e : events) {
+                if (e == TestConcurrencySubscriberEvent.onNext) {
+                    if (finished) {
+                        // already finished, we shouldn't get this again
+                        throw new IllegalStateException("Received onNext but we're already finished.");
+                    }
+                    nextCount++;
+                } else if (e == TestConcurrencySubscriberEvent.onError) {
+                    if (finished) {
+                        // already finished, we shouldn't get this again
+                        throw new IllegalStateException("Received onError but we're already finished.");
+                    }
+                    if (expectedEndingEvent != null && TestConcurrencySubscriberEvent.onError != expectedEndingEvent) {
+                        throw new IllegalStateException("Received onError ending event but expected " + expectedEndingEvent);
+                    }
+                    finished = true;
+                } else if (e == TestConcurrencySubscriberEvent.onCompleted) {
+                    if (finished) {
+                        // already finished, we shouldn't get this again
+                        throw new IllegalStateException("Received onCompleted but we're already finished.");
+                    }
+                    if (expectedEndingEvent != null && TestConcurrencySubscriberEvent.onCompleted != expectedEndingEvent) {
+                        throw new IllegalStateException("Received onCompleted ending event but expected " + expectedEndingEvent);
+                    }
+                    finished = true;
+                }
+            }
+
+            return nextCount;
+        }
+
+    }
+
+    /**
+     * This spawns a single thread for the subscribe execution
+     */
+    private static class TestSingleThreadedObservable implements Publisher<String> {
+
+        final String[] values;
+        private Thread t = null;
+
+        public TestSingleThreadedObservable(final String... values) {
+            this.values = values;
+
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            System.out.println("TestSingleThreadedObservable subscribed to ...");
+            t = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        System.out.println("running TestSingleThreadedObservable thread");
+                        for (String s : values) {
+                            System.out.println("TestSingleThreadedObservable onNext: " + s);
+                            observer.onNext(s);
+                        }
+                        observer.onComplete();
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+            });
+            System.out.println("starting TestSingleThreadedObservable thread");
+            t.start();
+            System.out.println("done starting TestSingleThreadedObservable thread");
+        }
+
+        public void waitToFinish() {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    /**
+     * This spawns a thread for the subscription, then a separate thread for each onNext call.
+     */
+    private static class TestMultiThreadedObservable implements Publisher<String> {
+
+        final String[] values;
+        Thread t = null;
+        AtomicInteger threadsRunning = new AtomicInteger();
+        AtomicInteger maxConcurrentThreads = new AtomicInteger();
+        ExecutorService threadPool;
+
+        public TestMultiThreadedObservable(String... values) {
+            this.values = values;
+            this.threadPool = Executors.newCachedThreadPool();
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super String> observer) {
+            observer.onSubscribe(EmptySubscription.INSTANCE);
+            final NullPointerException npe = new NullPointerException();
+            System.out.println("TestMultiThreadedObservable subscribed to ...");
+            t = new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        System.out.println("running TestMultiThreadedObservable thread");
+                        int j = 0;
+                        for (final String s : values) {
+                            final int fj = ++j;
+                            threadPool.execute(new Runnable() {
+
+                                @Override
+                                public void run() {
+                                    threadsRunning.incrementAndGet();
+                                    try {
+                                        // perform onNext call
+                                        System.out.println("TestMultiThreadedObservable onNext: " + s + " on thread " + Thread.currentThread().getName());
+                                        if (s == null) {
+                                            // force an error
+                                            throw npe;
+                                        } else {
+                                             // allow the exception to queue up
+                                            int sleep = (fj % 3) * 10;
+                                            if (sleep != 0) {
+                                                Thread.sleep(sleep);
+                                            }
+                                        }
+                                        observer.onNext(s);
+                                        // capture 'maxThreads'
+                                        int concurrentThreads = threadsRunning.get();
+                                        int maxThreads = maxConcurrentThreads.get();
+                                        if (concurrentThreads > maxThreads) {
+                                            maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
+                                        }
+                                    } catch (Throwable e) {
+                                        observer.onError(e);
+                                    } finally {
+                                        threadsRunning.decrementAndGet();
+                                    }
+                                }
+                            });
+                        }
+                        // we are done spawning threads
+                        threadPool.shutdown();
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    // wait until all threads are done, then mark it as COMPLETED
+                    try {
+                        // wait for all the threads to finish
+                        if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                            System.out.println("Threadpool did not terminate in time.");
+                        }
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    observer.onComplete();
+                }
+            });
+            System.out.println("starting TestMultiThreadedObservable thread");
+            t.start();
+            System.out.println("done starting TestMultiThreadedObservable thread");
+        }
+
+        public void waitToFinish() {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static class BusySubscriber extends Observer<String> {
+        volatile boolean onCompleted = false;
+        volatile boolean onError = false;
+        AtomicInteger onNextCount = new AtomicInteger();
+        AtomicInteger threadsRunning = new AtomicInteger();
+        AtomicInteger maxConcurrentThreads = new AtomicInteger();
+        final CountDownLatch terminalEvent = new CountDownLatch(1);
+
+        @Override
+        public void onComplete() {
+            threadsRunning.incrementAndGet();
+            try {
+                onCompleted = true;
+            } finally {
+                captureMaxThreads();
+                threadsRunning.decrementAndGet();
+                terminalEvent.countDown();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            System.out.println(">>>>>>>>>>>>>>>>>>>> onError received: " + e);
+            threadsRunning.incrementAndGet();
+            try {
+                onError = true;
+            } finally {
+                captureMaxThreads();
+                threadsRunning.decrementAndGet();
+                terminalEvent.countDown();
+            }
+        }
+
+        @Override
+        public void onNext(String args) {
+            threadsRunning.incrementAndGet();
+            try {
+                onNextCount.incrementAndGet();
+                try {
+                    // simulate doing something computational
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            } finally {
+                // capture 'maxThreads'
+                captureMaxThreads();
+                threadsRunning.decrementAndGet();
+            }
+        }
+
+        protected void captureMaxThreads() {
+            int concurrentThreads = threadsRunning.get();
+            int maxThreads = maxConcurrentThreads.get();
+            if (concurrentThreads > maxThreads) {
+                maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
+                if (concurrentThreads > 1) {
+                    new RuntimeException("should not be greater than 1").printStackTrace();
+                }
+            }
+        }
+
+    }
+    
+    @Test
+    @Ignore("Null values not permitted")
+    public void testSerializeNull() {
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                if (t != null && t == 0) {
+                    serial.get().onNext(null);
+                }
+                super.onNext(t);
+            }
+        };
+        
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(to);
+        serial.set(sobs);
+        
+        sobs.onNext(0);
+        
+        to.assertValues(0, null);
+    }
+    
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void testSerializeAllowsOnError() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                throw new TestException();
+            }
+        };
+        
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(to);
+        
+        try {
+            sobs.onNext(0);
+        } catch (TestException ex) {
+            sobs.onError(ex);
+        }
+        
+        to.assertError(TestException.class);
+    }
+    
+    @Test
+    @Ignore("Null values no longer permitted")
+    public void testSerializeReentrantNullAndComplete() {
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                serial.get().onComplete();
+                throw new TestException();
+            }
+        };
+        
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(to);
+        serial.set(sobs);
+        
+        try {
+            sobs.onNext(0);
+        } catch (TestException ex) {
+            sobs.onError(ex);
+        }
+        
+        to.assertError(TestException.class);
+        to.assertNotComplete();
+    }
+    
+    @Test
+    @Ignore("Subscribers can't throw")
+    public void testSerializeReentrantNullAndError() {
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                serial.get().onError(new RuntimeException());
+                throw new TestException();
+            }
+        };
+        
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(to);
+        serial.set(sobs);
+        
+        try {
+            sobs.onNext(0);
+        } catch (TestException ex) {
+            sobs.onError(ex);
+        }
+        
+        to.assertError(TestException.class);
+        to.assertNotComplete();
+    }
+    
+    @Test
+    @Ignore("Null values no longer permitted")
+    public void testSerializeDrainPhaseThrows() {
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                if (t != null && t == 0) {
+                    serial.get().onNext(null);
+                } else
+                if (t == null) {
+                    throw new TestException();
+                }
+                super.onNext(t);
+            }
+        };
+        
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(to);
+        serial.set(sobs);
+        
+        sobs.onNext(0);
+        
+        to.assertError(TestException.class);
+        to.assertNotComplete();
+    }
+    
+    @Test
+    public void testErrorReentry() {
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
+       
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer v) {
+                serial.get().onError(new TestException());
+                serial.get().onError(new TestException());
+                super.onNext(v);
+            }
+        };
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(ts);
+        serial.set(sobs);
+        
+        sobs.onNext(1);
+        
+        ts.assertValue(1);
+        ts.assertError(TestException.class);
+    }
+    @Test
+    public void testCompleteReentry() {
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
+       
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer v) {
+                serial.get().onComplete();
+                serial.get().onComplete();
+                super.onNext(v);
+            }
+        };
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(ts);
+        serial.set(sobs);
+        
+        sobs.onNext(1);
+        
+        ts.assertValue(1);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/SubscribersTest.java
+++ b/src/test/java/io/reactivex/subscribers/SubscribersTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.Consumer;
+
+import org.junit.*;
+
+import io.reactivex.exceptions.*;
+
+public class SubscribersTest {
+    @Test
+    public void testNotInstantiable() {
+        try {
+            Constructor<?> c = Subscribers.class.getDeclaredConstructor();
+            c.setAccessible(true);
+            Object instance = c.newInstance();
+            fail("Could instantiate Actions! " + instance);
+        } catch (NoSuchMethodException ex) {
+            ex.printStackTrace();
+        } catch (InvocationTargetException ex) {
+            ex.printStackTrace();
+        } catch (InstantiationException ex) {
+            ex.printStackTrace();
+        } catch (IllegalAccessException ex) {
+            ex.printStackTrace();
+        }
+    }
+    
+    @Test
+    @Ignore("Subscribers can't throw OnErrorNotImplementedException")
+    public void testEmptyOnErrorNotImplemented() {
+        try {
+            Subscribers.empty().onError(new TestException());
+            fail("OnErrorNotImplementedException not thrown!");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                fail("TestException not wrapped, instead: " + ex.getCause());
+            }
+        }
+    }
+    @Test
+    @Ignore("Subscribers can't throw OnErrorNotImplementedException")
+    public void testCreate1OnErrorNotImplemented() {
+        try {
+            Subscribers.create(v -> { }).onError(new TestException());
+            fail("OnErrorNotImplementedException not thrown!");
+        } catch (OnErrorNotImplementedException ex) {
+            if (!(ex.getCause() instanceof TestException)) {
+                fail("TestException not wrapped, instead: " + ex.getCause());
+            }
+        }
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate1Null() {
+        Subscribers.create(null);
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate2Null() {
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(null, throwAction);
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate3Null() {
+        Subscribers.create(e -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testCreate4Null() {
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(null, throwAction, () -> { });
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate5Null() {
+        Subscribers.create(e -> { }, null, () -> { });
+    }
+    @Test(expected = NullPointerException.class)
+    public void testCreate6Null() {
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(e -> { }, throwAction, null);
+    }
+    
+    @Test
+    public void testCreate1Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Consumer<Integer> action = new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                value.set(t);
+            }
+        };
+        Subscribers.create(action).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    @Test
+    public void testCreate2Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Consumer<Integer> action = new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                value.set(t);
+            }
+        };
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(action, throwAction).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testCreate3Value() {
+        final AtomicInteger value = new AtomicInteger();
+        Consumer<Integer> action = new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                value.set(t);
+            }
+        };
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(action, throwAction, () -> { }).onNext(1);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void testError2() {
+        final AtomicReference<Throwable> value = new AtomicReference<>();
+        Consumer<Throwable> action = new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Subscribers.create(e -> { }, action).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testError3() {
+        final AtomicReference<Throwable> value = new AtomicReference<>();
+        Consumer<Throwable> action = new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                value.set(t);
+            }
+        };
+        TestException exception = new TestException();
+        Subscribers.create(e -> { }, action, () -> { }).onError(exception);
+        
+        assertEquals(exception, value.get());
+    }
+    
+    @Test
+    public void testCompleted() {
+        Runnable action = mock(Runnable.class);
+        
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(e -> { }, throwAction, action).onComplete();
+
+        verify(action).run();
+    }
+    @Test
+    public void testEmptyCompleted() {
+        Subscribers.create(e -> { }).onComplete();
+        
+        Consumer<Throwable> throwAction = e -> { };
+        Subscribers.create(e -> { }, throwAction).onComplete();
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestObserverTest.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subjects.PublishSubject;
+
+public class TestObserverTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testAssert() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        o.assertValues(1, 2);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testAssertNotMatchCount() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        thrown.expect(AssertionError.class);
+        // FIXME different message format
+//        thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
+
+        o.assertValue(1);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testAssertNotMatchValue() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        thrown.expect(AssertionError.class);
+        // FIXME different message format
+//        thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
+
+        o.assertValues(1, 3);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testAssertTerminalEventNotReceived() {
+        PublishSubject<Integer> p = PublishSubject.create();
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        p.subscribe(o);
+
+        p.onNext(1);
+        p.onNext(2);
+
+        thrown.expect(AssertionError.class);
+        // FIXME different message format
+//        thrown.expectMessage("No terminal events received.");
+
+        o.assertValues(1, 2);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testWrappingMock() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+
+        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
+        
+        oi.subscribe(new TestSubscriber<>(mockObserver));
+
+        InOrder inOrder = inOrder(mockObserver);
+        inOrder.verify(mockObserver, times(1)).onNext(1);
+        inOrder.verify(mockObserver, times(1)).onNext(2);
+        inOrder.verify(mockObserver, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testWrappingMockWhenUnsubscribeInvolved() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
+        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
+        oi.subscribe(new TestSubscriber<>(mockObserver));
+
+        InOrder inOrder = inOrder(mockObserver);
+        inOrder.verify(mockObserver, times(1)).onNext(1);
+        inOrder.verify(mockObserver, times(1)).onNext(2);
+        inOrder.verify(mockObserver, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void testErrorSwallowed() {
+        Observable.error(new RuntimeException()).subscribe(new TestSubscriber<>());
+    }
+    
+    @Test
+    public void testGetEvents() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        to.onNext(1);
+        to.onNext(2);
+        
+        assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), 
+                Collections.emptyList(), 
+                Collections.emptyList()), to.getEvents());
+        
+        to.onComplete();
+        
+        assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), Collections.emptyList(),
+                Collections.singletonList(Notification.complete())), to.getEvents());
+        
+        TestException ex = new TestException();
+        TestSubscriber<Integer> to2 = new TestSubscriber<>();
+        to2.onNext(1);
+        to2.onNext(2);
+        
+        assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), 
+                Collections.emptyList(), 
+                Collections.emptyList()), to2.getEvents());
+        
+        to2.onError(ex);
+        
+        assertEquals(Arrays.<Object>asList(
+                Arrays.asList(1, 2),
+                Collections.singletonList(ex),
+                Collections.emptyList()), 
+                    to2.getEvents());
+    }
+
+    @Test
+    public void testNullExpected() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        to.onNext(1);
+
+        try {
+            to.assertValue(null);
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Null element check assertion didn't happen!");
+    }
+    
+    @Test
+    public void testNullActual() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        to.onNext(null);
+
+        try {
+            to.assertValue(1);
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Null element check assertion didn't happen!");
+    }
+    
+    @Test
+    public void testTerminalErrorOnce() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        to.onError(new TestException());
+        to.onError(new TestException());
+        
+        try {
+            to.assertTerminated();
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Failed to report multiple onError terminal events!");
+    }
+    @Test
+    public void testTerminalCompletedOnce() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        to.onComplete();
+        to.onComplete();
+        
+        try {
+            to.assertTerminated();
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Failed to report multiple onComplete terminal events!");
+    }
+    
+    @Test
+    public void testTerminalOneKind() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        to.onError(new TestException());
+        to.onComplete();
+        
+        try {
+            to.assertTerminated();
+        } catch (AssertionError ex) {
+            // this is expected
+            return;
+        }
+        fail("Failed to report multiple kinds of events!");
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1,0 +1,597 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.exceptions.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+
+public class TestSubscriberTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testAssert() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        o.assertValues(1, 2);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testAssertNotMatchCount() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        thrown.expect(AssertionError.class);
+        // FIXME different message pattern
+        // thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
+
+        o.assertValues(1);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testAssertNotMatchValue() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        thrown.expect(AssertionError.class);
+        // FIXME different message pattern
+        // thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
+
+
+        o.assertValues(1, 3);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testAssertTerminalEventNotReceived() {
+        PublishSubject<Integer> p = PublishSubject.create();
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        p.subscribe(o);
+
+        p.onNext(1);
+        p.onNext(2);
+
+        thrown.expect(AssertionError.class);
+        // FIXME different message pattern
+        // thrown.expectMessage("No terminal events received.");
+
+        o.assertValues(1, 2);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void testWrappingMock() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
+
+        oi.subscribe(new TestSubscriber<>(mockObserver));
+
+        InOrder inOrder = inOrder(mockObserver);
+        inOrder.verify(mockObserver, times(1)).onNext(1);
+        inOrder.verify(mockObserver, times(1)).onNext(2);
+        inOrder.verify(mockObserver, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testWrappingMockWhenUnsubscribeInvolved() {
+        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
+        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
+        oi.subscribe(new TestSubscriber<>(mockObserver));
+
+        InOrder inOrder = inOrder(mockObserver);
+        inOrder.verify(mockObserver, times(1)).onNext(1);
+        inOrder.verify(mockObserver, times(1)).onNext(2);
+        inOrder.verify(mockObserver, times(1)).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testAssertError() {
+        RuntimeException e = new RuntimeException("Oops");
+        TestSubscriber<Object> subscriber = new TestSubscriber<>();
+        Observable.error(e).subscribe(subscriber);
+        subscriber.assertError(e);
+    }
+    
+    @Test
+    public void testAwaitTerminalEventWithDuration() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+        Observable.just(1).subscribe(ts);
+        ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
+        ts.assertTerminated();
+    }
+    
+    @Test
+    public void testAwaitTerminalEventWithDurationAndUnsubscribeOnTimeout() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+        final AtomicBoolean unsub = new AtomicBoolean(false);
+        Observable.just(1)
+        //
+                .doOnCancel(new Runnable() {
+                    @Override
+                    public void run() {
+                        unsub.set(true);
+                    }
+                })
+                //
+                .delay(1000, TimeUnit.MILLISECONDS).subscribe(ts);
+        ts.awaitTerminalEvent(100, TimeUnit.MILLISECONDS);
+        ts.dispose();
+        assertTrue(unsub.get());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullDelegate1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Observer<Integer>)null);
+        ts.onComplete();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testNullDelegate2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Subscriber<Integer>)null);
+        ts.onComplete();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testNullDelegate3() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Subscriber<Integer>)null, null);
+        ts.onComplete();
+    }
+    
+    @Test
+    public void testDelegate1() {
+        TestSubscriber<Integer> to = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>(to);
+        ts.onComplete();
+        
+        to.assertTerminated();
+    }
+    
+    @Test
+    public void testDelegate2() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(ts1);
+        ts2.onComplete();
+        
+        ts1.assertComplete();
+    }
+    
+    @Test
+    public void testDelegate3() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(ts1, null);
+        ts2.onComplete();
+        ts1.assertComplete();
+    }
+    
+    @Test
+    public void testUnsubscribed() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        assertFalse(ts.isCancelled());
+    }
+    
+    @Test
+    public void testNoErrors() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new TestException());
+        try {
+            ts.assertNoErrors();
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testNotCompleted() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        try {
+            ts.assertComplete();
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Not completed and no assertion error!");
+    }
+    
+    @Test
+    public void testMultipleCompletions() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onComplete();
+        ts.onComplete();
+        try {
+            ts.assertComplete();
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Multiple completions and no assertion error!");
+    }
+    
+    @Test
+    public void testCompleted() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onComplete();
+        try {
+            ts.assertNotComplete();
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Completed and no assertion error!");
+    }
+    
+    @Test
+    public void testMultipleCompletions2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onComplete();
+        ts.onComplete();
+        try {
+            ts.assertNotComplete();
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Multiple completions and no assertion error!");
+    }
+    
+    @Test
+    public void testMultipleErrors() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new TestException());
+        ts.onError(new TestException());
+        try {
+            ts.assertNoErrors();
+        } catch (AssertionError ex) {
+            if (ex.getSuppressed().length != 2) {
+                fail("Multiple Error present but the reported error doesn't have a composite cause!");
+            }
+            // expected
+            return;
+        }
+        fail("Multiple Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testMultipleErrors2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new TestException());
+        ts.onError(new TestException());
+        try {
+            ts.assertError(TestException.class);
+        } catch (AssertionError ex) {
+            if (ex.getSuppressed().length != 2) {
+                fail("Multiple Error present but the reported error doesn't have a composite cause!");
+            }
+            // expected
+            return;
+        }
+        fail("Multiple Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testMultipleErrors3() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new TestException());
+        ts.onError(new TestException());
+        try {
+            ts.assertError(new TestException());
+        } catch (AssertionError ex) {
+            if (ex.getSuppressed().length != 2) {
+                fail("Multiple Error present but the reported error doesn't have a composite cause!");
+            }
+            // expected
+            return;
+        }
+        fail("Multiple Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testDifferentError() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new TestException());
+        try {
+            ts.assertError(new TestException());
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Different Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testDifferentError2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new RuntimeException());
+        try {
+            ts.assertError(new TestException());
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Different Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testDifferentError3() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onError(new RuntimeException());
+        try {
+            ts.assertError(TestException.class);
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Different Error present but no assertion error!");
+    }
+    
+    @Test
+    public void testNoError() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        try {
+            ts.assertError(TestException.class);
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("No present but no assertion error!");
+    }
+
+    @Test
+    public void testNoError2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        try {
+            ts.assertError(new TestException());
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("No present but no assertion error!");
+    }
+    
+    @Test
+    public void testInterruptTerminalEventAwait() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        final Thread t0 = Thread.currentThread();
+        Worker w = Schedulers.computation().createWorker();
+        try {
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    t0.interrupt();
+                }
+            }, 200, TimeUnit.MILLISECONDS);
+            
+            try {
+                if (ts.awaitTerminalEvent()) {
+                    fail("Did not interrupt wait!");
+                }
+            } catch (RuntimeException ex) {
+                if (!(ex.getCause() instanceof InterruptedException)) {
+                    fail("The cause is not InterruptedException! " + ex.getCause());
+                }
+            }
+        } finally {
+            w.dispose();
+        }
+    }
+    
+    @Test
+    public void testInterruptTerminalEventAwaitTimed() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        final Thread t0 = Thread.currentThread();
+        Worker w = Schedulers.computation().createWorker();
+        try {
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    t0.interrupt();
+                }
+            }, 200, TimeUnit.MILLISECONDS);
+            
+            try {
+                if (ts.awaitTerminalEvent(5, TimeUnit.SECONDS)) {
+                    fail("Did not interrupt wait!");
+                }
+            } catch (RuntimeException ex) {
+                if (!(ex.getCause() instanceof InterruptedException)) {
+                    fail("The cause is not InterruptedException! " + ex.getCause());
+                }
+            }
+        } finally {
+            Thread.interrupted(); // clear interrupted flag
+            w.dispose();
+        }
+    }
+    
+    @Test
+    public void testInterruptTerminalEventAwaitAndUnsubscribe() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        final Thread t0 = Thread.currentThread();
+        Worker w = Schedulers.computation().createWorker();
+        try {
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    t0.interrupt();
+                }
+            }, 200, TimeUnit.MILLISECONDS);
+            
+            ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+            ts.dispose();
+            if (!ts.isCancelled()) {
+                fail("Did not unsubscribe!");
+            }
+        } finally {
+            w.dispose();
+        }
+    }
+    
+    @Test
+    public void testNoTerminalEventBut1Completed() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        ts.onComplete();
+        
+        try {
+            ts.assertNotTerminated();
+            fail("Failed to report there were terminal event(s)!");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void testNoTerminalEventBut1Error() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        ts.onError(new TestException());
+        
+        try {
+            ts.assertNotTerminated();
+            fail("Failed to report there were terminal event(s)!");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void testNoTerminalEventBut1Error1Completed() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        ts.onComplete();
+        ts.onError(new TestException());
+        
+        try {
+            ts.assertNotTerminated();
+            fail("Failed to report there were terminal event(s)!");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void testNoTerminalEventBut2Errors() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        ts.onError(new TestException());
+        ts.onError(new TestException());
+        
+        try {
+            ts.assertNotTerminated();
+            fail("Failed to report there were terminal event(s)!");
+        } catch (AssertionError ex) {
+            // expected
+            if (ex.getSuppressed().length != 2) {
+                fail("Did not report a composite exception cause: " + ex.getCause());
+            }
+        }
+    }
+    
+    @Test
+    public void testNoValues() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onNext(1);
+        
+        try {
+            ts.assertNoValues();
+            fail("Failed to report there were values!");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void testValueCount() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ts.onNext(1);
+        ts.onNext(2);
+        
+        try {
+            ts.assertValueCount(3);
+            fail("Failed to report there were values!");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test(timeout = 1000)
+    public void testOnCompletedCrashCountsDownLatch() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        };
+        TestSubscriber<Integer> ts = new TestSubscriber<>(to);
+        
+        try {
+            ts.onComplete();
+        } catch (TestException ex) {
+            // expected
+        }
+        
+        ts.awaitTerminalEvent();
+    }
+    
+    @Test(timeout = 1000)
+    public void testOnErrorCrashCountsDownLatch() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+        };
+        TestSubscriber<Integer> ts = new TestSubscriber<>(to);
+        
+        try {
+            ts.onError(new RuntimeException());
+        } catch (TestException ex) {
+            // expected
+        }
+        
+        ts.awaitTerminalEvent();
+    }
+}


### PR DESCRIPTION
I had to ignore many tests because they either test with null or throw
an exception from a Subscriber method which are not allowed with RS.

+ added Observers and Subscribers to create Observers/Subscribers with convenience.