### PR TITLE
2.x: fix delaySubscription with supplied publisher: wrong value to trigger subscription

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1405,10 +1405,19 @@ public class Observable<T> implements Publisher<T> {
         return timer(delay, unit, scheduler).flatMap(v -> this);
     }
 
+    
+    static final Object OBJECT = new Object();
+    
+    // TODO a more efficient implementation if necessary
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<T> delaySubscription(Supplier<? extends Publisher<U>> delaySupplier) {
-        return fromCallable(delaySupplier::get).take(1).flatMap(v -> this);
+        return fromCallable(delaySupplier::get)
+                .flatMap(v -> v)
+                .take(1)
+                .cast(Object.class) // need a common supertype, the value is not relevant
+                .defaultIfEmpty(OBJECT) // in case the publisher is empty
+                .flatMap(v -> this);
     }
 
     @BackpressureSupport(BackpressureKind.FULL)

--- a/src/test/java/io/reactivex/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDelayTest.java
@@ -791,4 +791,68 @@ public class OperatorDelayTest {
         ts.assertError(TestException.class);
         ts.assertNotComplete();
     }
+    
+
+    public void testDelaySupplierSimple() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable<Integer> source = Observable.range(1, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ps.onNext(1);
+        
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testDelaySupplierCompletes() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable<Integer> source = Observable.range(1, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        // FIXME should this complete the source instead of consuming it?
+        ps.onComplete();
+        
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testDelaySupplierErrors() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable<Integer> source = Observable.range(1, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ps.onError(new TestException());
+        
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(TestException.class);
+    }
 }


### PR DESCRIPTION
The subscription was triggered by the supplied publisher and not one of its value or completion.

Btw, should an `onComplete` from this inner publisher be treated as an indication to not subscribe to the actual source?