### PR TITLE
Remove redundant onStart implementation in OperatorGroupBy

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -260,9 +260,6 @@ public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R
 
                     }).unsafeSubscribe(new Subscriber<T>(o) {
                         @Override
-                        public void onStart() {
-                        }
-                        @Override
                         public void onCompleted() {
                             o.onCompleted();
                             // eagerly cleanup instead of waiting for unsubscribe


### PR DESCRIPTION
Addresses #3067 - Removes a redundant `onStart` implementation in `OperatorGroupBy`.