### PR TITLE
Make BlockingOperatorToIterator exert backpressure.

### DIFF
--- a/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
@@ -26,6 +26,8 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.exceptions.TestException;
+import rx.internal.operators.BlockingOperatorToIterator.SubscriberIterator;
+import rx.internal.util.RxRingBuffer;
 
 public class BlockingOperatorToIteratorTest {
 
@@ -96,26 +98,28 @@ public class BlockingOperatorToIteratorTest {
         Iterator<Integer> it = toIterator(obs);
         while (it.hasNext()) {
             // Correct backpressure should cause this interleaved behavior.
+            // We first request RxRingBuffer.SIZE. Then in increments of
+            // SubscriberIterator.LIMIT.
             int i = it.next();
-            assertEquals(i + 1, src.count);
+            int expected = i - (i % SubscriberIterator.LIMIT) + RxRingBuffer.SIZE;
+            expected = Math.min(expected, Counter.MAX);
+
+            assertEquals(expected, src.count);
         }
     }
 
     public static final class Counter implements Iterator<Integer> {
+        static final int MAX = 5 * RxRingBuffer.SIZE;
         public int count;
-
-        public Counter() {
-            this.count = 0;
-        }
 
         @Override
         public boolean hasNext() {
-            return count < 5;
+            return count < MAX;
         }
 
         @Override
         public Integer next() {
-            return count++;
+            return ++count;
         }
 
         @Override

--- a/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
@@ -81,4 +81,46 @@ public class BlockingOperatorToIteratorTest {
             System.out.println(string);
         }
     }
+
+    @Test
+    public void testIteratorExertBackpressure() {
+        final Counter src = new Counter();
+
+        Observable<Integer> obs = Observable.from(new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return src;
+            }
+        });
+
+        Iterator<Integer> it = toIterator(obs);
+        while (it.hasNext()) {
+            // Correct backpressure should cause this interleaved behavior.
+            int i = it.next();
+            assertEquals(i + 1, src.count);
+        }
+    }
+
+    public static final class Counter implements Iterator<Integer> {
+        public int count;
+
+        public Counter() {
+            this.count = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return count < 5;
+        }
+
+        @Override
+        public Integer next() {
+            return count++;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
 }


### PR DESCRIPTION
The iterator created by `BlockingOperator#getIterator()` doesn't exert backpressure, which causes code like this to never terminate/run out of memory

```java
Observable.from(new Iterable<Integer>() {

    @Override
    public Iterator<Integer> iterator() {
        return new Iterator<Integer>() {

            @Override
            public boolean hasNext() {
                return true;
            }

            @Override
            public Integer next() {
                return 1;
            }
        };
    }
}).toBlocking().getIterator().next();
```

This PR adds the appropriate `request` calls so that this works. I had to combine the implementations of `Subscriber` and `Iterator` into a single class to get access to `request()`.