### PR TITLE
2.x: perf checks for flatMap and merge

### DIFF
--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -1,0 +1,91 @@
+package io.reactivex;
+
+import java.util.Iterator;
+
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.*;
+import io.reactivex.internal.subscriptions.*;
+
+/**
+ * Exposes an Observable and Observer that increments n Integers and consumes them in a Blackhole.
+ */
+public abstract class InputWithIncrementingInteger {
+    public Iterable<Integer> iterable;
+    public Observable<Integer> observable;
+    public Observable<Integer> firehose;
+    public Blackhole bh;
+
+    public abstract int getSize();
+
+    @Setup
+    public void setup(final Blackhole bh) {
+        this.bh = bh;
+        final int size = getSize();
+        observable = Observable.range(0, size);
+
+        firehose = Observable.create(new Publisher<Integer>() {
+
+            @Override
+            public void subscribe(Subscriber<? super Integer> s) {
+                s.onSubscribe(EmptySubscription.INSTANCE);
+                for (int i = 0; i < size; i++) {
+                    s.onNext(i);
+                }
+                s.onComplete();
+            }
+
+        });
+        iterable = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    int i = 0;
+                    
+                    @Override
+                    public boolean hasNext() {
+                        return i < size;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        Blackhole.consumeCPU(10);
+                        return i++;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        
+                    }
+                };
+            }
+        };
+
+    }
+
+    public LatchedObserver<Integer> newLatchedObserver() {
+        return new LatchedObserver<>(bh);
+    }
+
+    public Subscriber<Integer> newSubscriber() {
+        return new Observer<Integer>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                bh.consume(t);
+            }
+
+        };
+    }
+
+}

--- a/src/perf/java/io/reactivex/LatchedObserver.java
+++ b/src/perf/java/io/reactivex/LatchedObserver.java
@@ -1,0 +1,31 @@
+package io.reactivex;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+public class LatchedObserver<T> extends Observer<T> {
+
+    public CountDownLatch latch = new CountDownLatch(1);
+    private final Blackhole bh;
+
+    public LatchedObserver(Blackhole bh) {
+        this.bh = bh;
+    }
+
+    @Override
+    public void onComplete() {
+        latch.countDown();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        latch.countDown();
+    }
+
+    @Override
+    public void onNext(T t) {
+        bh.consume(t);
+    }
+
+}

--- a/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
+++ b/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
@@ -1,0 +1,60 @@
+package io.reactivex;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import io.reactivex.schedulers.*;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class OperatorFlatMapPerf {
+
+    @State(Scope.Thread)
+    public static class Input extends InputWithIncrementingInteger {
+
+        @Param({ "1", "1000", "1000000" })
+        public int size;
+
+        @Override
+        public int getSize() {
+            return size;
+        }
+
+    }
+
+    @Benchmark
+    public void flatMapIntPassthruSync(Input input) throws InterruptedException {
+        input.observable.flatMap(Observable::just).subscribe(input.newSubscriber());
+    }
+
+    @Benchmark
+    public void flatMapIntPassthruAsync(Input input) throws InterruptedException {
+        LatchedObserver<Integer> latchedObserver = input.newLatchedObserver();
+        input.observable.flatMap(i -> {
+                return Observable.just(i).subscribeOn(Schedulers.computation());
+        }).subscribe(latchedObserver);
+        latchedObserver.latch.await();
+    }
+
+    @Benchmark
+    public void flatMapTwoNestedSync(final Input input) throws InterruptedException {
+        Observable.range(1, 2).flatMap(i -> {
+                return input.observable;
+        }).subscribe(input.newSubscriber());
+    }
+
+    // this runs out of memory currently
+    //    @Benchmark
+    //    public void flatMapTwoNestedAsync(final Input input) throws InterruptedException {
+    //        Observable.range(1, 2).flatMap(new Func1<Integer, Observable<Integer>>() {
+    //
+    //            @Override
+    //            public Observable<Integer> call(Integer i) {
+    //                return input.observable.subscribeOn(Schedulers.computation());
+    //            }
+    //
+    //        }).subscribe(input.observer);
+    //    }
+
+}

--- a/src/perf/java/io/reactivex/OperatorMergePerf.java
+++ b/src/perf/java/io/reactivex/OperatorMergePerf.java
@@ -1,0 +1,120 @@
+package io.reactivex;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.schedulers.*;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class OperatorMergePerf {
+
+    // flatMap
+    @Benchmark
+    public void oneStreamOfNthatMergesIn1(final InputMillion input) throws InterruptedException {
+        Observable<Observable<Integer>> os = Observable.range(1, input.size).map(Observable::just);
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        Observable.merge(os).subscribe(o);
+        o.latch.await();
+    }
+
+    // flatMap
+    @Benchmark
+    public void merge1SyncStreamOfN(final InputMillion input) throws InterruptedException {
+        Observable<Observable<Integer>> os = Observable.just(1).map(i -> {
+                return Observable.range(0, input.size);
+        });
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        Observable.merge(os).subscribe(o);
+        o.latch.await();
+    }
+
+    @Benchmark
+    public void mergeNSyncStreamsOfN(final InputThousand input) throws InterruptedException {
+        Observable<Observable<Integer>> os = input.observable.map(i -> {
+                return Observable.range(0, input.size);
+        });
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        Observable.merge(os).subscribe(o);
+        o.latch.await();
+    }
+
+    @Benchmark
+    public void mergeNAsyncStreamsOfN(final InputThousand input) throws InterruptedException {
+        Observable<Observable<Integer>> os = input.observable.map(i -> {
+                return Observable.range(0, input.size).subscribeOn(Schedulers.computation());
+        });
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        Observable.merge(os).subscribe(o);
+        o.latch.await();
+    }
+
+    @Benchmark
+    public void mergeTwoAsyncStreamsOfN(final InputThousand input) throws InterruptedException {
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        Observable<Integer> ob = Observable.range(0, input.size).subscribeOn(Schedulers.computation());
+        Observable.merge(ob, ob).subscribe(o);
+        o.latch.await();
+    }
+
+    @Benchmark
+    public void mergeNSyncStreamsOf1(final InputForMergeN input) throws InterruptedException {
+        LatchedObserver<Integer> o = input.newLatchedObserver();
+        Observable.merge(input.observables).subscribe(o);
+        o.latch.await();
+    }
+
+    @State(Scope.Thread)
+    public static class InputForMergeN {
+        @Param({ "1", "100", "1000" })
+        //        @Param({ "1000" })
+        public int size;
+
+        private Blackhole bh;
+        List<Observable<Integer>> observables;
+
+        @Setup
+        public void setup(final Blackhole bh) {
+            this.bh = bh;
+            observables = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                observables.add(Observable.just(i));
+            }
+        }
+
+        public LatchedObserver<Integer> newLatchedObserver() {
+            return new LatchedObserver<>(bh);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class InputMillion extends InputWithIncrementingInteger {
+
+        @Param({ "1", "1000", "1000000" })
+        //        @Param({ "1000" })
+        public int size;
+
+        @Override
+        public int getSize() {
+            return size;
+        }
+
+    }
+
+    @State(Scope.Thread)
+    public static class InputThousand extends InputWithIncrementingInteger {
+
+        @Param({ "1", "1000" })
+        //        @Param({ "1000" })
+        public int size;
+
+        @Override
+        public int getSize() {
+            return size;
+        }
+
+    }
+}


### PR DESCRIPTION
Ported the two perf tests to evaluate 2.x throughput.

![image](https://cloud.githubusercontent.com/assets/1269832/9907226/67a454c8-5c8e-11e5-8644-c3196b2e58d8.png)

My primary suspect for the extra overhead are the atomics of queue-drain. The 1.x uses a synchronized-based emitter-loop which is elided by the JIT compiler but atomics can't be elided. As I mentioned before, synchronized works better for light-to-none asynchronous use whereas atomics work better for asynchronous use.

Also quote from #3157
> Exceptions that do not require a :+1: would be:
>
>javadoc changes
>unit test additions or refactoring
>**perf test additions, fixes or refactoring**
>grammatical and presentation fixes to README, CONTRIBUTING, and other such metadata files