### PR TITLE
2.x: range perf + added missing header.

### DIFF
--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex;
 
 import java.util.Iterator;

--- a/src/perf/java/io/reactivex/LatchedObserver.java
+++ b/src/perf/java/io/reactivex/LatchedObserver.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex;
 
 import java.util.concurrent.CountDownLatch;

--- a/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
+++ b/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex;
 
 import java.util.concurrent.TimeUnit;

--- a/src/perf/java/io/reactivex/OperatorMergePerf.java
+++ b/src/perf/java/io/reactivex/OperatorMergePerf.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex;
 
 import java.util.*;

--- a/src/perf/java/io/reactivex/RangePerf.java
+++ b/src/perf/java/io/reactivex/RangePerf.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.internal.schedulers.SingleScheduler;
+import io.reactivex.schedulers.Schedulers;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class RangePerf {
+    @Param({ "1", "1000", "1000000" })
+    public int times;
+    
+    Observable<Integer> range;
+    
+    Observable<Integer> rangeAsync;
+
+    Observable<Integer> rangeAsyncPipeline;
+
+    @Setup
+    public void setup() {
+        range = Observable.range(1, times);
+        
+        rangeAsync = range.observeOn(Schedulers.single());
+        
+        rangeAsyncPipeline = range.subscribeOn(new SingleScheduler()).observeOn(Schedulers.single());
+    }
+    
+    @Benchmark
+    public Object rangeSync(Blackhole bh) {
+        LatchedObserver<Integer> lo = new LatchedObserver<>(bh);
+        
+        range.subscribe(lo);
+        
+        return lo;
+    }
+
+    @Benchmark
+    public void rangeAsync(Blackhole bh) throws Exception {
+        LatchedObserver<Integer> lo = new LatchedObserver<>(bh);
+        
+        rangeAsync.subscribe(lo);
+        
+        lo.latch.await();
+    }
+
+    @Benchmark
+    public void rangePipeline(Blackhole bh) throws Exception {
+        LatchedObserver<Integer> lo = new LatchedObserver<>(bh);
+        
+        rangeAsyncPipeline.subscribe(lo);
+        
+        lo.latch.await();
+    }
+
+}


### PR DESCRIPTION
Benchmarks synchronous, asynchronous (where the emission can hop onto the receiver thread) and strictly-pipelined (the emitter and receiver are on different threads). Results on i7 4790, Windows 7 x64, Java 1.8u60:

```
Benchmark                (times)   Mode  Cnt         Score        Error  Units
RangePerf.rangeAsync           1  thrpt    5    135410,552 ?  20521,908  ops/s
RangePerf.rangeAsync        1000  thrpt    5     25634,730 ?    284,526  ops/s
RangePerf.rangeAsync     1000000  thrpt    5        59,073 ?      1,154  ops/s
RangePerf.rangePipeline        1  thrpt    5     98895,846 ?  11398,363  ops/s
RangePerf.rangePipeline     1000  thrpt    5     16233,903 ?    741,712  ops/s
RangePerf.rangePipeline  1000000  thrpt    5        10,621 ?      2,606  ops/s
RangePerf.rangeSync            1  thrpt    5  30367277,992 ? 170100,628  ops/s
RangePerf.rangeSync         1000  thrpt    5    212293,380 ?   3605,320  ops/s
RangePerf.rangeSync      1000000  thrpt    5       248,135 ?      1,775  ops/s
```