### PR TITLE
2.x: perf change wait to spin-loop for short async benchmarks

### DIFF
--- a/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
+++ b/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
@@ -47,7 +47,11 @@ public class OperatorFlatMapPerf {
         input.observable.flatMap(i -> {
                 return Observable.just(i).subscribeOn(Schedulers.computation());
         }).subscribe(latchedObserver);
-        latchedObserver.latch.await();
+        if (input.size == 1) {
+            while (latchedObserver.latch.getCount() != 0);
+        } else {
+            latchedObserver.latch.await();
+        }
     }
 
     @Benchmark

--- a/src/perf/java/io/reactivex/OperatorMergePerf.java
+++ b/src/perf/java/io/reactivex/OperatorMergePerf.java
@@ -31,7 +31,12 @@ public class OperatorMergePerf {
         Observable<Observable<Integer>> os = Observable.range(1, input.size).map(Observable::just);
         LatchedObserver<Integer> o = input.newLatchedObserver();
         Observable.merge(os).subscribe(o);
-        o.latch.await();
+
+        if (input.size == 1) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
     }
 
     // flatMap
@@ -42,7 +47,12 @@ public class OperatorMergePerf {
         });
         LatchedObserver<Integer> o = input.newLatchedObserver();
         Observable.merge(os).subscribe(o);
-        o.latch.await();
+        
+        if (input.size == 1) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
     }
 
     @Benchmark
@@ -52,7 +62,11 @@ public class OperatorMergePerf {
         });
         LatchedObserver<Integer> o = input.newLatchedObserver();
         Observable.merge(os).subscribe(o);
-        o.latch.await();
+        if (input.size == 1) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
     }
 
     @Benchmark
@@ -62,7 +76,11 @@ public class OperatorMergePerf {
         });
         LatchedObserver<Integer> o = input.newLatchedObserver();
         Observable.merge(os).subscribe(o);
-        o.latch.await();
+        if (input.size == 1) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
     }
 
     @Benchmark
@@ -70,14 +88,22 @@ public class OperatorMergePerf {
         LatchedObserver<Integer> o = input.newLatchedObserver();
         Observable<Integer> ob = Observable.range(0, input.size).subscribeOn(Schedulers.computation());
         Observable.merge(ob, ob).subscribe(o);
-        o.latch.await();
+        if (input.size == 1) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
     }
 
     @Benchmark
     public void mergeNSyncStreamsOf1(final InputForMergeN input) throws InterruptedException {
         LatchedObserver<Integer> o = input.newLatchedObserver();
         Observable.merge(input.observables).subscribe(o);
-        o.latch.await();
+        if (input.size == 1) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
     }
 
     @State(Scope.Thread)

--- a/src/perf/java/io/reactivex/RangePerf.java
+++ b/src/perf/java/io/reactivex/RangePerf.java
@@ -61,7 +61,11 @@ public class RangePerf {
         
         rangeAsync.subscribe(lo);
         
-        lo.latch.await();
+        if (times == 1) {
+            while (lo.latch.getCount() != 0);
+        } else {
+            lo.latch.await();
+        }
     }
 
     @Benchmark
@@ -70,7 +74,11 @@ public class RangePerf {
         
         rangeAsyncPipeline.subscribe(lo);
         
-        lo.latch.await();
+        if (times == 1) {
+            while (lo.latch.getCount() != 0);
+        } else {
+            lo.latch.await();
+        }
     }
 
 }


### PR DESCRIPTION
I've noticed that the `times = 1` async range sometimes produces double the throughput without any change to the underlying structure and I've figured out it is because how my operation system wakes up the await in the benchmark. I switched the tests to spin-loop and now I get a consistent and higher value than before:

![image](https://cloud.githubusercontent.com/assets/1269832/9958923/0ce916fe-5e0f-11e5-988a-3e8cac1098dc.png)

There are a few light-greens and a few light-reds which I attribute to other fluctuating factors on my computer.

In addition, I've experimented with two optimizations: one for observing a scalar value on a different thread and one where the `OperatorObserveOn` is turned into a `PublisherObserveOn` to save on the allocation of a `PublisherLift`. The scalar optimization ended up being slower by 15% for some reason I don't understand and the `PublishObserveOn` had no impact on the throughput within the error range.