### PR TITLE
2.x: perf comparison of Observable, NbpObservable and Single

### DIFF
--- a/src/perf/java/io/reactivex/EachTypeFlatMapPerf.java
+++ b/src/perf/java/io/reactivex/EachTypeFlatMapPerf.java
@@ -30,7 +30,7 @@ public class EachTypeFlatMapPerf {
     
     Observable<Integer> bpRange;
     NbpObservable<Integer> nbpRange;
-    Single<Integer> singleJust;
+    Single<Integer> singleRange;
 
     Observable<Integer> bpRangeMapJust;
     NbpObservable<Integer> nbpRangeMapJust;
@@ -50,8 +50,8 @@ public class EachTypeFlatMapPerf {
         bpRangeMapRange = bpRange.flatMap(v -> Observable.range(v, 2));
         nbpRangeMapRange = nbpRange.flatMap(v -> NbpObservable.range(v, 2));
 
-        singleJust = Single.just(1);
-        singleJustMapJust = singleJust.flatMap(Single::just);
+        singleRange = Single.just(1);
+        singleJustMapJust = singleRange.flatMap(Single::just);
     }
     
     @Benchmark
@@ -82,7 +82,7 @@ public class EachTypeFlatMapPerf {
 
     @Benchmark
     public void singleJust(Blackhole bh) {
-        singleJust.subscribe(new LatchedSingleObserver<>(bh));
+        singleRange.subscribe(new LatchedSingleObserver<>(bh));
     }
     @Benchmark
     public void singleJustMapJust(Blackhole bh) {


### PR DESCRIPTION
I've accidentally pushed this into 2.x (no rules violated though) but I'd like to show the run results on my machine (i7 4790, Windows 7 x64, Java 1.8u60)

![image](https://cloud.githubusercontent.com/assets/1269832/9959437/5768157c-5e14-11e5-8d9f-9b3157070633.png)

The backpressure-overhead on range is quite apparent. Naturally, scalar can't do range so I only compared it agains the `just` of the others. Single has no equivalent operators for the other cases right now.

There is still room for improvement for the range-flatMap-just in NbpObservable and Single.

Again, the lower overhead of NbpObservable shows through in RangeMapRange where there is no fast-path at all and everybody has to subscribe to the inner range.