### PR TITLE
2.x: non-backpressure Subscribers

### DIFF
--- a/src/main/java/io/reactivex/NbpObserver.java
+++ b/src/main/java/io/reactivex/NbpObserver.java
@@ -11,27 +11,31 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.disposables;
+package io.reactivex;
 
 import io.reactivex.NbpObservable.NbpSubscriber;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public enum EmptyDisposable implements Disposable {
-    INSTANCE
-    ;
-    
+public abstract class NbpObserver<T> implements NbpSubscriber<T> {
+    private Disposable s;
     @Override
-    public void dispose() {
-        // no-op
+    public final void onSubscribe(Disposable s) {
+        if (SubscriptionHelper.validateDisposable(this.s, s)) {
+            return;
+        }
+        this.s = s;
+        onStart();
     }
     
-    public static void complete(NbpSubscriber<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onComplete();
+    protected final void cancel() {
+        s.dispose();
+    }
+    /**
+     * Called once the subscription has been set on this observer; override this
+     * to perform initialization.
+     */
+    protected void onStart() {
     }
     
-    public static void error(Throwable e, NbpSubscriber<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
-    }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpBlockingSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpBlockingSubscriber.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.Notification;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.util.NotificationLite;
+
+public final class NbpBlockingSubscriber<T> extends AtomicReference<Disposable> implements NbpSubscriber<T>, Disposable {
+    /** */
+    private static final long serialVersionUID = -4875965440900746268L;
+
+    static final Disposable CANCELLED = () -> { };
+    
+    public static final Object TERMINATED = new Object();
+
+    public static final Object DISPOSABLE = new Object();
+
+    final Queue<Object> queue;
+    
+    public NbpBlockingSubscriber(Queue<Object> queue) {
+        this.queue = queue;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        if (!compareAndSet(null, s)) {
+            s.dispose();
+            if (get() != CANCELLED) {
+                onError(new IllegalStateException("Subscription already set"));
+            }
+            return;
+        }
+        queue.offer(DISPOSABLE);
+    }
+    
+    @Override
+    public void onNext(T t) {
+        queue.offer(NotificationLite.next(t));
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        queue.offer(NotificationLite.error(t));
+    }
+    
+    @Override
+    public void onComplete() {
+        queue.offer(Notification.complete());
+    }
+    
+    @Override
+    public void dispose() {
+        Disposable s = get();
+        if (s != CANCELLED) {
+            s = getAndSet(CANCELLED);
+            if (s != CANCELLED && s != null) {
+                s.dispose();
+                queue.offer(TERMINATED);
+            }
+        }
+    }
+    
+    public boolean isCancelled() {
+        return get() == CANCELLED;
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpCancelledSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpCancelledSubscriber.java
@@ -11,27 +11,41 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.disposables;
+package io.reactivex.internal.subscribers.nbp;
 
 import io.reactivex.NbpObservable.NbpSubscriber;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.plugins.RxJavaPlugins;
 
-public enum EmptyDisposable implements Disposable {
-    INSTANCE
-    ;
+/**
+ * A subscriber that cancels the subscription sent to it 
+ * and ignores all events (onError is forwarded to RxJavaPlugins though).
+ */
+public enum NbpCancelledSubscriber implements NbpSubscriber<Object> {
+    INSTANCE;
+    
+    @SuppressWarnings("unchecked")
+    public static <T> NbpSubscriber<T> instance() {
+        return (NbpSubscriber<T>)INSTANCE;
+    }
     
     @Override
-    public void dispose() {
-        // no-op
+    public void onSubscribe(Disposable s) {
+        s.dispose();
     }
     
-    public static void complete(NbpSubscriber<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onComplete();
+    @Override
+    public void onNext(Object t) {
+        
     }
     
-    public static void error(Throwable e, NbpSubscriber<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
+    @Override
+    public void onError(Throwable t) {
+        RxJavaPlugins.onError(t);
+    }
+    
+    @Override
+    public void onComplete() {
+        
     }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpConditionalSubscriber.java
@@ -11,27 +11,25 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.disposables;
+package io.reactivex.internal.subscribers.nbp;
 
 import io.reactivex.NbpObservable.NbpSubscriber;
-import io.reactivex.disposables.Disposable;
 
-public enum EmptyDisposable implements Disposable {
-    INSTANCE
-    ;
-    
-    @Override
-    public void dispose() {
-        // no-op
-    }
-    
-    public static void complete(NbpSubscriber<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onComplete();
-    }
-    
-    public static void error(Throwable e, NbpSubscriber<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
-    }
+/**
+ * An Subscriber with an additional onNextIf(T) method that
+ * tells the caller the specified value has been accepted or
+ * not.
+ * 
+ * <p>This allows certain queue-drain or source-drain operators
+ * to avoid requesting 1 on behalf of a dropped value.
+ * 
+ * @param <T> the value type
+ */
+public interface NbpConditionalSubscriber<T> extends NbpSubscriber<T> {
+    /**
+     * Conditionally takes the value.
+     * @param t the value to deliver
+     * @return true if the value has been accepted, false if the value has been rejected
+     */
+    boolean onNextIf(T t);
 }

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpDisposableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpDisposableSubscriber.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * An abstract subscription that allows asynchronous cancellation.
+ * 
+ * @param <T>
+ */
+public abstract class NbpDisposableSubscriber<T> implements NbpSubscriber<T>, Disposable {
+    volatile Disposable s;
+    @SuppressWarnings("rawtypes")
+    static final AtomicReferenceFieldUpdater<NbpDisposableSubscriber, Disposable> S =
+            AtomicReferenceFieldUpdater.newUpdater(NbpDisposableSubscriber.class, Disposable.class, "s");
+    
+    static final Disposable CANCELLED = () -> { };
+    
+    @Override
+    public final void onSubscribe(Disposable s) {
+        if (!S.compareAndSet(this, null, s)) {
+            s.dispose();
+            if (this.s != CANCELLED) {
+                SubscriptionHelper.reportSubscriptionSet();
+            }
+            return;
+        }
+        onStart();
+    }
+    
+    protected void onStart() {
+    }
+    
+    public final boolean isDisposed() {
+        return s == CANCELLED;
+    }
+    
+    @Override
+    public final void dispose() {
+        Disposable a = s;
+        if (a != CANCELLED) {
+            a = S.getAndSet(this, CANCELLED);
+            if (a != CANCELLED && a != null) {
+                a.dispose();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpEmptySubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpEmptySubscriber.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * A subscriber that ignores all events (onError is forwarded to RxJavaPlugins though).
+ */
+public enum NbpEmptySubscriber implements NbpSubscriber<Object> {
+    /** Empty instance that reports error to the plugins. */
+    INSTANCE(true),
+    /** Empty instance that doesn't report to the plugins to avoid flooding the test output. */
+    INSTANCE_NOERROR(false);
+    
+    final boolean reportError;
+    
+    NbpEmptySubscriber(boolean reportError) {
+        this.reportError = reportError;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        
+    }
+    
+    @Override
+    public void onNext(Object t) {
+        
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        if (reportError) {
+            RxJavaPlugins.onError(t);
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpLambdaSubscriber.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class NbpLambdaSubscriber<T> extends AtomicReference<Disposable> implements NbpSubscriber<T>, Disposable {
+    /** */
+    private static final long serialVersionUID = -7251123623727029452L;
+    final Consumer<? super T> onNext;
+    final Consumer<? super Throwable> onError;
+    final Runnable onComplete;
+    final Consumer<? super Disposable> onSubscribe;
+    
+    static final Disposable CANCELLED = () -> { };
+    
+    public NbpLambdaSubscriber(Consumer<? super T> onNext, Consumer<? super Throwable> onError, 
+            Runnable onComplete,
+            Consumer<? super Disposable> onSubscribe) {
+        super();
+        this.onNext = onNext;
+        this.onError = onError;
+        this.onComplete = onComplete;
+        this.onSubscribe = onSubscribe;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        if (compareAndSet(null, s)) {
+            onSubscribe.accept(this);
+        } else {
+            s.dispose();
+            if (get() != CANCELLED) {
+                SubscriptionHelper.reportDisposableSet();
+            }
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        try {
+            onNext.accept(t);
+        } catch (Throwable e) {
+            onError(e);
+        }
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        dispose();
+        try {
+            onError.accept(t);
+        } catch (Throwable e) {
+            e.addSuppressed(t);
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        dispose();
+        try {
+            onComplete.run();
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    @Override
+    public void dispose() {
+        Disposable o = get();
+        if (o != CANCELLED) {
+            o = getAndSet(CANCELLED);
+            if (o != CANCELLED && o != null) {
+                o.dispose();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpQueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpQueueDrainSubscriber.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.internal.util.NbpQueueDrain;
+
+/**
+ * Abstract base class for subscribers that hold another subscriber, a queue
+ * and requires queue-drain behavior.
+ * 
+ * @param <T> the source type to which this subscriber will be subscribed
+ * @param <U> the value type in the queue
+ * @param <V> the value type the child subscriber accepts
+ */
+public abstract class NbpQueueDrainSubscriber<T, U, V> extends QueueDrainSubscriberPad2 implements NbpSubscriber<T>, NbpQueueDrain<U, V> {
+    protected final NbpSubscriber<? super V> actual;
+    protected final Queue<U> queue;
+    
+    protected volatile boolean cancelled;
+    
+    protected volatile boolean done;
+    protected Throwable error;
+    
+    public NbpQueueDrainSubscriber(NbpSubscriber<? super V> actual, Queue<U> queue) {
+        this.actual = actual;
+        this.queue = queue;
+    }
+    
+    @Override
+    public final boolean cancelled() {
+        return cancelled;
+    }
+    
+    @Override
+    public final boolean done() {
+        return done;
+    }
+    
+    @Override
+    public final boolean enter() {
+        return WIP.getAndIncrement(this) == 0;
+    }
+    
+    public final boolean fastEnter() {
+        return wip == 0 && WIP.compareAndSet(this, 0, 1);
+    }
+    
+    protected final void fastpathEmit(U value, boolean delayError) {
+        final NbpSubscriber<? super V> s = actual;
+        final Queue<U> q = queue;
+        
+        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+            accept(s, value);
+            if (leave(-1) == 0) {
+                return;
+            }
+        } else {
+            q.offer(value);
+            if (!enter()) {
+                return;
+            }
+        }
+        drainLoop(q, s, delayError);
+    }
+
+    /**
+     * Makes sure the fast-path emits in order.
+     * @param value
+     * @param delayError
+     */
+    protected final void fastpathOrderedEmit(U value, boolean delayError) {
+        final NbpSubscriber<? super V> s = actual;
+        final Queue<U> q = queue;
+        
+        if (wip == 0 && WIP.compareAndSet(this, 0, 1)) {
+            if (q.isEmpty()) {
+                accept(s, value);
+                if (leave(-1) == 0) {
+                    return;
+                }
+            } else {
+                q.offer(value);
+            }
+        } else {
+            q.offer(value);
+            if (!enter()) {
+                return;
+            }
+        }
+        drainLoop(q, s, delayError);
+    }
+
+    @Override
+    public final Throwable error() {
+        return error;
+    }
+    
+    @Override
+    public final int leave(int m) {
+        return WIP.addAndGet(this, m);
+    }
+    
+    public void drain(boolean delayError) {
+        if (enter()) {
+            drainLoop(queue, actual, delayError);
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// Padding superclasses
+//-------------------------------------------------------------------
+
+/** Pads the header away from other fields. */
+class QueueDrainSubscriberPad0 {
+    volatile long p1, p2, p3, p4, p5, p6, p7;
+    volatile long p8, p9, p10, p11, p12, p13, p14, p15;
+}
+
+/** The WIP counter. */
+class QueueDrainSubscriberWip extends QueueDrainSubscriberPad0 {
+    volatile int wip;
+    static final AtomicIntegerFieldUpdater<QueueDrainSubscriberWip> WIP =
+            AtomicIntegerFieldUpdater.newUpdater(QueueDrainSubscriberWip.class, "wip");
+}
+
+/** Pads away the wip from the other fields. */
+class QueueDrainSubscriberPad2 extends QueueDrainSubscriberWip {
+    volatile long p1a, p2a, p3a, p4a, p5a, p6a, p7a;
+    volatile long p8a, p9a, p10a, p11a, p12a, p13a, p14a, p15a;
+}
+

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpSubscriptionLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpSubscriptionLambdaSubscriber.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import java.util.function.*;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class NbpSubscriptionLambdaSubscriber<T> implements NbpSubscriber<T>, Disposable {
+    final NbpSubscriber<? super T> actual;
+    final Consumer<? super Disposable> onSubscribe;
+    final LongConsumer onRequest;
+    final Runnable onCancel;
+    
+    Disposable s;
+    
+    public NbpSubscriptionLambdaSubscriber(NbpSubscriber<? super T> actual, 
+            Consumer<? super Disposable> onSubscribe,
+            LongConsumer onRequest,
+            Runnable onCancel) {
+        this.actual = actual;
+        this.onSubscribe = onSubscribe;
+        this.onCancel = onCancel;
+        this.onRequest = onRequest;
+    }
+
+    @Override
+    public void onSubscribe(Disposable s) {
+        // this way, multiple calls to onSubscribe can show up in tests that use doOnSubscribe to validate behavior
+        try {
+            onSubscribe.accept(s);
+        } catch (Throwable e) {
+            s.dispose();
+            RxJavaPlugins.onError(e);
+            
+            EmptyDisposable.error(e, actual);
+            return;
+        }
+        if (SubscriptionHelper.validateDisposable(this.s, s)) {
+            return;
+        }
+        this.s = s;
+        actual.onSubscribe(this);
+    }
+    
+    @Override
+    public void onNext(T t) {
+        actual.onNext(t);
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        actual.onError(t);
+    }
+    
+    @Override
+    public void onComplete() {
+        actual.onComplete();
+    }
+    
+    
+    @Override
+    public void dispose() {
+        try {
+            onCancel.run();
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+        s.dispose();
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/nbp/NbpToNotificationSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/nbp/NbpToNotificationSubscriber.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.nbp;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import io.reactivex.*;
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+public final class NbpToNotificationSubscriber<T> implements NbpSubscriber<T> {
+    final Consumer<? super Try<Optional<Object>>> consumer;
+    
+    Disposable s;
+    
+    public NbpToNotificationSubscriber(Consumer<? super Try<Optional<Object>>> consumer) {
+        this.consumer = consumer;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        if (SubscriptionHelper.validateDisposable(this.s, s)) {
+            return;
+        }
+        this.s = s;
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (t == null) {
+            s.dispose();
+            onError(new NullPointerException());
+        } else {
+            consumer.accept(Try.ofValue(Optional.of(t)));
+        }
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        consumer.accept(Try.ofError(t));
+    }
+    
+    @Override
+    public void onComplete() {
+        consumer.accept(Notification.complete());
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscriptions;
 
 import org.reactivestreams.*;
 
+import io.reactivex.disposables.Disposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public enum SubscriptionHelper {
@@ -35,6 +36,23 @@ public enum SubscriptionHelper {
     
     public static void reportSubscriptionSet() {
         RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+    }
+
+    public static boolean validateDisposable(Disposable current, Disposable next) {
+        if (next == null) {
+            RxJavaPlugins.onError(new NullPointerException("next is null"));
+            return true;
+        }
+        if (current != null) {
+            next.dispose();
+            reportDisposableSet();
+            return true;
+        }
+        return false;
+    }
+    
+    public static void reportDisposableSet() {
+        RxJavaPlugins.onError(new IllegalStateException("Disposable already set!"));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/util/NbpQueueDrain.java
+++ b/src/main/java/io/reactivex/internal/util/NbpQueueDrain.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import java.util.Queue;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+
+public interface NbpQueueDrain<T, U> {
+    
+    boolean cancelled();
+    
+    boolean done();
+    
+    Throwable error();
+    
+    boolean enter();
+    
+    /**
+     * Adds m to the wip counter.
+     * @param m
+     * @return
+     */
+    int leave(int m);
+    
+    /**
+     * Accept the value and return true if forwarded.
+     * @param a
+     * @param v
+     */
+    void accept(NbpSubscriber<? super U> a, T v);
+    
+    default void drainLoop(Queue<T> q, NbpSubscriber<? super U> a, boolean delayError) {
+        
+        int missed = 1;
+        
+        for (;;) {
+            if (checkTerminated(done(), q.isEmpty(), a, delayError, q)) {
+                return;
+            }
+            
+            for (;;) {
+                boolean d = done();
+                T v = q.poll();
+                
+                boolean empty = v == null;
+                
+                if (checkTerminated(d, empty, a, delayError, q)) {
+                    return;
+                }
+                
+                if (empty) {
+                    break;
+                }
+
+                accept(a, v);
+            }
+            
+            missed = leave(-missed);
+            if (missed == 0) {
+                break;
+            }
+        }
+    }
+
+    default boolean checkTerminated(boolean d, boolean empty, 
+            NbpSubscriber<?> s, boolean delayError, Queue<?> q) {
+        if (cancelled()) {
+            q.clear();
+            return true;
+        }
+        
+        if (d) {
+            if (delayError) {
+                if (empty) {
+                    Throwable err = error();
+                    if (err != null) {
+                        s.onError(err);
+                    } else {
+                        s.onComplete();
+                    }
+                    return true;
+                }
+            } else {
+                Throwable err = error();
+                if (err != null) {
+                    q.clear();
+                    s.onError(err);
+                    return true;
+                } else
+                if (empty) {
+                    s.onComplete();
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/nbp/NbpAsyncObserver.java
+++ b/src/main/java/io/reactivex/subscribers/nbp/NbpAsyncObserver.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers.nbp;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.ListCompositeResource;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * An abstract Subscriber implementation that allows asynchronous cancellation of its
+ * subscription.
+ * 
+ * <p>This implementation let's you chose if the AsyncObserver manages resources or not,
+ * thus saving memory on cases where there is no need for that.
+ * 
+ * <p>All pre-implemented final methods are thread-safe.
+ * 
+ * @param <T> the value type
+ */
+public abstract class NbpAsyncObserver<T> implements NbpSubscriber<T>, Disposable {
+    /** The active subscription. */
+    private volatile Disposable s;
+    /** Updater of s. */
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<NbpAsyncObserver, Disposable> S =
+            AtomicReferenceFieldUpdater.newUpdater(NbpAsyncObserver.class, Disposable.class, "s");
+
+    /** The resource composite, can be null. */
+    private final ListCompositeResource<Disposable> resources;
+    
+    /** The cancelled subscription indicator. */
+    private static final Disposable CANCELLED = () -> { };
+    
+    /**
+     * Constructs an AsyncObserver with resource support.
+     */
+    public NbpAsyncObserver() {
+        this(true);
+    }
+
+    /**
+     * Constructs an AsyncObserver and allows specifying if it should support resources or not.
+     * @param withResources true if resource support should be on.
+     */
+    public NbpAsyncObserver(boolean withResources) {
+        this.resources = withResources ? new ListCompositeResource<>(Disposable::dispose) : null;
+    }
+
+    /**
+     * Adds a resource to this AsyncObserver.
+     * 
+     * <p>Note that if the AsyncObserver doesn't manage resources, this method will
+     * throw an IllegalStateException. Use {@link #supportsResources()} to determine if
+     * this AsyncObserver manages resources or not.
+     * 
+     * @param resource the resource to add
+     * 
+     * @throws NullPointerException if resource is null
+     * @throws IllegalStateException if this AsyncObserver doesn't manage resources
+     * @see #supportsResources()
+     */
+    public final void add(Disposable resource) {
+        Objects.requireNonNull(resource);
+        if (resources != null) {
+            add(resource);
+        } else {
+            resource.dispose();
+            throw new IllegalStateException("This AsyncObserver doesn't manage additional resources");
+        }
+    }
+    
+    /**
+     * Returns true if this AsyncObserver supports resources added via the add() method. 
+     * @return true if this AsyncObserver supports resources added via the add() method
+     * @see #add(Disposable)
+     */
+    public final boolean supportsResources() {
+        return resources != null;
+    }
+    
+    @Override
+    public final void onSubscribe(Disposable s) {
+        if (!S.compareAndSet(this, null, s)) {
+            s.dispose();
+            if (s != CANCELLED) {
+                SubscriptionHelper.reportDisposableSet();
+            }
+            return;
+        }
+        
+        onStart();
+    }
+    
+    /**
+     * Called once the upstream sets a Subscription on this AsyncObserver.
+     * 
+     * <p>You can perform initialization at this moment. The default
+     * implementation does nothing.
+     */
+    protected void onStart() {
+    }
+    
+    /**
+     * Cancels the main disposable (if any) and disposes the resources associated with
+     * this AsyncObserver (if any).
+     * 
+     * <p>This method can be called before the upstream calls onSubscribe at which
+     * case the main Disposable will be immediately disposed.
+     */
+    protected final void cancel() {
+        Disposable a = s;
+        if (a != CANCELLED) {
+            a = S.getAndSet(this, CANCELLED);
+            if (a != CANCELLED && a != null) {
+                a.dispose();
+                if (resources != null) {
+                    resources.dispose();
+                }
+            }
+        }
+    }
+    
+    @Override
+    public final void dispose() {
+        cancel();
+    }
+    
+    /**
+     * Returns true if this AsyncObserver has been disposed/cancelled.
+     * @return true if this AsyncObserver has been disposed/cancelled
+     */
+    public final boolean isDisposed() {
+        return s == CANCELLED;
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/nbp/NbpObservers.java
+++ b/src/main/java/io/reactivex/subscribers/nbp/NbpObservers.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers.nbp;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.reactivex.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Utility class to create Observers from lambdas.
+ */
+public final class NbpObservers {
+    /** Utility class with factory methods only. */
+    private NbpObservers() {
+        throw new IllegalStateException("No instances!");
+    }
+    
+    public static <T> NbpObserver<T> empty() {
+        return new NbpObserver<T>() {
+            @Override
+            public void onNext(T t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                RxJavaPlugins.onError(t);
+            }
+            
+            @Override
+            public void onComplete() {
+                
+            }
+        };
+    }
+    
+    public static <T> NbpAsyncObserver<T> emptyAsync() {
+        return new NbpAsyncObserver<T>() {
+            @Override
+            public void onNext(T t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                RxJavaPlugins.onError(t);
+            }
+            
+            @Override
+            public void onComplete() {
+                
+            }
+        };
+    }
+    
+    public static <T> NbpObserver<T> create(Consumer<? super T> onNext) {
+        return create(onNext, RxJavaPlugins::onError, () -> { }, () -> { });
+    }
+
+    public static <T> NbpObserver<T> create(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError) {
+        return create(onNext, onError, () -> { }, () -> { });
+    }
+
+    public static <T> NbpObserver<T> create(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete) {
+        return create(onNext, onError, onComplete, () -> { });
+    }
+
+    public static <T> NbpObserver<T> create(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete, Runnable onStart) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new NbpObserver<T>() {
+            boolean done;
+            @Override
+            protected void onStart() {
+                super.onStart();
+                try {
+                    onStart.run();
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+    
+    public static <T> NbpAsyncObserver<T> createAsync(Consumer<? super T> onNext) {
+        return createAsync(onNext, RxJavaPlugins::onError, () -> { }, () -> { });
+    }
+
+    public static <T> NbpAsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError) {
+        return createAsync(onNext, onError, () -> { }, () -> { });
+    }
+
+    public static <T> NbpAsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete) {
+        return createAsync(onNext, onError, onComplete, () -> { });
+    }
+    
+    public static <T> NbpAsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+            Consumer<? super Throwable> onError, Runnable onComplete, Runnable onStart) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new NbpAsyncObserver<T>() {
+            boolean done;
+            @Override
+            protected void onStart() {
+                try {
+                    onStart.run();
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    cancel();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/nbp/NbpSafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/nbp/NbpSafeSubscriber.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.subscribers.nbp;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Wraps another Subscriber and ensures all onXXX methods conform the protocol
+ * (except the requirement for serialized access).
+ *
+ * @param <T> the value type
+ */
+public final class NbpSafeSubscriber<T> implements NbpSubscriber<T> {
+    /** The actual Subscriber. */
+    final NbpSubscriber<? super T> actual;
+    /** The subscription. */
+    Disposable subscription;
+    /** Indicates a terminal state. */
+    boolean done;
+    
+    public NbpSafeSubscriber(NbpSubscriber<? super T> actual) {
+        this.actual = actual;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        if (done) {
+            return;
+        }
+        if (this.subscription != null) {
+            IllegalStateException ise = new IllegalStateException("Disposable already set!");
+            try {
+                s.dispose();
+            } catch (Throwable e) {
+                ise.addSuppressed(e);
+            }
+            onError(ise);
+            return;
+        }
+        if (s == null) {
+            subscription = EmptyDisposable.INSTANCE;
+            onError(new NullPointerException("Subscription is null!"));
+            return;
+        }
+        this.subscription = s;
+        try {
+            actual.onSubscribe(s);
+        } catch (Throwable e) {
+            done = true;
+            // can't call onError because the actual's state may be corrupt at this point
+            try {
+                s.dispose();
+            } catch (Throwable e1) {
+                e.addSuppressed(e1);
+            }
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (done) {
+            return;
+        }
+        if (t == null) {
+            onError(new NullPointerException());
+            return;
+        }
+        if (subscription == null) {
+            onError(null); // null is okay here, onError checks for subscription == null first
+            return;
+        }
+        try {
+            actual.onNext(t);
+        } catch (Throwable e) {
+            onError(e);
+        }
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        if (done) {
+            return;
+        }
+        done = true;
+        
+        if (subscription == null) {
+            Throwable t2;
+            if (t == null) {
+                t2 = new NullPointerException("Subscription not set!");
+            } else {
+                t2 = t;
+                t2.addSuppressed(new NullPointerException("Subscription not set!"));
+            }
+            try {
+                actual.onSubscribe(EmptyDisposable.INSTANCE);
+            } catch (Throwable e) {
+                // can't call onError because the actual's state may be corrupt at this point
+                e.addSuppressed(t2);
+                
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            try {
+                actual.onError(t2);
+            } catch (Throwable e) {
+                // if onError failed, all that's left is to report the error to plugins
+                e.addSuppressed(t2);
+                
+                RxJavaPlugins.onError(e);
+            }
+            return;
+        }
+        
+        if (t == null) {
+            t = new NullPointerException();
+        }
+
+        try {
+            subscription.dispose();
+        } catch (Throwable e) {
+            t.addSuppressed(e);
+        }
+
+        try {
+            actual.onError(t);
+        } catch (Throwable e) {
+            e.addSuppressed(t);
+            
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        if (subscription == null) {
+            onError(null); // null is okay here, onError checks for subscription == null first
+            return;
+        }
+
+        done = true;
+
+        try {
+            subscription.dispose();
+        } catch (Throwable e) {
+            try {
+                actual.onError(e);
+            } catch (Throwable e1) {
+                e1.addSuppressed(e);
+                
+                RxJavaPlugins.onError(e1);
+            }
+            return;
+        }
+        
+        try {
+            actual.onComplete();
+        } catch (Throwable e) {
+            RxJavaPlugins.onError(e);
+        }
+    }
+    
+    /* test */ NbpSubscriber<? super T> actual() {
+        return actual;
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/nbp/NbpSerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/nbp/NbpSerializedSubscriber.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.subscribers.nbp;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Serializes access to the onNext, onError and onComplete methods of another Subscriber.
+ * 
+ * <p>Note that onSubscribe is not serialized in respect of the other methods so
+ * make sure the Subscription is set before any of the other methods are called.
+ * 
+ * <p>The implementation assumes that the actual Subscriber's methods don't throw.
+ * 
+ * @param <T> the value type
+ */
+public final class NbpSerializedSubscriber<T> implements NbpSubscriber<T> {
+    final NbpSubscriber<? super T> actual;
+    final boolean delayError;
+    
+    static final int QUEUE_LINK_SIZE = 4;
+    
+    Disposable subscription;
+    
+    boolean emitting;
+    AppendOnlyLinkedArrayList<Object> queue;
+    
+    volatile boolean done;
+    
+    public NbpSerializedSubscriber(NbpSubscriber<? super T> actual) {
+        this(actual, false);
+    }
+    
+    public NbpSerializedSubscriber(NbpSubscriber<? super T> actual, boolean delayError) {
+        this.actual = actual;
+        this.delayError = delayError;
+    }
+    @Override
+    public void onSubscribe(Disposable s) {
+        if (SubscriptionHelper.validateDisposable(this.subscription, s)) {
+            return;
+        }
+        this.subscription = s;
+        
+        actual.onSubscribe(s);
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (done) {
+            return;
+        }
+        if (t == null) {
+            subscription.dispose();
+            onError(new NullPointerException());
+            return;
+        }
+        synchronized (this) {
+            if (done) {
+                return;
+            }
+            if (emitting) {
+                AppendOnlyLinkedArrayList<Object> q = queue;
+                if (q == null) {
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
+                    queue = q;
+                }
+                q.add(NotificationLite.next(t));
+                return;
+            }
+            emitting = true;
+        }
+        
+        actual.onNext(t);
+        
+        emitLoop();
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        boolean reportError;
+        synchronized (this) {
+            if (done) {
+                reportError = true;
+            } else
+            if (emitting) {
+                done = true;
+                AppendOnlyLinkedArrayList<Object> q = queue;
+                if (q == null) {
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
+                    queue = q;
+                }
+                Object err = NotificationLite.error(t);
+                if (delayError) {
+                    q.add(err);
+                } else {
+                    q.setFirst(err);
+                }
+                return;
+            } else {
+                done = true;
+                emitting = true;
+                reportError = false;
+            }
+        }
+        
+        if (reportError) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        
+        actual.onError(t);
+        // no need to loop because this onError is the last event
+    }
+    
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        synchronized (this) {
+            if (done) {
+                return;
+            }
+            if (emitting) {
+                AppendOnlyLinkedArrayList<Object> q = queue;
+                if (q == null) {
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
+                    queue = q;
+                }
+                q.add(NotificationLite.complete());
+                return;
+            }
+            done = true;
+            emitting = true;
+        }
+        
+        actual.onComplete();
+        // no need to loop because this onComplete is the last event
+    }
+    
+    void emitLoop() {
+        for (;;) {
+            AppendOnlyLinkedArrayList<Object> q;
+            synchronized (this) {
+                q = queue;
+                if (q == null) {
+                    emitting = false;
+                    return;
+                }
+                queue = null;
+            }
+            
+            q.forEachWhile(this::accept);
+        }
+    }
+    
+    boolean accept(Object value) {
+        if (NotificationLite.isComplete(value)) {
+            actual.onComplete();
+            return true;
+        } else
+        if (NotificationLite.isError(value)) {
+            actual.onError(NotificationLite.getError(value));
+            return true;
+        }
+        actual.onNext(NotificationLite.getValue(value));
+        return false;
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/nbp/NbpSubscribers.java
+++ b/src/main/java/io/reactivex/subscribers/nbp/NbpSubscribers.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers.nbp;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscribers.nbp.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Utility class to construct various resource-holding and disposable Subscribers from lambdas.
+ */
+public final class NbpSubscribers {
+    /** Utility class. */
+    private NbpSubscribers() {
+        throw new IllegalStateException("No instances!");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> NbpSubscriber<T> empty() {
+        return (NbpSubscriber<T>)NbpEmptySubscriber.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> NbpSubscriber<T> cancelled() {
+        return (NbpSubscriber<T>)NbpCancelledSubscriber.INSTANCE;
+    }
+
+    public static <T> NbpDisposableSubscriber<T> emptyDisposable() {
+        return new NbpDisposableSubscriber<T>() {
+            @Override
+            public void onNext(T t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                
+            }
+            
+            @Override
+            public void onComplete() {
+                
+            }
+        };
+    }
+
+    public static <T> NbpDisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext
+    ) {
+        return createDisposable(onNext, RxJavaPlugins::onError, () -> { }, () -> { });
+    }
+
+    public static <T> NbpDisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError
+    ) {
+        return createDisposable(onNext, onError, () -> { }, () -> { });
+    }
+
+    public static <T> NbpDisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete
+    ) {
+        return createDisposable(onNext, onError, onComplete, () -> { });
+    }
+    
+    public static <T> NbpDisposableSubscriber<T> createDisposable(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete,
+            Runnable onStart
+    ) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new NbpDisposableSubscriber<T>() {
+            boolean done;
+            @Override
+            protected void onStart() {
+                super.onStart();
+                try {
+                    onStart.run();
+                } catch (Throwable e) {
+                    done = true;
+                    dispose();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    dispose();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+
+    public static <T> NbpSubscriber<T> create(
+            Consumer<? super T> onNext
+    ) {
+        return create(onNext, RxJavaPlugins::onError, () -> { }, s -> { });
+    }
+
+    public static <T> NbpSubscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError
+    ) {
+        return create(onNext, onError, () -> { }, s -> { });
+    }
+
+    public static <T> NbpSubscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete
+    ) {
+        return create(onNext, onError, onComplete, s -> { });
+    }
+    
+    public static <T> NbpSubscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Runnable onComplete,
+            Consumer<? super Disposable> onStart
+    ) {
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onComplete);
+        Objects.requireNonNull(onStart);
+        return new NbpSubscriber<T>() {
+            boolean done;
+            
+            Disposable s;
+            @Override
+            public void onSubscribe(Disposable s) {
+                if (SubscriptionHelper.validateDisposable(this.s, s)) {
+                    return;
+                }
+                this.s = s;
+                try {
+                    onStart.accept(s);
+                } catch (Throwable e) {
+                    done = true;
+                    s.dispose();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            @Override
+            public void onNext(T t) {
+                if (done) {
+                    return;
+                }
+                try {
+                    onNext.accept(t);
+                } catch (Throwable e) {
+                    done = true;
+                    s.dispose();
+                    try {
+                        onError.accept(e);
+                    } catch (Throwable ex) {
+                        ex.addSuppressed(e);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                if (done) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                done = true;
+                try {
+                    onError.accept(t);
+                } catch (Throwable ex) {
+                    ex.addSuppressed(t);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+            
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                done = true;
+                try {
+                    onComplete.run();
+                } catch (Throwable e) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/io/reactivex/subscribers/nbp/NbpTestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/nbp/NbpTestSubscriber.java
@@ -1,0 +1,663 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.subscribers.nbp;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.Notification;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscribers.nbp.NbpEmptySubscriber;
+
+/**
+ * A subscriber that records events and allows making assertions about them.
+ *
+ * <p>You can override the onSubscribe, onNext, onError, onComplete, request and
+ * cancel methods but not the others (this is by desing).
+ * 
+ * <p>The TestSubscriber implements Disposable for convenience where dispose calls cancel.
+ * 
+ * <p>When calling the default request method, you are requesting on behalf of the
+ * wrapped actual subscriber.
+ * 
+ * @param <T> the value type
+ */
+public class NbpTestSubscriber<T> implements NbpSubscriber<T>, Disposable {
+    /** The actual subscriber to forward events to. */
+    private final NbpSubscriber<? super T> actual;
+    /** The latch that indicates an onError or onCompleted has been called. */
+    private final CountDownLatch done;
+    /** The list of values received. */
+    private final List<T> values;
+    /** The list of errors received. */
+    private final List<Throwable> errors;
+    /** The number of completions. */
+    private long completions;
+    /** The last thread seen by the subscriber. */
+    private Thread lastThread;
+    
+    /** Makes sure the incoming Subscriptions get cancelled immediately. */
+    private volatile boolean cancelled;
+
+    /** Holds the current subscription if any. */
+    private volatile Disposable subscription;
+    /** Updater for subscription. */
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<NbpTestSubscriber, Disposable> SUBSCRIPTION =
+            AtomicReferenceFieldUpdater.newUpdater(NbpTestSubscriber.class, Disposable.class, "subscription");
+    
+    /** Indicates a cancelled subscription. */
+    private static final Disposable CANCELLED = () -> { };
+    /**
+     * Constructs a non-forwarding TestSubscriber with an initial request value of Long.MAX_VALUE.
+     */
+    public NbpTestSubscriber() {
+        this(NbpEmptySubscriber.INSTANCE_NOERROR);
+    }
+
+    /**
+     * Constructs a forwarding TestSubscriber but leaves the requesting to the wrapped subscriber.
+     * @param actual the actual Subscriber to forward events to
+     */
+    public NbpTestSubscriber(NbpSubscriber<? super T> actual) {
+        this.actual = actual;
+        this.values = new ArrayList<>();
+        this.errors = new ArrayList<>();
+        this.done = new CountDownLatch(1);
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        lastThread = Thread.currentThread();
+        
+        if (s == null) {
+            errors.add(new NullPointerException("onSubscribe received a null Subscription"));
+            return;
+        }
+        if (!SUBSCRIPTION.compareAndSet(this, null, s)) {
+            s.dispose();
+            if (subscription != CANCELLED) {
+                errors.add(new NullPointerException("onSubscribe received multiple subscriptions: " + s));
+            }
+            return;
+        }
+        
+        if (cancelled) {
+            s.dispose();
+        }
+        
+        actual.onSubscribe(s);
+        
+        if (cancelled) {
+            return;
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        lastThread = Thread.currentThread();
+        values.add(t);
+        
+        if (t == null) {
+            errors.add(new NullPointerException("onNext received a null Subscription"));
+        }
+        
+        actual.onNext(t);
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        try {
+            lastThread = Thread.currentThread();
+            errors.add(t);
+
+            if (t == null) {
+                errors.add(new NullPointerException("onError received a null Subscription"));
+            }
+
+            actual.onError(t);
+        } finally {
+            done.countDown();
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        try {
+            lastThread = Thread.currentThread();
+            completions++;
+            
+            actual.onComplete();
+        } finally {
+            done.countDown();
+        }
+    }
+    
+    /**
+     * Returns true if this TestSubscriber has been cancelled.
+     * @return true if this TestSubscriber has been cancelled
+     */
+    public final boolean isCancelled() {
+        return cancelled;
+    }
+    
+    @Override
+    public final void dispose() {
+        if (!cancelled) {
+            cancelled = true;
+            Disposable s = subscription;
+            if (s != CANCELLED) {
+                s = SUBSCRIPTION.getAndSet(this, CANCELLED);
+                if (s != CANCELLED && s != null) {
+                    s.dispose();
+                }
+            }
+        }
+    }
+    
+    // state retrieval methods
+    
+    /**
+     * Returns the last thread which called the onXXX methods of this TestSubscriber.
+     * @return the last thread which called the onXXX methods
+     */
+    public final Thread lastThread() {
+        return lastThread;
+    }
+    
+    /**
+     * Returns a shared list of received onNext values.
+     * @return a list of received onNext values
+     */
+    public final List<T> values() {
+        return values;
+    }
+    
+    /**
+     * Returns a shared list of received onError exceptions.
+     * @return a list of received events onError exceptions
+     */
+    public final List<Throwable> errors() {
+        return errors;
+    }
+    
+    /**
+     * Returns the number of times onComplete was called.
+     * @return the number of times onComplete was called
+     */
+    public final long completions() {
+        return completions;
+    }
+
+    /**
+     * Returns true if TestSubscriber received any onError or onComplete events.
+     * @return true if TestSubscriber received any onError or onComplete events
+     */
+    public final boolean isTerminated() {
+        return done.getCount() == 0;
+    }
+    
+    /**
+     * Returns the number of onNext values received.
+     * @return the number of onNext values received
+     */
+    public final int valueCount() {
+        return values.size();
+    }
+    
+    /**
+     * Returns the number of onError exceptions received.
+     * @return the number of onError exceptions received
+     */
+    public final int errorCount() {
+        return errors.size();
+    }
+
+    /**
+     * Returns true if this TestSubscriber received a subscription.
+     * @return true if this TestSubscriber received a subscription
+     */
+    public final boolean hasSubscription() {
+        return subscription != null;
+    }
+    
+    /**
+     * Awaits until this TestSubscriber receives an onError or onComplete events.
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @see #awaitTerminalEvent()
+     */
+    public final void await() throws InterruptedException {
+        if (done.getCount() == 0) {
+            return;
+        }
+        
+        done.await();
+    }
+    
+    /**
+     * Awaits the specified amount of time or until this TestSubscriber 
+     * receives an onError or onComplete events, whichever happens first.
+     * @param time the waiting time
+     * @param unit the time unit of the waiting time
+     * @return true if the TestSubscriber terminated, false if timeout happened
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @see #awaitTerminalEvent(long, TimeUnit)
+     */
+    public final boolean await(long time, TimeUnit unit) throws InterruptedException {
+        if (done.getCount() == 0) {
+            return true;
+        }
+        return done.await(time, unit);
+    }
+    
+    // assertion methods
+    
+    /**
+     * Fail with the given message and add the sequence of errors as suppressed ones.
+     * <p>Note this is delibarately the only fail method. Most of the times an assertion
+     * would fail but it is possible it was due to an exception somewhere. This construct
+     * will capture those potential errors and report it along with the original failure.
+     * 
+     * @param message the message to use
+     * @param errors the sequence of errors to add as suppressed exception
+     */
+    private void fail(String prefix, String message, Iterable<? extends Throwable> errors) {
+        AssertionError ae = new AssertionError(prefix + message);
+        errors.forEach(e -> {
+            if (e == null) {
+                ae.addSuppressed(new NullPointerException("Throwable was null!"));
+            } else {
+                ae.addSuppressed(e);
+            }
+        });
+        throw ae;
+    }
+    
+    /**
+     * Assert that this TestSubscriber received exactly one onComplete event.
+     */
+    public void assertComplete() {
+        String prefix = "";
+        /*
+         * This creates a happens-before relation with the possible completion of the TestSubscriber.
+         * Don't move it after the instance reads or into fail()!
+         */
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        long c = completions;
+        if (c == 0) {
+            fail(prefix, "Not completed", errors);
+        } else
+        if (c > 1) {
+            fail(prefix, "Multiple completions: " + c, errors);
+        }
+    }
+    
+    /**
+     * Assert that this TestSubscriber has not received any onComplete event.
+     */
+    public void assertNotComplete() {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        long c = completions;
+        if (c == 1) {
+            fail(prefix, "Completed!", errors);
+        } else 
+        if (c > 1) {
+            fail(prefix, "Multiple completions: " + c, errors);
+        }
+    }
+    
+    /**
+     * Assert that this TestSubscriber has not received any onError event.
+     */
+    public void assertNoErrors() {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = errors.size();
+        if (s != 0) {
+            fail(prefix, "Error(s) present: " + errors, errors);
+        }
+    }
+    
+    /**
+     * Assert that this TestSubscriber received exactly the specified onError event value.
+     * 
+     * <p>The comparison is performed via Objects.equals(); since most exceptions don't
+     * implement equals(), this assertion may fail. Use the {@link #assertError(Class)}
+     * overload to test against the class of an error instead of an instance of an error.
+     * @param error the error to check
+     * @see #assertError(Class)
+     */
+    public void assertError(Throwable error) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = errors.size();
+        if (s == 0) {
+            fail(prefix, "No errors", Collections.emptyList());
+        }
+        if (errors.contains(error)) {
+            if (s != 1) {
+                fail(prefix, "Error present but other errors as well", errors);
+            }
+        } else {
+            fail(prefix, "Error not present", errors);
+        }
+    }
+    
+    /**
+     * Asserts that this TestSubscriber received exactly one onError event which is an
+     * instance of the specified errorClass class.
+     * @param errorClass the error class to expect
+     */
+    public void assertError(Class<? extends Throwable> errorClass) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = errors.size();
+        if (s == 0) {
+            fail(prefix, "No errors", Collections.emptyList());
+        }
+        
+        boolean found = errors.stream()
+                .anyMatch(errorClass::isInstance);
+        
+        if (found) {
+            if (s != 1) {
+                fail(prefix, "Error present but other errors as well", errors);
+            }
+        } else {
+            fail(prefix, "Error not present", errors);
+        }
+    }
+    
+    /**
+     * Assert that this TestSubscriber received exactly one onNext value which is equal to
+     * the given value with respect to Objects.equals.
+     * @param value the value to expect
+     */
+    public final void assertValue(T value) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = values.size();
+        if (s != 1) {
+            fail(prefix, "Expected: " + valueAndClass(value) + ", Actual: " + values, errors);
+        }
+        T v = values.get(0);
+        if (!Objects.equals(value, v)) {
+            fail(prefix, "Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v), errors);
+        }
+    }
+    
+    /** Appends the class name to a non-null value. */
+    static String valueAndClass(Object o) {
+        if (o != null) {
+            return o + " (class: " + o.getClass().getSimpleName() + ")";
+        }
+        return "null";
+    }
+    
+    /**
+     * Assert that this TestSubscriber received the specified number onNext events.
+     * @param count the expected number of onNext events
+     */
+    public final void assertValueCount(int count) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = values.size();
+        if (s != count) {
+            fail(prefix, "Value counts differ; Expected: " + count + ", Actual: " + s, errors);
+        }
+    }
+    
+    /**
+     * Assert that this TestSubscriber has not received any onNext events.
+     */
+    public final void assertNoValues() {
+        assertValueCount(0);
+    }
+    
+    /**
+     * Assert that the TestSubscriber received only the specified values in the specified order.
+     * @param values the values expected
+     * @see #assertValueSet(Collection)
+     */
+    @SafeVarargs
+    public final void assertValues(T... values) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = this.values.size();
+        if (s != values.length) {
+            fail(prefix, "Value count differs; Expected: " + values.length + " " + Arrays.toString(values)
+            + ", Actual: " + s + " " + this.values, errors);
+        }
+        for (int i = 0; i < s; i++) {
+            T v = this.values.get(i);
+            T u = values[i];
+            if (!Objects.equals(u, v)) {
+                fail(prefix, "Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v), errors);
+            }
+        }
+    }
+    
+    /**
+     * Assert that the TestSubscriber received only the specified values in any order.
+     * <p>This helps asserting when the order of the values is not guaranteed, i.e., when merging
+     * asynchronous streams.
+     * 
+     * @param values the collection of values expected in any order
+     */
+    public final void assertValueSet(Collection<? extends T> values) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = this.values.size();
+        if (s != values.size()) {
+            fail(prefix, "Value count differs; Expected: " + values.size() + " " + values
+            + ", Actual: " + s + " " + this.values, errors);
+        }
+        for (int i = 0; i < s; i++) {
+            T v = this.values.get(i);
+            
+            if (!values.contains(v)) {
+                fail(prefix, "Value not in the expected collection: " + valueAndClass(v), errors);
+            }
+        }
+    }
+    
+    /**
+     * Assert that the TestSubscriber received only the specified sequence of values in the same order.
+     * @param sequence the sequence of expected values in order
+     */
+    public final void assertValueSequence(Iterable<? extends T> sequence) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int i = 0;
+        Iterator<T> vit = values.iterator();
+        Iterator<? extends T> it = sequence.iterator();
+        boolean itNext = false;
+        boolean vitNext = false;
+        while ((itNext = it.hasNext()) && (vitNext = vit.hasNext())) {
+            T v = it.next();
+            T u = vit.next();
+            
+            if (!Objects.equals(u, v)) {
+                fail(prefix, "Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v), errors);
+            }
+            i++;
+        }
+        
+        if (itNext && !vitNext) {
+            fail(prefix, "More values received than expected (" + i + ")", errors);
+        }
+        if (!itNext && !vitNext) {
+            fail(prefix, "Fever values received than expected (" + i + ")", errors);
+        }
+    }
+    
+    /**
+     * Assert that the TestSubscriber terminated (i.e., the terminal latch reached zero).
+     */
+    public final void assertTerminated() {
+        if (done.getCount() != 0) {
+            fail("", "Subscriber still running!", errors);
+        }
+        long c = completions;
+        if (c > 1) {
+            fail("", "Terminated with multiple completions: " + c, errors);
+        }
+        int s = errors.size();
+        if (s > 1) {
+            fail("", "Terminated with multiple errors: " + s, errors);
+        }
+        
+        if (c != 0 && s != 0) {
+            fail("", "Terminated with multiple completions and errors: " + c, errors);
+        }
+    }
+    
+    /**
+     * Assert that the TestSubscriber has not terminated (i.e., the terminal latch is still non-zero).
+     */
+    public final void assertNotTerminated() {
+        if (done.getCount() == 0) {
+            fail("", "Subscriber terminated!", errors);
+        }
+    }
+    
+    /**
+     * Assert that the onSubscribe method was called exactly once.
+     */
+    public final void assertSubscribed() {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        if (subscription == null) {
+            fail(prefix, "Not subscribed!", errors);
+        }
+    }
+    
+    /**
+     * Assert that the onSubscribe method hasn't been called at all.
+     */
+    public final void assertNotSubscribed() {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        if (subscription != null) {
+            fail(prefix, "Subscribed!", errors);
+        } else
+        if (!errors.isEmpty()) {
+            fail(prefix, "Not subscribed but errors found", errors);
+        }
+    }
+    
+    /**
+     * Waits until the any terminal event has been received by this TestSubscriber
+     * or returns false if the wait has been interrupted.
+     * @return true if the TestSubscriber terminated, false if the wait has been interrupted
+     */
+    public boolean awaitTerminalEvent() {
+        try {
+            await();
+            return true;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+    
+    /**
+     * Awaits the specified amount of time or until this TestSubscriber 
+     * receives an onError or onComplete events, whichever happens first.
+     * @param time the waiting time
+     * @param unit the time unit of the waiting time
+     * @return true if the TestSubscriber terminated, false if timeout or interrupt happened
+     */
+    public boolean awaitTerminalEvent(long duration, TimeUnit unit) {
+        try {
+            return await(duration, unit);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+    
+    public void assertErrorMessage(String message) {
+        String prefix = "";
+        if (done.getCount() != 0) {
+            prefix = "Subscriber still running! ";
+        }
+        int s = errors.size();
+        if (s == 0) {
+            fail(prefix, "No errors", Collections.emptyList());
+        } else
+        if (s == 1) {
+            Throwable e = errors.get(0);
+            if (e == null) {
+                fail(prefix, "Error is null", Collections.emptyList());
+            }
+            String errorMessage = e.getMessage();
+            if (!Objects.equals(message, errorMessage)) {
+                fail(prefix, "Error message differs; Expected: " + message + ", Actual: " + errorMessage, Collections.singletonList(e));
+            }
+        } else {
+            fail(prefix, "Multiple errors", errors);
+        }
+    }
+    
+    /**
+     * Returns a list of 3 other lists: the first inner list contains the plain
+     * values received; the second list contains the potential errors
+     * and the final list contains the potential completions as Notifications.
+     * 
+     * @return a list of (values, errors, completion-notifications)
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public List<List<Object>> getEvents() {
+        List<List<Object>> result = new ArrayList<>();
+        
+        result.add((List)values());
+        
+        result.add((List)errors());
+        
+        List<Object> completeList = new ArrayList<>();
+        for (long i = 0; i < completions; i++) {
+            completeList.add(Notification.complete());
+        }
+        result.add(completeList);
+        
+        return result;
+    }
+}


### PR DESCRIPTION
These classes enable the porting of backpressure-aware operators for non-backpressure Observable.

It would be great if this could be merged sooner.