### PR TITLE
Safer error handling in BlockingOperatorToFuture

### DIFF
--- a/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
@@ -118,8 +118,10 @@ public final class BlockingOperatorToFuture {
             }
 
             private T getValue() throws ExecutionException {
-                if (error.get() != null) {
-                    throw new ExecutionException("Observable onError", error.get());
+                final Throwable throwable = error.get();
+
+                if (throwable != null) {
+                    throw new ExecutionException("Observable onError", throwable);
                 } else if (cancelled) {
                     // Contract of Future.get() requires us to throw this:
                     throw new CancellationException("Subscription unsubscribed");


### PR DESCRIPTION
Not very important since `onError` should be called once, but anyway it's `AtomicReference` and we need to store the value returned from `get()` locally.

P.S. I don't use `Future`s, just found this piece of code.