### PR TITLE
Observable.empty().collect() should not throw an exception

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -3731,14 +3731,7 @@ public class Observable<T> {
             }
 
         };
-        
-        /*
-         * Discussion and confirmation of implementation at
-         * https://github.com/ReactiveX/RxJava/issues/423#issuecomment-27642532
-         * 
-         * It should use last() not takeLast(1) since it needs to emit an error if the sequence is empty.
-         */
-        return lift(new OperatorScan<R, T>(stateFactory, accumulator)).last();
+        return lift(new OperatorScan<R, T>(stateFactory, accumulator)).takeLast(1);
     }
 
     /**

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1021,6 +1021,27 @@ public class ObservableTests {
     }
     
     @Test
+    public void testCollectEmpty() {
+        List<Integer> list = Observable.<Integer> empty()
+                .collect(new Func0<List<Integer>>() {
+
+                    @Override
+                    public List<Integer> call() {
+                        return new ArrayList<Integer>();
+                    }
+
+                }, new Action2<List<Integer>, Integer>() {
+
+                    @Override
+                    public void call(List<Integer> list, Integer v) {
+                        list.add(v);
+                    }
+                }).toBlocking().single();
+
+        assertTrue(list.isEmpty());
+    }
+    
+    @Test
     public void testMergeWith() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Observable.just(1).mergeWith(Observable.just(2)).subscribe(ts);


### PR DESCRIPTION
`Observable.empty().collect(stateFactory, accumulator)` should return the result of `stateFactory.call()` but throws an exception.

I've added a unit test for this and removed an irrelevant reference to a discussion on `reduce`.