### PR TITLE
Optimize Exceptions.throwIfFatal()

### DIFF
--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -73,25 +73,28 @@ public final class Exceptions {
      * @see <a href="https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495">RxJava: StackOverflowError is swallowed (Issue #748)</a>
      */
     public static void throwIfFatal(Throwable t) {
-        if (t instanceof OnErrorNotImplementedException) {
-            throw (OnErrorNotImplementedException) t;
-        } else if (t instanceof OnErrorFailedException) {
-            Throwable cause = t.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw (OnErrorFailedException) t;
+        if (t instanceof RuntimeException) {
+            if (t instanceof OnErrorNotImplementedException) {
+                throw (OnErrorNotImplementedException) t;
+            } else if (t instanceof OnErrorFailedException) {
+                Throwable cause = t.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                } else {
+                    throw (OnErrorFailedException) t;
+                }
             }
-        }
-        // values here derived from https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495
-        else if (t instanceof StackOverflowError) {
-            throw (StackOverflowError) t;
-        } else if (t instanceof VirtualMachineError) {
-            throw (VirtualMachineError) t;
-        } else if (t instanceof ThreadDeath) {
-            throw (ThreadDeath) t;
-        } else if (t instanceof LinkageError) {
-            throw (LinkageError) t;
+        } else if (t instanceof Error) {
+            // values here derived from https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495
+            if (t instanceof StackOverflowError) {
+                throw (StackOverflowError) t;
+            } else if (t instanceof VirtualMachineError) {
+                throw (VirtualMachineError) t;
+            } else if (t instanceof ThreadDeath) {
+                throw (ThreadDeath) t;
+            } else if (t instanceof LinkageError) {
+                throw (LinkageError) t;
+            }
         }
     }
 
@@ -194,7 +197,6 @@ public final class Exceptions {
      * Forwards a fatal exception or reports it to the given Observer.
      * @param t the exception
      * @param o the observer to report to
-     * @param value the value that caused the exception
      */
     @Experimental
     public static void throwOrReport(Throwable t, Observer<?> o) {

--- a/src/perf/java/rx/exceptions/ExceptionsThrowIfFatalPerf.java
+++ b/src/perf/java/rx/exceptions/ExceptionsThrowIfFatalPerf.java
@@ -1,0 +1,64 @@
+package rx.exceptions;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class ExceptionsThrowIfFatalPerf {
+
+    @State(Scope.Thread)
+    public static class StateWithIOException {
+        public Throwable throwable = new IOException();
+    }
+
+    @State(Scope.Thread)
+    public static class StateWithIllegalArgumentException {
+        public Throwable throwable = new IllegalArgumentException();
+    }
+
+    @State(Scope.Thread)
+    public static class StateWithOutOfMemoryError {
+        public Throwable throwable = new OutOfMemoryError();
+    }
+
+    @Benchmark
+    public Object throwIfFatalNonFatalCheckedException(StateWithIOException state) {
+        try {
+            Exceptions.throwIfFatal(state.throwable);
+            return new Object();
+        } catch (Throwable expected) {
+            // We should return the result to exclude dead code elimination problem
+            return expected;
+        }
+    }
+
+    @Benchmark
+    public Object throwIfFatalNonFatalRuntimeException(StateWithIllegalArgumentException state) {
+        try {
+            Exceptions.throwIfFatal(state.throwable);
+            return new Object();
+        } catch (Throwable expected) {
+            // We should return the result to exclude dead code elimination problem
+            return expected;
+        }
+    }
+
+    @Benchmark
+    public Object throwIfFatalNonFatalError(StateWithOutOfMemoryError state) {
+        try {
+            Exceptions.throwIfFatal(state.throwable);
+            return new Object();
+        } catch (Throwable expected) {
+            // We should return the result to exclude dead code elimination problem
+            return expected;
+        }
+    }
+}


### PR DESCRIPTION
`Exceptions.throwIfFatal()` used in almost all RxJava operators.

Basically, in this PR I've just divided `throwable` into 3 groups: `RuntimeException`, `Error` and `Exception` (we don't need to check them).

With this PR `Exceptions.throwIfFatal()` becomes ~7% faster than current implementation in case of non-fatal exceptions (because if it's fatal — app will be crashed :smiley_cat:) on the Oracle JRE 1.8.0_45.

I guess, on Android it will be even more faster! (I am not sure in quality of our JITs/VMs).

I've checked the bytecode after compilation in hope that javac will optimize `Exceptions.throwIfFatal()` into same construction, but it does not perform any optimizations over this method at compile time, so the only hope is JIT and even after JIT, optimized version slightly faster (~7%).

Results of the benchmarks:

```
OPTIMIZED VERSION:

Benchmark                                                               Mode   Samples        Score  Score error    Units
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalCheckedException     avgt         5        2.569        0.389    ns/op
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalError                avgt         5        2.332        0.030    ns/op
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalRuntimeException     avgt         5        2.511        0.037    ns/op

Benchmark                                                               Mode   Samples        Score  Score error    Units
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalCheckedException    thrpt         5 395071210.861  1644491.739    ops/s
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalError               thrpt         5 429656328.864  3230560.292    ops/s
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalRuntimeException    thrpt         5 398472020.961  3961447.943    ops/s

OLD VERSION:

Benchmark                                                               Mode   Samples        Score  Score error    Units
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalCheckedException     avgt         5        2.812        0.954    ns/op
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalError                avgt         5        2.338        0.019    ns/op
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalRuntimeException     avgt         5        2.771        0.064    ns/op

Benchmark                                                               Mode   Samples        Score  Score error    Units
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalCheckedException    thrpt         5 370211340.236  9093081.248    ops/s
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalError               thrpt         5 427943417.424  6168313.153    ops/s
r.e.ExceptionsThrowIfFatalPerf.throwIfFatalNonFatalRuntimeException    thrpt         5 368255154.316  4520997.005    ops/s
```