### PR TITLE
2.x: fix take() reentrancy problem.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/OperatorTake.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorTake.java
@@ -62,9 +62,10 @@ public final class OperatorTake<T> implements Operator<T, T> {
         }
         @Override
         public void onNext(T t) {
-            if (!done) {
+            if (!done && remaining-- > 0) {
+                boolean stop = remaining == 0;
                 actual.onNext(t);
-                if (--remaining == 0L) {
+                if (stop) {
                     onComplete();
                 }
             }

--- a/src/test/java/io/reactivex/internal/operators/OperatorTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorTakeTest.java
@@ -30,6 +30,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorTakeTest {
@@ -419,5 +420,20 @@ public class OperatorTakeTest {
         ts.assertNoValues();
         ts.assertError(TestException.class);
         ts.assertNotComplete();
+    }
+    
+    @Test
+    public void testReentrantTake() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.take(1).doOnNext(v -> source.onNext(2)).subscribe(ts);
+        
+        source.onNext(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/nbp/NbpOperatorTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/nbp/NbpOperatorTakeTest.java
@@ -31,6 +31,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.nbp.NbpPublishSubject;
 import io.reactivex.subscribers.nbp.NbpTestSubscriber;
 
 public class NbpOperatorTakeTest {
@@ -337,5 +338,20 @@ public class NbpOperatorTakeTest {
         ts.assertNoValues();
         ts.assertError(TestException.class);
         ts.assertNotComplete();
+    }
+    
+    @Test
+    public void testReentrantTake() {
+        NbpPublishSubject<Integer> source = NbpPublishSubject.create();
+        
+        NbpTestSubscriber<Integer> ts = new NbpTestSubscriber<>();
+        
+        source.take(1).doOnNext(v -> source.onNext(2)).subscribe(ts);
+        
+        source.onNext(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
     }
 }


### PR DESCRIPTION
Discovered by @mgp in #3346 and using his supplied fix. I've already
applied it to NbpObservable's take this Monday so all that's left was
the unit test.