### PR TITLE
2.x: UnicastSubject fix for the child becoming visible before onSubscribe is called.

### DIFF
--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -167,8 +167,9 @@ public final class UnicastSubject<T> extends Subject<T, T> {
         @Override
         public void subscribe(Subscriber<? super T> s) {
             if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
-                SUBSCRIBER.lazySet(this, s);
                 s.onSubscribe(this);
+                SUBSCRIBER.lazySet(this, s); // full barrier in drain
+                drain();
             } else {
                 if (done) {
                     Throwable e = error;

--- a/src/main/java/io/reactivex/subjects/nbp/NbpUnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/nbp/NbpUnicastSubject.java
@@ -144,8 +144,8 @@ public final class NbpUnicastSubject<T> extends NbpSubject<T, T> {
         @Override
         public void accept(NbpSubscriber<? super T> s) {
             if (once == 0 && ONCE.compareAndSet(this, 0, 1)) {
-                SUBSCRIBER.lazySet(this, s);
                 s.onSubscribe(this);
+                SUBSCRIBER.lazySet(this, s); // full barrier in drain
                 drain();
             } else {
                 s.onSubscribe(EmptyDisposable.INSTANCE);


### PR DESCRIPTION
Discovered while the test `NbpOperatorConcatTest.testIssue2890NoStackoverflow` hung on Travis.

What happened is that the reference to the child became visible before the call to its `onSubscribe` method so a concurrent source emitting at the exact same time could already see the "unstarted" child. The PR fixes this in both `NbpUnicastSubject` and `UnicastSubject` by changing the order of calls. The rest of the subjects behave correctly (call `onSubscribe` first, make child visible second).

In addition, `UnicastSubject` now calls `drain()` because when the `onSubscribe` calls `request` and `drain`, the child is not visible and nothing gets replayed. Once both `onSubscribe` call returns and the child is becomes visible, a call to `drain` again will now correctly replay all available contents that were requested.