### PR TITLE
2.x: fix SpscLinkedArrayQueue leaves 1 slot null just before growing

### DIFF
--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -79,7 +79,7 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
             if (null == lvElement(buffer, lookAheadElementOffset)) {// LoadLoad
                 producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
                 return writeToQueue(buffer, e, index, offset);
-            } else if (null != lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
+            } else if (null == lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
                 return writeToQueue(buffer, e, index, offset);
             } else {
                 resize(buffer, index, offset, e, mask); // add a buffer and link old to new


### PR DESCRIPTION
Discovered while debugging #3381. Confirmed with JCTools in https://github.com/JCTools/JCTools/pull/80