### PR TITLE
Fix for take() reentrancy bug.

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorTake.java
+++ b/src/main/java/rx/internal/operators/OperatorTake.java
@@ -68,8 +68,8 @@ public final class OperatorTake<T> implements Operator<T, T> {
 
             @Override
             public void onNext(T i) {
-                if (!isUnsubscribed()) {
-                    boolean stop = ++count >= limit;
+                if (!isUnsubscribed() && count++ < limit) {
+                    boolean stop = count == limit;
                     child.onNext(i);
                     if (stop && !completed) {
                         completed = true;

--- a/src/test/java/rx/internal/operators/OperatorTakeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeTest.java
@@ -32,6 +32,7 @@ import rx.exceptions.TestException;
 import rx.functions.*;
 import rx.observers.*;
 import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
 
 public class OperatorTakeTest {
 
@@ -416,5 +417,25 @@ public class OperatorTakeTest {
         ts.assertNoValues();
         ts.assertError(TestException.class);
         ts.assertNotCompleted();
+    }
+    
+    @Test
+    public void testReentrantTake() {
+        final PublishSubject<Integer> source = PublishSubject.create();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        source.take(1).doOnNext(new Action1<Integer>() {
+            @Override
+            public void call(Integer v) {
+                source.onNext(2);
+            }
+        }).subscribe(ts);
+        
+        source.onNext(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 }


### PR DESCRIPTION
Fixes the bug reported in  #3346. (I've done this for 1.x as well since the original poster disappeared). 