### PR TITLE
1.1.0 - Changed Observable.doOnRequest(Action1) to @Experimental from @Beta

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -4444,20 +4444,26 @@ public class Observable<T> {
 
         return lift(new OperatorDoOnEach<T>(observer));
     }
-    
+
     /**
-     * Modifies the source {@code Observable} so that it invokes the given action when it receives a request for
-     * more items. 
+     * Modifies the source {@code Observable} so that it invokes the given action when it receives a
+     * request for more items.
+     * <p>
+     * <b>Note:</b> This operator is for tracing the internal behavior of back-pressure request
+     * patterns and generally intended for debugging use.
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doOnRequest} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code doOnRequest} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onRequest
-     *            the action that gets called when an observer requests items from this {@code Observable}
+     *            the action that gets called when an observer requests items from this
+     *            {@code Observable}
      * @return the source {@code Observable} modified so as to call this Action when appropriate
-     * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators
+     *      documentation: Do</a>
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
+     *        with the release number)
      */
     @Beta
     public final Observable<T> doOnRequest(final Action1<Long> onRequest) {


### PR DESCRIPTION
This is one of the many 1.1.0 promotion related pull requests. There is a split decision on the operator `Observable.doOnRequest(Action1)`. A majority of core committers have voted to promote this operator from `@Beta` to public. There is currently a minority is support for removing the convenience method on `Observable` or demoting it to `@Experimental`. Instead users would lift the underlying operator `obs.lift(new OperatorDoOnRequest<T>(onRequest))`. In this pull request I have taken the more conservative approach and expect that comments will guide our decisions. 

### Rationale:

 - the `doOnRequest` use case is to debug back-pressure use cases and as such should not pollute the public operator namespace. 
 - the existence of this operator may mislead and confuse users. it could be misinterpreted and abused to alter or reset over arching state when the back-pressure mechanics should be more or less self contained (with the exception of `AsyncOnSubscribe`).

If my understanding is incorrect and there is a valid use case aside from debugging then please comment. 