### PR TITLE
1.1.0: promote ConnectableObservable.autoConnect to beta

### DIFF
--- a/src/main/java/rx/observables/ConnectableObservable.java
+++ b/src/main/java/rx/observables/ConnectableObservable.java
@@ -16,7 +16,7 @@
 package rx.observables;
 
 import rx.*;
-import rx.annotations.Experimental;
+import rx.annotations.Beta;
 import rx.functions.*;
 import rx.internal.operators.*;
 
@@ -88,7 +88,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         when the first Subscriber subscribes
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
-    @Experimental
+    @Beta
     public Observable<T> autoConnect() {
         return autoConnect(1);
     }
@@ -103,7 +103,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         when the specified number of Subscribers subscribe to it
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
-    @Experimental
+    @Beta
     public Observable<T> autoConnect(int numberOfSubscribers) {
         return autoConnect(numberOfSubscribers, Actions.empty());
     }
@@ -123,7 +123,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         specified callback with the Subscription associated with the established connection
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
-    @Experimental
+    @Beta
     public Observable<T> autoConnect(int numberOfSubscribers, Action1<? super Subscription> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);


### PR DESCRIPTION
Based on votes, `autoConnect` can step up one level.