### PR TITLE
1.1.0: takeUntil with predicate promote to public

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -8293,9 +8293,8 @@ public class Observable<T> {
      *         condition after each item, and then completes if the condition is satisfied.
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      * @see Observable#takeWhile(Func1)
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.0.15
      */
-    @Experimental
     public final Observable<T> takeUntil(final Func1<? super T, Boolean> stopPredicate) {
         return lift(new OperatorTakeUntilPredicate<T>(stopPredicate));
     }

--- a/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
@@ -17,7 +17,6 @@ package rx.internal.operators;
 
 import rx.*;
 import rx.Observable.Operator;
-import rx.annotations.Experimental;
 import rx.exceptions.Exceptions;
 import rx.functions.Func1;
 
@@ -26,7 +25,6 @@ import rx.functions.Func1;
  * the provided predicate returns false
  * <p>
  */
-@Experimental
 public final class OperatorTakeUntilPredicate<T> implements Operator<T, T> {
     /** Subscriber returned to the upstream. */
     private final class ParentSubscriber extends Subscriber<T> {


### PR DESCRIPTION
Based on votes, the predicate version of `takeUntil` should be promoted to be public.