### PR TITLE
1.1.0: BackpressureDrainManager promotion to public internal API?!

### DIFF
--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -23,9 +23,10 @@ import rx.annotations.Experimental;
 /**
  * Manages the producer-backpressure-consumer interplay by
  * matching up available elements with requested elements and/or
- * terminal events. 
+ * terminal events.
+ * 
+ * @since 1.0.15
  */
-@Experimental
 public final class BackpressureDrainManager implements Producer {
     /**
      * Interface representing the minimal callbacks required


### PR DESCRIPTION
Based on votes, the BackpressureDrainManager class can drop the
experimental tag, but since it is an internal class, this change doesn't
affect the public API. Not sure why I marked the class as experimental
back then.