### PR TITLE
1.1.0: Exceptions.throwIfAny promotion to public API

### DIFF
--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -157,8 +157,8 @@ public final class Exceptions {
      * @param exceptions the collection of exceptions. If null or empty, no exception is thrown.
      * If the collection contains a single exception, that exception is either thrown as-is or wrapped into a
      * CompositeException. Multiple exceptions are wrapped into a CompositeException.
+     * @since 1.0.15
      */
-    @Experimental
     public static void throwIfAny(List<? extends Throwable> exceptions) {
         if (exceptions != null && !exceptions.isEmpty()) {
             if (exceptions.size() == 1) {


### PR DESCRIPTION
Based on votes, the method Exceptions.throwIfAny can now be part of the
public API.