### PR TITLE
1.1.0: promote Subscriptions.unsubscribed to be part of the public API

### DIFF
--- a/src/main/java/rx/subscriptions/Subscriptions.java
+++ b/src/main/java/rx/subscriptions/Subscriptions.java
@@ -18,7 +18,6 @@ package rx.subscriptions;
 import java.util.concurrent.Future;
 
 import rx.Subscription;
-import rx.annotations.Experimental;
 import rx.functions.Action0;
 
 /**
@@ -57,9 +56,8 @@ public final class Subscriptions {
      * </code></pre>
      *
      * @return a {@link Subscription} to which {@code unsubscribe} does nothing, as it is already unsubscribed
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.0.15
      */
-    @Experimental
     public static Subscription unsubscribed() {
         return UNSUBSCRIBED;
     }


### PR DESCRIPTION
Based on unanimous votes, Subscriptions.unsubscribed can now be part of
the public API.