### PR TITLE
DoOnEach: report both original exception and callback exception.

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -4362,6 +4362,10 @@ public class Observable<T> {
     /**
      * Modifies the source Observable so that it notifies an Observer for each item it emits.
      * <p>
+     * In case the onError of the supplied observer throws, the downstream will receive a composite exception containing
+     * the original exception and the exception thrown by onError. If the onNext or the onCompleted methods
+     * of the supplied observer throws, the downstream will be terminated and wil receive this thrown exception.
+     * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnEach.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -4379,6 +4383,9 @@ public class Observable<T> {
 
     /**
      * Modifies the source Observable so that it invokes an action if it calls {@code onError}.
+     * <p>
+     * In case the onError action throws, the downstream will receive a composite exception containing
+     * the original exception and the exception thrown by onError.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnError.png" alt="">
      * <dl>

--- a/src/main/java/rx/internal/operators/OperatorDoOnEach.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnEach.java
@@ -15,9 +15,11 @@
  */
 package rx.internal.operators;
 
+import java.util.Arrays;
+
 import rx.*;
 import rx.Observable.Operator;
-import rx.exceptions.Exceptions;
+import rx.exceptions.*;
 
 /**
  * Converts the elements of an observable sequence to the specified type.
@@ -62,7 +64,8 @@ public class OperatorDoOnEach<T> implements Operator<T, T> {
                 try {
                     doOnEachObserver.onError(e);
                 } catch (Throwable e2) {
-                    Exceptions.throwOrReport(e2, observer);
+                    Exceptions.throwIfFatal(e2);
+                    observer.onError(new CompositeException(Arrays.asList(e, e2)));
                     return;
                 }
                 observer.onError(e);


### PR DESCRIPTION
This came up in a [Stackoverflow](http://stackoverflow.com/questions/32889008/do-operators-instead-of-a-whole-subscriber) answer. If the `doOnError`'s callback or the `doOnEach`'s `onError` method throws, any non-fatal exception replaced the original error which got lost. This PR will wrap them both into a `CompositeException`.

2.x note: since Java 8 supports `addSuppressed` all callbacks in this situation either attach to the original exception or the original exception is attached to the callback's exception.