### PR TITLE
2.x: null safety checks and fixes

### DIFF
--- a/src/main/java/io/reactivex/NbpObservable.java
+++ b/src/main/java/io/reactivex/NbpObservable.java
@@ -346,6 +346,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> NbpObservable<T> defer(Supplier<? extends NbpObservable<? extends T>> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
         return create(new NbpOnSubscribeDefer<>(supplier));
     }
 
@@ -565,6 +566,7 @@ public class NbpObservable<T> {
     }
 
     public static <T> NbpObservable<T> just(T value) {
+        Objects.requireNonNull(value, "The value is null");
         return new NbpObservableScalarSource<>(value);
     }
 
@@ -613,6 +615,7 @@ public class NbpObservable<T> {
         Objects.requireNonNull(v3, "The third value is null");
         Objects.requireNonNull(v4, "The fourth value is null");
         Objects.requireNonNull(v5, "The fifth value is null");
+        Objects.requireNonNull(v6, "The sixth value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6);
     }
@@ -877,6 +880,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> NbpObservable<R> zip(NbpObservable<? extends NbpObservable<? extends T>> sources, Function<Object[], R> zipper) {
+        Objects.requireNonNull(zipper, "zipper is null");
         return sources.toList().flatMap(list -> {
             return zipIterable(zipper, false, bufferSize(), list);
         });
@@ -998,6 +1002,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> ambWith(NbpObservable<? extends T> other) {
+        Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
 
@@ -1155,6 +1160,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> cast(Class<U> clazz) {
+        Objects.requireNonNull(clazz, "clazz is null");
         return map(clazz::cast);
     }
 
@@ -1167,6 +1173,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> collectInto(U initialValue, BiConsumer<? super U, ? super T> collector) {
+        Objects.requireNonNull(initialValue, "initialValue is null");
         return collect(() -> initialValue, collector);
     }
 
@@ -1190,6 +1197,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> concatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
         return concatMap(v -> fromIterable(mapper.apply(v)));
     }
 
@@ -1292,6 +1300,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<T> delaySubscription(Supplier<? extends NbpObservable<U>> delaySupplier) {
+        Objects.requireNonNull(delaySupplier, "delaySupplier is null");
         return fromCallable(delaySupplier::get).flatMap(v -> v).take(1).cast(Object.class).defaultIfEmpty(OBJECT).flatMap(v -> this);
     }
 
@@ -1314,6 +1323,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K> NbpObservable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return lift(NbpOperatorDistinct.withCollection(keySelector, collectionSupplier));
     }
 
@@ -1324,6 +1335,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K> NbpObservable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
+        Objects.requireNonNull(keySelector, "keySelector is null");
         return lift(NbpOperatorDistinct.untilChanged(keySelector));
     }
 
@@ -1348,6 +1360,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> doOnEach(Consumer<? super Try<Optional<T>>> consumer) {
+        Objects.requireNonNull(consumer, "consumer is null");
         return doOnEach(
                 v -> consumer.accept(Try.ofValue(Optional.of(v))),
                 e -> consumer.accept(Try.ofError(e)),
@@ -1358,6 +1371,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> doOnEach(NbpSubscriber<? super T> observer) {
+        Objects.requireNonNull(observer, "observer is null");
         return doOnEach(observer::onNext, observer::onError, observer::onComplete, () -> { });
     }
 
@@ -1368,6 +1382,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> doOnLifecycle(Consumer<? super Disposable> onSubscribe, Runnable onCancel) {
+        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        Objects.requireNonNull(onCancel, "onCancel is null");
         return lift(s -> new NbpSubscriptionLambdaSubscriber<>(s, onSubscribe, onCancel));
     }
     
@@ -1504,6 +1520,9 @@ public class NbpObservable<T> {
             Function<? super T, ? extends NbpObservable<? extends R>> onNextMapper, 
             Function<? super Throwable, ? extends NbpObservable<? extends R>> onErrorMapper, 
             Supplier<? extends NbpObservable<? extends R>> onCompleteSupplier) {
+        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
+        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(lift(new NbpOperatorMapNotification<>(onNextMapper, onErrorMapper, onCompleteSupplier)));
     }
 
@@ -1513,6 +1532,9 @@ public class NbpObservable<T> {
             Function<Throwable, ? extends NbpObservable<? extends R>> onErrorMapper, 
             Supplier<? extends NbpObservable<? extends R>> onCompleteSupplier, 
             int maxConcurrency) {
+        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
+        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(lift(new NbpOperatorMapNotification<>(onNextMapper, onErrorMapper, onCompleteSupplier)), maxConcurrency);
     }
 
@@ -1538,6 +1560,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> NbpObservable<R> flatMap(Function<? super T, ? extends NbpObservable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return flatMap(t -> {
             @SuppressWarnings("unchecked")
             NbpObservable<U> u = (NbpObservable<U>)mapper.apply(t);
@@ -1552,6 +1576,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
         return flatMap(v -> fromIterable(mapper.apply(v)));
     }
 
@@ -1707,6 +1732,7 @@ public class NbpObservable<T> {
     }
 
     public final <R> NbpObservable<R> map(Function<? super T, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
         return lift(new NbpOperatorMap<>(mapper));
     }
 
@@ -1717,6 +1743,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> mergeWith(NbpObservable<? extends T> other) {
+        Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
 
@@ -1745,6 +1772,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> ofType(Class<U> clazz) {
+        Objects.requireNonNull(clazz, "clazz is null");
         return filter(clazz::isInstance).cast(clazz);
     }
 
@@ -1856,6 +1884,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> repeatUntil(BooleanSupplier stop) {
+        Objects.requireNonNull(stop, "stop is null");
         return create(new NbpOnSubscribeRepeatUntil<>(this, stop));
     }
 
@@ -1914,11 +1943,16 @@ public class NbpObservable<T> {
     
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final <R> NbpObservable<R> replay(Function<? super NbpObservable<T>, ? extends NbpObservable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
+        Objects.requireNonNull(selector, "selector is null");
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.multicastSelector(() -> replay(time, unit, scheduler), selector);
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final <R> NbpObservable<R> replay(final Function<? super NbpObservable<T>, ? extends NbpObservable<R>> selector, final Scheduler scheduler) {
+        Objects.requireNonNull(selector, "selector is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.multicastSelector(() -> replay(), 
                 t -> selector.apply(t).observeOn(scheduler));
     }
@@ -1938,6 +1972,8 @@ public class NbpObservable<T> {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.create(this, time, unit, scheduler, bufferSize);
     }
     
@@ -1953,6 +1989,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpConnectableObservable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.create(this, time, unit, scheduler);
     }
 
@@ -1997,6 +2035,7 @@ public class NbpObservable<T> {
     
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> retryUntil(BooleanSupplier stop) {
+        Objects.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, e -> !stop.getAsBoolean());
     }
     
@@ -2381,6 +2420,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpObservable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return lift(new NbpOperatorThrottleFirstTimed<T>(skipDuration, unit, scheduler));
     }
 
@@ -2421,6 +2462,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpObservable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return lift(new NbpOperatorTimeInterval<>(unit, scheduler));
     }
 
@@ -2505,6 +2548,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpObservable<Timed<T>> timestamp(TimeUnit unit, Scheduler scheduler) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return map(v -> new Timed<>(v, scheduler.now(unit), unit));
     }
 
@@ -2546,6 +2591,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K, V> NbpObservable<Map<K, V>> toMap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMap::new, (m, t) -> {
             K key = keySelector.apply(t);
             V value = valueSelector.apply(t);
@@ -2586,6 +2633,10 @@ public class NbpObservable<T> {
             Function<? super T, ? extends V> valueSelector, 
             Supplier<? extends Map<K, Collection<V>>> mapSupplier,
             Function<? super K, ? extends Collection<? super V>> collectionFactory) {
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        Objects.requireNonNull(mapSupplier, "mapSupplier is null");
+        Objects.requireNonNull(collectionFactory, "collectionFactory is null");
         return collect(mapSupplier, (m, t) -> {
             K key = keySelector.apply(t);
 
@@ -2832,6 +2883,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <B> NbpObservable<NbpObservable<T>> window(NbpObservable<B> boundary, int bufferSize) {
+        Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundary<>(boundary, bufferSize));
     }
 
@@ -2846,6 +2898,8 @@ public class NbpObservable<T> {
     public final <U, V> NbpObservable<NbpObservable<T>> window(
             NbpObservable<U> windowOpen, 
             Function<? super U, ? extends NbpObservable<V>> windowClose, int bufferSize) {
+        Objects.requireNonNull(windowOpen, "windowOpen is null");
+        Objects.requireNonNull(windowClose, "windowClose is null");
         return lift(new NbpOperatorWindowBoundarySelector<>(windowOpen, windowClose, bufferSize));
     }
     
@@ -2856,6 +2910,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <B> NbpObservable<NbpObservable<T>> window(Supplier<? extends NbpObservable<B>> boundary, int bufferSize) {
+        Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundarySupplier<>(boundary, bufferSize));
     }
 
@@ -2869,11 +2924,14 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> NbpObservable<R> zipWith(Iterable<? extends U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
+        Objects.requireNonNull(other, "other is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return create(new NbpOnSubscribeZipIterable<>(this, other, zipper));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> NbpObservable<R> zipWith(NbpObservable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+        Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/OperatorCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorCollect.java
@@ -39,6 +39,10 @@ public final class OperatorCollect<T, U> implements Operator<U, T> {
             EmptySubscription.error(e, t);
             return CancelledSubscriber.INSTANCE;
         }
+        if (u == null) {
+            EmptySubscription.error(new NullPointerException("The initial value supplied is null"), t);
+            return CancelledSubscriber.INSTANCE;
+        }
         
         return new CollectSubscriber<>(t, u, collector);
     }

--- a/src/main/java/io/reactivex/internal/operators/OperatorConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorConcatMap.java
@@ -150,6 +150,13 @@ public final class OperatorConcatMap<T, U> implements Operator<U, T> {
                 actual.onError(e);
                 return;
             }
+            
+            if (p == null) {
+                cancel();
+                actual.onError(new NullPointerException("The publisher returned is null"));
+                return;
+            }
+            
             index++;
             // this is not RS but since our Subscriber doesn't hold state by itself,
             // subscribing it to each source is safe and saves allocation

--- a/src/main/java/io/reactivex/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorGroupBy.java
@@ -124,6 +124,12 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 return;
             }
 
+            if (v == null) {
+                s.cancel();
+                onError(new NullPointerException("The value selector returned a null"));
+                return;
+            }
+            
             group.onNext(v);
             
             if (notNew) {

--- a/src/main/java/io/reactivex/internal/operators/OperatorOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorOnErrorNext.java
@@ -92,15 +92,15 @@ public final class OperatorOnErrorNext<T> implements Operator<T, T> {
             try {
                 p = nextSupplier.apply(t);
             } catch (Throwable e) {
-                t.addSuppressed(e);
-                actual.onError(t);
+                e.addSuppressed(t);
+                actual.onError(e);
                 return;
             }
             
             if (p == null) {
                 NullPointerException npe = new NullPointerException("Publisher is null");
-                t.addSuppressed(npe);
-                actual.onError(t);
+                npe.addSuppressed(t);
+                actual.onError(npe);
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/OperatorOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorOnErrorReturn.java
@@ -92,8 +92,9 @@ public final class OperatorOnErrorReturn<T> implements Operator<T, T> {
             
             if (v == null) {
                 STATE.lazySet(this, HAS_REQUEST_HAS_VALUE);
-                t.addSuppressed(new NullPointerException("The supplied value is null"));
-                actual.onError(t);
+                NullPointerException npe = new NullPointerException("The supplied value is null");
+                npe.addSuppressed(t);
+                actual.onError(npe);
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/OperatorReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/OperatorReplay.java
@@ -55,9 +55,23 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
             Publisher<R> observable;
             try {
                 co = connectableFactory.get();
+            } catch (Throwable e) {
+                EmptySubscription.error(e, child);
+                return;
+            }
+            if (co == null) {
+                EmptySubscription.error(new NullPointerException("The connectableFactory returned null"), child);
+                return;
+            }
+
+            try {
                 observable = selector.apply(co);
             } catch (Throwable e) {
                 EmptySubscription.error(e, child);
+                return;
+            }
+            if (observable == null) {
+                EmptySubscription.error(new NullPointerException("The selector returned a null Publisher"), child);
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/PublisherZip.java
+++ b/src/main/java/io/reactivex/internal/operators/PublisherZip.java
@@ -199,6 +199,12 @@ public final class PublisherZip<T, R> implements Publisher<R> {
                         return;
                     }
                     
+                    if (v == null) {
+                        clear();
+                        a.onError(new NullPointerException("The zipper returned null"));
+                        return;
+                    }
+                    
                     a.onNext(v);
                     
                     r--;

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOnSubscribeArraySource.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOnSubscribeArraySource.java
@@ -37,7 +37,12 @@ public final class NbpOnSubscribeArraySource<T> implements NbpOnSubscribe<T> {
         int n = a.length;
         
         for (int i = 0; i < n && !bd.isDisposed(); i++) {
-            s.onNext(a[i]);
+            T value = a[i];
+            if (value == null) {
+                s.onError(new NullPointerException("The " + i + "th element is null"));
+                return;
+            }
+            s.onNext(value);
         }
         if (!bd.isDisposed()) {
             s.onComplete();

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOnSubscribeZip.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOnSubscribeZip.java
@@ -180,6 +180,12 @@ public final class NbpOnSubscribeZip<T, R> implements NbpOnSubscribe<R> {
                         return;
                     }
                     
+                    if (v == null) {
+                        clear();
+                        a.onError(new NullPointerException("The zipper returned a null value"));
+                        return;
+                    }
+                    
                     a.onNext(v);
                 }
                 

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorCollect.java
@@ -40,6 +40,11 @@ public final class NbpOperatorCollect<T, U> implements NbpOperator<U, T> {
             return NbpCancelledSubscriber.INSTANCE;
         }
         
+        if (u == null) {
+            EmptyDisposable.error(new NullPointerException("The inital supplier returned a null value"), t);
+            return NbpCancelledSubscriber.INSTANCE;
+        }
+        
         return new CollectSubscriber<>(t, u, collector);
     }
     

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorConcatMap.java
@@ -137,6 +137,13 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
                 actual.onError(e);
                 return;
             }
+            
+            if (p == null) {
+                cancel();
+                actual.onError(new NullPointerException("The NbpObservable returned is null"));
+                return;
+            }
+            
             index++;
             // this is not RS but since our Subscriber doesn't hold state by itself,
             // subscribing it to each source is safe and saves allocation

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorGroupBy.java
@@ -119,6 +119,12 @@ public final class NbpOperatorGroupBy<T, K, V> implements NbpOperator<NbpGrouped
                 onError(e);
                 return;
             }
+            
+            if (v == null) {
+                s.dispose();
+                onError(new NullPointerException("The value supplied is null"));
+                return;
+            }
 
             group.onNext(v);
         }

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorOnErrorNext.java
@@ -88,15 +88,15 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
             try {
                 p = nextSupplier.apply(t);
             } catch (Throwable e) {
-                t.addSuppressed(e);
-                actual.onError(t);
+                e.addSuppressed(t);
+                actual.onError(e);
                 return;
             }
             
             if (p == null) {
                 NullPointerException npe = new NullPointerException("Observable is null");
-                t.addSuppressed(npe);
-                actual.onError(t);
+                npe.addSuppressed(t);
+                actual.onError(npe);
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/nbp/NbpOperatorOnErrorReturn.java
@@ -64,14 +64,15 @@ public final class NbpOperatorOnErrorReturn<T> implements NbpOperator<T, T> {
             try {
                 v = valueSupplier.apply(t);
             } catch (Throwable e) {
-                t.addSuppressed(e);
-                actual.onError(t);
+                e.addSuppressed(t);
+                actual.onError(e);
                 return;
             }
             
             if (v == null) {
-                t.addSuppressed(new NullPointerException("The supplied value is null"));
-                actual.onError(t);
+                NullPointerException e = new NullPointerException("The supplied value is null");
+                e.addSuppressed(t);
+                actual.onError(e);
                 return;
             }
             

--- a/src/main/java/io/reactivex/observables/BlockingObservable.java
+++ b/src/main/java/io/reactivex/observables/BlockingObservable.java
@@ -297,6 +297,8 @@ public final class BlockingObservable<T> implements Publisher<T>, Iterable<T> {
             cdl.countDown();
         }, s -> s.request(Long.MAX_VALUE));
         
+        o.subscribe(ls);
+        
         awaitForComplete(cdl, ls);
         Throwable e = error[0];
         if (e != null) {

--- a/src/main/java/io/reactivex/observables/nbp/NbpBlockingObservable.java
+++ b/src/main/java/io/reactivex/observables/nbp/NbpBlockingObservable.java
@@ -284,12 +284,14 @@ public final class NbpBlockingObservable<T> implements Iterable<T> {
     public void run() {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] error = { null };
-        LambdaSubscriber<T> ls = new LambdaSubscriber<>(v -> { }, e -> {
+        NbpLambdaSubscriber<T> ls = new NbpLambdaSubscriber<>(v -> { }, e -> {
             error[0] = e;
             cdl.countDown();
         }, () -> {
             cdl.countDown();
-        }, s -> s.request(Long.MAX_VALUE));
+        }, s -> { });
+        
+        o.subscribe(ls);
         
         awaitForComplete(cdl, ls);
         Throwable e = error[0];

--- a/src/main/java/io/reactivex/subjects/nbp/NbpAsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/nbp/NbpAsyncSubject.java
@@ -258,6 +258,10 @@ public final class NbpAsyncSubject<T> extends NbpSubject<T, T> {
             if (done) {
                 return;
             }
+            if (value == null) {
+                onError(new NullPointerException());
+                return;
+            }
             lazySet(value);
         }
         
@@ -268,6 +272,9 @@ public final class NbpAsyncSubject<T> extends NbpSubject<T, T> {
                 return;
             }
             done = true;
+            if (e == null) {
+                e = new NullPointerException();
+            }
             for (NbpSubscriber<? super T> v : terminate(NotificationLite.error(e))) {
                 v.onError(e);
             }

--- a/src/test/java/io/reactivex/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/ObservableNullTests.java
@@ -1,0 +1,1917 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+/**
+ * Verifies the operators handle null values properly by emitting/throwing NullPointerExceptions
+ */
+public class ObservableNullTests {
+
+    Observable<Integer> just1 = Observable.just(1);
+    
+    //***********************************************************
+    // Static methods
+    //***********************************************************
+    
+    @Test(expected = NullPointerException.class)
+    public void ambVarargsNull() {
+        Observable.amb((Publisher<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambVarargsOneIsNull() {
+        Observable.amb(Observable.never(), null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableNull() {
+        Observable.amb((Iterable<Publisher<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableIteratorNull() {
+        Observable.amb(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableOneIsNull() {
+        Observable.amb(Arrays.asList(Observable.never(), null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsNull() {
+        Observable.combineLatest(v -> 1, true, 128, (Publisher<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsOneIsNull() {
+        Observable.combineLatest(v -> 1, true, 128, Observable.never(), null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableNull() {
+        Observable.combineLatest((Iterable<Publisher<Object>>)null, v -> 1, true, 128);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableIteratorNull() {
+        Observable.combineLatest(() -> null, v -> 1, true, 128).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableOneIsNull() {
+        Observable.combineLatest(Arrays.asList(Observable.never(), null), v -> 1, true, 128).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsFunctionNull() {
+        Observable.combineLatest(null, true, 128, Observable.never());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsFunctionReturnsNull() {
+        Observable.combineLatest(v -> null, true, 128, just1).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableFunctionNull() {
+        Observable.combineLatest(Arrays.asList(just1), null, true, 128);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableFunctionReturnsNull() {
+        Observable.combineLatest(Arrays.asList(just1), v -> null, true, 128).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableNull() {
+        Observable.concat((Iterable<Publisher<Object>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concatIterableIteratorNull() {
+        Observable.concat(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableOneIsNull() {
+        Observable.concat(Arrays.asList(just1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatPublisherNull() {
+        Observable.concat((Publisher<Publisher<Object>>)null);
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concatArrayNull() {
+        Observable.concatArray((Publisher<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatArrayOneIsNull() {
+        Observable.concatArray(just1, null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void createNull() {
+        Observable.create(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void deferFunctionNull() {
+        Observable.defer(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void deferFunctionReturnsNull() {
+        Observable.defer(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorFunctionNull() {
+        Observable.error((Supplier<Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorFunctionReturnsNull() {
+        Observable.error(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorThrowableNull() {
+        Observable.error((Throwable)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromArrayNull() {
+        Observable.fromArray((Object[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromArrayOneIsNull() {
+        Observable.fromArray(1, null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromCallableNull() {
+        Observable.fromCallable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromCallableReturnsNull() {
+        Observable.fromCallable(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureNull() {
+        Observable.fromFuture(null);
+    }
+    
+    @Test
+    public void fromFutureReturnsNull() {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+        Observable.fromFuture(f).subscribe(ts);
+        f.complete(null);
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(NullPointerException.class);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedFutureNull() {
+        Observable.fromFuture(null, 1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedUnitNull() {
+        Observable.fromFuture(new CompletableFuture<>(), 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedSchedulerNull() {
+        Observable.fromFuture(new CompletableFuture<>(), 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedReturnsNull() {
+        CompletableFuture<Object> f = CompletableFuture.completedFuture(null);
+        Observable.fromFuture(f, 1, TimeUnit.SECONDS).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureSchedulerNull() {
+        Observable.fromFuture(new CompletableFuture<>(), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromIterableNull() {
+        Observable.fromIterable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromIterableIteratorNull() {
+        Observable.fromIterable(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromIterableValueNull() {
+        Observable.fromIterable(Arrays.asList(1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromPublisherNull() {
+        Observable.fromPublisher(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromStreamNull() {
+        Observable.fromStream(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromStreamOneIsNull() {
+        Observable.fromStream(Arrays.asList(1, null).stream()).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateConsumerNull() {
+        Observable.generate(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateConsumerEmitsNull() {
+        Observable.generate(s -> s.onNext(null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateStateConsumerInitialStateNull() {
+        Observable.generate(null, (BiConsumer<Integer, Subscriber<Integer>>)(s, o) -> o.onNext(1));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void generateStateFunctionInitialStateNull() {
+        Observable.generate(null, (s, o) -> { o.onNext(1); return s; });
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void generateStateConsumerNull() {
+        Observable.generate(() -> 1, (BiConsumer<Integer, Subscriber<Object>>)null);
+    }
+    
+    @Test
+    public void generateConsumerStateNullAllowed() {
+        Observable.generate(() -> null, (BiConsumer<Integer, Subscriber<Integer>>)(s, o) -> o.onComplete()).toBlocking().lastOption();
+    }
+
+    @Test
+    public void generateFunctionStateNullAllowed() {
+        Observable.generate(() -> null, (s, o) -> { o.onComplete(); return s; }).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateConsumerDisposeNull() {
+        Observable.generate(() -> 1, (BiConsumer<Integer, Subscriber<Integer>>)(s, o) -> o.onNext(1), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateFunctionDisposeNull() {
+        Observable.generate(() -> 1, (s, o) -> { o.onNext(1); return s; }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalUnitNull() {
+        Observable.interval(1, null);
+    }
+    
+    public void intervalSchedulerNull() {
+        Observable.interval(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalPeriodUnitNull() {
+        Observable.interval(1, 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalPeriodSchedulerNull() {
+        Observable.interval(1, 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalRangeUnitNull() {
+        Observable.intervalRange(1,1, 1, 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalRangeSchedulerNull() {
+        Observable.intervalRange(1, 1, 1, 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test
+    public void justNull() throws Exception {
+        @SuppressWarnings("rawtypes")
+        Class<Observable> clazz = Observable.class;
+        for (int argCount = 1; argCount < 10; argCount++) {
+            for (int argNull = 1; argNull <= argCount; argNull++) {
+                Class<?>[] params = new Class[argCount];
+                Arrays.fill(params, Object.class);
+
+                Object[] values = new Object[argCount];
+                Arrays.fill(values, 1);
+                values[argNull - 1] = null;
+                
+                Method m = clazz.getMethod("just", params);
+                
+                try {
+                    m.invoke(null, values);
+                    Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
+                } catch (InvocationTargetException ex) {
+                    if (!(ex.getCause() instanceof NullPointerException)) {
+                        Assert.fail("Unexpected exception for argCount " + argCount + " / argNull " + argNull + ": " + ex);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableNull() {
+        Observable.merge(128, 128, (Iterable<Publisher<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableIteratorNull() {
+        Observable.merge(128, 128, () -> null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableOneIsNull() {
+        Observable.merge(128, 128, Arrays.asList(just1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeArrayNull() {
+        Observable.merge(128, 128, (Publisher<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeArrayOneIsNull() {
+        Observable.merge(128, 128, just1, null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorIterableNull() {
+        Observable.mergeDelayError(128, 128, (Iterable<Publisher<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorIterableIteratorNull() {
+        Observable.mergeDelayError(128, 128, () -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorIterableOneIsNull() {
+        Observable.mergeDelayError(128, 128, Arrays.asList(just1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorArrayNull() {
+        Observable.mergeDelayError(128, 128, (Publisher<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorArrayOneIsNull() {
+        Observable.mergeDelayError(128, 128, just1, null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sequenceEqualFirstNull() {
+        Observable.sequenceEqual(null, just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sequenceEqualSecondNull() {
+        Observable.sequenceEqual(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sequenceEqualComparatorNull() {
+        Observable.sequenceEqual(just1, just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchOnNextNull() {
+        Observable.switchOnNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timerUnitNull() {
+        Observable.timer(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timerSchedulerNull() {
+        Observable.timer(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingResourceSupplierNull() {
+        Observable.using(null, d -> just1, d -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingObservableSupplierNull() {
+        Observable.using(() -> 1, null, d -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingObservableSupplierReturnsNull() {
+        Observable.using(() -> 1, d -> null, d -> { }).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingDisposeNull() {
+        Observable.using(() -> 1, d -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableNull() {
+        Observable.zip((Iterable<Publisher<Object>>)null, v -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableIteratorNull() {
+        Observable.zip(() -> null, v -> 1).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableFunctionNull() {
+        Observable.zip(Arrays.asList(just1, just1), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableFunctionReturnsNull() {
+        Observable.zip(Arrays.asList(just1, just1), a -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipPublisherNull() {
+        Observable.zip((Publisher<Publisher<Object>>)null, a -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipPublisherFunctionNull() {
+        Observable.zip((Observable.just(just1)), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipPublisherFunctionReturnsNull() {
+        Observable.zip((Observable.just(just1)), a -> null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2Null() {
+        Observable.zipIterable(a -> 1, true, 128, (Iterable<Publisher<Object>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2IteratorNull() {
+        Observable.zipIterable(a -> 1, true, 128, () -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2FunctionNull() {
+        Observable.zipIterable(null, true, 128, Arrays.asList(just1, just1));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2FunctionReturnsNull() {
+        Observable.zipIterable(a -> null, true, 128, Arrays.asList(just1, just1)).toBlocking().lastOption();
+    }
+
+    //*************************************************************
+    // Instance methods
+    //*************************************************************
+
+    @Test(expected = NullPointerException.class)
+    public void allPredicateNull() {
+        just1.all(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambWithNull() {
+        just1.ambWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void anyPredicateNull() {
+        just1.any(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferSupplierNull() {
+        just1.buffer(1, 1, (Supplier<List<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferSupplierReturnsNull() {
+        just1.buffer(1, 1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedUnitNull() {
+        just1.buffer(1L, 1L, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedSchedulerNull() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedSupplierNull() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedSupplierReturnsNull() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferOpenCloseOpenNull() {
+        just1.buffer(null, o -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferOpenCloseCloseNull() {
+        just1.buffer(just1, (Function<Integer, Publisher<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferOpenCloseCloseReturnsNull() {
+        just1.buffer(just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundaryNull() {
+        just1.buffer((Publisher<Object>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplierNull() {
+        just1.buffer(just1, (Supplier<List<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplierReturnsNull() {
+        just1.buffer(just1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2Null() {
+        just1.buffer((Supplier<Publisher<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2ReturnsNull() {
+        just1.buffer(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2SupplierNull() {
+        just1.buffer(() -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2SupplierReturnsNull() {
+        just1.buffer(() -> just1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void castNull() {
+        just1.cast(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectInitialSupplierNull() {
+        just1.collect((Supplier<Integer>)null, (a, b) -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectInitialSupplierReturnsNull() {
+        just1.collect(() -> null, (a, b) -> { }).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectInitialCollectorNull() {
+        just1.collect(() -> 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectIntoInitialNull() {
+        just1.collectInto(null, (a, b) -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectIntoCollectorNull() {
+        just1.collectInto(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void composeNull() {
+        just1.compose(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapNull() {
+        just1.concatMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapReturnsNull() {
+        just1.concatMap(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapIterableNull() {
+        just1.concatMapIterable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapIterableReturnNull() {
+        just1.concatMapIterable(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapIterableIteratorNull() {
+        just1.concatMapIterable(v -> () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatWithNull() {
+        just1.concatWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void containsNull() {
+        just1.contains(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceFunctionNull() {
+        just1.debounce(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceFunctionReturnsNull() {
+        just1.debounce(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceTimedUnitNull() {
+        just1.debounce(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceTimedSchedulerNull() {
+        just1.debounce(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void defaultIfEmptyNull() {
+        just1.defaultIfEmpty(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayWithFunctionNull() {
+        just1.delay(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayWithFunctionReturnsNull() {
+        just1.delay(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayTimedUnitNull() {
+        just1.delay(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayTimedSchedulerNull() {
+        just1.delay(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionTimedUnitNull() {
+        just1.delaySubscription(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionTimedSchedulerNull() {
+        just1.delaySubscription(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionFunctionNull() {
+        just1.delaySubscription(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothInitialSupplierNull() {
+        just1.delay(null, v -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothInitialSupplierReturnsNull() {
+        just1.delay(() -> null, v -> just1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothItemSupplierNull() {
+        just1.delay(() -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothItemSupplierReturnsNull() {
+        just1.delay(() -> just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctFunctionNull() {
+        just1.distinct(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctSupplierNull() {
+        just1.distinct(v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctSupplierReturnsNull() {
+        just1.distinct(v -> v, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctFunctionReturnsNull() {
+        just1.distinct(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctUntilChangedFunctionNull() {
+        just1.distinctUntilChanged(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctUntilChangedFunctionReturnsNull() {
+        just1.distinctUntilChanged(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnCancelNull() {
+        just1.doOnCancel(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnCompleteNull() {
+        just1.doOnComplete(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnEachSupplierNull() {
+        just1.doOnEach((Consumer<Try<Optional<Integer>>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnEachSubscriberNull() {
+        just1.doOnEach((Subscriber<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnErrorNull() {
+        just1.doOnError(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnLifecycleOnSubscribeNull() {
+        just1.doOnLifecycle(null, v -> { }, () -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnLifecycleOnRequestNull() {
+        just1.doOnLifecycle(s -> { }, null, () -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnLifecycleOnCancelNull() {
+        just1.doOnLifecycle(s -> { }, v -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnNextNull() {
+        just1.doOnNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnRequestNull() {
+        just1.doOnRequest(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnSubscribeNull() {
+        just1.doOnSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnTerminatedNull() {
+        just1.doOnTerminate(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void elementAtNull() {
+        just1.elementAt(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithIterableNull() {
+        just1.endWith((Iterable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithIterableIteratorNull() {
+        just1.endWith(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithIterableOneIsNull() {
+        just1.endWith(Arrays.asList(1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithPublisherNull() {
+        just1.endWith((Publisher<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithNull() {
+        just1.endWith((Integer)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithArrayNull() {
+        just1.endWithArray((Integer[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithArrayOneIsNull() {
+        just1.endWithArray(1, null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void filterNull() {
+        just1.filter(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void finallyDoNull() {
+        just1.finallyDo(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void firstNull() {
+        just1.first(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapNull() {
+        just1.flatMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapFunctionReturnsNull() {
+        just1.flatMap(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnNextNull() {
+        just1.flatMap(null, e -> just1, () -> just1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnNextReturnsNull() {
+        just1.flatMap(v -> null, e -> just1, () -> just1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnErrorNull() {
+        just1.flatMap(v -> just1, null, () -> just1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnErrorReturnsNull() {
+        Observable.error(new TestException()).flatMap(v -> just1, e -> null, () -> just1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnCompleteNull() {
+        just1.flatMap(v -> just1, e -> just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnCompleteReturnsNull() {
+        just1.flatMap(v -> just1, e -> just1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerMapperNull() {
+        just1.flatMap(null, (a, b) -> 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerMapperReturnsNull() {
+        just1.flatMap(v -> null, (a, b) -> 1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerCombinerNull() {
+        just1.flatMap(v -> just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerCombinerReturnsNull() {
+        just1.flatMap(v -> just1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperNull() {
+        just1.flatMapIterable(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperReturnsNull() {
+        just1.flatMapIterable(v -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperIteratorNull() {
+        just1.flatMapIterable(v -> () -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperIterableOneNull() {
+        just1.flatMapIterable(v -> Arrays.asList(1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableCombinerNull() {
+        just1.flatMapIterable(v -> Arrays.asList(1), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableCombinerReturnsNull() {
+        just1.flatMapIterable(v -> Arrays.asList(1), (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachNull() {
+        just1.forEach(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachWhileNull() {
+        just1.forEachWhile(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachWhileOnErrorNull() {
+        just1.forEachWhile(v -> true, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachWhileOnCompleteNull() {
+        just1.forEachWhile(v -> true, e-> { }, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void groupByNull() {
+        just1.groupBy(null);
+    }
+    
+    public void groupByKeyNull() {
+        just1.groupBy(v -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void groupByValueNull() {
+        just1.groupBy(v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void groupByValueReturnsNull() {
+        just1.groupBy(v -> v, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void lastNull() {
+        just1.last(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void liftNull() {
+        just1.lift(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void liftReturnsNull() {
+        just1.lift(s -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mapNull() {
+        just1.map(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mapReturnsNull() {
+        just1.map(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeWithNull() {
+        just1.mergeWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void observeOnNull() {
+        just1.observeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ofTypeNull() {
+        just1.ofType(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onBackpressureBufferOverflowNull() {
+        just1.onBackpressureBuffer(10, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onBackpressureDropActionNull() {
+        just1.onBackpressureDrop(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFunctionNull() {
+        just1.onErrorResumeNext((Function<Throwable, Publisher<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFunctionReturnsNull() {
+        Observable.error(new TestException()).onErrorResumeNext(e -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextPublisherNull() {
+        just1.onErrorResumeNext((Publisher<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnFunctionNull() {
+        just1.onErrorReturn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnValueNull() {
+        just1.onErrorReturnValue(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnFunctionReturnsNull() {
+        Observable.error(new TestException()).onErrorReturn(e -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onExceptionResumeNext() {
+        just1.onExceptionResumeNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void publishFunctionNull() {
+        just1.publish(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void publishFunctionReturnsNull() {
+        just1.publish(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceFunctionNull() {
+        just1.reduce(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceFunctionReturnsNull() {
+        Observable.just(1, 1).reduce((a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceSeedNull() {
+        just1.reduce(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceSeedFunctionNull() {
+        just1.reduce(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceSeedFunctionReturnsNull() {
+        just1.reduce(1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceWithSeedNull() {
+        just1.reduceWith(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceWithSeedReturnsNull() {
+        just1.reduceWith(() -> null, (a, b) -> 1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatUntilNull() {
+        just1.repeatUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatWhenNull() {
+        just1.repeatWhen(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatWhenFunctionReturnsNull() {
+        just1.repeatWhen(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorNull() {
+        just1.replay((Function<Observable<Integer>, Observable<Integer>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorReturnsNull() {
+        just1.replay(o -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedSelectorNull() {
+        just1.replay((Function<Observable<Integer>, Observable<Integer>>)null, 1, 1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedSelectorReturnsNull() {
+        just1.replay(v -> null, 1, 1, TimeUnit.SECONDS).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySchedulerNull() {
+        just1.replay((Scheduler)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedUnitNull() {
+        just1.replay(v -> v, 1, 1, null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedSchedulerNull() {
+        just1.replay(v -> v, 1, 1, TimeUnit.SECONDS, null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedSelectorNull() {
+        just1.replay(null, 1, TimeUnit.SECONDS, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedSelectorReturnsNull() {
+        just1.replay(v -> null, 1, TimeUnit.SECONDS, Schedulers.single()).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorTimeBoundedUnitNull() {
+        just1.replay(v -> v, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorTimeBoundedSchedulerNull() {
+        just1.replay(v -> v, 1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeSizeBoundedUnitNull() {
+        just1.replay(1, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeSizeBoundedSchedulerNull() {
+        just1.replay(1, 1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayBufferSchedulerNull() {
+        just1.replay(1, (Scheduler)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedUnitNull() {
+        just1.replay(1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedSchedulerNull() {
+        just1.replay(1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void retryFunctionNull() {
+        just1.retry((BiPredicate<Integer, Throwable>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void retryCountFunctionNull() {
+        just1.retry(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryPredicateNull() {
+        just1.retry((Predicate<Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryWhenFunctionNull() {
+        just1.retryWhen(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryWhenFunctionReturnsNull() {
+        Observable.error(new TestException()).retryWhen(f -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryUntil() {
+        just1.retryUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void safeSubscribeNull() {
+        just1.safeSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sampleUnitNull() {
+        just1.sample(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sampleSchedulerNull() {
+        just1.sample(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void samplePublisherNull() {
+        just1.sample(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanFunctionNull() {
+        just1.scan(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanFunctionReturnsNull() {
+        Observable.just(1, 1).scan((a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedNull() {
+        just1.scan(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedFunctionNull() {
+        just1.scan(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedFunctionReturnsNull() {
+        just1.scan(1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierNull() {
+        just1.scanWith(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierReturnsNull() {
+        just1.scanWith(() -> null, (a, b) -> 1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierFunctionNull() {
+        just1.scanWith(() -> 1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierFunctionReturnsNull() {
+        just1.scanWith(() -> 1, (a, b) -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void singleNull() {
+        just1.single(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipTimedUnitNull() {
+        just1.skip(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipTimedSchedulerNull() {
+        just1.skip(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipLastTimedUnitNull() {
+        just1.skipLast(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipLastTimedSchedulerNull() {
+        just1.skipLast(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipUntilNull() {
+        just1.skipUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipWhileNull() {
+        just1.skipWhile(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithIterableNull() {
+        just1.startWith((Iterable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithIterableIteratorNull() {
+        just1.startWith(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithIterableOneNull() {
+        just1.startWith(Arrays.asList(1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithSingleNull() {
+        just1.startWith((Integer)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithPublisherNull() {
+        just1.startWith((Publisher<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithArrayNull() {
+        just1.startWithArray((Integer[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithArrayOneNull() {
+        just1.startWithArray(1, null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnNextNull() {
+        just1.subscribe((Consumer<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnErrorNull() {
+        just1.subscribe(e -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnCompleteNull() {
+        just1.subscribe(e -> { }, e -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnSubscribeNull() {
+        just1.subscribe(e -> { }, e -> { }, () -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeNull() {
+        just1.subscribe((Subscriber<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnNull() {
+        just1.subscribeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchIfEmptyNull() {
+        just1.switchIfEmpty(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchMapNull() {
+        just1.switchMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchMapFunctionReturnsNull() {
+        just1.switchMap(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeTimedUnitNull() {
+        just1.take(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeTimedSchedulerNull() {
+        just1.take(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeFirstNull() {
+        just1.takeFirst(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeLastTimedUnitNull() {
+        just1.takeLast(1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastSizeTimedUnitNull() {
+        just1.takeLast(1, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastTimedSchedulerNull() {
+        just1.takeLast(1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastSizeTimedSchedulerNull() {
+        just1.takeLast(1, 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferTimedUnitNull() {
+        just1.takeLastBuffer(1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferTimedSchedulerNull() {
+        just1.takeLastBuffer(1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferSizeTimedUnitNull() {
+        just1.takeLastBuffer(1, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferSizeTimedSchedulerNull() {
+        just1.takeLastBuffer(1, 1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeUntilPredicateNull() {
+        just1.takeUntil((Predicate<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeUntilPublisherNull() {
+        just1.takeUntil((Publisher<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeWhileNull() {
+        just1.takeWhile(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleFirstUnitNull() {
+        just1.throttleFirst(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleFirstSchedulerNull() {
+        just1.throttleFirst(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleLastUnitNull() {
+        just1.throttleLast(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleLastSchedulerNull() {
+        just1.throttleLast(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleWithTimeoutUnitNull() {
+        just1.throttleWithTimeout(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleWithTimeoutSchedulerNull() {
+        just1.throttleWithTimeout(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeIntervalUnitNull() {
+        just1.timeInterval(null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeIntervalSchedulerNull() {
+        just1.timeInterval(TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSelectorNull() {
+        just1.timeout(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSelectorReturnsNull() {
+        just1.timeout(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSelectorOtherNull() {
+        just1.timeout(v -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutUnitNull() {
+        just1.timeout(1, null, just1, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void timeouOtherNull() {
+        just1.timeout(1, TimeUnit.SECONDS, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void timeouSchedulerNull() {
+        just1.timeout(1, TimeUnit.SECONDS, just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstNull() {
+        just1.timeout((Supplier<Publisher<Integer>>)null, v -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstReturnsNull() {
+        just1.timeout(() -> null, v -> just1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstItemNull() {
+        just1.timeout(() -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstItemReturnsNull() {
+        just1.timeout(() -> just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timestampUnitNull() {
+        just1.timestamp(null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timestampSchedulerNull() {
+        just1.timestamp(TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toNull() {
+        just1.to(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toListNull() {
+        just1.toList(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toListSupplierReturnsNull() {
+        just1.toList(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toSortedListNull() {
+        just1.toSortedList(null);
+    }
+    
+    @Test
+    public void toMapKeyNullAllowed() {
+        just1.toMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMapValueNull() {
+        just1.toMap(v -> v, null);
+    }
+    
+    @Test
+    public void toMapValueSelectorReturnsNull() {
+        just1.toMap(v -> v, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMapMapSupplierNull() {
+        just1.toMap(v -> v, v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMapMapSupplierReturnsNull() {
+        just1.toMap(v -> v, v -> v, () -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toMultimapKeyNull() {
+        just1.toMultimap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapValueNull() {
+        just1.toMultimap(v -> v, null);
+    }
+    
+    @Test
+    public void toMultiMapValueSelectorReturnsNullAllowed() {
+        just1.toMap(v -> v, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapMapSupplierNull() {
+        just1.toMultimap(v -> v, v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapSupplierReturnsNull() {
+        just1.toMultimap(v -> v, v -> v, () -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapMapCollectionSupplierNull() {
+        just1.toMultimap(v -> v, v -> v, () -> new HashMap<>(), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapCollectionSupplierReturnsNull() {
+        just1.toMultimap(v -> v, v -> v, () -> new HashMap<>(), v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsafeSubscribeNull() {
+        just1.unsafeSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsubscribeOnNull() {
+        just1.unsubscribeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowTimedUnitNull() {
+        just1.window(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowSizeTimedUnitNull() {
+        just1.window(1, null, Schedulers.single(), 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void windowTimedSchedulerNull() {
+        just1.window(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowSizeTimedSchedulerNull() {
+        just1.window(1, TimeUnit.SECONDS, null, 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowBoundaryNull() {
+        just1.window((Publisher<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowOpenCloseOpenNull() {
+        just1.window(null, v -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowOpenCloseCloseNull() {
+        just1.window(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowOpenCloseCloseReturnsNull() {
+        Observable.never().window(just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowBoundarySupplierNull() {
+        just1.window((Supplier<Publisher<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowBoundarySupplierReturnsNull() {
+        just1.window(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void withLatestFromOtherNull() {
+        just1.withLatestFrom(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void withLatestFromCombinerNull() {
+        just1.withLatestFrom(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void withLatestFromCombinerReturnsNull() {
+        just1.withLatestFrom(just1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableNull() {
+        just1.zipWith((Iterable<Integer>)null, (a, b) -> 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableCombinerNull() {
+        just1.zipWith(Arrays.asList(1), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableCombinerReturnsNull() {
+        just1.zipWith(Arrays.asList(1), (a, b) -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableIteratorNull() {
+        just1.zipWith(() -> null, (a, b) -> 1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableOneIsNull() {
+        Observable.just(1, 2).zipWith(Arrays.asList(1, null), (a, b) -> 1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithPublisherNull() {
+        just1.zipWith((Publisher<Integer>)null, (a, b) -> 1);
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithCombinerNull() {
+        just1.zipWith(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithCombinerReturnsNull() {
+        just1.zipWith(just1, (a, b) -> null).toBlocking().run();
+    }
+
+    //*********************************************
+    // Subject null tests
+    //*********************************************
+    
+    @Test(expected = NullPointerException.class)
+    public void asyncSubjectOnNextNull() {
+        Subject<Integer, Integer> subject = AsyncSubject.create();
+        subject.onNext(null);
+        subject.toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void asyncSubjectOnErrorNull() {
+        Subject<Integer, Integer> subject = AsyncSubject.create();
+        subject.onError(null);
+        subject.toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void behaviorSubjectOnNextNull() {
+        Subject<Integer, Integer> subject = BehaviorSubject.create();
+        subject.onNext(null);
+        subject.toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void behaviorSubjectOnErrorNull() {
+        Subject<Integer, Integer> subject = BehaviorSubject.create();
+        subject.onError(null);
+        subject.toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void publishSubjectOnNextNull() {
+        Subject<Integer, Integer> subject = PublishSubject.create();
+        subject.onNext(null);
+        subject.toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void publishSubjectOnErrorNull() {
+        Subject<Integer, Integer> subject = PublishSubject.create();
+        subject.onError(null);
+        subject.toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaycSubjectOnNextNull() {
+        Subject<Integer, Integer> subject = ReplaySubject.create();
+        subject.onNext(null);
+        subject.toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replaySubjectOnErrorNull() {
+        Subject<Integer, Integer> subject = ReplaySubject.create();
+        subject.onError(null);
+        subject.toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void serializedcSubjectOnNextNull() {
+        Subject<Integer, Integer> subject = PublishSubject.<Integer>create().toSerialized();
+        subject.onNext(null);
+        subject.toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void serializedSubjectOnErrorNull() {
+        Subject<Integer, Integer> subject = PublishSubject.<Integer>create().toSerialized();
+        subject.onError(null);
+        subject.toBlocking().run();
+    }
+
+}

--- a/src/test/java/io/reactivex/SingleNullTests.java
+++ b/src/test/java/io/reactivex/SingleNullTests.java
@@ -1,0 +1,654 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.lang.reflect.*;
+import java.util.Arrays;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+import org.junit.*;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Single.SingleSubscriber;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.Schedulers;
+
+public class SingleNullTests {
+
+    Single<Integer> just1 = Single.just(1);
+    
+    Single<Integer> error = Single.error(new TestException());
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableNull() {
+        Single.amb((Iterable<Single<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableIteratorNull() {
+        Single.amb(() -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableOneIsNull() {
+        Single.amb(Arrays.asList(null, just1)).get();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void ambArrayNull() {
+        Single.amb((Single<Integer>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambArrayOneIsNull() {
+        Single.amb(null, just1).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableNull() {
+        Single.concat((Iterable<Single<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableIteratorNull() {
+        Single.concat(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableOneIsNull() {
+        Single.concat(Arrays.asList(just1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatObservableNull() {
+        Single.concat((Observable<Single<Integer>>)null);
+    }
+    
+    @Test
+    public void concatNull() throws Exception {
+        @SuppressWarnings("rawtypes")
+        Class<Single> clazz = Single.class;
+        for (int argCount = 2; argCount < 10; argCount++) {
+            for (int argNull = 1; argNull <= argCount; argNull++) {
+                Class<?>[] params = new Class[argCount];
+                Arrays.fill(params, Single.class);
+
+                Object[] values = new Object[argCount];
+                Arrays.fill(values, just1);
+                values[argNull - 1] = null;
+                
+                Method m = clazz.getMethod("concat", params);
+                
+                try {
+                    m.invoke(null, values);
+                    Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
+                } catch (InvocationTargetException ex) {
+                    if (!(ex.getCause() instanceof NullPointerException)) {
+                        Assert.fail("Unexpected exception for argCount " + argCount + " / argNull " + argNull + ": " + ex);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNull() {
+        Single.create(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void deferNull() {
+        Single.defer(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void deferReturnsNull() {
+        Single.defer(() -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorSupplierNull() {
+        Single.error((Supplier<Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorSupplierReturnsNull() {
+        Single.error(() -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorNull() {
+        Single.error((Throwable)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromCallableNull() {
+        Single.fromCallable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromCallableReturnsNull() {
+        Single.fromCallable(() -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureNull() {
+        Single.fromFuture((CompletableFuture<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureReturnsNull() {
+        CompletableFuture<Object> f = CompletableFuture.completedFuture(null);
+        Single.fromFuture(f).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedFutureNull() {
+        Single.fromFuture(null, 1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedUnitNull() {
+        Single.fromFuture(new CompletableFuture<>(), 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedSchedulerNull() {
+        Single.fromFuture(new CompletableFuture<>(), 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedReturnsNull() {
+        CompletableFuture<Object> f = CompletableFuture.completedFuture(null);
+        Single.fromFuture(f, 1, TimeUnit.SECONDS).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureSchedulerNull() {
+        Single.fromFuture(new CompletableFuture<>(), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void fromPublisherNull() {
+        Single.fromPublisher(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void justNull() {
+        Single.just(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableNull() {
+        Single.merge((Iterable<Single<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableIteratorNull() {
+        Single.merge(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableOneIsNull() {
+        Single.merge(Arrays.asList(null, just1)).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeSingleNull() {
+        Single.merge((Single<Single<Integer>>)null);
+    }
+
+    @Test
+    public void mergeNull() throws Exception {
+        @SuppressWarnings("rawtypes")
+        Class<Single> clazz = Single.class;
+        for (int argCount = 2; argCount < 10; argCount++) {
+            for (int argNull = 1; argNull <= argCount; argNull++) {
+                Class<?>[] params = new Class[argCount];
+                Arrays.fill(params, Single.class);
+
+                Object[] values = new Object[argCount];
+                Arrays.fill(values, just1);
+                values[argNull - 1] = null;
+                
+                Method m = clazz.getMethod("merge", params);
+                
+                try {
+                    m.invoke(null, values);
+                    Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
+                } catch (InvocationTargetException ex) {
+                    if (!(ex.getCause() instanceof NullPointerException)) {
+                        Assert.fail("Unexpected exception for argCount " + argCount + " / argNull " + argNull + ": " + ex);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void timerUnitNull() {
+        Single.timer(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timerSchedulerNull() {
+        Single.timer(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void equalsFirstNull() {
+        Single.equals(null, just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void equalsSecondNull() {
+        Single.equals(just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void usingResourceSupplierNull() {
+        Single.using(null, d -> just1, d -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingSingleSupplierNull() {
+        Single.using(() -> 1, null, d -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingSingleSupplierReturnsNull() {
+        Single.using(() -> 1, d -> null, d -> { }).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingDisposeNull() {
+        Single.using(() -> 1, d -> just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterableNull() {
+        Single.zip((Iterable<Single<Integer>>)null, v -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableIteratorNull() {
+        Single.zip(() -> null, v -> 1).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableOneIsNull() {
+        Single.zip(Arrays.asList(null, just1), v -> 1).get();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterableOneFunctionNull() {
+        Single.zip(Arrays.asList(just1, just1), null).get();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterableOneFunctionReturnsNull() {
+        Single.zip(Arrays.asList(just1, just1), v -> null).get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void zipNull() throws Exception {
+        @SuppressWarnings("rawtypes")
+        Class<Single> clazz = Single.class;
+        for (int argCount = 3; argCount < 10; argCount++) {
+            for (int argNull = 1; argNull <= argCount; argNull++) {
+                Class<?>[] params = new Class[argCount + 1];
+                Arrays.fill(params, Single.class);
+                Class<?> fniClass = Class.forName("io.reactivex.functions.Function" + argCount);
+                params[argCount] = fniClass;
+
+                Object[] values = new Object[argCount + 1];
+                Arrays.fill(values, just1);
+                values[argNull - 1] = null;
+                values[argCount] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { fniClass }, (o, m, a) -> 1);
+                
+                Method m = clazz.getMethod("zip", params);
+                
+                try {
+                    m.invoke(null, values);
+                    Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
+                } catch (InvocationTargetException ex) {
+                    if (!(ex.getCause() instanceof NullPointerException)) {
+                        Assert.fail("Unexpected exception for argCount " + argCount + " / argNull " + argNull + ": " + ex);
+                    }
+                }
+
+                values[argCount] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { fniClass }, (o, m1, a) -> null);
+                try {
+                    ((Single<Object>)m.invoke(null, values)).get();
+                    Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
+                } catch (InvocationTargetException ex) {
+                    if (!(ex.getCause() instanceof NullPointerException)) {
+                        Assert.fail("Unexpected exception for argCount " + argCount + " / argNull " + argNull + ": " + ex);
+                    }
+                }
+
+            }
+            
+            Class<?>[] params = new Class[argCount + 1];
+            Arrays.fill(params, Single.class);
+            Class<?> fniClass = Class.forName("io.reactivex.functions.Function" + argCount);
+            params[argCount] = fniClass;
+
+            Object[] values = new Object[argCount + 1];
+            Arrays.fill(values, just1);
+            values[argCount] = null;
+            
+            Method m = clazz.getMethod("zip", params);
+            
+            try {
+                m.invoke(null, values);
+                Assert.fail("No exception for argCount " + argCount + " / zipper function ");
+            } catch (InvocationTargetException ex) {
+                if (!(ex.getCause() instanceof NullPointerException)) {
+                    Assert.fail("Unexpected exception for argCount " + argCount + " / zipper function: " + ex);
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zip2FirstNull() {
+        Single.zip(null, just1, (a, b) -> 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zip2SecondNull() {
+        Single.zip(just1, null, (a, b) -> 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zip2ZipperNull() {
+        Single.zip(just1, just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zip2ZipperReturnsdNull() {
+        Single.zip(just1, null, (a, b) -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipArrayNull() {
+        Single.zipArray(v -> 1, (Single<Integer>[])null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipArrayOneIsNull() {
+        Single.zipArray(v -> 1, just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipArrayFunctionNull() {
+        Single.zipArray(null, just1, just1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipArrayFunctionReturnsNull() {
+        Single.zipArray(v -> null, just1, just1).get();
+    }
+
+    //**************************************************
+    // Instance methods
+    //**************************************************
+
+    @Test(expected = NullPointerException.class)
+    public void ambWithNull() {
+        just1.ambWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void composeNull() {
+        just1.compose(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void castNull() {
+        just1.cast(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatWith() {
+        just1.concatWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayUnitNull() {
+        just1.delay(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySchedulerNull() {
+        just1.delay(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnSubscribeNull() {
+        just1.doOnSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnSuccess() {
+        just1.doOnSuccess(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnError() {
+        error.doOnError(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnCancelNull() {
+        just1.doOnCancel(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapNull() {
+        just1.flatMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapFunctionReturnsNull() {
+        just1.flatMap(v -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapPublisherNull() {
+        just1.flatMapPublisher(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapPublisherFunctionReturnsNull() {
+        just1.flatMapPublisher(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void liftNull() {
+        just1.lift(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void liftFunctionReturnsNull() {
+        just1.lift(s -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void containsNull() {
+        just1.contains(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void containsComparerNull() {
+        just1.contains(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeWithNull() {
+        just1.mergeWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void observeOnNull() {
+        just1.observeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnSupplierNull() {
+        just1.onErrorReturn((Supplier<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnsSupplierReturnsNull() {
+        error.onErrorReturn(() -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnValueNull() {
+        error.onErrorReturn((Integer)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextNull() {
+        error.onErrorResumeNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFunctionReturnsNull() {
+        error.onErrorResumeNext(e -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatWhenNull() {
+        error.repeatWhen(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatWhenFunctionReturnsNull() {
+        error.repeatWhen(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatUntilNull() {
+        error.repeatUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryBiPreducateNull() {
+        error.retry((BiPredicate<Integer, Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryPredicateNull() {
+        error.retry((Predicate<Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryWhenNull() {
+        error.retryWhen(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryWhenFunctionReturnsNull() {
+        error.retryWhen(e -> null).get();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void safeSubscribeNull() {
+        just1.safeSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeBiConsumerNull() {
+        just1.subscribe((BiConsumer<Integer, Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeConsumerNull() {
+        just1.subscribe((Consumer<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeSingeSubscriberNull() {
+        just1.subscribe((SingleSubscriber<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnSuccessNull() {
+        just1.subscribe(null, e -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnErrorNull() {
+        just1.subscribe(v -> { }, null);
+    }
+    @Test(expected = NullPointerException.class)
+    public void subscribeSubscriberNull() {
+        just1.subscribe((Subscriber<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnNull() {
+        just1.subscribeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutUnitNull() {
+        just1.timeout(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSchedulerNull() {
+        just1.timeout(1, TimeUnit.SECONDS, (Scheduler)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutOtherNull() {
+        just1.timeout(1, TimeUnit.SECONDS, Schedulers.single(), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void timeoutOther2Null() {
+        just1.timeout(1, TimeUnit.SECONDS, (Single<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toNull() {
+        just1.to(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsafeSubscribeNull() {
+        just1.unsafeSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithNull() {
+        just1.zipWith(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithFunctionNull() {
+        just1.zipWith(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithFunctionReturnsNull() {
+        just1.zipWith(just1, (a, b) -> null).get();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorDelayTest.java
@@ -791,4 +791,67 @@ public class OperatorDelayTest {
         ts.assertError(TestException.class);
         ts.assertNotComplete();
     }
+    public void testDelaySupplierSimple() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable<Integer> source = Observable.range(1, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ps.onNext(1);
+        
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testDelaySupplierCompletes() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable<Integer> source = Observable.range(1, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        // FIXME should this complete the source instead of consuming it?
+        ps.onComplete();
+        
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testDelaySupplierErrors() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable<Integer> source = Observable.range(1, 5);
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ps.onError(new TestException());
+        
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(TestException.class);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/nbp/NbpOperatorDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/nbp/NbpOperatorDelayTest.java
@@ -791,4 +791,68 @@ public class NbpOperatorDelayTest {
         ts.assertError(TestException.class);
         ts.assertNotComplete();
     }
+    
+    public void testDelaySupplierSimple() {
+        NbpPublishSubject<Integer> ps = NbpPublishSubject.create();
+        
+        NbpObservable<Integer> source = NbpObservable.range(1, 5);
+        
+        NbpTestSubscriber<Integer> ts = new NbpTestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ps.onNext(1);
+        
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testDelaySupplierCompletes() {
+        NbpPublishSubject<Integer> ps = NbpPublishSubject.create();
+        
+        NbpObservable<Integer> source = NbpObservable.range(1, 5);
+        
+        NbpTestSubscriber<Integer> ts = new NbpTestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        // FIXME should this complete the source instead of consuming it?
+        ps.onComplete();
+        
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testDelaySupplierErrors() {
+        NbpPublishSubject<Integer> ps = NbpPublishSubject.create();
+        
+        NbpObservable<Integer> source = NbpObservable.range(1, 5);
+        
+        NbpTestSubscriber<Integer> ts = new NbpTestSubscriber<>();
+        
+        source.delaySubscription(() -> ps).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ps.onError(new TestException());
+        
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(TestException.class);
+    }
+
 }

--- a/src/test/java/io/reactivex/nbp/NbpObservableNullTests.java
+++ b/src/test/java/io/reactivex/nbp/NbpObservableNullTests.java
@@ -1,0 +1,1818 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.nbp;
+
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+import org.junit.*;
+
+import io.reactivex.*;
+import io.reactivex.NbpObservable.NbpSubscriber;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.nbp.NbpTestSubscriber;
+
+/**
+ * Verifies the operators handle null values properly by emitting/throwing NullPointerExceptions
+ */
+public class NbpObservableNullTests {
+
+    NbpObservable<Integer> just1 = NbpObservable.just(1);
+    
+    //***********************************************************
+    // Static methods
+    //***********************************************************
+    
+    @Test(expected = NullPointerException.class)
+    public void ambVarargsNull() {
+        NbpObservable.amb((NbpObservable<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambVarargsOneIsNull() {
+        NbpObservable.amb(NbpObservable.never(), null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableNull() {
+        NbpObservable.amb((Iterable<NbpObservable<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableIteratorNull() {
+        NbpObservable.amb(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambIterableOneIsNull() {
+        NbpObservable.amb(Arrays.asList(NbpObservable.never(), null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsNull() {
+        NbpObservable.combineLatest(v -> 1, true, 128, (NbpObservable<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsOneIsNull() {
+        NbpObservable.combineLatest(v -> 1, true, 128, NbpObservable.never(), null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableNull() {
+        NbpObservable.combineLatest((Iterable<NbpObservable<Object>>)null, v -> 1, true, 128);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableIteratorNull() {
+        NbpObservable.combineLatest(() -> null, v -> 1, true, 128).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableOneIsNull() {
+        NbpObservable.combineLatest(Arrays.asList(NbpObservable.never(), null), v -> 1, true, 128).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsFunctionNull() {
+        NbpObservable.combineLatest(null, true, 128, NbpObservable.never());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestVarargsFunctionReturnsNull() {
+        NbpObservable.combineLatest(v -> null, true, 128, just1).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableFunctionNull() {
+        NbpObservable.combineLatest(Arrays.asList(just1), null, true, 128);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestIterableFunctionReturnsNull() {
+        NbpObservable.combineLatest(Arrays.asList(just1), v -> null, true, 128).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableNull() {
+        NbpObservable.concat((Iterable<NbpObservable<Object>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concatIterableIteratorNull() {
+        NbpObservable.concat(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatIterableOneIsNull() {
+        NbpObservable.concat(Arrays.asList(just1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatNbpObservableNull() {
+        NbpObservable.concat((NbpObservable<NbpObservable<Object>>)null);
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concatArrayNull() {
+        NbpObservable.concatArray((NbpObservable<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatArrayOneIsNull() {
+        NbpObservable.concatArray(just1, null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void createNull() {
+        NbpObservable.create(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void deferFunctionNull() {
+        NbpObservable.defer(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void deferFunctionReturnsNull() {
+        NbpObservable.defer(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorFunctionNull() {
+        NbpObservable.error((Supplier<Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorFunctionReturnsNull() {
+        NbpObservable.error(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void errorThrowableNull() {
+        NbpObservable.error((Throwable)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromArrayNull() {
+        NbpObservable.fromArray((Object[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromArrayOneIsNull() {
+        NbpObservable.fromArray(1, null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromCallableNull() {
+        NbpObservable.fromCallable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromCallableReturnsNull() {
+        NbpObservable.fromCallable(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureNull() {
+        NbpObservable.fromFuture(null);
+    }
+    
+    @Test
+    public void fromFutureReturnsNull() {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        NbpTestSubscriber<Object> ts = new NbpTestSubscriber<>();
+        NbpObservable.fromFuture(f).subscribe(ts);
+        f.complete(null);
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(NullPointerException.class);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedFutureNull() {
+        NbpObservable.fromFuture(null, 1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedUnitNull() {
+        NbpObservable.fromFuture(new CompletableFuture<>(), 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedSchedulerNull() {
+        NbpObservable.fromFuture(new CompletableFuture<>(), 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureTimedReturnsNull() {
+        CompletableFuture<Object> f = CompletableFuture.completedFuture(null);
+        NbpObservable.fromFuture(f, 1, TimeUnit.SECONDS).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromFutureSchedulerNull() {
+        NbpObservable.fromFuture(new CompletableFuture<>(), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromIterableNull() {
+        NbpObservable.fromIterable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromIterableIteratorNull() {
+        NbpObservable.fromIterable(() -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromIterableValueNull() {
+        NbpObservable.fromIterable(Arrays.asList(1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromStreamNull() {
+        NbpObservable.fromStream(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void fromStreamOneIsNull() {
+        NbpObservable.fromStream(Arrays.asList(1, null).stream()).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateConsumerNull() {
+        NbpObservable.generate(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateConsumerEmitsNull() {
+        NbpObservable.generate(s -> s.onNext(null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateStateConsumerInitialStateNull() {
+        NbpObservable.generate(null, (BiConsumer<Integer, NbpSubscriber<Integer>>)(s, o) -> o.onNext(1));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void generateStateFunctionInitialStateNull() {
+        NbpObservable.generate(null, (s, o) -> { o.onNext(1); return s; });
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void generateStateConsumerNull() {
+        NbpObservable.generate(() -> 1, (BiConsumer<Integer, NbpSubscriber<Object>>)null);
+    }
+    
+    @Test
+    public void generateConsumerStateNullAllowed() {
+        NbpObservable.generate(() -> null, (BiConsumer<Integer, NbpSubscriber<Integer>>)(s, o) -> o.onComplete()).toBlocking().lastOption();
+    }
+
+    @Test
+    public void generateFunctionStateNullAllowed() {
+        NbpObservable.generate(() -> null, (s, o) -> { o.onComplete(); return s; }).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateConsumerDisposeNull() {
+        NbpObservable.generate(() -> 1, (BiConsumer<Integer, NbpSubscriber<Integer>>)(s, o) -> o.onNext(1), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void generateFunctionDisposeNull() {
+        NbpObservable.generate(() -> 1, (s, o) -> { o.onNext(1); return s; }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalUnitNull() {
+        NbpObservable.interval(1, null);
+    }
+    
+    public void intervalSchedulerNull() {
+        NbpObservable.interval(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalPeriodUnitNull() {
+        NbpObservable.interval(1, 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalPeriodSchedulerNull() {
+        NbpObservable.interval(1, 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalRangeUnitNull() {
+        NbpObservable.intervalRange(1,1, 1, 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void intervalRangeSchedulerNull() {
+        NbpObservable.intervalRange(1, 1, 1, 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test
+    public void justNull() throws Exception {
+        @SuppressWarnings("rawtypes")
+        Class<NbpObservable> clazz = NbpObservable.class;
+        for (int argCount = 1; argCount < 10; argCount++) {
+            for (int argNull = 1; argNull <= argCount; argNull++) {
+                Class<?>[] params = new Class[argCount];
+                Arrays.fill(params, Object.class);
+
+                Object[] values = new Object[argCount];
+                Arrays.fill(values, 1);
+                values[argNull - 1] = null;
+                
+                Method m = clazz.getMethod("just", params);
+                
+                try {
+                    m.invoke(null, values);
+                    Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
+                } catch (InvocationTargetException ex) {
+                    if (!(ex.getCause() instanceof NullPointerException)) {
+                        Assert.fail("Unexpected exception for argCount " + argCount + " / argNull " + argNull + ": " + ex);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableNull() {
+        NbpObservable.merge(128, 128, (Iterable<NbpObservable<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableIteratorNull() {
+        NbpObservable.merge(128, 128, () -> null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeIterableOneIsNull() {
+        NbpObservable.merge(128, 128, Arrays.asList(just1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeArrayNull() {
+        NbpObservable.merge(128, 128, (NbpObservable<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeArrayOneIsNull() {
+        NbpObservable.merge(128, 128, just1, null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorIterableNull() {
+        NbpObservable.mergeDelayError(128, 128, (Iterable<NbpObservable<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorIterableIteratorNull() {
+        NbpObservable.mergeDelayError(128, 128, () -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorIterableOneIsNull() {
+        NbpObservable.mergeDelayError(128, 128, Arrays.asList(just1, null)).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorArrayNull() {
+        NbpObservable.mergeDelayError(128, 128, (NbpObservable<Object>[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeDelayErrorArrayOneIsNull() {
+        NbpObservable.mergeDelayError(128, 128, just1, null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sequenceEqualFirstNull() {
+        NbpObservable.sequenceEqual(null, just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sequenceEqualSecondNull() {
+        NbpObservable.sequenceEqual(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sequenceEqualComparatorNull() {
+        NbpObservable.sequenceEqual(just1, just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchOnNextNull() {
+        NbpObservable.switchOnNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timerUnitNull() {
+        NbpObservable.timer(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timerSchedulerNull() {
+        NbpObservable.timer(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingResourceSupplierNull() {
+        NbpObservable.using(null, d -> just1, d -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingNbpObservableSupplierNull() {
+        NbpObservable.using(() -> 1, null, d -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingNbpObservableSupplierReturnsNull() {
+        NbpObservable.using(() -> 1, d -> null, d -> { }).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void usingDisposeNull() {
+        NbpObservable.using(() -> 1, d -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableNull() {
+        NbpObservable.zip((Iterable<NbpObservable<Object>>)null, v -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableIteratorNull() {
+        NbpObservable.zip(() -> null, v -> 1).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableFunctionNull() {
+        NbpObservable.zip(Arrays.asList(just1, just1), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterableFunctionReturnsNull() {
+        NbpObservable.zip(Arrays.asList(just1, just1), a -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipNbpObservableNull() {
+        NbpObservable.zip((NbpObservable<NbpObservable<Object>>)null, a -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipNbpObservableFunctionNull() {
+        NbpObservable.zip((NbpObservable.just(just1)), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipNbpObservableFunctionReturnsNull() {
+        NbpObservable.zip((NbpObservable.just(just1)), a -> null).toBlocking().lastOption();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2Null() {
+        NbpObservable.zipIterable(a -> 1, true, 128, (Iterable<NbpObservable<Object>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2IteratorNull() {
+        NbpObservable.zipIterable(a -> 1, true, 128, () -> null).toBlocking().lastOption();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2FunctionNull() {
+        NbpObservable.zipIterable(null, true, 128, Arrays.asList(just1, just1));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipIterable2FunctionReturnsNull() {
+        NbpObservable.zipIterable(a -> null, true, 128, Arrays.asList(just1, just1)).toBlocking().lastOption();
+    }
+
+    //*************************************************************
+    // Instance methods
+    //*************************************************************
+
+    @Test(expected = NullPointerException.class)
+    public void allPredicateNull() {
+        just1.all(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ambWithNull() {
+        just1.ambWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void anyPredicateNull() {
+        just1.any(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferSupplierNull() {
+        just1.buffer(1, 1, (Supplier<List<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferSupplierReturnsNull() {
+        just1.buffer(1, 1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedUnitNull() {
+        just1.buffer(1L, 1L, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedSchedulerNull() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedSupplierNull() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferTimedSupplierReturnsNull() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferOpenCloseOpenNull() {
+        just1.buffer(null, o -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferOpenCloseCloseNull() {
+        just1.buffer(just1, (Function<Integer, NbpObservable<Object>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferOpenCloseCloseReturnsNull() {
+        just1.buffer(just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundaryNull() {
+        just1.buffer((NbpObservable<Object>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplierNull() {
+        just1.buffer(just1, (Supplier<List<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplierReturnsNull() {
+        just1.buffer(just1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2Null() {
+        just1.buffer((Supplier<NbpObservable<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2ReturnsNull() {
+        just1.buffer(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2SupplierNull() {
+        just1.buffer(() -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void bufferBoundarySupplier2SupplierReturnsNull() {
+        just1.buffer(() -> just1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void castNull() {
+        just1.cast(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectInitialSupplierNull() {
+        just1.collect((Supplier<Integer>)null, (a, b) -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectInitialSupplierReturnsNull() {
+        just1.collect(() -> null, (a, b) -> { }).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectInitialCollectorNull() {
+        just1.collect(() -> 1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectIntoInitialNull() {
+        just1.collectInto(null, (a, b) -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void collectIntoCollectorNull() {
+        just1.collectInto(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void composeNull() {
+        just1.compose(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapNull() {
+        just1.concatMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapReturnsNull() {
+        just1.concatMap(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapIterableNull() {
+        just1.concatMapIterable(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapIterableReturnNull() {
+        just1.concatMapIterable(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatMapIterableIteratorNull() {
+        just1.concatMapIterable(v -> () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatWithNull() {
+        just1.concatWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void containsNull() {
+        just1.contains(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceFunctionNull() {
+        just1.debounce(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceFunctionReturnsNull() {
+        just1.debounce(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceTimedUnitNull() {
+        just1.debounce(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void debounceTimedSchedulerNull() {
+        just1.debounce(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void defaultIfEmptyNull() {
+        just1.defaultIfEmpty(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayWithFunctionNull() {
+        just1.delay(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayWithFunctionReturnsNull() {
+        just1.delay(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayTimedUnitNull() {
+        just1.delay(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayTimedSchedulerNull() {
+        just1.delay(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionTimedUnitNull() {
+        just1.delaySubscription(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionTimedSchedulerNull() {
+        just1.delaySubscription(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionFunctionNull() {
+        just1.delaySubscription(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothInitialSupplierNull() {
+        just1.delay(null, v -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothInitialSupplierReturnsNull() {
+        just1.delay(() -> null, v -> just1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothItemSupplierNull() {
+        just1.delay(() -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delayBothItemSupplierReturnsNull() {
+        just1.delay(() -> just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctFunctionNull() {
+        just1.distinct(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctSupplierNull() {
+        just1.distinct(v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctSupplierReturnsNull() {
+        just1.distinct(v -> v, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctFunctionReturnsNull() {
+        just1.distinct(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctUntilChangedFunctionNull() {
+        just1.distinctUntilChanged(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void distinctUntilChangedFunctionReturnsNull() {
+        just1.distinctUntilChanged(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnCancelNull() {
+        just1.doOnCancel(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnCompleteNull() {
+        just1.doOnComplete(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnEachSupplierNull() {
+        just1.doOnEach((Consumer<Try<Optional<Integer>>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnEachSubscriberNull() {
+        just1.doOnEach((NbpSubscriber<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnErrorNull() {
+        just1.doOnError(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnLifecycleOnSubscribeNull() {
+        just1.doOnLifecycle(null, () -> { });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnLifecycleOnCancelNull() {
+        just1.doOnLifecycle(s -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnNextNull() {
+        just1.doOnNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnSubscribeNull() {
+        just1.doOnSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnTerminatedNull() {
+        just1.doOnTerminate(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void elementAtNull() {
+        just1.elementAt(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithIterableNull() {
+        just1.endWith((Iterable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithIterableIteratorNull() {
+        just1.endWith(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithIterableOneIsNull() {
+        just1.endWith(Arrays.asList(1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithNbpObservableNull() {
+        just1.endWith((NbpObservable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithNull() {
+        just1.endWith((Integer)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithArrayNull() {
+        just1.endWithArray((Integer[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void endWithArrayOneIsNull() {
+        just1.endWithArray(1, null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void filterNull() {
+        just1.filter(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void finallyDoNull() {
+        just1.finallyDo(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void firstNull() {
+        just1.first(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapNull() {
+        just1.flatMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapFunctionReturnsNull() {
+        just1.flatMap(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnNextNull() {
+        just1.flatMap(null, e -> just1, () -> just1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnNextReturnsNull() {
+        just1.flatMap(v -> null, e -> just1, () -> just1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnErrorNull() {
+        just1.flatMap(v -> just1, null, () -> just1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnErrorReturnsNull() {
+        NbpObservable.error(new TestException()).flatMap(v -> just1, e -> null, () -> just1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnCompleteNull() {
+        just1.flatMap(v -> just1, e -> just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapNotificationOnCompleteReturnsNull() {
+        just1.flatMap(v -> just1, e -> just1, () -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerMapperNull() {
+        just1.flatMap(null, (a, b) -> 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerMapperReturnsNull() {
+        just1.flatMap(v -> null, (a, b) -> 1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerCombinerNull() {
+        just1.flatMap(v -> just1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapCombinerCombinerReturnsNull() {
+        just1.flatMap(v -> just1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperNull() {
+        just1.flatMapIterable(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperReturnsNull() {
+        just1.flatMapIterable(v -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperIteratorNull() {
+        just1.flatMapIterable(v -> () -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableMapperIterableOneNull() {
+        just1.flatMapIterable(v -> Arrays.asList(1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableCombinerNull() {
+        just1.flatMapIterable(v -> Arrays.asList(1), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void flatMapIterableCombinerReturnsNull() {
+        just1.flatMapIterable(v -> Arrays.asList(1), (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachNull() {
+        just1.forEach(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachWhileNull() {
+        just1.forEachWhile(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachWhileOnErrorNull() {
+        just1.forEachWhile(v -> true, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void forEachWhileOnCompleteNull() {
+        just1.forEachWhile(v -> true, e-> { }, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void groupByNull() {
+        just1.groupBy(null);
+    }
+    
+    public void groupByKeyNull() {
+        just1.groupBy(v -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void groupByValueNull() {
+        just1.groupBy(v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void groupByValueReturnsNull() {
+        just1.groupBy(v -> v, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void lastNull() {
+        just1.last(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void liftNull() {
+        just1.lift(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void liftReturnsNull() {
+        just1.lift(s -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mapNull() {
+        just1.map(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mapReturnsNull() {
+        just1.map(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void mergeWithNull() {
+        just1.mergeWith(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void observeOnNull() {
+        just1.observeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void ofTypeNull() {
+        just1.ofType(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFunctionNull() {
+        just1.onErrorResumeNext((Function<Throwable, NbpObservable<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFunctionReturnsNull() {
+        NbpObservable.error(new TestException()).onErrorResumeNext(e -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextNbpObservableNull() {
+        just1.onErrorResumeNext((NbpObservable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnFunctionNull() {
+        just1.onErrorReturn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnValueNull() {
+        just1.onErrorReturnValue(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onErrorReturnFunctionReturnsNull() {
+        NbpObservable.error(new TestException()).onErrorReturn(e -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onExceptionResumeNext() {
+        just1.onExceptionResumeNext(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void publishFunctionNull() {
+        just1.publish(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void publishFunctionReturnsNull() {
+        just1.publish(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceFunctionNull() {
+        just1.reduce(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceFunctionReturnsNull() {
+        NbpObservable.just(1, 1).reduce((a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceSeedNull() {
+        just1.reduce(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceSeedFunctionNull() {
+        just1.reduce(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceSeedFunctionReturnsNull() {
+        just1.reduce(1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceWithSeedNull() {
+        just1.reduceWith(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void reduceWithSeedReturnsNull() {
+        just1.reduceWith(() -> null, (a, b) -> 1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatUntilNull() {
+        just1.repeatUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatWhenNull() {
+        just1.repeatWhen(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void repeatWhenFunctionReturnsNull() {
+        just1.repeatWhen(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorNull() {
+        just1.replay((Function<NbpObservable<Integer>, NbpObservable<Integer>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorReturnsNull() {
+        just1.replay(o -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedSelectorNull() {
+        just1.replay((Function<NbpObservable<Integer>, NbpObservable<Integer>>)null, 1, 1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedSelectorReturnsNull() {
+        just1.replay(v -> null, 1, 1, TimeUnit.SECONDS).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySchedulerNull() {
+        just1.replay((Scheduler)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedUnitNull() {
+        just1.replay(v -> v, 1, 1, null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayBoundedSchedulerNull() {
+        just1.replay(v -> v, 1, 1, TimeUnit.SECONDS, null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedSelectorNull() {
+        just1.replay(null, 1, TimeUnit.SECONDS, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedSelectorReturnsNull() {
+        just1.replay(v -> null, 1, TimeUnit.SECONDS, Schedulers.single()).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorTimeBoundedUnitNull() {
+        just1.replay(v -> v, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replaySelectorTimeBoundedSchedulerNull() {
+        just1.replay(v -> v, 1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeSizeBoundedUnitNull() {
+        just1.replay(1, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeSizeBoundedSchedulerNull() {
+        just1.replay(1, 1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayBufferSchedulerNull() {
+        just1.replay(1, (Scheduler)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedUnitNull() {
+        just1.replay(1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void replayTimeBoundedSchedulerNull() {
+        just1.replay(1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void retryFunctionNull() {
+        just1.retry((BiPredicate<Integer, Throwable>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void retryCountFunctionNull() {
+        just1.retry(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryPredicateNull() {
+        just1.retry((Predicate<Throwable>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryWhenFunctionNull() {
+        just1.retryWhen(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryWhenFunctionReturnsNull() {
+        NbpObservable.error(new TestException()).retryWhen(f -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void retryUntil() {
+        just1.retryUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void safeSubscribeNull() {
+        just1.safeSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sampleUnitNull() {
+        just1.sample(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sampleSchedulerNull() {
+        just1.sample(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sampleNbpObservableNull() {
+        just1.sample(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanFunctionNull() {
+        just1.scan(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanFunctionReturnsNull() {
+        NbpObservable.just(1, 1).scan((a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedNull() {
+        just1.scan(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedFunctionNull() {
+        just1.scan(1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedFunctionReturnsNull() {
+        just1.scan(1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierNull() {
+        just1.scanWith(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierReturnsNull() {
+        just1.scanWith(() -> null, (a, b) -> 1).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierFunctionNull() {
+        just1.scanWith(() -> 1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void scanSeedSupplierFunctionReturnsNull() {
+        just1.scanWith(() -> 1, (a, b) -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void singleNull() {
+        just1.single(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipTimedUnitNull() {
+        just1.skip(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipTimedSchedulerNull() {
+        just1.skip(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipLastTimedUnitNull() {
+        just1.skipLast(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipLastTimedSchedulerNull() {
+        just1.skipLast(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipUntilNull() {
+        just1.skipUntil(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void skipWhileNull() {
+        just1.skipWhile(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithIterableNull() {
+        just1.startWith((Iterable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithIterableIteratorNull() {
+        just1.startWith(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithIterableOneNull() {
+        just1.startWith(Arrays.asList(1, null)).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithSingleNull() {
+        just1.startWith((Integer)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithNbpObservableNull() {
+        just1.startWith((NbpObservable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithArrayNull() {
+        just1.startWithArray((Integer[])null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithArrayOneNull() {
+        just1.startWithArray(1, null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnNextNull() {
+        just1.subscribe((Consumer<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnErrorNull() {
+        just1.subscribe(e -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnCompleteNull() {
+        just1.subscribe(e -> { }, e -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnSubscribeNull() {
+        just1.subscribe(e -> { }, e -> { }, () -> { }, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeNull() {
+        just1.subscribe((NbpSubscriber<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void subscribeOnNull() {
+        just1.subscribeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchIfEmptyNull() {
+        just1.switchIfEmpty(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchMapNull() {
+        just1.switchMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void switchMapFunctionReturnsNull() {
+        just1.switchMap(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeTimedUnitNull() {
+        just1.take(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeTimedSchedulerNull() {
+        just1.take(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeFirstNull() {
+        just1.takeFirst(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeLastTimedUnitNull() {
+        just1.takeLast(1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastSizeTimedUnitNull() {
+        just1.takeLast(1, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastTimedSchedulerNull() {
+        just1.takeLast(1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastSizeTimedSchedulerNull() {
+        just1.takeLast(1, 1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferTimedUnitNull() {
+        just1.takeLastBuffer(1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferTimedSchedulerNull() {
+        just1.takeLastBuffer(1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferSizeTimedUnitNull() {
+        just1.takeLastBuffer(1, 1, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeLastBufferSizeTimedSchedulerNull() {
+        just1.takeLastBuffer(1, 1, TimeUnit.SECONDS, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void takeUntilPredicateNull() {
+        just1.takeUntil((Predicate<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeUntilNbpObservableNull() {
+        just1.takeUntil((NbpObservable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeWhileNull() {
+        just1.takeWhile(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleFirstUnitNull() {
+        just1.throttleFirst(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleFirstSchedulerNull() {
+        just1.throttleFirst(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleLastUnitNull() {
+        just1.throttleLast(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleLastSchedulerNull() {
+        just1.throttleLast(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleWithTimeoutUnitNull() {
+        just1.throttleWithTimeout(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void throttleWithTimeoutSchedulerNull() {
+        just1.throttleWithTimeout(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeIntervalUnitNull() {
+        just1.timeInterval(null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeIntervalSchedulerNull() {
+        just1.timeInterval(TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSelectorNull() {
+        just1.timeout(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSelectorReturnsNull() {
+        just1.timeout(v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutSelectorOtherNull() {
+        just1.timeout(v -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutUnitNull() {
+        just1.timeout(1, null, just1, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void timeouOtherNull() {
+        just1.timeout(1, TimeUnit.SECONDS, null, Schedulers.single());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void timeouSchedulerNull() {
+        just1.timeout(1, TimeUnit.SECONDS, just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstNull() {
+        just1.timeout((Supplier<NbpObservable<Integer>>)null, v -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstReturnsNull() {
+        just1.timeout(() -> null, v -> just1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstItemNull() {
+        just1.timeout(() -> just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timeoutFirstItemReturnsNull() {
+        NbpObservable.just(1, 1).timeout(() -> NbpObservable.never(), v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timestampUnitNull() {
+        just1.timestamp(null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void timestampSchedulerNull() {
+        just1.timestamp(TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toNull() {
+        just1.to(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toListNull() {
+        just1.toList(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toListSupplierReturnsNull() {
+        just1.toList(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toSortedListNull() {
+        just1.toSortedList(null);
+    }
+    
+    @Test
+    public void toMapKeyNullAllowed() {
+        just1.toMap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMapValueNull() {
+        just1.toMap(v -> v, null);
+    }
+    
+    @Test
+    public void toMapValueSelectorReturnsNull() {
+        just1.toMap(v -> v, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMapMapSupplierNull() {
+        just1.toMap(v -> v, v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMapMapSupplierReturnsNull() {
+        just1.toMap(v -> v, v -> v, () -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toMultimapKeyNull() {
+        just1.toMultimap(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapValueNull() {
+        just1.toMultimap(v -> v, null);
+    }
+    
+    @Test
+    public void toMultiMapValueSelectorReturnsNullAllowed() {
+        just1.toMap(v -> v, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapMapSupplierNull() {
+        just1.toMultimap(v -> v, v -> v, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapSupplierReturnsNull() {
+        just1.toMultimap(v -> v, v -> v, () -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapMapCollectionSupplierNull() {
+        just1.toMultimap(v -> v, v -> v, () -> new HashMap<>(), null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void toMultimapMapCollectionSupplierReturnsNull() {
+        just1.toMultimap(v -> v, v -> v, () -> new HashMap<>(), v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsafeSubscribeNull() {
+        just1.unsafeSubscribe(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsubscribeOnNull() {
+        just1.unsubscribeOn(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowTimedUnitNull() {
+        just1.window(1, null, Schedulers.single());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowSizeTimedUnitNull() {
+        just1.window(1, null, Schedulers.single(), 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void windowTimedSchedulerNull() {
+        just1.window(1, TimeUnit.SECONDS, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowSizeTimedSchedulerNull() {
+        just1.window(1, TimeUnit.SECONDS, null, 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowBoundaryNull() {
+        just1.window((NbpObservable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowOpenCloseOpenNull() {
+        just1.window(null, v -> just1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowOpenCloseCloseNull() {
+        just1.window(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowOpenCloseCloseReturnsNull() {
+        NbpObservable.never().window(just1, v -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowBoundarySupplierNull() {
+        just1.window((Supplier<NbpObservable<Integer>>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void windowBoundarySupplierReturnsNull() {
+        just1.window(() -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void withLatestFromOtherNull() {
+        just1.withLatestFrom(null, (a, b) -> 1);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void withLatestFromCombinerNull() {
+        just1.withLatestFrom(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void withLatestFromCombinerReturnsNull() {
+        just1.withLatestFrom(just1, (a, b) -> null).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableNull() {
+        just1.zipWith((Iterable<Integer>)null, (a, b) -> 1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableCombinerNull() {
+        just1.zipWith(Arrays.asList(1), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableCombinerReturnsNull() {
+        just1.zipWith(Arrays.asList(1), (a, b) -> null).toBlocking().run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableIteratorNull() {
+        just1.zipWith(() -> null, (a, b) -> 1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithIterableOneIsNull() {
+        NbpObservable.just(1, 2).zipWith(Arrays.asList(1, null), (a, b) -> 1).toBlocking().run();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithNbpObservableNull() {
+        just1.zipWith((NbpObservable<Integer>)null, (a, b) -> 1);
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void zipWithCombinerNull() {
+        just1.zipWith(just1, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithCombinerReturnsNull() {
+        just1.zipWith(just1, (a, b) -> null).toBlocking().run();
+    }
+    
+}


### PR DESCRIPTION
This PR adds over 900 new null checks. Null checks are essential because RS doesn't allow null values and sometimes a missed null check may lead to operator hangs as well.