### PR TITLE
2.x: fix to ReplaySubject not properly accounting for emitted events.

### DIFF
--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -487,7 +487,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
                 int s = size;
                 long r = rs.requested;
                 boolean unbounded = r == Long.MAX_VALUE;
-                long e = 0;
+                long e = 0L;
                 
                 while (s != index) {
                     
@@ -515,7 +515,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
                     }
                     
                     if (r == 0) {
-                        r = rs.requested;
+                        r = rs.requested + e;
                         if (r == 0) {
                             break;
                         }
@@ -527,8 +527,10 @@ public final class ReplaySubject<T> extends Subject<T, T> {
                     index++;
                 }
                 
-                if (!unbounded) {
-                    r = ReplaySubscription.REQUESTED.addAndGet(rs, e);
+                if (e != 0L) {
+                    if (!unbounded) {
+                        r = ReplaySubscription.REQUESTED.addAndGet(rs, e);
+                    }
                 }
                 if (index != size && r != 0L) {
                     continue;
@@ -748,7 +750,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
                     }
                     
                     if (r == 0) {
-                        r = rs.requested;
+                        r = rs.requested + e;
                         if (r == 0) {
                             break;
                         }
@@ -1029,7 +1031,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
                     }
                     
                     if (r == 0) {
-                        r = rs.requested;
+                        r = rs.requested + e;
                         if (r == 0) {
                             break;
                         }

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -820,4 +820,91 @@ public class ReplaySubjectTest {
         assertArrayEquals(expected, rs.getValues());
         
     }
+    
+    @Test
+    public void testBackpressureHonored() {
+        ReplaySubject<Integer> rs = ReplaySubject.create();
+        rs.onNext(1);
+        rs.onNext(2);
+        rs.onNext(3);
+        rs.onComplete();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        
+        rs.subscribe(ts);
+        
+        ts.request(1);
+        ts.assertValue(1);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+        
+        
+        ts.request(1);
+        ts.assertValues(1, 2);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+
+        ts.request(1);
+        ts.assertValues(1, 2, 3);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testBackpressureHonoredSizeBound() {
+        ReplaySubject<Integer> rs = ReplaySubject.createWithSize(100);
+        rs.onNext(1);
+        rs.onNext(2);
+        rs.onNext(3);
+        rs.onComplete();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        
+        rs.subscribe(ts);
+        
+        ts.request(1);
+        ts.assertValue(1);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+        
+        
+        ts.request(1);
+        ts.assertValues(1, 2);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+
+        ts.request(1);
+        ts.assertValues(1, 2, 3);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void testBackpressureHonoredTimeBound() {
+        ReplaySubject<Integer> rs = ReplaySubject.createWithTime(1, TimeUnit.DAYS);
+        rs.onNext(1);
+        rs.onNext(2);
+        rs.onNext(3);
+        rs.onComplete();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        
+        rs.subscribe(ts);
+        
+        ts.request(1);
+        ts.assertValue(1);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+        
+        
+        ts.request(1);
+        ts.assertValues(1, 2);
+        ts.assertNotComplete();
+        ts.assertNoErrors();
+
+        ts.request(1);
+        ts.assertValues(1, 2, 3);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
 }


### PR DESCRIPTION
The subject tries to avoid the request reduction via addAndGet by re-reading the requested amount and continuing the loop as long as possible. The bug was in ignoring the total emission amount and thus a single request(1) from the child ended up replaying all values.