### PR TITLE
pull back the Experimental/Beta of the changes until 1.1.x (+1 squashed commit)

### DIFF
--- a/src/main/java/rx/subjects/AsyncSubject.java
+++ b/src/main/java/rx/subjects/AsyncSubject.java
@@ -203,6 +203,7 @@ public final class AsyncSubject<T> extends Subject<T, T> {
     }
     @Override
     @Experimental
+    @Deprecated
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] a) {
         Object v = lastValue;

--- a/src/main/java/rx/subjects/PublishSubject.java
+++ b/src/main/java/rx/subjects/PublishSubject.java
@@ -155,23 +155,44 @@ public final class PublishSubject<T> extends Subject<T, T> {
         return null;
     }
     
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public boolean hasValue() {
         return false;
     }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public T getValue() {
         return null;
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public Object[] getValues() {
         return new Object[0];
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public T[] getValues(T[] a) {
         if (a.length > 0) {
             a[0] = null;

--- a/src/main/java/rx/subjects/ReplaySubject.java
+++ b/src/main/java/rx/subjects/ReplaySubject.java
@@ -1162,7 +1162,9 @@ public final class ReplaySubject<T> extends Subject<T, T> {
     public T[] getValues(T[] a) {
         return state.toArray(a);
     }
+    
     @Override
+    @Experimental
     public T getValue() {
         return state.latest();
     }

--- a/src/main/java/rx/subjects/SerializedSubject.java
+++ b/src/main/java/rx/subjects/SerializedSubject.java
@@ -69,38 +69,74 @@ public class SerializedSubject<T, R> extends Subject<T, R> {
     public boolean hasObservers() {
         return actual.hasObservers();
     }
+    
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public boolean hasCompleted() {
         return actual.hasCompleted();
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public boolean hasThrowable() {
         return actual.hasThrowable();
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public boolean hasValue() {
         return actual.hasValue();
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public Throwable getThrowable() {
         return actual.getThrowable();
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public T getValue() {
         return actual.getValue();
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public Object[] getValues() {
         return actual.getValues();
     }
+    /**
+     * {@inheritDoc}
+     * @deprecated this method is scheduled to be removed in the next release
+     */
     @Override
     @Experimental
+    @Deprecated
     public T[] getValues(T[] a) {
         return actual.getValues(a);
     }

--- a/src/main/java/rx/subjects/Subject.java
+++ b/src/main/java/rx/subjects/Subject.java
@@ -64,8 +64,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      *
      * @return {@code true} if the subject has received a throwable through {@code onError}.
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @Experimental
+    @Deprecated
     public boolean hasThrowable() {
         throw new UnsupportedOperationException();
     }
@@ -75,8 +77,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      *
      * @return {@code true} if the subject completed normally via {@code onCompleted}
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @Experimental
+    @Deprecated
     public boolean hasCompleted() {
         throw new UnsupportedOperationException();
     }
@@ -87,8 +91,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      * @return the Throwable that terminated the Subject or {@code null} if the subject hasn't terminated yet or
      *         if it terminated normally.
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @Experimental
+    @Deprecated
     public Throwable getThrowable() {
         throw new UnsupportedOperationException();
     }
@@ -101,8 +107,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      *
      * @return {@code true} if and only if the subject has some value but not an error
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @Experimental
+    @Deprecated
     public boolean hasValue() {
         throw new UnsupportedOperationException();
     }
@@ -117,8 +125,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      * @return the current value or {@code null} if the Subject doesn't have a value, has terminated with an
      *         exception or has an actual {@code null} as a value.
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @Experimental
+    @Deprecated
     public T getValue() {
         throw new UnsupportedOperationException();
     }
@@ -130,9 +140,11 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      *
      * @return a snapshot of the currently buffered non-terminal events.
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @SuppressWarnings("unchecked")
     @Experimental
+    @Deprecated
     public Object[] getValues() {
         T[] r = getValues((T[])EMPTY_ARRAY);
         if (r == EMPTY_ARRAY) {
@@ -152,8 +164,10 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
      * @param a the array to fill in
      * @return the array {@code a} if it had enough capacity or a new array containing the available values 
      * @since (If this graduates from being an Experimental class method, replace this parenthetical with the release number)
+     * @deprecated this method will be moved to each Subject class individually in the next release
      */
     @Experimental
+    @Deprecated
     public T[] getValues(T[] a) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Squashed commits:
[c6e43fc] 1.0.15. Beta/Deprecation of Subject state peeking methods.

This should give users one release to prepare for the class structure
changes.