### PR TITLE
GroupBy backpressure fix

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -15,25 +15,17 @@
  */
 package rx.internal.operators;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
-import rx.Observable;
-import rx.Observable.OnSubscribe;
-import rx.Observable.Operator;
-import rx.exceptions.*;
-import rx.Observer;
-import rx.Producer;
-import rx.Subscriber;
-import rx.functions.Action0;
-import rx.functions.Func1;
+import rx.*;
+import rx.Observable.*;
+import rx.functions.*;
+import rx.internal.producers.ProducerArbiter;
+import rx.internal.util.*;
 import rx.observables.GroupedObservable;
-import rx.subjects.Subject;
+import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -49,381 +41,523 @@ import rx.subscriptions.Subscriptions;
  * @param <R>
  *            the value type of the groups
  */
-public class OperatorGroupBy<T, K, R> implements Operator<GroupedObservable<K, R>, T> {
+public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservable<K, V>, T>{
     final Func1<? super T, ? extends K> keySelector;
-    final Func1<? super T, ? extends R> valueSelector;
-
-    @SuppressWarnings("unchecked")
-    public OperatorGroupBy(final Func1<? super T, ? extends K> keySelector) {
-        this(keySelector, (Func1<T, R>) IDENTITY);
+    final Func1<? super T, ? extends V> valueSelector;
+    final int bufferSize;
+    final boolean delayError;
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector) {
+        this(keySelector, (Func1)UtilityFunctions.<T>identity(), RxRingBuffer.SIZE, false);
     }
 
-    public OperatorGroupBy(
-            Func1<? super T, ? extends K> keySelector,
-            Func1<? super T, ? extends R> valueSelector) {
+    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector) {
+        this(keySelector, valueSelector, RxRingBuffer.SIZE, false);
+    }
+
+    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
         this.keySelector = keySelector;
         this.valueSelector = valueSelector;
+        this.bufferSize = bufferSize;
+        this.delayError = delayError;
     }
-
+    
     @Override
-    public Subscriber<? super T> call(final Subscriber<? super GroupedObservable<K, R>> child) {
-        return new GroupBySubscriber<K, T, R>(keySelector, valueSelector, child);
+    public Subscriber<? super T> call(Subscriber<? super GroupedObservable<K, V>> t) {
+        final GroupBySubscriber<T, K, V> parent = new GroupBySubscriber<T, K, V>(t, keySelector, valueSelector, bufferSize, delayError);
+
+        t.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                parent.cancel();
+            }
+        }));
+
+        t.setProducer(parent.producer);
+        
+        return parent;
     }
 
-    static final class GroupBySubscriber<K, T, R> extends Subscriber<T> {
-        private static final int MAX_QUEUE_SIZE = 1024;
-        final GroupBySubscriber<K, T, R> self = this;
+    public static final class GroupByProducer implements Producer {
+        final GroupBySubscriber<?, ?, ?> parent;
+        
+        public GroupByProducer(GroupBySubscriber<?, ?, ?> parent) {
+            this.parent = parent;
+        }
+        @Override
+        public void request(long n) {
+            parent.requestMore(n);
+        }
+    }
+    
+    public static final class GroupBySubscriber<T, K, V> 
+    extends Subscriber<T> {
+        final Subscriber<? super GroupedObservable<K, V>> actual;
         final Func1<? super T, ? extends K> keySelector;
-        final Func1<? super T, ? extends R> elementSelector;
-        final Subscriber<? super GroupedObservable<K, R>> child;
-
-        // We should not call `unsubscribe()` until `groups.isEmpty() && child.isUnsubscribed()` is true.
-        // Use `WIP_FOR_UNSUBSCRIBE_UPDATER` to monitor these statuses and call `unsubscribe()` properly.
-        // Should check both when `child.unsubscribe` is called and any group is removed.
+        final Func1<? super T, ? extends V> valueSelector;
+        final int bufferSize;
+        final boolean delayError;
+        final Map<Object, GroupedUnicast<K, V>> groups;
+        final Queue<GroupedObservable<K, V>> queue;
+        final GroupByProducer producer;
+        
+        static final Object NULL_KEY = new Object();
+        
+        final ProducerArbiter s;
+        
+        volatile int cancelled;
         @SuppressWarnings("rawtypes")
-        static final AtomicIntegerFieldUpdater<GroupBySubscriber> WIP_FOR_UNSUBSCRIBE_UPDATER = AtomicIntegerFieldUpdater.newUpdater(GroupBySubscriber.class, "wipForUnsubscribe");
-        volatile int wipForUnsubscribe = 1;
-
-        public GroupBySubscriber(
-                Func1<? super T, ? extends K> keySelector,
-                Func1<? super T, ? extends R> elementSelector,
-                Subscriber<? super GroupedObservable<K, R>> child) {
-            super();
-            this.keySelector = keySelector;
-            this.elementSelector = elementSelector;
-            this.child = child;
-            child.add(Subscriptions.create(new Action0() {
-
-                @Override
-                public void call() {
-                    if (WIP_FOR_UNSUBSCRIBE_UPDATER.decrementAndGet(self) == 0) {
-                        self.unsubscribe();
-                    }
-                }
-
-            }));
-        }
-
-        private static class GroupState<K, T> {
-            private final Subject<T, T> s = BufferUntilSubscriber.create();
-            private final AtomicLong requested = new AtomicLong();
-            private final AtomicLong count = new AtomicLong();
-            private final Queue<Object> buffer = new ConcurrentLinkedQueue<Object>(); // TODO should this be lazily created?
-
-            public Observable<T> getObservable() {
-                return s;
-            }
-
-            public Observer<T> getObserver() {
-                return s;
-            }
-
-        }
-
-        private final ConcurrentHashMap<Object, GroupState<K, T>> groups = new ConcurrentHashMap<Object, GroupState<K, T>>();
-
-        private static final NotificationLite<Object> nl = NotificationLite.instance();
-
-        volatile int completionEmitted;
-
-        private static final int UNTERMINATED = 0;
-        private static final int TERMINATED_WITH_COMPLETED = 1;
-        private static final int TERMINATED_WITH_ERROR = 2;
-
-        // Must be one of `UNTERMINATED`, `TERMINATED_WITH_COMPLETED`, `TERMINATED_WITH_ERROR`
-        volatile int terminated = UNTERMINATED;
-
-        @SuppressWarnings("rawtypes")
-        static final AtomicIntegerFieldUpdater<GroupBySubscriber> COMPLETION_EMITTED_UPDATER = AtomicIntegerFieldUpdater.newUpdater(GroupBySubscriber.class, "completionEmitted");
-        @SuppressWarnings("rawtypes")
-        static final AtomicIntegerFieldUpdater<GroupBySubscriber> TERMINATED_UPDATER = AtomicIntegerFieldUpdater.newUpdater(GroupBySubscriber.class, "terminated");
+        static final AtomicIntegerFieldUpdater<GroupBySubscriber> CANCELLED =
+                AtomicIntegerFieldUpdater.newUpdater(GroupBySubscriber.class, "cancelled");
 
         volatile long requested;
         @SuppressWarnings("rawtypes")
-        static final AtomicLongFieldUpdater<GroupBySubscriber> REQUESTED = AtomicLongFieldUpdater.newUpdater(GroupBySubscriber.class, "requested");
-
-        volatile long bufferedCount;
+        static final AtomicLongFieldUpdater<GroupBySubscriber> REQUESTED =
+                AtomicLongFieldUpdater.newUpdater(GroupBySubscriber.class, "requested");
+        
+        volatile int groupCount;
         @SuppressWarnings("rawtypes")
-        static final AtomicLongFieldUpdater<GroupBySubscriber> BUFFERED_COUNT = AtomicLongFieldUpdater.newUpdater(GroupBySubscriber.class, "bufferedCount");
+        static final AtomicIntegerFieldUpdater<GroupBySubscriber> GROUP_COUNT =
+                AtomicIntegerFieldUpdater.newUpdater(GroupBySubscriber.class, "groupCount");
+        
+        Throwable error;
+        volatile boolean done;
 
-        @Override
-        public void onStart() {
-            REQUESTED.set(this, MAX_QUEUE_SIZE);
-            request(MAX_QUEUE_SIZE);
+        volatile int wip;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<GroupBySubscriber> WIP =
+                AtomicIntegerFieldUpdater.newUpdater(GroupBySubscriber.class, "wip");
+        
+        public GroupBySubscriber(Subscriber<? super GroupedObservable<K, V>> actual, Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
+            this.actual = actual;
+            this.keySelector = keySelector;
+            this.valueSelector = valueSelector;
+            this.bufferSize = bufferSize;
+            this.delayError = delayError;
+            this.groups = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
+            this.queue = new ConcurrentLinkedQueue<GroupedObservable<K, V>>();
+            GROUP_COUNT.lazySet(this, 1);
+            this.s = new ProducerArbiter();
+            this.s.request(bufferSize);
+            this.producer = new GroupByProducer(this);
         }
-
+        
         @Override
-        public void onCompleted() {
-            if (TERMINATED_UPDATER.compareAndSet(this, UNTERMINATED, TERMINATED_WITH_COMPLETED)) {
-                // if we receive onCompleted from our parent we onComplete children
-                // for each group check if it is ready to accept more events if so pass the oncomplete through else buffer it.
-                for (GroupState<K, T> group : groups.values()) {
-                    emitItem(group, nl.completed());
-                }
+        public void setProducer(Producer s) {
+            this.s.setProducer(s);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
 
-                // special case (no groups emitted ... or all unsubscribed)
-                if (groups.isEmpty()) {
-                    // we must track 'completionEmitted' seperately from 'completed' since `completeInner` can result in childObserver.onCompleted() being emitted
-                    if (COMPLETION_EMITTED_UPDATER.compareAndSet(this, 0, 1)) {
-                        child.onCompleted();
-                    }
+            final Queue<GroupedObservable<K, V>> q = this.queue;
+            final Subscriber<? super GroupedObservable<K, V>> a = this.actual;
+
+            K key;
+            try {
+                key = keySelector.call(t);
+            } catch (Throwable ex) {
+                unsubscribe();
+                errorAll(a, q, ex);
+                return;
+            }
+            
+            boolean notNew = true;
+            Object mapKey = key != null ? key : NULL_KEY;
+            GroupedUnicast<K, V> group = groups.get(mapKey);
+            if (group == null) {
+                // if the main has been cancelled, stop creating groups
+                // and skip this value
+                if (cancelled == 0) {
+                    group = GroupedUnicast.createWith(key, bufferSize, this, delayError);
+                    groups.put(mapKey, group);
+                    
+                    GROUP_COUNT.getAndIncrement(this);
+                    
+                    notNew = false;
+                    q.offer(group);
+                    drain();
+                } else {
+                    return;
                 }
             }
+            
+            V v;
+            try {
+                v = valueSelector.call(t);
+            } catch (Throwable ex) {
+                unsubscribe();
+                errorAll(a, q, ex);
+                return;
+            }
+
+            group.onNext(v);
+
+            if (notNew) {
+                s.request(1);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                return;
+            }
+            error = t;
+            done = true;
+            GROUP_COUNT.decrementAndGet(this);
+            drain();
+        }
+        
+        @Override
+        public void onCompleted() {
+            if (done) {
+                return;
+            }
+            done = true;
+            GROUP_COUNT.decrementAndGet(this);
+            drain();
         }
 
-        @Override
-        public void onError(Throwable e) {
-            if (TERMINATED_UPDATER.compareAndSet(this, UNTERMINATED, TERMINATED_WITH_ERROR)) {
-                // It's safe to access all groups and emit the error.
-                // onNext and onError are in sequence so no group will be created in the loop.
-                for (GroupState<K, T> group : groups.values()) {
-                    emitItem(group, nl.error(e));
-                }
-                try {
-                    // we immediately tear everything down if we receive an error
-                    child.onError(e);
-                } finally {
-                    // We have not chained the subscribers, so need to call it explicitly.
+        public void requestMore(long n) {
+            if (n < 0) {
+                throw new IllegalArgumentException("n >= 0 required but it was " + n);
+            }
+            
+            BackpressureUtils.getAndAddRequest(REQUESTED, this, n);
+            drain();
+        }
+        
+        public void cancel() {
+            // cancelling the main source means we don't want any more groups
+            // but running groups still require new values
+            if (CANCELLED.compareAndSet(this, 0, 1)) {
+                if (GROUP_COUNT.decrementAndGet(this) == 0) {
                     unsubscribe();
                 }
             }
         }
-
-        // The grouped observable propagates the 'producer.request' call from it's subscriber to this method
-        // Here we keep track of the requested count for each group
-        // If we already have items queued when a request comes in we vend those and decrement the outstanding request count
-
-        void requestFromGroupedObservable(long n, GroupState<K, T> group) {
-            BackpressureUtils.getAndAddRequest(group.requested, n);
-            if (group.count.getAndIncrement() == 0) {
-                pollQueue(group);
+        
+        public void cancel(K key) {
+            Object mapKey = key != null ? key : NULL_KEY;
+            if (groups.remove(mapKey) != null) {
+                if (GROUP_COUNT.decrementAndGet(this) == 0) {
+                    unsubscribe();
+                }
             }
         }
-
-        private Object groupedKey(K key) {
-            return key == null ? NULL_KEY : key;
-        }
-
-        @SuppressWarnings("unchecked")
-        private K getKey(Object groupedKey) {
-            return groupedKey == NULL_KEY ? null : (K) groupedKey;
-        }
-
-        @Override
-        public void onNext(T t) {
-            try {
-                final Object key = groupedKey(keySelector.call(t));
-                GroupState<K, T> group = groups.get(key);
-                if (group == null) {
-                    // this group doesn't exist
-                    if (child.isUnsubscribed()) {
-                        // we have been unsubscribed on the outer so won't send any  more groups
+        
+        void drain() {
+            if (WIP.getAndIncrement(this) != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            
+            final Queue<GroupedObservable<K, V>> q = this.queue;
+            final Subscriber<? super GroupedObservable<K, V>> a = this.actual;
+            
+            for (;;) {
+                
+                if (checkTerminated(done, q.isEmpty(), a, q)) {
+                    return;
+                }
+                
+                long r = requested;
+                boolean unbounded = r == Long.MAX_VALUE;
+                long e = 0L;
+                
+                while (r != 0) {
+                    boolean d = done;
+                    
+                    GroupedObservable<K, V> t = q.poll();
+                    
+                    boolean empty = t == null;
+                    
+                    if (checkTerminated(d, empty, a, q)) {
                         return;
                     }
-                    group = createNewGroup(key);
-                }
-                if (group != null) {
-                    emitItem(group, nl.next(t));
-                }
-            } catch (Throwable e) {
-                Exceptions.throwOrReport(e, this, t);
-            }
-        }
-
-        private GroupState<K, T> createNewGroup(final Object key) {
-            final GroupState<K, T> groupState = new GroupState<K, T>();
-
-            GroupedObservable<K, R> go = GroupedObservable.create(getKey(key), new OnSubscribe<R>() {
-
-                @Override
-                public void call(final Subscriber<? super R> o) {
-                    o.setProducer(new Producer() {
-
-                        @Override
-                        public void request(long n) {
-                            requestFromGroupedObservable(n, groupState);
-                        }
-
-                    });
-
-                    final AtomicBoolean once = new AtomicBoolean();
-
-                    groupState.getObservable().doOnUnsubscribe(new Action0() {
-
-                        @Override
-                        public void call() {
-                            if (once.compareAndSet(false, true)) {
-                                // done once per instance, either onComplete or onUnSubscribe
-                                cleanupGroup(key);
-                            }
-                        }
-
-                    }).unsafeSubscribe(new Subscriber<T>(o) {
-                        @Override
-                        public void onCompleted() {
-                            o.onCompleted();
-                            // eagerly cleanup instead of waiting for unsubscribe
-                            if (once.compareAndSet(false, true)) {
-                                // done once per instance, either onComplete or onUnSubscribe
-                                cleanupGroup(key);
-                            }
-                        }
-
-                        @Override
-                        public void onError(Throwable e) {
-                            o.onError(e);
-                            // eagerly cleanup instead of waiting for unsubscribe
-                            if (once.compareAndSet(false, true)) {
-                                // done once per instance, either onComplete or onUnSubscribe
-                                cleanupGroup(key);
-                            }
-                        }
-
-                        @Override
-                        public void onNext(T t) {
-                            try {
-                                o.onNext(elementSelector.call(t));
-                            } catch (Throwable e) {
-                                Exceptions.throwOrReport(e, this, t);
-                            }
-                        }
-                    });
-                }
-            });
-
-            GroupState<K, T> putIfAbsent;
-            for (;;) {
-                int wip = wipForUnsubscribe;
-                if (wip <= 0) {
-                    return null;
-                }
-                if (WIP_FOR_UNSUBSCRIBE_UPDATER.compareAndSet(this, wip, wip + 1)) {
-                    putIfAbsent = groups.putIfAbsent(key, groupState);
-                    break;
-                }
-            }
-            if (putIfAbsent != null) {
-                // this shouldn't happen (because we receive onNext sequentially) and would mean we have a bug
-                throw new IllegalStateException("Group already existed while creating a new one");
-            }
-            child.onNext(go);
-
-            return groupState;
-        }
-
-        private void cleanupGroup(Object key) {
-            GroupState<K, T> removed;
-            removed = groups.remove(key);
-            if (removed != null) {
-                if (!removed.buffer.isEmpty()) {
-                    BUFFERED_COUNT.addAndGet(self, -removed.buffer.size());
-                }
-                completeInner();
-                // since we may have unsubscribed early with items in the buffer 
-                // we remove those above and have freed up room to request more
-                // so give it a chance to request more now
-                requestMoreIfNecessary();
-            }
-        }
-
-        private void emitItem(GroupState<K, T> groupState, Object item) {
-            Queue<Object> q = groupState.buffer;
-            AtomicLong keyRequested = groupState.requested;
-            //don't need to check for requested being Long.MAX_VALUE because this
-            //field is capped at MAX_QUEUE_SIZE
-            REQUESTED.decrementAndGet(this);
-            // short circuit buffering
-            if (keyRequested != null && keyRequested.get() > 0 && (q == null || q.isEmpty())) {
-                @SuppressWarnings("unchecked")
-                Observer<Object> obs = (Observer<Object>)groupState.getObserver();
-                nl.accept(obs, item);
-                if (keyRequested.get() != Long.MAX_VALUE) {
-                    // best endeavours check (no CAS loop here) because we mainly care about 
-                    // the initial request being Long.MAX_VALUE and that value being conserved.
-                    keyRequested.decrementAndGet();
-                }
-            } else {
-                q.add(item);
-                BUFFERED_COUNT.incrementAndGet(this);
-
-                if (groupState.count.getAndIncrement() == 0) {
-                    pollQueue(groupState);
-                }
-            }
-            requestMoreIfNecessary();
-        }
-
-        private void pollQueue(GroupState<K, T> groupState) {
-            do {
-                drainIfPossible(groupState);
-                long c = groupState.count.decrementAndGet();
-                if (c > 1) {
-
-                    /*
-                     * Set down to 1 and then iterate again.
-                     * we lower it to 1 otherwise it could have grown very large while in the last poll loop
-                     * and then we can end up looping all those times again here before existing even once we've drained
-                     */
-                    groupState.count.set(1);
-                    // we now loop again, and if anything tries scheduling again after this it will increment and cause us to loop again after
-                }
-            } while (groupState.count.get() > 0);
-        }
-
-        private void requestMoreIfNecessary() {
-            if (REQUESTED.get(this) == 0 && terminated == 0) {
-                long toRequest = MAX_QUEUE_SIZE - BUFFERED_COUNT.get(this);
-                if (toRequest > 0 && REQUESTED.compareAndSet(this, 0, toRequest)) {
-                    request(toRequest);
-                }
-            }
-        }
-
-        private void drainIfPossible(GroupState<K, T> groupState) {
-            while (groupState.requested.get() > 0) {
-                Object t = groupState.buffer.poll();
-                if (t != null) {
-                    @SuppressWarnings("unchecked")
-                    Observer<Object> obs = (Observer<Object>)groupState.getObserver();
-                    nl.accept(obs, t);
-                    if (groupState.requested.get()!=Long.MAX_VALUE) {
-                        // best endeavours check (no CAS loop here) because we mainly care about 
-                        // the initial request being Long.MAX_VALUE and that value being conserved.
-                        groupState.requested.decrementAndGet();
+                    
+                    if (empty) {
+                        break;
                     }
-                    BUFFERED_COUNT.decrementAndGet(this);
 
-                    // if we have used up all the events we requested from upstream then figure out what to ask for this time based on the empty space in the buffer
-                    requestMoreIfNecessary();
-                } else {
-                    // queue is empty break
+                    a.onNext(t);
+                    
+                    r--;
+                    e--;
+                }
+                
+                if (e != 0L) {
+                    if (!unbounded) {
+                        REQUESTED.addAndGet(this, e);
+                    }
+                    s.request(-e);
+                }
+                
+                missed = WIP.addAndGet(this, -missed);
+                if (missed == 0) {
                     break;
                 }
             }
         }
+        
+        void errorAll(Subscriber<? super GroupedObservable<K, V>> a, Queue<?> q, Throwable ex) {
+            q.clear();
+            List<GroupedUnicast<K, V>> list = new ArrayList<GroupedUnicast<K, V>>(groups.values());
+            groups.clear();
+            
+            for (GroupedUnicast<K, V> e : list) {
+                e.onError(ex);
+            }
+            
+            a.onError(ex);
+        }
+        
+        boolean checkTerminated(boolean d, boolean empty, 
+                Subscriber<? super GroupedObservable<K, V>> a, Queue<?> q) {
+            if (d) {
+                Throwable err = error;
+                if (err != null) {
+                    errorAll(a, q, err);
+                    return true;
+                } else
+                if (empty) {
+                    List<GroupedUnicast<K, V>> list = new ArrayList<GroupedUnicast<K, V>>(groups.values());
+                    groups.clear();
+                    
+                    for (GroupedUnicast<K, V> e : list) {
+                        e.onComplete();
+                    }
+                    
+                    actual.onCompleted();
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+    
+    static final class GroupedUnicast<K, T> extends GroupedObservable<K, T> {
+        
+        public static <T, K> GroupedUnicast<K, T> createWith(K key, int bufferSize, GroupBySubscriber<?, K, T> parent, boolean delayError) {
+            State<T, K> state = new State<T, K>(bufferSize, parent, key, delayError);
+            return new GroupedUnicast<K, T>(key, state);
+        }
+        
+        final State<T, K> state;
+        
+        protected GroupedUnicast(K key, State<T, K> state) {
+            super(key, state);
+            this.state = state;
+        }
+        
+        public void onNext(T t) {
+            state.onNext(t);
+        }
+        
+        public void onError(Throwable e) {
+            state.onError(e);
+        }
+        
+        public void onComplete() {
+            state.onComplete();
+        }
+    }
+    
+    static final class State<T, K> extends AtomicInteger implements Producer, Subscription, OnSubscribe<T> {
+        /** */
+        private static final long serialVersionUID = -3852313036005250360L;
 
-        private void completeInner() {
-            // A group is removed, so check if we need to call `unsubscribe`
-            if (WIP_FOR_UNSUBSCRIBE_UPDATER.decrementAndGet(this) == 0) {
-                // It means `groups.isEmpty() && child.isUnsubscribed()` is true
-                unsubscribe();
-            } else if (groups.isEmpty() && terminated == TERMINATED_WITH_COMPLETED) {
-                // if we have no outstanding groups (all completed or unsubscribe) and terminated on outer
-                // completionEmitted ensures we only emit onCompleted once
-                if (COMPLETION_EMITTED_UPDATER.compareAndSet(this, 0, 1)) {
-                    child.onCompleted();
+        final K key;
+        final Queue<Object> queue;
+        final GroupBySubscriber<?, K, T> parent;
+        final boolean delayError;
+        
+        volatile long requested;
+        @SuppressWarnings("rawtypes")
+        static final AtomicLongFieldUpdater<State> REQUESTED =
+                AtomicLongFieldUpdater.newUpdater(State.class, "requested");
+        
+        volatile boolean done;
+        Throwable error;
+        
+        volatile int cancelled;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<State> CANCELLED =
+                AtomicIntegerFieldUpdater.newUpdater(State.class, "cancelled");
+        
+        volatile Subscriber<? super T> actual;
+        @SuppressWarnings("rawtypes")
+        static final AtomicReferenceFieldUpdater<State, Subscriber> ACTUAL =
+                AtomicReferenceFieldUpdater.newUpdater(State.class, Subscriber.class, "actual");
+
+        volatile int once;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<State> ONCE =
+                AtomicIntegerFieldUpdater.newUpdater(State.class, "once");
+
+        
+        public State(int bufferSize, GroupBySubscriber<?, K, T> parent, K key, boolean delayError) {
+            this.queue = new ConcurrentLinkedQueue<Object>();
+            this.parent = parent;
+            this.key = key;
+            this.delayError = delayError;
+        }
+        
+        @Override
+        public void request(long n) {
+            if (n < 0) {
+                throw new IllegalArgumentException("n >= required but it was " + n);
+            }
+            if (n != 0L) {
+                BackpressureUtils.getAndAddRequest(REQUESTED, this, n);
+                drain();
+            }
+        }
+        
+        @Override
+        public boolean isUnsubscribed() {
+            return cancelled != 0;
+        }
+        
+        @Override
+        public void unsubscribe() {
+            if (CANCELLED.compareAndSet(this, 0, 1)) {
+                if (getAndIncrement() == 0) {
+                    parent.cancel(key);
                 }
             }
         }
-
-    }
-
-    private final static Func1<Object, Object> IDENTITY = new Func1<Object, Object>() {
+        
         @Override
-        public Object call(Object t) {
-            return t;
+        public void call(Subscriber<? super T> s) {
+            if (ONCE.compareAndSet(this, 0, 1)) {
+                s.add(this);
+                s.setProducer(this);
+                ACTUAL.lazySet(this, s);
+                drain();
+            } else {
+                s.onError(new IllegalStateException("Only one Subscriber allowed!"));
+            }
         }
-    };
 
-    private static final Object NULL_KEY = new Object();
+        public void onNext(T t) {
+            if (t == null) {
+                error = new NullPointerException();
+                done = true;
+            } else {
+                queue.offer(NotificationLite.instance().next(t));
+            }
+            drain();
+        }
+        
+        public void onError(Throwable e) {
+            error = e;
+            done = true;
+            drain();
+        }
+        
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            int missed = 1;
+            
+            final Queue<Object> q = queue;
+            final boolean delayError = this.delayError;
+            Subscriber<? super T> a = actual;
+            NotificationLite<T> nl = NotificationLite.instance();
+            for (;;) {
+                if (a != null) {
+                    if (checkTerminated(done, q.isEmpty(), a, delayError)) {
+                        return;
+                    }
+                    
+                    long r = requested;
+                    boolean unbounded = r == Long.MAX_VALUE;
+                    long e = 0;
+                    
+                    while (r != 0L) {
+                        boolean d = done;
+                        Object v = q.poll();
+                        boolean empty = v == null;
+                        
+                        if (checkTerminated(d, empty, a, delayError)) {
+                            return;
+                        }
+                        
+                        if (empty) {
+                            break;
+                        }
+                        
+                        a.onNext(nl.getValue(v));
+                        
+                        r--;
+                        e--;
+                    }
+                    
+                    if (e != 0L) {
+                        if (!unbounded) {
+                            REQUESTED.addAndGet(this, e);
+                        }
+                        parent.s.request(-e);
+                    }
+                }
+                
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+                if (a == null) {
+                    a = actual;
+                }
+            }
+        }
+        
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a, boolean delayError) {
+            if (cancelled != 0) {
+                queue.clear();
+                parent.cancel(key);
+                return true;
+            }
+            
+            if (d) {
+                if (delayError) {
+                    if (empty) {
+                        Throwable e = error;
+                        if (e != null) {
+                            a.onError(e);
+                        } else {
+                            a.onCompleted();
+                        }
+                        return true;
+                    }
+                } else {
+                    Throwable e = error;
+                    if (e != null) {
+                        queue.clear();
+                        a.onError(e);
+                        return true;
+                    } else
+                    if (empty) {
+                        a.onCompleted();
+                        return true;
+                    }
+                }
+            }
+            
+            return false;
+        }
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -15,45 +15,24 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.MockitoAnnotations;
+import org.junit.*;
+import org.mockito.*;
 
-import rx.Notification;
+import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
-import rx.Subscriber;
-import rx.Subscription;
 import rx.exceptions.TestException;
-import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.functions.Func1;
-import rx.internal.util.UtilityFunctions;
+import rx.functions.*;
+import rx.internal.util.*;
 import rx.observables.GroupedObservable;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -1501,4 +1480,105 @@ public class OperatorGroupByTest {
                     }});
         assertTrue(completed.get());
     }
+    
+    /**
+     * Issue #3425.
+     * 
+     * The problem is that a request of 1 may create a new group, emit to the desired group
+     * or emit to a completely different group. In this test, the merge requests N which
+     * must be produced by the range, however it will create a bunch of groups before the actual
+     * group receives a value.
+     */
+    @Test
+    public void testBackpressureObserveOnOuter() {
+        for (int j = 0; j < 1000; j++) {
+            Observable.merge(
+                    Observable.range(0, 500)
+                    .groupBy(new Func1<Integer, Object>() {
+                        @Override
+                        public Object call(Integer i) {
+                            return i % (RxRingBuffer.SIZE + 2);
+                        }
+                    })
+                    .observeOn(Schedulers.computation())
+            ).toBlocking().last();
+        }
+    }
+    
+    /**
+     * Synchronous verification of issue #3425.
+     */
+    @Test
+    public void testBackpressureInnerDoesntOverflowOuter() {
+        TestSubscriber<Object> ts = TestSubscriber.create(0);
+        
+        Observable.just(1, 2)
+                .groupBy(new Func1<Integer, Object>() {
+                    @Override
+                    public Object call(Integer v) {
+                        return v;
+                    }
+                })
+                .doOnNext(new Action1<GroupedObservable<Object, Integer>>() {
+                    @Override
+                    public void call(GroupedObservable<Object, Integer> g) {
+                        // this will request Long.MAX_VALUE
+                        g.subscribe();
+                    }
+                })
+                // this won't request anything just yet
+                .subscribe(ts)
+                ;
+        ts.requestMore(1);
+        
+        ts.assertNotCompleted();
+        ts.assertNoErrors();
+        ts.assertValueCount(1);
+    }
+    
+    @Test
+    public void testOneGroupInnerRequestsTwiceBuffer() {
+        TestSubscriber<Object> ts1 = TestSubscriber.create(0);
+        final TestSubscriber<Object> ts2 = TestSubscriber.create(0);
+        
+        Observable.range(1, RxRingBuffer.SIZE * 2)
+        .groupBy(new Func1<Integer, Object>() {
+            @Override
+            public Object call(Integer v) {
+                return 1;
+            }
+        })
+        .doOnNext(new Action1<GroupedObservable<Object, Integer>>() {
+            @Override
+            public void call(GroupedObservable<Object, Integer> g) {
+                g.subscribe(ts2);
+            }
+        })
+        .subscribe(ts1);
+        
+        ts1.assertNoValues();
+        ts1.assertNoErrors();
+        ts1.assertNotCompleted();
+        
+        ts2.assertNoValues();
+        ts2.assertNoErrors();
+        ts2.assertNotCompleted();
+        
+        ts1.requestMore(1);
+        
+        ts1.assertValueCount(1);
+        ts1.assertNoErrors();
+        ts1.assertNotCompleted();
+        
+        ts2.assertNoValues();
+        ts2.assertNoErrors();
+        ts2.assertNotCompleted();
+        
+        ts2.requestMore(RxRingBuffer.SIZE * 2);
+        
+        ts2.assertValueCount(RxRingBuffer.SIZE * 2);
+        ts2.assertNoErrors();
+        ts2.assertNotCompleted();
+    }
+
 }

--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -874,6 +874,7 @@ public class OperatorRetryTest {
         });
         
         origin.retry()
+        .onBackpressureBuffer() // FIXME the new GroupBy won't request enough for this particular test and retry overflows
         .groupBy(new Func1<String, String>() {
             @Override
             public String call(String t1) {


### PR DESCRIPTION
This is a backport of the 2.x GroupBy operator which solves #3425.

One unit test in OperatorRetryTest had to be altered a bit. I believe
the original code relied on a GroupBy behavior which caused the bug in
#3425.