### PR TITLE
1.x: Add action != null check in OperatorFinally

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorFinally.java
+++ b/src/main/java/rx/internal/operators/OperatorFinally.java
@@ -33,6 +33,9 @@ public final class OperatorFinally<T> implements Operator<T, T> {
     final Action0 action;
 
     public OperatorFinally(Action0 action) {
+        if (action == null) {
+            throw new NullPointerException("Action can not be null");
+        }
         this.action = action;
     }
 

--- a/src/test/java/rx/internal/operators/OperatorFinallyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFinallyTest.java
@@ -15,6 +15,8 @@
  */
 package rx.internal.operators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,5 +54,15 @@ public class OperatorFinallyTest {
     @Test
     public void testFinallyCalledOnError() {
         checkActionCalled(Observable.<String> error(new RuntimeException("expected")));
+    }
+
+    @Test
+    public void nullActionShouldBeCheckedInConstructor() {
+        try {
+            new OperatorFinally<Object>(null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("Action can not be null", expected.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Part of #3435.

Personally, I'd also add same test to `Observable.finallyDo()` and `Single.finallyDo()` because there are no guarantees that in future they will use exact same operator as implementation and this contract is more a contract of `Observable.finallyDo()` and `Single.finallyDo()`.