### PR TITLE
Better null tolerance in rx.exceptions.*Exception classes.

### DIFF
--- a/src/main/java/rx/exceptions/MissingBackpressureException.java
+++ b/src/main/java/rx/exceptions/MissingBackpressureException.java
@@ -48,9 +48,17 @@ public class MissingBackpressureException extends Exception {
 
     private static final long serialVersionUID = 7250870679677032194L;
 
+    /**
+     * Constructs the exception without any custom message.
+     */
     public MissingBackpressureException() {
+        
     }
 
+    /**
+     * Constructs the exception with the given customized message.
+     * @param message the customized message
+     */
     public MissingBackpressureException(String message) {
         super(message);
     }

--- a/src/main/java/rx/exceptions/OnCompletedFailedException.java
+++ b/src/main/java/rx/exceptions/OnCompletedFailedException.java
@@ -15,15 +15,35 @@
  */
 package rx.exceptions;
 
+import rx.Subscriber;
+
+/**
+ * Represents an exception used to re-throw errors thrown from {@link Subscriber#onCompleted()}.
+ */
 public final class OnCompletedFailedException extends RuntimeException {
 
     private static final long serialVersionUID = 8622579378868820554L;
 
+    /**
+     * Wraps the {@code Throwable} before it is to be re-thrown as an {@code OnCompletedFailedException}.
+     *
+     * @param e
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
+     */
     public OnCompletedFailedException(Throwable throwable) {
-        super(throwable);
+        super(throwable != null ? throwable : new NullPointerException());
     }
     
+    /**
+     * Customizes the {@code Throwable} with a custom message and wraps it before it is to be re-thrown as an
+     * {@code OnCompletedFailedException}.
+     *
+     * @param message
+     *          the message to assign to the {@code Throwable} to re-throw
+     * @param e
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
+     */
     public OnCompletedFailedException(String message, Throwable throwable) {
-        super(message, throwable);
+        super(message, throwable != null ? throwable : new NullPointerException());
     }
 }

--- a/src/main/java/rx/exceptions/OnErrorFailedException.java
+++ b/src/main/java/rx/exceptions/OnErrorFailedException.java
@@ -32,19 +32,19 @@ public class OnErrorFailedException extends RuntimeException {
      * @param message
      *          the message to assign to the {@code Throwable} to re-throw
      * @param e
-     *          the {@code Throwable} to re-throw
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
      */
     public OnErrorFailedException(String message, Throwable e) {
-        super(message, e);
+        super(message, e != null ? e : new NullPointerException());
     }
 
     /**
      * Wraps the {@code Throwable} before it is to be re-thrown as an {@code OnErrorFailedException}.
      *
      * @param e
-     *          the {@code Throwable} to re-throw
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
      */
     public OnErrorFailedException(Throwable e) {
-        super(e.getMessage(), e);
+        super(e != null ? e.getMessage() : null, e != null ? e : new NullPointerException());
     }
 }

--- a/src/main/java/rx/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/rx/exceptions/OnErrorNotImplementedException.java
@@ -40,19 +40,19 @@ public class OnErrorNotImplementedException extends RuntimeException {
      * @param message
      *          the message to assign to the {@code Throwable} to re-throw
      * @param e
-     *          the {@code Throwable} to re-throw
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
      */
     public OnErrorNotImplementedException(String message, Throwable e) {
-        super(message, e);
+        super(message, e != null ? e : new NullPointerException());
     }
 
     /**
      * Wraps the {@code Throwable} before it is to be re-thrown as an {@code OnErrorNotImplementedException}.
      *
      * @param e
-     *          the {@code Throwable} to re-throw
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
      */
     public OnErrorNotImplementedException(Throwable e) {
-        super(e.getMessage(), e);
+        super(e != null ? e.getMessage() : null, e != null ? e : new NullPointerException());
     }
 }

--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -69,16 +69,18 @@ public final class OnErrorThrowable extends RuntimeException {
      * Converts a {@link Throwable} into an {@link OnErrorThrowable}.
      *
      * @param t
-     *          the {@code Throwable} to convert
+     *          the {@code Throwable} to convert; if null, a NullPointerException is constructed
      * @return an {@code OnErrorThrowable} representation of {@code t}
      */
     public static OnErrorThrowable from(Throwable t) {
+        if (t == null) {
+            t = new NullPointerException();
+        }
         Throwable cause = Exceptions.getFinalCause(t);
         if (cause instanceof OnErrorThrowable.OnNextValue) {
             return new OnErrorThrowable(t, ((OnNextValue) cause).getValue());
-        } else {
-            return new OnErrorThrowable(t);
         }
+        return new OnErrorThrowable(t);
     }
 
     /**
@@ -93,6 +95,9 @@ public final class OnErrorThrowable extends RuntimeException {
      *         cause
      */
     public static Throwable addValueAsLastCause(Throwable e, Object value) {
+        if (e == null) {
+            e = new NullPointerException();
+        }
         Throwable lastCause = Exceptions.getFinalCause(e);
         if (lastCause != null && lastCause instanceof OnNextValue) {
             // purposefully using == for object reference check

--- a/src/main/java/rx/exceptions/UnsubscribeFailedException.java
+++ b/src/main/java/rx/exceptions/UnsubscribeFailedException.java
@@ -15,16 +15,36 @@
  */
 package rx.exceptions;
 
+import rx.Subscriber;
+
+/**
+ * Represents an exception used to re-throw errors thrown from {@link Subscriber#unsubscribe()}.
+ */
 public final class UnsubscribeFailedException extends RuntimeException {
 
     private static final long serialVersionUID = 4594672310593167598L;
 
+    /**
+     * Wraps the {@code Throwable} before it is to be re-thrown as an {@code OnErrorFailedException}.
+     *
+     * @param throwable
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
+     */
     public UnsubscribeFailedException(Throwable throwable) {
-        super(throwable);
+        super(throwable != null ? throwable : new NullPointerException());
     }
     
+    /**
+     * Customizes the {@code Throwable} with a custom message and wraps it before it is to be re-thrown as an
+     * {@code UnsubscribeFailedException}.
+     *
+     * @param message
+     *          the message to assign to the {@code Throwable} to re-throw
+     * @param throwable
+     *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
+     */
     public UnsubscribeFailedException(String message, Throwable throwable) {
-        super(message, throwable);
+        super(message, throwable != null ? throwable : new NullPointerException());
     }
     
 }

--- a/src/test/java/rx/exceptions/ExceptionsNullTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsNullTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.exceptions;
+
+import org.junit.*;
+
+/**
+ * Checks the Exception classes to verify they don't crash with null argument
+ */
+public class ExceptionsNullTest {
+
+    @Test
+    public void testOnCompleteFailedExceptionNull() {
+        Throwable t = new OnCompletedFailedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnCompleteFailedExceptionMessageAndNull() {
+        Throwable t = new OnCompletedFailedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+
+    @Test
+    public void testOnErrorFailedExceptionNull() {
+        Throwable t = new OnErrorFailedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnErrorFailedExceptionMessageAndNull() {
+        Throwable t = new OnErrorFailedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testUnsubscribeFailedExceptionNull() {
+        Throwable t = new UnsubscribeFailedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testUnsubscribeFailedExceptionMessageAndNull() {
+        Throwable t = new UnsubscribeFailedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+
+    @Test
+    public void testOnErrorNotImplementedExceptionNull() {
+        Throwable t = new OnErrorNotImplementedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnErrorNotImplementedExceptionMessageAndNull() {
+        Throwable t = new OnErrorNotImplementedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnErrorThrowableFrom() {
+        Throwable t = OnErrorThrowable.from(null);
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnErrorThrowableAddValueAsLastCause() {
+        Throwable t = OnErrorThrowable.addValueAsLastCause(null, "value");
+        Assert.assertTrue(t instanceof NullPointerException);
+    }
+
+}


### PR DESCRIPTION
There seems to be a tendency to send `null` values through `onError` which eventually causes repeated failures. This PR converts these `null` values into `NullPointerException`s so the error origin is can be discovered and prevents the XXXExceptions from throwing NPEs in their constructors as well.

I've also added some missing javadoc.