### PR TITLE
1.x: Observable.ignoreElementsThen

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5595,6 +5595,24 @@ public class Observable<T> {
     public final Observable<T> ignoreElements() {
         return lift(OperatorIgnoreElements.<T> instance());
     }
+    
+    /**
+     * Returns the source with all {@code onNext} emissions ignored concatenated with the Observable {@code following}.  
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ignoreElementsThen.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code ignoreElementsThen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @return the concatenation of {@code source.ignoreElements()} with {@code following}
+     * @see <a href="http://reactivex.io/documentation/operators/ignoreelements.html">ReactiveX operators documentation: IgnoreElementsThen</a>
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public final <R> Observable<R> ignoreElementsThen(Observable<R> following) {
+        return ((Observable<R>) (Observable<?>) ignoreElements()).concatWith(following);
+    }
 
     /**
      * Returns an Observable that emits {@code true} if the source Observable is empty, otherwise {@code false}.

--- a/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
+++ b/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
@@ -1,9 +1,11 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -130,18 +132,36 @@ public class OperatorIgnoreElementsTest {
     @Test
     public void testIgnoreElementsThen() {
         final AtomicBoolean firstCompleted = new AtomicBoolean(false);
-        assertEquals(Arrays.asList(1, 2, 3), 
-                Observable
-                    .just("a","b","c")
-                    .doOnCompleted(new Action0() {
-
-                        @Override
-                        public void call() {
-                            firstCompleted.set(true);
-                        }})
-                    .ignoreElementsThen(Observable.just(1, 2, 3))
-                    .toList().toBlocking().single());
+        List<Integer> list = Observable
+                .just("a","b","c")
+                .doOnCompleted(new Action0() {
+                    @Override
+                    public void call() {
+                        firstCompleted.set(true);
+                    }})
+                .ignoreElementsThen(Observable.just(1, 2, 3))
+                .toList().toBlocking().single();
+        assertEquals(Arrays.asList(1, 2, 3), list          );
         assertTrue(firstCompleted.get());
+    }
+    
+    @Test
+    public void testIgnoreElementsThenWhenFirstObservableErrorsThatSecondObservableDoesNotGetSubscribedTo() {
+        final AtomicBoolean secondSubscribed = new AtomicBoolean(false);
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable
+                .error(new RuntimeException())
+                .ignoreElementsThen(
+                     Observable.just(1, 2, 3)
+                        .doOnSubscribe(new Action0() {
+                            @Override
+                            public void call() {
+                                secondSubscribed.set(true);
+                            }}))
+                .subscribe(ts);
+        ts.assertError(RuntimeException.class);
+        ts.assertNoValues();
+        assertFalse(secondSubscribed.get());
     }
     
 }

--- a/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
+++ b/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
@@ -127,4 +127,21 @@ public class OperatorIgnoreElementsTest {
         assertEquals(0, count.get());
     }
     
+    @Test
+    public void testIgnoreElementsThen() {
+        final AtomicBoolean firstCompleted = new AtomicBoolean(false);
+        assertEquals(Arrays.asList(1, 2, 3), 
+                Observable
+                    .just("a","b","c")
+                    .doOnCompleted(new Action0() {
+
+                        @Override
+                        public void call() {
+                            firstCompleted.set(true);
+                        }})
+                    .ignoreElementsThen(Observable.just(1, 2, 3))
+                    .toList().toBlocking().single());
+        assertTrue(firstCompleted.get());
+    }
+    
 }


### PR DESCRIPTION
As discussed in #3113.

I also considered on a consistency basis calling it `ignoreElementsWith` but I don't think it carries the same clarity of meaning like `startWith` or `concatWith`. "ignore" and "then" seems to be a more natural combination in English to capture the sequential nature.