### PR TITLE
1.x: Change the signature of ignoreElements is also an implicit cast to whatever type you want.

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5592,8 +5592,8 @@ public class Observable<T> {
      *         called by the source Observable
      * @see <a href="http://reactivex.io/documentation/operators/ignoreelements.html">ReactiveX operators documentation: IgnoreElements</a>
      */
-    public final Observable<T> ignoreElements() {
-        return lift(OperatorIgnoreElements.<T> instance());
+    public final <R> Observable<R> ignoreElements() {
+        return lift(OperatorIgnoreElements.<R, T>instance());
     }
 
     /**

--- a/src/main/java/rx/internal/operators/OperatorIgnoreElements.java
+++ b/src/main/java/rx/internal/operators/OperatorIgnoreElements.java
@@ -18,15 +18,15 @@ package rx.internal.operators;
 import rx.Observable.Operator;
 import rx.Subscriber;
 
-public class OperatorIgnoreElements<T> implements Operator<T, T> {
+public class OperatorIgnoreElements<R, T> implements Operator<R, T> {
 
     private static class Holder {
-        static final OperatorIgnoreElements<?> INSTANCE = new OperatorIgnoreElements<Object>();
+        static final OperatorIgnoreElements<?, ?> INSTANCE = new OperatorIgnoreElements<Object, Object>();
     }
     
     @SuppressWarnings("unchecked")
-    public static <T> OperatorIgnoreElements<T> instance() {
-        return (OperatorIgnoreElements<T>) Holder.INSTANCE;
+    public static <T, R> OperatorIgnoreElements<T, R> instance() {
+        return (OperatorIgnoreElements<T, R>) Holder.INSTANCE;
     }
 
     private OperatorIgnoreElements() {
@@ -34,7 +34,7 @@ public class OperatorIgnoreElements<T> implements Operator<T, T> {
     }
 
     @Override
-    public Subscriber<? super T> call(final Subscriber<? super T> child) {
+    public Subscriber<? super T> call(final Subscriber<? super R> child) {
         Subscriber<T> parent = new Subscriber<T>() {
 
             @Override

--- a/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
+++ b/src/test/java/rx/internal/operators/OperatorIgnoreElementsTest.java
@@ -92,7 +92,7 @@ public class OperatorIgnoreElementsTest {
                     }
                 })
                 //
-                .ignoreElements()
+                .<Integer>ignoreElements()
                 //
                 .doOnNext(new Action1<Integer>() {
 


### PR DESCRIPTION
to remove the need for mergeWithEmpty and concatWithEmpty in #3430.  I'm pretty sure that this doesn't count as a breaking change because of type erasure.