### PR TITLE
1.x: compensation for significant clock drifts in schedulePeriodically

### DIFF
--- a/src/test/java/rx/SchedulerWorkerTest.java
+++ b/src/test/java/rx/SchedulerWorkerTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import rx.functions.Action0;
+import rx.schedulers.Schedulers;
+
+public class SchedulerWorkerTest {
+    
+    static final class CustomDriftScheduler extends Scheduler {
+        public volatile long drift;
+        @Override
+        public Worker createWorker() {
+            final Worker w = Schedulers.computation().createWorker();
+            return new Worker() {
+
+                @Override
+                public void unsubscribe() {
+                    w.unsubscribe();
+                }
+
+                @Override
+                public boolean isUnsubscribed() {
+                    return w.isUnsubscribed();
+                }
+
+                @Override
+                public Subscription schedule(Action0 action) {
+                    return w.schedule(action);
+                }
+
+                @Override
+                public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
+                    return w.schedule(action, delayTime, unit);
+                }
+                
+                @Override
+                public long now() {
+                    return super.now() + drift;
+                }
+            };
+        }
+        
+        @Override
+        public long now() {
+            return super.now() + drift;
+        }
+    }
+    
+    @Test
+    public void testCurrentTimeDriftBackwards() throws Exception {
+        CustomDriftScheduler s = new CustomDriftScheduler();
+        
+        Scheduler.Worker w = s.createWorker();
+        
+        try {
+            final List<Long> times = new ArrayList<Long>();
+            
+            Subscription d = w.schedulePeriodically(new Action0() {
+                @Override
+                public void call() {
+                    times.add(System.currentTimeMillis());
+                }
+            }, 100, 100, TimeUnit.MILLISECONDS);
+
+            Thread.sleep(150);
+            
+            s.drift = -1000 - TimeUnit.NANOSECONDS.toMillis(Scheduler.CLOCK_DRIFT_TOLERANCE_NANOS);
+            
+            Thread.sleep(400);
+            
+            d.unsubscribe();
+            
+            Thread.sleep(150);
+            
+            System.out.println("Runs: " + times.size());
+            
+            for (int i = 0; i < times.size() - 1 ; i++) {
+                long diff = times.get(i + 1) - times.get(i);
+                System.out.println("Diff #" + i + ": " + diff);
+                assertTrue("" + i + ":" + diff, diff < 150 && diff > 50);
+            }
+
+            assertTrue("Too few invocations: " + times.size(), times.size() > 2);
+            
+        } finally {
+            w.unsubscribe();
+        }
+        
+    }
+    
+    @Test
+    public void testCurrentTimeDriftForwards() throws Exception {
+        CustomDriftScheduler s = new CustomDriftScheduler();
+        
+        Scheduler.Worker w = s.createWorker();
+        
+        try {
+            final List<Long> times = new ArrayList<Long>();
+            
+            Subscription d = w.schedulePeriodically(new Action0() {
+                @Override
+                public void call() {
+                    times.add(System.currentTimeMillis());
+                }
+            }, 100, 100, TimeUnit.MILLISECONDS);
+
+            Thread.sleep(150);
+            
+            s.drift = 1000 + TimeUnit.NANOSECONDS.toMillis(Scheduler.CLOCK_DRIFT_TOLERANCE_NANOS);
+            
+            Thread.sleep(400);
+            
+            d.unsubscribe();
+            
+            Thread.sleep(150);
+            
+            System.out.println("Runs: " + times.size());
+            
+            assertTrue(times.size() > 2);
+            
+            for (int i = 0; i < times.size() - 1 ; i++) {
+                long diff = times.get(i + 1) - times.get(i);
+                System.out.println("Diff #" + i + ": " + diff);
+                assertTrue("Diff out of range: " + diff, diff < 250 && diff > 50);
+            }
+            
+        } finally {
+            w.unsubscribe();
+        }
+        
+    }
+}


### PR DESCRIPTION
There is a problem, reported in #3461 and #2943, in which if the system clock drifts, the periodic calculation inside Scheduler.Worker gets off and either taking a longer time for the next invocation of the task or doing "catching-up" with all the lost invocations.

The solution checks the wall clock difference between the last run and the current run and if it went back or forward significantly, it rebases the timer period and schedules the next execution relative to now.

If the clock goes back, the original code scheduled the next invocation way into the future. This PR will schedule it after the period.

If the clock goes forward, the original code scheduled executions for all the missed time between the last run and the new time immediately, yielding a bunch of 0 delays. This PR will simply schedule the next invocation after the period.

The algorithm for both cases is the same: make sure the next invocation is scheduled relative to now and recalculate the start timestamp as if the whole sequence run under the new drifted clock all along. The subsequent invocations will be scheduled at a fixed rate again.

I've added the system parameter `rx.scheduler.drift-tolerance` (unit: minutes, default: 15 minutes), which is used to determine if the clock drifted too far between invocations of the periodic task.