### PR TITLE
1.x: reduce Subscriber's creation overhead

### DIFF
--- a/src/perf/java/rx/SubscribingPerf.java
+++ b/src/perf/java/rx/SubscribingPerf.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
+import rx.functions.Func1;
+
 /**
  * Benchmark the cost of subscription and initial request management.
  * <p>
@@ -38,64 +40,121 @@ public class SubscribingPerf {
     
     @Benchmark
     public void justDirect(Blackhole bh) {
-        just.subscribe(new DirectSubscriber<Integer>(Long.MAX_VALUE, bh));
+        DirectSubscriber<Integer> subscriber = new DirectSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        just.subscribe(subscriber);
     }
 
     @Benchmark
     public void justStarted(Blackhole bh) {
-        just.subscribe(new StartedSubscriber<Integer>(Long.MAX_VALUE, bh));
+        StartedSubscriber<Integer> subscriber = new StartedSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        just.subscribe(subscriber);
     }
 
     @Benchmark
     public void justUsual(Blackhole bh) {
-        just.subscribe(new UsualSubscriber<Integer>(Long.MAX_VALUE, bh));
+        UsualSubscriber<Integer> subscriber = new UsualSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        just.subscribe(subscriber);
     }
 
     @Benchmark
     public void rangeDirect(Blackhole bh) {
-        range.subscribe(new DirectSubscriber<Integer>(Long.MAX_VALUE, bh));
+        DirectSubscriber<Integer> subscriber = new DirectSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        range.subscribe(subscriber);
     }
 
     @Benchmark
     public void rangeStarted(Blackhole bh) {
-        range.subscribe(new DirectSubscriber<Integer>(Long.MAX_VALUE, bh));
+        StartedSubscriber<Integer> subscriber = new StartedSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        range.subscribe(subscriber);
     }
 
     @Benchmark
     public void rangeUsual(Blackhole bh) {
-        range.subscribe(new UsualSubscriber<Integer>(Long.MAX_VALUE, bh));
+        UsualSubscriber<Integer> subscriber = new UsualSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        range.subscribe(subscriber);
     }
 
     @Benchmark
     public void justDirectUnsafe(Blackhole bh) {
-        just.unsafeSubscribe(new DirectSubscriber<Integer>(Long.MAX_VALUE, bh));
+        DirectSubscriber<Integer> subscriber = new DirectSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        just.unsafeSubscribe(subscriber);
     }
 
     @Benchmark
     public void justStartedUnsafe(Blackhole bh) {
-        just.unsafeSubscribe(new StartedSubscriber<Integer>(Long.MAX_VALUE, bh));
+        StartedSubscriber<Integer> subscriber = new StartedSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        just.unsafeSubscribe(subscriber);
     }
 
     @Benchmark
     public void justUsualUnsafe(Blackhole bh) {
-        just.unsafeSubscribe(new UsualSubscriber<Integer>(Long.MAX_VALUE, bh));
+        UsualSubscriber<Integer> subscriber = new UsualSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        just.unsafeSubscribe(subscriber);
     }
 
     @Benchmark
     public void rangeDirectUnsafe(Blackhole bh) {
-        range.unsafeSubscribe(new DirectSubscriber<Integer>(Long.MAX_VALUE, bh));
+        DirectSubscriber<Integer> subscriber = new DirectSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        range.unsafeSubscribe(subscriber);
     }
 
     @Benchmark
     public void rangeStartedUnsafe(Blackhole bh) {
-        range.unsafeSubscribe(new DirectSubscriber<Integer>(Long.MAX_VALUE, bh));
+        StartedSubscriber<Integer> subscriber = new StartedSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        range.unsafeSubscribe(subscriber);
     }
 
     @Benchmark
     public void rangeUsualUnsafe(Blackhole bh) {
-        range.unsafeSubscribe(new UsualSubscriber<Integer>(Long.MAX_VALUE, bh));
+        UsualSubscriber<Integer> subscriber = new UsualSubscriber<Integer>(Long.MAX_VALUE, bh);
+        bh.consume(subscriber);
+        range.unsafeSubscribe(subscriber);
     }
 
+    @State(Scope.Thread)
+    public static class Chain {
+        @Param({"10", "1000", "1000000"})
+        public int times;
+        
+        @Param({"1", "2", "3", "4", "5"})
+        public int maps;
+        
+        Observable<Integer> source;
+        
+        @Setup
+        public void setup() {
+            Observable<Integer> o = Observable.range(1, times);
+            
+            for (int i = 0; i < maps; i++) {
+                o = o.map(new Func1<Integer, Integer>() {
+                    @Override
+                    public Integer call(Integer v) {
+                        return v + 1;
+                    }
+                });
+            }
+            
+            source = o;
+        }
+        
+        @Benchmark
+        public void mapped(Chain c, Blackhole bh) {
+            DirectSubscriber<Integer> subscriber = new DirectSubscriber<Integer>(Long.MAX_VALUE, bh);
+            bh.consume(subscriber);
+            c.source.subscribe(subscriber);
+        }
+    }
     
     static final class DirectSubscriber<T> extends Subscriber<T> {
         final long r;


### PR DESCRIPTION
This PR changes the internals of the `Subscriber` class to reduce its creation overhead by deferring the creation of the SubscriptionList until it is actually needed.

Benchmark (i7 4770K, Windows 7 x64, Java 8u66)

![image](https://cloud.githubusercontent.com/assets/1269832/10806351/14e6567e-7dd5-11e5-8c06-3716454ccbc7.png)

For no-backpressure sources, the throughput is now doubled for the safe case and improved by ~20% for the unsafe case. For a backpressuring source, the improvement is between 3-10% but the error ranges overlap.

There is one case where the the throughput halved for some reason. Since JITs are smart, my best guess is that generally the benchmark method gets stack-allocated instead of heap allocated, hence the very large amounts relative to a range(1, 1) benchmark (which tops at 24 MOps/s). 

However, the justStart case is worse than the baseline. My guess is that the `this` looks like it escaped and thus a regular heap allocation is required. I'll test this theory in the morning by blackholing the test `Subscriber`s before subscription thus forcing a heap allocation in each case.

Note that `Subscriber` has now more synchronization which combined with the synchronization in `SubscriptionList` may increase the overhead elsewhere; I plan to run more benchmarks in the morning. The solution would be to inline the logic of `SubscriptionList` into `Subscriber` directly. 

Note also the recursive call to `add` and `unsubscribe` in case the `Subscriber` was created in sharing mode. In RxJava 1.x, operators like to share a single underlying `SubscriptionList` and if the chain is very long, that may prevent some JIT optimizations due to stack dept. The upside is that generally only a few resources are added to a `Subscriber`, especially in async operators, whose overhead may be shadowed by other things and thus not really a problem.