### PR TITLE
1.x: fix scan() not accepting a null initial value

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/src/main/java/rx/internal/operators/OperatorScan.java
@@ -36,6 +36,9 @@ import rx.internal.util.unsafe.*;
  * <p>
  * Note that when you pass a seed to {@code scan} the resulting Observable will emit that seed as its
  * first emitted item.
+ * 
+ * @param <R> the aggregate and output type
+ * @param <T> the input value type
  */
 public final class OperatorScan<R, T> implements Operator<R, T> {
 
@@ -192,7 +195,7 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                 q = new SpscLinkedAtomicQueue<Object>();  // new SpscUnboundedAtomicArrayQueue<R>(8);
             }
             this.queue = q;
-            q.offer(initialValue);
+            q.offer(NotificationLite.instance().next(initialValue));
         }
         
         @Override

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -391,4 +391,39 @@ public class OperatorScanTest {
         ts.assertNotCompleted();
         ts.assertValue(0);
     }
+    
+    @Test
+    public void testInitialValueNull() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 10).scan(null, new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                if (t1 == null) {
+                    return t2;
+                }
+                return t1 + t2;
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(null, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void testEverythingIsNull() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 6).scan(null, new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return null;
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(null, null, null, null, null, null, null);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }


### PR DESCRIPTION
I forgot a NotificationLite conversion in the constructor. Note that
there were no tests verifying null behavior at all.