### PR TITLE
1.x: OnBackpressureBuffer: DROP_LATEST and DROP_OLDEST

### DIFF
--- a/src/main/java/rx/BackpressureOverflow.java
+++ b/src/main/java/rx/BackpressureOverflow.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx;
+
+import rx.annotations.Experimental;
+import rx.exceptions.MissingBackpressureException;
+
+/**
+ * Generic strategy and default implementations to deal with backpressure buffer overflows.
+ */
+@Experimental
+public final class BackpressureOverflow {
+
+    public interface Strategy {
+
+        /**
+         * Whether the Backpressure manager should attempt to drop the oldest item, or simply
+         * drop the item currently causing backpressure.
+         *
+         * @return true to request drop of the oldest item, false to drop the newest.
+         * @throws MissingBackpressureException
+         */
+        boolean mayAttemptDrop() throws MissingBackpressureException;
+    }
+
+    public static final BackpressureOverflow.Strategy ON_OVERFLOW_DEFAULT = Error.INSTANCE;
+    @SuppressWarnings("unused")
+    public static final BackpressureOverflow.Strategy ON_OVERFLOW_ERROR = Error.INSTANCE;
+    @SuppressWarnings("unused")
+    public static final BackpressureOverflow.Strategy ON_OVERFLOW_DROP_OLDEST = DropOldest.INSTANCE;
+    @SuppressWarnings("unused")
+    public static final BackpressureOverflow.Strategy ON_OVERFLOW_DROP_LATEST = DropLatest.INSTANCE;
+
+    /**
+     * Drop oldest items from the buffer making room for newer ones.
+     */
+    static class DropOldest implements BackpressureOverflow.Strategy {
+        static final DropOldest INSTANCE = new DropOldest();
+
+        private DropOldest() {}
+
+        @Override
+        public boolean mayAttemptDrop() {
+            return true;
+        }
+    }
+
+    /**
+     * Drop most recent items, but not {@code onError} nor unsubscribe from source
+     * (as {code OperatorOnBackpressureDrop}).
+     */
+    static class DropLatest implements BackpressureOverflow.Strategy {
+        static final DropLatest INSTANCE = new DropLatest();
+
+        private DropLatest() {}
+
+        @Override
+        public boolean mayAttemptDrop() {
+            return false;
+        }
+    }
+
+    /**
+     * {@code onError} a MissingBackpressureException and unsubscribe from source.
+     */
+    static class Error implements BackpressureOverflow.Strategy {
+
+        static final Error INSTANCE = new Error();
+
+        private Error() {}
+
+        @Override
+        public boolean mayAttemptDrop() throws MissingBackpressureException {
+            throw new MissingBackpressureException("Overflowed buffer");
+        }
+    }
+}

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -6399,7 +6399,8 @@ public class Observable<T> {
      *  <dd>{@code onBackpressureBuffer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the source Observable modified to buffer items up to the given capacity
+     * @param capacity number of slots available in the buffer.
+     * @return the source {@code Observable} modified to buffer items up to the given capacity.
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
      * @since 1.1.0
      */
@@ -6419,12 +6420,49 @@ public class Observable<T> {
      *  <dd>{@code onBackpressureBuffer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the source Observable modified to buffer items up to the given capacity
+     * @param capacity number of slots available in the buffer.
+     * @param onOverflow action to execute if an item needs to be buffered, but there are no available slots.  Null is allowed.
+     * @return the source {@code Observable} modified to buffer items up to the given capacity
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
      * @since 1.1.0
      */
     public final Observable<T> onBackpressureBuffer(long capacity, Action0 onOverflow) {
         return lift(new OperatorOnBackpressureBuffer<T>(capacity, onOverflow));
+    }
+
+    /**
+     * Instructs an Observable that is emitting items faster than its observer can consume them to buffer up to
+     * a given amount of items until they can be emitted. The resulting Observable will behave as determined
+     * by {@code overflowStrategy} if the buffer capacity is exceeded.
+     *
+     * <ul>
+     *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_ERROR} (default) will {@code onError} dropping all undelivered items,
+     *     unsubscribing from the source, and notifying the producer with {@code onOverflow}. </li>
+     *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_DROP_LATEST} will drop any new items emitted by the producer while
+     *     the buffer is full, without generating any {@code onError}.  Each drop will however invoke {@code onOverflow}
+     *     to signal the overflow to the producer.</li>j
+     *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_DROP_OLDEST} will drop the oldest items in the buffer in order to make
+     *     room for newly emitted ones. Overflow will not generate an{@code onError}, but each drop will invoke
+     *     {@code onOverflow} to signal the overflow to the producer.</li>
+     * </ul>
+     *
+     * <p>
+     * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onBackpressureBuffer} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param capacity number of slots available in the buffer.
+     * @param onOverflow action to execute if an item needs to be buffered, but there are no available slots.  Null is allowed.
+     * @param overflowStrategy how should the {@code Observable} react to buffer overflows.  Null is not allowed.
+     * @return the source {@code Observable} modified to buffer items up to the given capacity
+     * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final Observable<T> onBackpressureBuffer(long capacity, Action0 onOverflow, BackpressureOverflow.Strategy overflowStrategy) {
+        return lift(new OperatorOnBackpressureBuffer<T>(capacity, onOverflow, overflowStrategy));
     }
 
     /**

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,17 @@ package rx.internal.operators;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static rx.BackpressureOverflow.*;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Observer;
-import rx.Subscriber;
-import rx.Subscription;
 import rx.exceptions.MissingBackpressureException;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -101,24 +98,19 @@ public class OperatorOnBackpressureBufferTest {
         Observable.empty().onBackpressureBuffer(0);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testFixBackpressureBufferNullStrategy() throws InterruptedException {
+        Observable.empty().onBackpressureBuffer(10, new Action0() {
+            @Override
+            public void call() { }
+        }, null);
+    }
+
     @Test
     public void testFixBackpressureBoundedBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch backpressureCallback = new CountDownLatch(1);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new Observer<Long>() {
-
-            @Override
-            public void onCompleted() { }
-
-            @Override
-            public void onError(Throwable e) { }
-
-            @Override
-            public void onNext(Long t) {
-                l1.countDown();
-            }
-
-        });
+        final TestSubscriber<Long> ts = testSubscriber(l1);
 
         ts.requestMore(100);
         Subscription s = infinite.subscribeOn(Schedulers.computation())
@@ -128,17 +120,111 @@ public class OperatorOnBackpressureBufferTest {
                                          backpressureCallback.countDown();
                                      }
                                  }).take(1000).subscribe(ts);
-        l1.await();
+        assertTrue(l1.await(2, TimeUnit.SECONDS));
 
         ts.requestMore(50);
 
-        assertTrue(backpressureCallback.await(500, TimeUnit.MILLISECONDS));
+        assertTrue(backpressureCallback.await(2, TimeUnit.SECONDS));
         assertTrue(ts.getOnErrorEvents().get(0) instanceof MissingBackpressureException);
 
         int size = ts.getOnNextEvents().size();
         assertTrue(size <= 150);  // will get up to 50 more
         assertTrue(ts.getOnNextEvents().get(size-1) == size-1);
         assertTrue(s.isUnsubscribed());
+    }
+
+    @Test
+    public void testFixBackpressureBoundedBufferDroppingOldest()
+        throws InterruptedException {
+        List<Long> events = overflowBufferWithBehaviour(100, 10, ON_OVERFLOW_DROP_OLDEST);
+
+        // The consumer takes 100 initial elements, then 10 are temporarily
+        // buffered and the oldest (100, 101, etc.) are dropped to make room for
+        // higher items.
+        int i = 0;
+        for (Long n : events) {
+            if (i < 100) {  // backpressure is expected to kick in after the
+                            // initial batch is consumed
+                assertEquals(Long.valueOf(i), n);
+            } else {
+                assertTrue(i < n);
+            }
+            i++;
+        }
+    }
+
+    @Test
+    public void testFixBackpressueBoundedBufferDroppingLatest()
+        throws InterruptedException {
+
+        List<Long> events = overflowBufferWithBehaviour(100, 10, ON_OVERFLOW_DROP_LATEST);
+
+        // The consumer takes 100 initial elements, then 10 are temporarily
+        // buffered and the newest are dropped to make room for higher items.
+        int i = 0;
+        for (Long n : events) {
+            if (i < 110) {
+                assertEquals(Long.valueOf(i), n);
+            } else {
+                assertTrue(i < n);
+            }
+            i++;
+        }
+    }
+
+    private List<Long> overflowBufferWithBehaviour(int initialRequest, int bufSize,
+                                                   BackpressureOverflow.Strategy backpressureStrategy)
+        throws InterruptedException {
+
+        final CountDownLatch l1 = new CountDownLatch(initialRequest * 2);
+        final CountDownLatch backpressureCallback = new CountDownLatch(1);
+
+        final TestSubscriber<Long> ts = testSubscriber(l1);
+
+        ts.requestMore(initialRequest);
+        Subscription s = infinite.subscribeOn(Schedulers.computation())
+            .onBackpressureBuffer(bufSize, new Action0() {
+                                      @Override
+                                      public void call() {
+                                          backpressureCallback.countDown();
+                                      }
+                                  }, backpressureStrategy
+            ).subscribe(ts);
+
+        assertTrue(backpressureCallback.await(2, TimeUnit.SECONDS));
+
+        ts.requestMore(initialRequest);
+
+        assertTrue(l1.await(2, TimeUnit.SECONDS));
+
+        // Stop receiving elements
+        s.unsubscribe();
+
+        // No failure despite overflows
+        assertTrue(ts.getOnErrorEvents().isEmpty());
+        assertEquals(initialRequest * 2, ts.getOnNextEvents().size());
+
+        assertTrue(ts.isUnsubscribed());
+
+        return ts.getOnNextEvents();
+    }
+
+    static <T> TestSubscriber<T> testSubscriber(final CountDownLatch latch) {
+        return new TestSubscriber<T>(new Observer<T>() {
+
+            @Override
+            public void onCompleted() {
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onNext(T t) {
+                latch.countDown();
+            }
+        });
     }
 
     static final Observable<Long> infinite = Observable.create(new OnSubscribe<Long>() {

--- a/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
@@ -118,7 +118,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
     @Test
     public void testErrorPassesThru() {
         // Trigger failure on second element
-        TestObservable f = new TestObservable("one", "ERROR", "two", "three");
+        TestObservable f = new TestObservable("one", "ON_OVERFLOW_ERROR", "two", "three");
         Observable<String> w = Observable.create(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
@@ -240,7 +240,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
                                 throw new Exception("Forced Exception");
                             else if ("RUNTIMEEXCEPTION".equals(s))
                                 throw new RuntimeException("Forced RuntimeException");
-                            else if ("ERROR".equals(s))
+                            else if ("ON_OVERFLOW_ERROR".equals(s))
                                 throw new Error("Forced Error");
                             else if ("THROWABLE".equals(s))
                                 throw new Throwable("Forced Throwable");


### PR DESCRIPTION
Introduce a new interface BackpressureOverflowStrategy that allows implementing different handlers for an overflow situation.  This patch adds three implementations, reachable via OverflowStrategy:

    static class OverflowStrategy {
        static final BackpressureOverflowStrategy DEFAULT = Error.INSTANCE;
        static final Error ERROR = Error.INSTANCE;
        static final DropOldest DROP_OLDEST = DropOldest.INSTANCE;
        static final DropLatest DROP_LATEST = DropLatest.INSTANCE;
    }

The behavior for each is the following:

- ERROR remains the default as the existing implementation.
- DROP_LATEST will drop newly produced items after the buffer fills up.
- DROP_OLDEST will drop the oldest elements in the buffer, making room for
  newer ones.

In all cases, a drop will result in a notification to the producer by invoking the onOverflow callback.

None of the two new behaviours (DROP_*) will unsubscribe from the source nor onError.