### PR TITLE
1.x: make scan's delayed Producer independent of event serialization

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/src/main/java/rx/internal/operators/OperatorScan.java
@@ -16,6 +16,7 @@
 package rx.internal.operators;
 
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
 
 import rx.*;
 import rx.Observable.Operator;
@@ -175,12 +176,10 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
         boolean missed;
         /** Missed a request. */
         long missedRequested;
-        /** Missed a producer. */
-        Producer missedProducer;
         /** The current requested amount. */
-        long requested;
+        final AtomicLong requested;
         /** The current producer. */
-        Producer producer;
+        volatile Producer producer;
         
         volatile boolean done;
         Throwable error;
@@ -196,41 +195,7 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
             }
             this.queue = q;
             q.offer(NotificationLite.instance().next(initialValue));
-        }
-        
-        @Override
-        public void request(long n) {
-            if (n < 0L) {
-                throw new IllegalArgumentException("n >= required but it was " + n);
-            } else
-            if (n != 0L) {
-                synchronized (this) {
-                    if (emitting) {
-                        long mr = missedRequested;
-                        long mu = mr + n;
-                        if (mu < 0L) {
-                            mu = Long.MAX_VALUE;
-                        }
-                        missedRequested = mu;
-                        return;
-                    }
-                    emitting = true;
-                }
-                
-                long r = requested;
-                long u = r + n;
-                if (u < 0L) {
-                    u = Long.MAX_VALUE;
-                }
-                requested = u;
-                
-                Producer p = producer;
-                if (p != null) {
-                    p.request(n);
-                }
-                
-                emitLoop();
-            }
+            this.requested = new AtomicLong();
         }
         
         @Override
@@ -270,23 +235,51 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
             emit();
         }
         
+        @Override
+        public void request(long n) {
+            if (n < 0L) {
+                throw new IllegalArgumentException("n >= required but it was " + n);
+            } else
+            if (n != 0L) {
+                BackpressureUtils.getAndAddRequest(requested, n);
+                Producer p = producer;
+                if (p == null) {
+                    // not synchronizing on this to avoid clash with emit()
+                    synchronized (requested) {
+                        p = producer;
+                        if (p == null) {
+                            long mr = missedRequested;
+                            missedRequested = BackpressureUtils.addCap(mr, n);
+                        }
+                    }
+                }
+                if (p != null) {
+                    p.request(n);
+                }
+                emit();
+            }
+        }
+        
         public void setProducer(Producer p) {
             if (p == null) {
                 throw new NullPointerException();
             }
-            synchronized (this) {
-                if (emitting) {
-                    missedProducer = p;
-                    return;
+            long mr;
+            // not synchronizing on this to avoid clash with emit()
+            synchronized (requested) {
+                if (producer != null) {
+                    throw new IllegalStateException("Can't set more than one Producer!");
                 }
-                emitting = true;
+                // request one less because of the initial value, this happens once
+                mr = missedRequested - 1;
+                missedRequested = 0L;
+                producer = p;
             }
-            producer = p;
-            long r = requested;
-            if (r != 0L) {
-                p.request(r);
+            
+            if (mr > 0L) {
+                p.request(mr);
             }
-            emitLoop();
+            emit();
         }
         
         void emit() {
@@ -304,7 +297,9 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
             final Subscriber<? super R> child = this.child;
             final Queue<Object> queue = this.queue;
             final NotificationLite<R> nl = NotificationLite.instance();
-            long r = requested;
+            AtomicLong requested = this.requested;
+            
+            long r = requested.get();
             for (;;) {
                 boolean max = r == Long.MAX_VALUE;
                 boolean d = done;
@@ -312,6 +307,7 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                 if (checkTerminated(d, empty, child)) {
                     return;
                 }
+                long e = 0L;
                 while (r != 0L) {
                     d = done;
                     Object o = queue.poll();
@@ -325,52 +321,25 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                     R v = nl.getValue(o);
                     try {
                         child.onNext(v);
-                    } catch (Throwable e) {
-                        Exceptions.throwIfFatal(e);
-                        child.onError(OnErrorThrowable.addValueAsLastCause(e, v));
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        child.onError(OnErrorThrowable.addValueAsLastCause(ex, v));
                         return;
                     }
-                    if (!max) {
-                        r--;
-                    }
-                }
-                if (!max) {
-                    requested = r;
+                    r--;
+                    e--;
                 }
                 
-                Producer p;
-                long mr;
+                if (e != 0 && !max) {
+                    r = requested.addAndGet(e);
+                }
+                
                 synchronized (this) {
-                    p = missedProducer;
-                    mr = missedRequested;
-                    if (!missed && p == null && mr == 0L) {
+                    if (!missed) {
                         emitting = false;
                         return;
                     }
                     missed = false;
-                    missedProducer = null;
-                    missedRequested = 0L;
-                }
-                
-                if (mr != 0L && !max) {
-                    long u = r + mr;
-                    if (u < 0L) {
-                        u = Long.MAX_VALUE;
-                    }
-                    requested = u;
-                    r = u;
-                }
-                
-                if (p != null) {
-                    producer = p;
-                    if (r != 0L) {
-                        p.request(r);
-                    }
-                } else {
-                    p = producer;
-                    if (p != null && mr != 0L) {
-                        p.request(mr);
-                    }
                 }
             }
         }

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -426,4 +426,24 @@ public class OperatorScanTest {
         ts.assertNoErrors();
         ts.assertCompleted();
     }
+    
+    @Test(timeout = 1000)
+    public void testUnboundedSource() {
+        Observable.range(0, Integer.MAX_VALUE)
+        .scan(0, new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer a, Integer b) {
+                return 0;
+            }
+        })
+        .subscribe(new TestSubscriber<Integer>() {
+            int count;
+            @Override
+            public void onNext(Integer t) {
+                if (++count == 2) {
+                    unsubscribe();
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
It turns out serializing `request()` calls with regular `onXXX()` calls can be problematic because a `request()` may trigger an emission of events which then end up being queued (since `emitting == true`). If the request is large and the queue otherwise unbounded, this will likely cause OOME.

In case of `scan`, the fix was to make the missing request accounting and arrival of the `Producer` independent of the event's emitter loop; there is no need for them to be serialized in respect to each other.

In case of the `ProducerObserverArbiter` where the request accounting and producer swapping has to be serialized with the value emission, the solution is to call `request()` outside the emitter-loop.

There shouldn't be any issue with 2.x `scan()` because in 2.x, scan receives the `Subscription` before it allows the downstream to request anything so there is no missing requested to be handled.

This should resolve #3490. As far as I can remember, no other operator should have such problems because all others use `ProducerArbiter` which is independent of `onXXX` emission serializations.