### PR TITLE
2.x: fix takeLast(time) replay behavior causing discontinuity

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/OperatorTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/OperatorTakeLastTimedTest.java
@@ -24,8 +24,9 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorTakeLastTimedTest {
 
@@ -199,5 +200,41 @@ public class OperatorTakeLastTimedTest {
 
         verify(o, never()).onNext(any());
         verify(o, never()).onError(any(Throwable.class));
+    }
+    
+    @Test
+    public void testContinuousDelivery() {
+        TestScheduler scheduler = Schedulers.test();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<>((Long)null);
+        
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        ps.takeLast(1000, TimeUnit.MILLISECONDS, scheduler).subscribe(ts);
+        
+        ps.onNext(1);
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        ps.onNext(2);
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        ps.onNext(3);
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        ps.onNext(4);
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        ps.onComplete();
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+
+        ts.assertNoValues();
+        
+        ts.request(1);
+        
+        ts.assertValue(3);
+        
+        scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        ts.request(1);
+        
+        ts.assertValues(3, 4);
+        ts.assertComplete();
+        ts.assertNoErrors();
+        
     }
 }


### PR DESCRIPTION
The internal queue has to be trimmed while the source is active and the
backpressured-replay shouldn't drop values in case the requests are
delayed relative to each other.