### PR TITLE
Some code clean ups.

### DIFF
--- a/src/main/java/rx/internal/operators/BlockingOperatorNext.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorNext.java
@@ -79,11 +79,11 @@ public final class BlockingOperatorNext {
             }
             // Since an iterator should not be used in different thread,
             // so we do not need any synchronization.
-            if (hasNext == false) {
+            if (!hasNext) {
                 // the iterator has reached the end.
                 return false;
             }
-            if (isNextConsumed == false) {
+            if (!isNextConsumed) {
                 // next has not been used yet.
                 return true;
             }

--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -195,7 +195,7 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
         final AtomicBoolean resumeBoundary = new AtomicBoolean(true);
         
         // incremented when requests are made, decremented when requests are fulfilled
-        final AtomicLong consumerCapacity = new AtomicLong(0l);
+        final AtomicLong consumerCapacity = new AtomicLong();
 
         final Scheduler.Worker worker = scheduler.createWorker();
         child.add(worker);

--- a/src/main/java/rx/internal/operators/OperatorBufferWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferWithSize.java
@@ -156,7 +156,6 @@ public final class OperatorBufferWithSize<T> implements Operator<List<T>, T> {
                         }
                         if (n == Long.MAX_VALUE) {
                             requestInfinite();
-                            return;
                         } else {
                             if (firstRequest) {
                                 firstRequest = false;

--- a/src/main/java/rx/internal/operators/OperatorConcat.java
+++ b/src/main/java/rx/internal/operators/OperatorConcat.java
@@ -229,5 +229,5 @@ public final class OperatorConcat<T> implements Operator<T, Observable<? extends
             arbiter.setProducer(producer);
         }
 
-    };
+    }
 }

--- a/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
@@ -117,7 +117,6 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
                 noWindow = true;
                 if (child.isUnsubscribed()) {
                     unsubscribe();
-                    return;
                 }
             }
         }

--- a/src/main/java/rx/internal/operators/OperatorWithLatestFrom.java
+++ b/src/main/java/rx/internal/operators/OperatorWithLatestFrom.java
@@ -60,7 +60,6 @@ public final class OperatorWithLatestFrom<T, U, R> implements Operator<R, T>  {
                         s.onNext(result);
                     } catch (Throwable e) {
                         Exceptions.throwOrReport(e, this);
-                        return;
                     }
                 }
             }

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -160,18 +160,16 @@ public class EventLoopsScheduler extends Scheduler implements SchedulerLifecycle
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
-            ScheduledAction s = poolWorker.scheduleActual(action, 0, null, serial);
-            
-            return s;
+
+            return poolWorker.scheduleActual(action, 0, null, serial);
         }
         @Override
         public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
-            ScheduledAction s = poolWorker.scheduleActual(action, delayTime, unit, timed);
-            
-            return s;
+
+            return poolWorker.scheduleActual(action, delayTime, unit, timed);
         }
     }
     

--- a/src/main/java/rx/internal/schedulers/GenericScheduledExecutorService.java
+++ b/src/main/java/rx/internal/schedulers/GenericScheduledExecutorService.java
@@ -70,7 +70,6 @@ public final class GenericScheduledExecutorService implements SchedulerLifecycle
                     NewThreadWorker.registerExecutor((ScheduledThreadPoolExecutor)exec);
                 }
             }
-            return;
         } else {
             exec.shutdownNow();
         }

--- a/src/main/java/rx/internal/util/SubscriptionRandomList.java
+++ b/src/main/java/rx/internal/util/SubscriptionRandomList.java
@@ -108,7 +108,7 @@ public final class SubscriptionRandomList<T extends Subscription> implements Sub
     }
 
     public void forEach(Action1<T> action) {
-        T[] ss=null;
+        T[] ss = null;
         synchronized (this) {
             if (unsubscribed || subscriptions == null) {
                 return;

--- a/src/main/java/rx/observables/AbstractOnSubscribe.java
+++ b/src/main/java/rx/observables/AbstractOnSubscribe.java
@@ -597,10 +597,7 @@ public abstract class AbstractOnSubscribe<T, S> implements OnSubscribe<T> {
          */
         protected void free() {
             int i = inUse.get();
-            if (i <= 0) {
-                return;
-            } else
-            if (inUse.decrementAndGet() == 0) {
+            if (i > 0 && inUse.decrementAndGet() == 0) {
                 parent.onTerminated(state);
             }
         }

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -29,7 +29,7 @@ import rx.internal.operators.*;
 import rx.observers.*;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.CompositeSubscription;
-;
+
 /**
  * A utility class to create {@code OnSubscribe<T>} functions that respond correctly to back
  * pressure requests from subscribers. This is an improvement over

--- a/src/main/java/rx/subjects/ReplaySubject.java
+++ b/src/main/java/rx/subjects/ReplaySubject.java
@@ -958,7 +958,7 @@ public final class ReplaySubject<T> extends Subject<T, T> {
         public boolean test(Object value, long now) {
             return first.test(value, now) || second.test(value, now);
         }
-    };
+    }
     
     /** Maps the values to Timestamped. */
     static final class AddTimestamped implements Func1<Object, Object> {

--- a/src/main/java/rx/subscriptions/RefCountSubscription.java
+++ b/src/main/java/rx/subscriptions/RefCountSubscription.java
@@ -143,5 +143,5 @@ public final class RefCountSubscription implements Subscription {
         public boolean isUnsubscribed() {
             return innerDone != 0;
         }
-    };
+    }
 }

--- a/src/test/java/rx/CovarianceTest.java
+++ b/src/test/java/rx/CovarianceTest.java
@@ -211,7 +211,7 @@ public class CovarianceTest {
 
                 return Observable.from(delta);
             }
-        };
+        }
     };
 
     /*

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -251,7 +251,7 @@ public class OnSubscribeCombineLatestTest {
     }
 
     private Func3<String, String, String, String> getConcat3StringsCombineLatestFunction() {
-        Func3<String, String, String, String> combineLatestFunction = new Func3<String, String, String, String>() {
+        return new Func3<String, String, String, String>() {
 
             @Override
             public String call(String a1, String a2, String a3) {
@@ -268,11 +268,10 @@ public class OnSubscribeCombineLatestTest {
             }
 
         };
-        return combineLatestFunction;
     }
 
     private Func2<String, Integer, String> getConcatStringIntegerCombineLatestFunction() {
-        Func2<String, Integer, String> combineLatestFunction = new Func2<String, Integer, String>() {
+        return new Func2<String, Integer, String>() {
 
             @Override
             public String call(String s, Integer i) {
@@ -280,11 +279,10 @@ public class OnSubscribeCombineLatestTest {
             }
 
         };
-        return combineLatestFunction;
     }
 
     private Func3<String, Integer, int[], String> getConcatStringIntegerIntArrayCombineLatestFunction() {
-        Func3<String, Integer, int[], String> combineLatestFunction = new Func3<String, Integer, int[], String>() {
+        return new Func3<String, Integer, int[], String>() {
 
             @Override
             public String call(String s, Integer i, int[] iArray) {
@@ -292,7 +290,6 @@ public class OnSubscribeCombineLatestTest {
             }
 
         };
-        return combineLatestFunction;
     }
 
     private static String getStringValue(Object o) {

--- a/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
@@ -45,9 +45,9 @@ import rx.subscriptions.Subscriptions;
 public class OnSubscribeUsingTest {
 
     private interface Resource {
-        public String getTextFromWeb();
-
-        public void dispose();
+        String getTextFromWeb();
+        
+        void dispose();
     }
 
     private static class DisposeAction implements Action1<Resource> {

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -749,7 +749,7 @@ public class OperatorConcatTest {
                 if (counter.getAndIncrement() % 100 == 0) {
                     System.out.print("testIssue2890NoStackoverflow -> ");
                     System.out.println(counter.get());
-                };
+                }
             }
 
             @Override

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -976,7 +976,7 @@ public class OperatorGroupByTest {
 
     Observable<Event> ASYNC_INFINITE_OBSERVABLE_OF_EVENT(final int numGroups, final AtomicInteger subscribeCounter, final AtomicInteger sentEventCounter) {
         return SYNC_INFINITE_OBSERVABLE_OF_EVENT(numGroups, subscribeCounter, sentEventCounter).subscribeOn(Schedulers.newThread());
-    };
+    }
 
     Observable<Event> SYNC_INFINITE_OBSERVABLE_OF_EVENT(final int numGroups, final AtomicInteger subscribeCounter, final AtomicInteger sentEventCounter) {
         return Observable.create(new OnSubscribe<Event>() {
@@ -997,7 +997,7 @@ public class OperatorGroupByTest {
             }
 
         });
-    };
+    }
 
     @Test
     public void testGroupByOnAsynchronousSourceAcceptsMultipleSubscriptions() throws InterruptedException {

--- a/src/test/java/rx/internal/operators/OperatorMapTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMapTest.java
@@ -91,7 +91,7 @@ public class OperatorMapTest {
             @Override
             public Observable<String> call(Integer id) {
                 /* simulate making a nested async call which creates another Observable */
-                Observable<Map<String, String>> subObservable = null;
+                Observable<Map<String, String>> subObservable;
                 if (id == 1) {
                     Map<String, String> m1 = getMap("One");
                     Map<String, String> m2 = getMap("Two");

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -946,7 +946,7 @@ public class OperatorMergeTest {
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
-        Observable<Integer> observable = Observable.from(new Iterable<Integer>() {
+        return Observable.from(new Iterable<Integer>() {
             @Override
             public Iterator<Integer> iterator() {
                 return new Iterator<Integer>() {
@@ -967,7 +967,6 @@ public class OperatorMergeTest {
                 };
             }
         });
-        return observable;
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -199,7 +199,7 @@ public class OperatorPublishTest {
                         sourceUnsubscribed.set(true);
                     }
                 }).share();
-        ;
+
         
         final AtomicBoolean child1Unsubscribed = new AtomicBoolean();
         final AtomicBoolean child2Unsubscribed = new AtomicBoolean();

--- a/src/test/java/rx/internal/operators/OperatorSerializeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSerializeTest.java
@@ -213,7 +213,7 @@ public class OperatorSerializeTest {
         }
     }
 
-    private static enum TestConcurrencyobserverEvent {
+    private enum TestConcurrencyobserverEvent {
         onCompleted, onError, onNext
     }
 

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -30,7 +30,7 @@ import rx.exceptions.TestException;
 import rx.functions.Func1;
 import rx.internal.util.UtilityFunctions;
 import rx.observers.TestSubscriber;
-;
+
 
 public class OperatorTakeUntilPredicateTest {
     @Test

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -594,7 +594,7 @@ public class OperatorZipTest {
     }
 
     private Func2<Integer, Integer, Integer> getDivideZipr() {
-        Func2<Integer, Integer, Integer> zipr = new Func2<Integer, Integer, Integer>() {
+        return new Func2<Integer, Integer, Integer>() {
 
             @Override
             public Integer call(Integer i1, Integer i2) {
@@ -602,11 +602,10 @@ public class OperatorZipTest {
             }
 
         };
-        return zipr;
     }
 
     private Func3<String, String, String, String> getConcat3StringsZipr() {
-        Func3<String, String, String, String> zipr = new Func3<String, String, String, String>() {
+        return new Func3<String, String, String, String>() {
 
             @Override
             public String call(String a1, String a2, String a3) {
@@ -623,11 +622,10 @@ public class OperatorZipTest {
             }
 
         };
-        return zipr;
     }
 
     private Func2<String, Integer, String> getConcatStringIntegerZipr() {
-        Func2<String, Integer, String> zipr = new Func2<String, Integer, String>() {
+        return new Func2<String, Integer, String>() {
 
             @Override
             public String call(String s, Integer i) {
@@ -635,11 +633,10 @@ public class OperatorZipTest {
             }
 
         };
-        return zipr;
     }
 
     private Func3<String, Integer, int[], String> getConcatStringIntegerIntArrayZipr() {
-        Func3<String, Integer, int[], String> zipr = new Func3<String, Integer, int[], String>() {
+        return new Func3<String, Integer, int[], String>() {
 
             @Override
             public String call(String s, Integer i, int[] iArray) {
@@ -647,7 +644,6 @@ public class OperatorZipTest {
             }
 
         };
-        return zipr;
     }
 
     private static String getStringValue(Object o) {
@@ -1147,7 +1143,7 @@ public class OperatorZipTest {
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
-        Observable<Integer> observable = Observable.from(new Iterable<Integer>() {
+        return Observable.from(new Iterable<Integer>() {
             @Override
             public Iterator<Integer> iterator() {
                 return new Iterator<Integer>() {
@@ -1168,7 +1164,6 @@ public class OperatorZipTest {
                 };
             }
         });
-        return observable;
     }
 
     Observable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());

--- a/src/test/java/rx/internal/util/IndexedRingBufferTest.java
+++ b/src/test/java/rx/internal/util/IndexedRingBufferTest.java
@@ -191,11 +191,8 @@ public class IndexedRingBufferTest {
             @Override
             public Boolean call(String t1) {
                 list.add(t1);
-                if (i++ == 2) {
-                    return false;
-                } else {
-                    return true;
-                }
+                i++;
+                return i != 3;
             }
 
         }, 0);

--- a/src/test/java/rx/observers/SerializedObserverTest.java
+++ b/src/test/java/rx/observers/SerializedObserverTest.java
@@ -500,7 +500,7 @@ public class SerializedObserverTest {
         }
     }
 
-    private static enum TestConcurrencyObserverEvent {
+    private enum TestConcurrencyObserverEvent {
         onCompleted, onError, onNext
     }
 


### PR DESCRIPTION
Nothing that could change logic or application flow, just minor refactors to be consistent with good practices and clean code.
To sum up changes:
- Simplified some conditions
- Changed small l to L in long number, as l tends to look like 1 and might confuse
- Removed "return" statements where those are not necessary (last instruction in function)
- Inlined returns where there were no need for creating new variable (easier to read)
- Deleted unnecessary colons