### PR TITLE
1.x: Test adjustments to reduce problems when tests run on Android

### DIFF
--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -818,6 +818,7 @@ public class OnSubscribeCombineLatestTest {
         final AtomicInteger count = new AtomicInteger();
         final int SIZE = 2000;
         Observable<Long> timer = Observable.interval(0, 1, TimeUnit.MILLISECONDS)
+                .onBackpressureBuffer()
                 .observeOn(Schedulers.newThread())
                 .doOnEach(new Action1<Notification<? super Long>>() {
 

--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -21,14 +21,14 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 import org.mockito.*;
 
 import rx.*;
-import rx.Observable.OnSubscribe;
 import rx.Observable;
+import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.functions.*;
 import rx.observers.*;
@@ -528,6 +528,10 @@ public class OnSubscribeRefCountTest {
 
     @Test(timeout = 10000)
     public void testUpstreamErrorAllowsRetry() throws InterruptedException {
+        
+        final AtomicReference<Throwable> err1 = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> err2 = new AtomicReference<Throwable>();
+        
         final AtomicInteger intervalSubscribed = new AtomicInteger();
         Observable<String> interval =
                 Observable.interval(200,TimeUnit.MILLISECONDS)
@@ -572,6 +576,11 @@ public class OnSubscribeRefCountTest {
                     public void call(String t1) {
                         System.out.println("Subscriber 1: " + t1);
                     }
+                }, new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable t) {
+                        err1.set(t);
+                    }
                 });
         Thread.sleep(100);
         interval
@@ -587,11 +596,19 @@ public class OnSubscribeRefCountTest {
                     public void call(String t1) {
                         System.out.println("Subscriber 2: " + t1);
                     }
+                }, new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable t) {
+                        err2.set(t);
+                    }
                 });
         
         Thread.sleep(1300);
         
         System.out.println(intervalSubscribed.get());
         assertEquals(6, intervalSubscribed.get());
+        
+        assertNotNull("First subscriber didn't get the error", err1);
+        assertNotNull("Second subscriber didn't get the error", err2);
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -27,6 +27,7 @@ import org.mockito.*;
 import rx.*;
 import rx.Observable;
 import rx.Observer;
+import rx.internal.util.PlatformDependent;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
@@ -218,7 +219,11 @@ public class OperatorMergeMaxConcurrentTest {
     }
     @Test(timeout = 10000)
     public void testSimpleOneLessAsyncLoop() {
-        for (int i = 0; i < 200; i++) {
+        int max = 200;
+        if (PlatformDependent.isAndroid()) {
+            max = 50;
+        }
+        for (int i = 0; i < max; i++) {
             testSimpleOneLessAsync();
         }
     }

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -46,6 +46,7 @@ import rx.functions.Func1;
 import rx.internal.operators.OperatorReplay.BoundedReplayBuffer;
 import rx.internal.operators.OperatorReplay.Node;
 import rx.internal.operators.OperatorReplay.SizeAndTimeBoundReplayBuffer;
+import rx.internal.util.PlatformDependent;
 import rx.observables.ConnectableObservable;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -1049,7 +1050,13 @@ public class OperatorReplayTest {
     
     @Test
     public void testNoMissingBackpressureException() {
-        final int m = 4 * 1000 * 1000;
+        final int m;
+        if (PlatformDependent.isAndroid()) {
+            m = 500 * 1000;
+        } else {
+            m = 4 * 1000 * 1000;
+        }
+        
         Observable<Integer> firehose = Observable.create(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {


### PR DESCRIPTION
These changes may help in reducing problems when the tests are run on an Android emulation:

  - set an uncaught exception handler because the native error handler crashes the entire test run.
  - reduce memory usage by some tests by doing fewer loops or items.
  - fix a missing backpressure case as Android starts threads much slower (100ms?).