### PR TITLE
1.x: enable operator/source fusion by named operator lifter

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -144,7 +144,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/create.html">ReactiveX operators documentation: Create</a>
      */
     public final static <T> Single<T> create(OnSubscribe<T> f) {
-        return new Single<T>(f); // TODO need hook 
+        return new Single<T>(f); // TODO need HOOK 
     }
 
     /**
@@ -1492,8 +1492,8 @@ public class Single<T> {
         try {
             // new Subscriber so onStart it
             subscriber.onStart();
-            // TODO add back the hook
-            //            hook.onSubscribeStart(this, onSubscribe).call(subscriber);
+            // TODO add back the HOOK
+            //            HOOK.onSubscribeStart(this, onSubscribe).call(subscriber);
             onSubscribe.call(subscriber);
             hook.onSubscribeReturn(subscriber);
         } catch (Throwable e) {
@@ -1507,9 +1507,9 @@ public class Single<T> {
                 // if this happens it means the onError itself failed (perhaps an invalid function implementation)
                 // so we are unable to propagate the error correctly and will just throw
                 RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
-                // TODO could the hook be the cause of the error in the on error handling.
+                // TODO could the HOOK be the cause of the error in the on error handling.
                 hook.onSubscribeError(r);
-                // TODO why aren't we throwing the hook's return value.
+                // TODO why aren't we throwing the HOOK's return value.
                 throw r;
             }
         }
@@ -1578,9 +1578,9 @@ public class Single<T> {
 
         // The code below is exactly the same an unsafeSubscribe but not used because it would add a sigificent depth to alreay huge call stacks.
         try {
-            // allow the hook to intercept and/or decorate
-            // TODO add back the hook
-            //            hook.onSubscribeStart(this, onSubscribe).call(subscriber);
+            // allow the HOOK to intercept and/or decorate
+            // TODO add back the HOOK
+            //            HOOK.onSubscribeStart(this, onSubscribe).call(subscriber);
             onSubscribe.call(subscriber);
             return hook.onSubscribeReturn(subscriber);
         } catch (Throwable e) {
@@ -1594,9 +1594,9 @@ public class Single<T> {
                 // if this happens it means the onError itself failed (perhaps an invalid function implementation)
                 // so we are unable to propagate the error correctly and will just throw
                 RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
-                // TODO could the hook be the cause of the error in the on error handling.
+                // TODO could the HOOK be the cause of the error in the on error handling.
                 hook.onSubscribeError(r);
-                // TODO why aren't we throwing the hook's return value.
+                // TODO why aren't we throwing the HOOK's return value.
                 throw r;
             }
             return Subscriptions.empty();

--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -28,6 +28,8 @@ import rx.Observable.OnSubscribe;
  * <p>
  * You can convert any object that supports the Iterable interface into an Observable that emits each item in
  * the object, with the {@code toObservable} operation.
+ * 
+ * @param <T> the value type
  */
 public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
 
@@ -38,6 +40,10 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
             throw new NullPointerException("iterable must not be null");
         }
         this.is = iterable;
+    }
+    
+    public Iterable<? extends T> iterable() {
+        return is;
     }
 
     @Override

--- a/src/main/java/rx/internal/operators/OnSubscribeLift.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeLift.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Observable.*;
+import rx.exceptions.Exceptions;
+import rx.plugins.*;
+
+/**
+ * Applies an operator to the incoming child Subscriber and subscribes
+ * the resulting Subscriber to a source Observable.
+ * <p>
+ * By turning the original lift from an anonymous class into a named class,
+ * operator optimizations can now look at the graph and discover the
+ * operators and sources.
+ *
+ * @param <T> the source value type
+ * @param <R> the result value type;
+ */
+public final class OnSubscribeLift<T, R> implements OnSubscribe<R> {
+    /** The operator. */
+    final Operator<? extends R, ? super T> operator;
+    /** The upstream. */
+    final OnSubscribe<? extends T> source;
+    /** The callback hook to transform the operator if necessary. */
+    static final RxJavaObservableExecutionHook HOOK = 
+            RxJavaPlugins.getInstance().getObservableExecutionHook();
+    
+    /**
+     * Constructs an OnSubscribeLift instance with the given source and operators.
+     * <p>
+     * The constructor has to take in an OnSubscribe instead of an Observable, unfortunately,
+     * because the subscribe/unsafeSubscribe activities would interfere (double onStart, 
+     * double wrapping by hooks, etc). 
+     * @param source the source OnSubscribe
+     * @param operator the operator to apply on the child subscribers to get a Subscriber for source
+     */
+    public OnSubscribeLift(OnSubscribe<? extends T> source, Operator<? extends R, ? super T> operator) {
+        this.operator = operator;
+        this.source = source;
+    }
+
+    /**
+     * Returns the operator instance of this lifting OnSubscribe.
+     * @return the operator instance of this lifting OnSubscribe
+     */
+    public Operator<? extends R, ? super T> operator() {
+        return operator;
+    }
+    
+    /**
+     * Returns the source OnSubscribe of this OnSubscribe.
+     * @return the source OnSubscribe of this OnSubscribe
+     */
+    public OnSubscribe<? extends T> source() {
+        return source;
+    }
+    
+    @Override
+    public void call(Subscriber<? super R> child) {
+        try {
+            Operator<? extends R, ? super T> onLift = HOOK.onLift(operator);
+            
+            Subscriber<? super T> st = onLift.call(child);
+            
+            try {
+                // new Subscriber created and being subscribed with so 'onStart' it
+                st.onStart();
+                source.call(st);
+            } catch (Throwable e) {
+                // localized capture of errors rather than it skipping all operators 
+                // and ending up in the try/catch of the subscribe method which then
+                // prevents onErrorResumeNext and other similar approaches to error handling
+                Exceptions.throwIfFatal(e);
+                st.onError(e);
+            }
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            // if the lift function failed all we can do is pass the error to the final Subscriber
+            // as we don't have the operator available to us
+            child.onError(e);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
@@ -70,7 +70,7 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
              */
             this.child = child;
             /*
-             * Add unsubscribe hook to child to get unsubscribe on outer (unsubscribing on next window, not on the inner window itself)
+             * Add unsubscribe HOOK to child to get unsubscribe on outer (unsubscribing on next window, not on the inner window itself)
              */
         }
         void init() {
@@ -156,7 +156,7 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
 
         void init() {
             /*
-             * Add unsubscribe hook to child to get unsubscribe on outer (unsubscribing on next window, not on the inner window itself)
+             * Add unsubscribe HOOK to child to get unsubscribe on outer (unsubscribing on next window, not on the inner window itself)
              */
             child.add(Subscriptions.create(new Action0() {
 

--- a/src/main/java/rx/plugins/RxJavaSchedulersHook.java
+++ b/src/main/java/rx/plugins/RxJavaSchedulersHook.java
@@ -25,10 +25,10 @@ import rx.functions.Action0;
  * the 3 methods that return Scheduler (io(), computation(), newThread()).
  * 2.  You may wrap/decorate an {@link Action0}, before it is handed off to a Scheduler.  The system-
  * supplied Schedulers (Schedulers.ioScheduler, Schedulers.computationScheduler,
- * Scheduler.newThreadScheduler) all use this hook, so it's a convenient way to
+ * Scheduler.newThreadScheduler) all use this HOOK, so it's a convenient way to
  * modify Scheduler functionality without redefining Schedulers wholesale.
  *
- * Also, when redefining Schedulers, you are free to use/not use the onSchedule decoration hook.
+ * Also, when redefining Schedulers, you are free to use/not use the onSchedule decoration HOOK.
  * <p>
  * See {@link RxJavaPlugins} or the RxJava GitHub Wiki for information on configuring plugins:
  * <a href="https://github.com/ReactiveX/RxJava/wiki/Plugins">https://github.com/ReactiveX/RxJava/wiki/Plugins</a>.

--- a/src/test/java/rx/internal/operators/OperatorMergeWithTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeWithTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+public class OperatorMergeWithTest {
+    @Test
+    public void mergeLargeAmountOfSources() {
+        Observable<Integer> source = Observable.range(1, 2);
+        
+        Observable<Integer> result = source;
+        int n = 5000;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.mergeWith(source);
+        }
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        long t = System.nanoTime();
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount((n + 1) * 2);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        t = System.nanoTime() - t;
+        
+        System.out.printf("Merging took: %,d ns%n", t);
+    }
+}


### PR DESCRIPTION
This change factors out the body of `lift()` into a named class that gives access to the operator and source parameters. By using this information, other operators can perform what I call **operator macro-fusion**.

One such example with this PR is the repeated use of the operator `mergeWith` which when done in the classical way creates a long linked-list of sources merged in pairs, often leading to stack overflows
and degraded performance. However, if `mergeWith` can see that it is applied to an existing mergeWith, the two operators can use a common list of sources and then turn into a one-level merge() with n + 1
sources (the previous graph will then be GC'd). Don't worry, this doesn't destroy the original assembled sequence. For example, given `c = a.mergeWith(b); d = c.mergeWith(e);` both c and d can be freely subscribed to and still do the same thing.

Note also that this PR conflicts with PR #3477 since the array-based `merge(from(os))` has a different type.

I didn't officially benchmarked this due to the stackoverflow with head. Given the 10002 values merged in the unit test in 34ms (i7 4790, Windows 7 x64, Java 8u66) which yields ~294 kOps/s.