### PR TITLE
1.x: split Android detection and version detection

### DIFF
--- a/src/main/java/rx/internal/util/PlatformDependent.java
+++ b/src/main/java/rx/internal/util/PlatformDependent.java
@@ -34,6 +34,8 @@ public final class PlatformDependent {
 
     private static final boolean IS_ANDROID = ANDROID_API_VERSION != ANDROID_API_VERSION_IS_NOT_ANDROID;
 
+    /** If Android detected but couldn't get the version number. */
+    private static final int ANDROID_API_VERSION_MIN = 7;
     /**
      * Returns {@code true} if and only if the current platform is Android.
      */
@@ -59,15 +61,21 @@ public final class PlatformDependent {
      * @see <a href="http://developer.android.com/reference/android/os/Build.VERSION.html#SDK_INT">Documentation</a>
      */
     private static int resolveAndroidApiVersion() {
+        Class<?> verClass;
         try {
-            return (Integer) Class
-                    .forName("android.os.Build$VERSION", true, getSystemClassLoader())
-                    .getField("SDK_INT")
-                    .get(null);
+            verClass = Class
+                    .forName("android.os.Build$VERSION", true, getSystemClassLoader());
         } catch (Exception e) {
             // Can not resolve version of Android API, maybe current platform is not Android
             // or API of resolving current Version of Android API has changed in some release of Android
             return ANDROID_API_VERSION_IS_NOT_ANDROID;
+        }
+        try {
+            return (Integer) verClass
+                    .getField("SDK_INT")
+                    .get(null);
+        } catch (Exception ex) {
+            return ANDROID_API_VERSION_MIN;
         }
     }
 


### PR DESCRIPTION
It seems some Samsung devices running 5.x mess with field names so
reflection can't find them.

If the `PlatformDependent.resolveAndroidApiVersion` logic throws due to
the missing field (but not the class), the original code considered it
to be a non-Android platform and went ahead with `Unsafe` stuff which
causes NPEs at many places.

The change splits the class check and the version check. If the version
check fails, it returns a default version (7) value so the `Unsafe`
paths are not triggered.