### PR TITLE
1.x: Run tests on Android!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ bin/
 # Scala build
 *.cache
 /.nb-gradle/private/
+
+# Android build local properties
+local.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,30 @@
-language: java
-jdk:
-- oraclejdk7
-sudo: false
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
+sudo: false
 
-# script for build and release via Travis to Bintray
-script: gradle/buildViaTravis.sh
+language: android
+
+android:
+  components:
+    - build-tools-23.0.1
+    - android-23
+    - extra-android-m2repository
+    - sys-img-armeabi-v7a-android-18
+
+jdk:
+  - oraclejdk7
+
+script: gradle/build.sh
 
 # cache between builds
 cache:
   directories:
   - $HOME/.m2
   - $HOME/.gradle
+
 env:
+  matrix:
+    - TARGET_PLATFORM=jdk
+    - TARGET_PLATFORM="android-18 --abi armeabi-v7a"
   global:
   - secure: YcLpYfNc/dyDON+oDvnJK5pFNhpPeJHxlAHV8JBt42e51prAl6njqrg1Qlfdp0pvBiskTPQHUxbFy9DOB1Z+43lPj5vlqz6qBgtS3vtBnsrczr+5Xx7NTdVKq6oZGl45VjfNPT7zdM6GQ5ifdzOid6kJIFu34g9JZkCzOY3BWGM=
   - secure: WVmfSeW1UMNdem7+X4cVDjkEkqdeNavYH4udn3bFN1IFaWdliWFp4FYVBVi+p1T/IgkRSqzoW9Bm43DABe1UMFoErFCbfd7B0Ofgb4NZAsxFgokHGVLCe6k5+rQyASseiO7k0itSj3Kq9TrDueKPhv+g+IG0w1A8yZTnXdhXHvY=

--- a/android-tests/build.gradle
+++ b/android-tests/build.gradle
@@ -1,0 +1,61 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        // Android Gradle plugin
+        classpath 'com.android.tools.build:gradle:1.3.1'
+
+        // Resolves android-sdk dependencies
+        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+apply plugin: 'android-sdk-manager'
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 23
+    buildToolsVersion '23.0.1'
+
+    defaultConfig {
+        minSdkVersion 14
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    }
+
+    sourceSets {
+        androidTest {
+            java.srcDir '../src/test/java'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
+}
+
+dependencies {
+    compile libraries.rxJava
+
+    androidTestCompile libraries.mockitoCore
+    androidTestCompile libraries.dexMaker
+    androidTestCompile libraries.dexMakerDx
+    androidTestCompile libraries.dexMakerMockito
+    androidTestCompile libraries.androidSupportTestRunner
+}
+
+afterEvaluate {
+    tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) { task ->
+        task.doFirst {
+            logging.level = LogLevel.INFO
+        }
+        task.doLast {
+            logging.level = LogLevel.LIFECYCLE
+        }
+    }
+}

--- a/android-tests/src/main/AndroidManifest.xml
+++ b/android-tests/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="io.reactivex.rxjava.android_tests">
+
+</manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,23 @@
 buildscript {
-  repositories { jcenter() }
-  dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.2.3' }
+    repositories { jcenter() }
+    dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.2.3' }
 }
 
-description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'
+allprojects {
+    repositories {
+        jcenter()
+    }
 
-apply plugin: 'rxjava-project'
-apply plugin: 'java'
-
-dependencies {
-    testCompile 'junit:junit-dep:4.10'
-    testCompile 'org.mockito:mockito-core:1.8.5'
+    apply plugin: 'rxjava-project'
 }
 
-javadoc {
-    exclude "**/rx/internal/**"
-}
+ext.libraries = [
+        rxJava                  : project(':rxjava'),
 
-// support for snapshot/final releases with the various branches RxJava uses
-nebulaRelease {
-    addReleaseBranchPattern(/\d+\.\d+\.\d+/)
-    addReleaseBranchPattern('HEAD')
-}
-
-if (project.hasProperty('release.useLastTag')) {
-    tasks.prepare.enabled = false
-}
-
-test{
-     maxHeapSize = "2g"
-}
+        junit                   : 'junit:junit-dep:4.10',
+        mockitoCore             : 'org.mockito:mockito-core:1.10.19',
+        dexMaker                : 'com.crittercism.dexmaker:dexmaker:1.4',
+        dexMakerDx              : 'com.crittercism.dexmaker:dexmaker-dx:1.4',
+        dexMakerMockito         : 'com.crittercism.dexmaker:dexmaker-mockito:1.4',
+        androidSupportTestRunner: 'com.android.support.test:runner:0.4'
+]

--- a/gradle/build.sh
+++ b/gradle/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$TARGET_PLATFORM" == "jdk" ]; then
+    sh "${SCRIPTS_DIR}/buildViaTravis.sh"
+elif [[ "$TARGET_PLATFORM" == android-* ]]; then
+    sh "${SCRIPTS_DIR}/runTestsOnAndroid.sh"
+fi

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -3,14 +3,14 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew -Prelease.useLastTag=true build
+  ./gradlew -Prelease.useLastTag=true :rxjava:build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot --stacktrace
+  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" :rxjava:build :rxjava:snapshot --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
-  ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final --stacktrace
+  ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" :rxjava:final --stacktrace
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-  ./gradlew -Prelease.useLastTag=true build
+  ./gradlew -Prelease.useLastTag=true :rxjava:build
 fi

--- a/gradle/runTestsOnAndroid.sh
+++ b/gradle/runTestsOnAndroid.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo no | eval "android create avd --force -n test -t $TARGET_PLATFORM"
+emulator -avd test -no-skin -no-audio -no-window &
+android-wait-for-emulator
+adb shell input keyevent 82
+./gradlew connectedAndroidTest

--- a/rxjava/build.gradle
+++ b/rxjava/build.gradle
@@ -1,0 +1,43 @@
+description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'
+
+apply plugin: 'java'
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+sourceSets {
+    main {
+        java {
+            srcDir '../src/main/java'
+        }
+    }
+
+    test {
+        java {
+            srcDir '../src/test/java'
+        }
+    }
+}
+
+dependencies {
+    testCompile libraries.junit
+    testCompile libraries.mockitoCore
+}
+
+javadoc {
+    exclude '**/rx/internal/**'
+}
+
+// support for snapshot/final releases with the various branches RxJava uses
+nebulaRelease {
+    addReleaseBranchPattern(/\d+\.\d+\.\d+/)
+    addReleaseBranchPattern('HEAD')
+}
+
+if (project.hasProperty('release.useLastTag')) {
+    tasks.prepare.enabled = false
+}
+
+test {
+     maxHeapSize = '2g'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
-rootProject.name='rxjava'
+include ':rxjava'
+include ':android-tests'

--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -470,7 +470,7 @@ public class BackpressureTests {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testOnBackpressureDropWithAction() {
         for (int i = 0; i < 100; i++) {
             final AtomicInteger emitCount = new AtomicInteger();
@@ -508,7 +508,7 @@ public class BackpressureTests {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testOnBackpressureDropSynchronous() {
         for (int i = 0; i < 100; i++) {
             int NUM = (int) (RxRingBuffer.SIZE * 1.1); // > 1 so that take doesn't prevent buffer overflow
@@ -530,7 +530,7 @@ public class BackpressureTests {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testOnBackpressureDropSynchronousWithAction() {
         for (int i = 0; i < 100; i++) {
             final AtomicInteger dropCount = new AtomicInteger();

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -818,6 +818,7 @@ public class OnSubscribeCombineLatestTest {
         final AtomicInteger count = new AtomicInteger();
         final int SIZE = 2000;
         Observable<Long> timer = Observable.interval(0, 1, TimeUnit.MILLISECONDS)
+                .onBackpressureBuffer()
                 .observeOn(Schedulers.newThread())
                 .doOnEach(new Action1<Notification<? super Long>>() {
 

--- a/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -27,6 +27,7 @@ import org.mockito.*;
 import rx.*;
 import rx.Observable;
 import rx.Observer;
+import rx.internal.util.PlatformDependent;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
@@ -218,10 +219,15 @@ public class OperatorMergeMaxConcurrentTest {
     }
     @Test(timeout = 10000)
     public void testSimpleOneLessAsyncLoop() {
-        for (int i = 0; i < 200; i++) {
+        int max = 200;
+        if (PlatformDependent.isAndroid()) {
+            max = 50;
+        }
+        for (int i = 0; i < max; i++) {
             testSimpleOneLessAsync();
         }
     }
+
     @Test(timeout = 10000)
     public void testSimpleOneLessAsync() {
         long t = System.currentTimeMillis();

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -46,6 +46,7 @@ import rx.functions.Func1;
 import rx.internal.operators.OperatorReplay.BoundedReplayBuffer;
 import rx.internal.operators.OperatorReplay.Node;
 import rx.internal.operators.OperatorReplay.SizeAndTimeBoundReplayBuffer;
+import rx.internal.util.PlatformDependent;
 import rx.observables.ConnectableObservable;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -1049,7 +1050,13 @@ public class OperatorReplayTest {
     
     @Test
     public void testNoMissingBackpressureException() {
-        final int m = 4 * 1000 * 1000;
+        final int m;
+        if (PlatformDependent.isAndroid()) {
+            m = 500 * 1000;
+        } else {
+            m = 4 * 1000 * 1000;
+        }
+        
         Observable<Integer> firehose = Observable.create(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {


### PR DESCRIPTION
Closes #3503.

In short:

* Created `rxjava` gradle module and moved `src` to `rxjava/src`.
* Created `android-tests` module and configured it to run tests from `rxjava/src/test` on Android.
* Tuned build scripts so we can run builds on Android/JDK concurrently.
* Changed `MemoryMXBean` to `Runtime` in `ExecutorSchedulerTest` because `MemoryMXBean` is not presented on Android.

TODO:

* Fix all failing tests Android (usually timeout problems since Android emulator is :snail:): #3504, cc @akarnokd.
* Decide which Android APIs we want to run tests on, I suggest at least one API with Dalvik VM (with Java 6 and Java 7) and one with ART, for example 18, 19 and 22.

@JakeWharton PTAL