### PR TITLE
1.x: Avoid to call next when Iterator is drained

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorZipIterable.java
+++ b/src/main/java/rx/internal/operators/OperatorZipIterable.java
@@ -46,23 +46,30 @@ public final class OperatorZipIterable<T1, T2, R> implements Operator<R, T1> {
             return Subscribers.empty();
         }
         return new Subscriber<T1>(subscriber) {
-            boolean once;
+            boolean done;
             @Override
             public void onCompleted() {
-                if (once) {
+                if (done) {
                     return;
                 }
-                once = true;
+                done = true;
                 subscriber.onCompleted();
             }
 
             @Override
             public void onError(Throwable e) {
+                if (done) {
+                    return;
+                }
+                done = true;
                 subscriber.onError(e);
             }
 
             @Override
             public void onNext(T1 t) {
+                if (done) {
+                    return;
+                }
                 try {
                     subscriber.onNext(zipFunction.call(t, iterator.next()));
                     if (!iterator.hasNext()) {

--- a/src/test/java/rx/internal/operators/OperatorZipIterableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipIterableTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 
@@ -37,6 +38,8 @@ import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.functions.Func3;
+import rx.observers.TestSubscriber;
+import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
 public class OperatorZipIterableTest {
@@ -377,5 +380,23 @@ public class OperatorZipIterableTest {
         o.map(squareStr).zipWith(it, concat2Strings).take(2).subscribe(printer);
         
         assertEquals(2, squareStr.counter.get());
+    }
+
+    @Test
+    public void testZipIterableWithDelay() {
+        TestScheduler scheduler = new TestScheduler();
+        Observable<Integer> o = Observable.just(1, 2).zipWith(Arrays.asList(1), new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer v1, Integer v2) {
+                return v1;
+            }
+        }).delay(500, TimeUnit.MILLISECONDS, scheduler);
+
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        o.subscribe(subscriber);
+        scheduler.advanceTimeBy(1000, TimeUnit.MILLISECONDS);
+        subscriber.assertValue(1);
+        subscriber.assertNoErrors();
+        subscriber.assertCompleted();
     }
 }


### PR DESCRIPTION
`delay` delays the `onCompleted` event and `unsubscribe` is called when `onCompleted` finishes. So if we put a `o.zipWith(Iterable, func)` before `delay`, such as `o.zipWith(Iterable, func).delay(...)`, `o` may keep emitting items even if `zipWith` emits an `onCompleted` event. This PR just fixed `OperatorZipIterable` to handle this case.

Fixes https://github.com/ReactiveX/RxScala/issues/180