### PR TITLE
1.x: fix time windows in throttleFirst

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -8789,6 +8789,9 @@ public class Observable<T> {
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Backpressure">RxJava wiki: Backpressure</a>
      */
     public final Observable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
+        if (skipDuration <= 0) {
+            throw new IllegalArgumentException("skipDuration must be greater than zero");
+        }
         return lift(new OperatorThrottleFirst<T>(skipDuration, unit, scheduler));
     }
 

--- a/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
+++ b/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
@@ -158,4 +158,40 @@ public class OperatorThrottleFirstTest {
         inOrder.verify(observer).onCompleted();
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void testThrottleWindowIsConstantDuration() {
+        @SuppressWarnings("unchecked")
+        Observer<Integer> observer = mock(Observer.class);
+        TestScheduler s = new TestScheduler();
+        PublishSubject<Integer> o = PublishSubject.create();
+        o.throttleFirst(1000, TimeUnit.MILLISECONDS, s).subscribe(observer);
+
+        // send events with simulated time increments
+        s.advanceTimeTo(0, TimeUnit.MILLISECONDS);
+        o.onNext(1); 
+        s.advanceTimeTo(1200, TimeUnit.MILLISECONDS);
+        o.onNext(2); 
+        s.advanceTimeTo(2100, TimeUnit.MILLISECONDS);
+        o.onNext(3); 
+        o.onCompleted();
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onNext(1);
+        inOrder.verify(observer).onNext(2);
+        inOrder.verify(observer).onNext(3);
+        inOrder.verify(observer).onCompleted();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testSkipDurationOfZeroThrowsIllegalArgumentException() {
+        Observable.just(1).throttleFirst(0, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testSkipDurationOfLessThanZeroThrowsIllegalArgumentException() {
+        Observable.just(1).throttleFirst(-1, TimeUnit.SECONDS);
+    }
 }


### PR DESCRIPTION
As a result of #3527 discussion I noticed that `throttleFirst` does not comply with behaviour described in javadocs. Time windows used for emissions were supposed to be of constant duration yet could be effectively lengthened because the next time window always started at the time of the emission to downstream plus the window duration.

To demonstrate:

Consider  `source.throttleWithFirst(1000, TimeUnit.MILLISECONDS)` where source emits 

```
Time   Value    
0       "a"
1200    "b"
2100    "c"
```

Desired result is:

`a, b, c`

yet previous version produced

`a, b`

A unit test has been added that failed with the previous version.
