### PR TITLE
Remove double whitespace in if conditions

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorDebounceWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorDebounceWithTime.java
@@ -163,7 +163,7 @@ public final class OperatorDebounceWithTime<T> implements Operator<T, T> {
                 emitting = true;
             }
 
-            if  (localHasValue) {
+            if (localHasValue) {
                 try {
                     onNextAndComplete.onNext(localValue);
                 } catch (Throwable e) {

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -122,7 +122,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     
     @Override
     public void onStart() {
-        if  (initialRequest >= 0) {
+        if (initialRequest >= 0) {
             requestMore(initialRequest);
         }
     }


### PR DESCRIPTION
Just found them while walking through the source code trying to get a better overview of the Rx internals. 