### PR TITLE
1.x: No more need to convert Singles to Observables for Single.zip()

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -956,9 +956,9 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -966,8 +966,13 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, final Func2<? super T1, ? super T2, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, final Func2<? super T1, ? super T2, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1]);
+            }
+        });
     }
 
     /**
@@ -980,11 +985,11 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -992,8 +997,13 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Func3<? super T1, ? super T2, ? super T3, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, final Func3<? super T1, ? super T2, ? super T3, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2]);
+            }
+        });
     }
 
     /**
@@ -1006,13 +1016,13 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
-     * @param o4
+     * @param s4
      *            a fourth source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -1020,8 +1030,13 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, T4, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Single<? extends T4> o4, Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3), asObservable(o4) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, T4, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, final Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3]);
+            }
+        });
     }
 
     /**
@@ -1034,15 +1049,15 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
-     * @param o4
+     * @param s4
      *            a fourth source Single
-     * @param o5
+     * @param s5
      *            a fifth source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -1050,8 +1065,13 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, T4, T5, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Single<? extends T4> o4, Single<? extends T5> o5, Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3), asObservable(o4), asObservable(o5) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, T4, T5, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, final Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4]);
+            }
+        });
     }
 
     /**
@@ -1064,17 +1084,17 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
-     * @param o4
+     * @param s4
      *            a fourth source Single
-     * @param o5
+     * @param s5
      *            a fifth source Single
-     * @param o6
+     * @param s6
      *            a sixth source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -1082,9 +1102,14 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Single<? extends T4> o4, Single<? extends T5> o5, Single<? extends T6> o6,
-            Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3), asObservable(o4), asObservable(o5), asObservable(o6) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, T4, T5, T6, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6,
+                                                            final Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5]);
+            }
+        });
     }
 
     /**
@@ -1097,19 +1122,19 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
-     * @param o4
+     * @param s4
      *            a fourth source Single
-     * @param o5
+     * @param s5
      *            a fifth source Single
-     * @param o6
+     * @param s6
      *            a sixth source Single
-     * @param o7
+     * @param s7
      *            a seventh source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -1117,9 +1142,14 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Single<? extends T4> o4, Single<? extends T5> o5, Single<? extends T6> o6, Single<? extends T7> o7,
-            Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3), asObservable(o4), asObservable(o5), asObservable(o6), asObservable(o7) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7,
+                                                                final Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6, s7}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6]);
+            }
+        });
     }
 
     /**
@@ -1132,21 +1162,21 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
-     * @param o4
+     * @param s4
      *            a fourth source Single
-     * @param o5
+     * @param s5
      *            a fifth source Single
-     * @param o6
+     * @param s6
      *            a sixth source Single
-     * @param o7
+     * @param s7
      *            a seventh source Single
-     * @param o8
+     * @param s8
      *            an eighth source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -1154,9 +1184,14 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Single<? extends T4> o4, Single<? extends T5> o5, Single<? extends T6> o6, Single<? extends T7> o7, Single<? extends T8> o8,
-            Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3), asObservable(o4), asObservable(o5), asObservable(o6), asObservable(o7), asObservable(o8) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
+                                                                    final Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6, s7, s8}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], (T8) args[7]);
+            }
+        });
     }
 
     /**
@@ -1169,23 +1204,23 @@ public class Single<T> {
      * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param o1
+     * @param s1
      *            the first source Single
-     * @param o2
+     * @param s2
      *            a second source Single
-     * @param o3
+     * @param s3
      *            a third source Single
-     * @param o4
+     * @param s4
      *            a fourth source Single
-     * @param o5
+     * @param s5
      *            a fifth source Single
-     * @param o6
+     * @param s6
      *            a sixth source Single
-     * @param o7
+     * @param s7
      *            a seventh source Single
-     * @param o8
+     * @param s8
      *            an eighth source Single
-     * @param o9
+     * @param s9
      *            a ninth source Single
      * @param zipFunction
      *            a function that, when applied to the item emitted by each of the source Singles, results in an
@@ -1193,9 +1228,14 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    public final static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(Single<? extends T1> o1, Single<? extends T2> o2, Single<? extends T3> o3, Single<? extends T4> o4, Single<? extends T5> o5, Single<? extends T6> o6, Single<? extends T7> o7, Single<? extends T8> o8,
-            Single<? extends T9> o9, Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipFunction) {
-        return just(new Observable<?>[] { asObservable(o1), asObservable(o2), asObservable(o3), asObservable(o4), asObservable(o5), asObservable(o6), asObservable(o7), asObservable(o8), asObservable(o9) }).lift(new OperatorZip<R>(zipFunction));
+    public static final <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
+                                                                        Single<? extends T9> s9, final Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipFunction) {
+        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6, s7, s8, s9}, new FuncN<R>() {
+            @Override
+            public R call(Object... args) {
+                return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], (T8) args[7], (T9) args[8]);
+            }
+        });
     }
 
     /**

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -45,11 +44,17 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import rx.Single.OnSubscribe;
 import rx.exceptions.CompositeException;
-import rx.functions.Action;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.functions.Func2;
+import rx.functions.Func3;
+import rx.functions.Func4;
+import rx.functions.Func5;
+import rx.functions.Func6;
+import rx.functions.Func7;
+import rx.functions.Func8;
+import rx.functions.Func9;
 import rx.functions.FuncN;
 import rx.schedulers.TestScheduler;
 import rx.singles.BlockingSingle;
@@ -102,21 +107,199 @@ public class SingleTest {
     }
 
     @Test
-    public void testZip() {
+    public void zip2Singles() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Single<String> a = Single.just("A");
-        Single<String> b = Single.just("B");
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
 
-        Single.zip(a, b, new Func2<String, String, String>() {
+        Single.zip(a, b, new Func2<Integer, Integer, String>() {
 
             @Override
-            public String call(String a, String b) {
-                return a + b;
+            public String call(Integer a, Integer b) {
+                return "" + a + b;
             }
 
         })
                 .subscribe(ts);
-        ts.assertReceivedOnNext(Arrays.asList("AB"));
+
+        ts.assertValue("12");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip3Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+
+        Single.zip(a, b, c, new Func3<Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c) {
+                return "" + a + b + c;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("123");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip4Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+        Single<Integer> d = Single.just(4);
+
+        Single.zip(a, b, c, d, new Func4<Integer, Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c, Integer d) {
+                return "" + a + b + c + d;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("1234");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip5Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+        Single<Integer> d = Single.just(4);
+        Single<Integer> e = Single.just(5);
+
+        Single.zip(a, b, c, d, e, new Func5<Integer, Integer, Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c, Integer d, Integer e) {
+                return "" + a + b + c + d + e;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("12345");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip6Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+        Single<Integer> d = Single.just(4);
+        Single<Integer> e = Single.just(5);
+        Single<Integer> f = Single.just(6);
+
+        Single.zip(a, b, c, d, e, f, new Func6<Integer, Integer, Integer, Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f) {
+                return "" + a + b + c + d + e + f;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("123456");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip7Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+        Single<Integer> d = Single.just(4);
+        Single<Integer> e = Single.just(5);
+        Single<Integer> f = Single.just(6);
+        Single<Integer> g = Single.just(7);
+
+        Single.zip(a, b, c, d, e, f, g, new Func7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g) {
+                return "" + a + b + c + d + e + f + g;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("1234567");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip8Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+        Single<Integer> d = Single.just(4);
+        Single<Integer> e = Single.just(5);
+        Single<Integer> f = Single.just(6);
+        Single<Integer> g = Single.just(7);
+        Single<Integer> h = Single.just(8);
+
+        Single.zip(a, b, c, d, e, f, g, h, new Func8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g, Integer h) {
+                return "" + a + b + c + d + e + f + g + h;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("12345678");
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void zip9Singles() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        Single<Integer> a = Single.just(1);
+        Single<Integer> b = Single.just(2);
+        Single<Integer> c = Single.just(3);
+        Single<Integer> d = Single.just(4);
+        Single<Integer> e = Single.just(5);
+        Single<Integer> f = Single.just(6);
+        Single<Integer> g = Single.just(7);
+        Single<Integer> h = Single.just(8);
+        Single<Integer> i = Single.just(9);
+
+        Single.zip(a, b, c, d, e, f, g, h, i, new Func9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, String>() {
+
+            @Override
+            public String call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g, Integer h, Integer i) {
+                return "" + a + b + c + d + e + f + g + h + i;
+            }
+
+        })
+                .subscribe(ts);
+
+        ts.assertValue("123456789");
+        ts.assertCompleted();
+        ts.assertNoErrors();
     }
 
     @Test


### PR DESCRIPTION
PTAL