### PR TITLE
Remove the need for javac to generate synthetic methods.

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -60,7 +60,7 @@ public class Observable<T> {
         this.onSubscribe = f;
     }
 
-    private static final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
+    static final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
 
     /**
      * Returns an Observable that will execute the specified function when a {@link Subscriber} subscribes to

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -111,7 +111,7 @@ public class Single<T> {
         this.onSubscribe = f;
     }
 
-    private static final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
+    static final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
 
     /**
      * Returns a Single that will execute the specified function when a {@link SingleSubscriber} executes it or

--- a/src/main/java/rx/functions/Actions.java
+++ b/src/main/java/rx/functions/Actions.java
@@ -43,6 +43,9 @@ public final class Actions {
             Action8<T0, T1, T2, T3, T4, T5, T6, T7>,
             Action9<T0, T1, T2, T3, T4, T5, T6, T7, T8>,
             ActionN {
+        EmptyAction() {
+        }
+
         @Override
         public void call() {
         }

--- a/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
@@ -63,8 +63,8 @@ public final class BlockingOperatorMostRecent {
     private static final class MostRecentObserver<T> extends Subscriber<T> {
         final NotificationLite<T> nl = NotificationLite.instance();
         volatile Object value;
-        
-        private MostRecentObserver(T value) {
+
+        MostRecentObserver(T value) {
             this.value = nl.next(value);
         }
 

--- a/src/main/java/rx/internal/operators/BlockingOperatorNext.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorNext.java
@@ -66,7 +66,7 @@ public final class BlockingOperatorNext {
         private Throwable error = null;
         private boolean started = false;
 
-        private NextIterator(Observable<? extends T> items, NextObserver<T> observer) {
+        NextIterator(Observable<? extends T> items, NextObserver<T> observer) {
             this.items = items;
             this.observer = observer;
         }
@@ -148,6 +148,9 @@ public final class BlockingOperatorNext {
     private static class NextObserver<T> extends Subscriber<Notification<? extends T>> {
         private final BlockingQueue<Notification<? extends T>> buf = new ArrayBlockingQueue<Notification<? extends T>>(1);
         final AtomicInteger waiting = new AtomicInteger();
+
+        NextObserver() {
+        }
 
         @Override
         public void onCompleted() {

--- a/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
+++ b/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
@@ -187,7 +187,7 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
     }
 
     @SuppressWarnings("rawtypes")
-    private final static Observer EMPTY_OBSERVER = new Observer() {
+    final static Observer EMPTY_OBSERVER = new Observer() {
 
         @Override
         public void onCompleted() {

--- a/src/main/java/rx/internal/operators/NotificationLite.java
+++ b/src/main/java/rx/internal/operators/NotificationLite.java
@@ -71,7 +71,7 @@ public final class NotificationLite<T> {
 
     private static class OnErrorSentinel implements Serializable {
         private static final long serialVersionUID = 3;
-        private final Throwable e;
+        final Throwable e;
 
         public OnErrorSentinel(Throwable e) {
             this.e = e;

--- a/src/main/java/rx/internal/operators/OnSubscribeAmb.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeAmb.java
@@ -271,7 +271,7 @@ public final class OnSubscribeAmb<T> implements OnSubscribe<T>{
         private final Selection<T> selection;
         private boolean chosen;
 
-        private AmbSubscriber(long requested, Subscriber<? super T> subscriber, Selection<T> selection) {
+        AmbSubscriber(long requested, Subscriber<? super T> subscriber, Selection<T> selection) {
             this.subscriber = subscriber;
             this.selection = selection;
             // initial request
@@ -434,7 +434,7 @@ public final class OnSubscribeAmb<T> implements OnSubscribe<T>{
         });
     }
 
-    private static <T> void unsubscribeAmbSubscribers(Collection<AmbSubscriber<T>> ambSubscribers) {
+    static <T> void unsubscribeAmbSubscribers(Collection<AmbSubscriber<T>> ambSubscribers) {
         if(!ambSubscribers.isEmpty()) {
             for (AmbSubscriber<T> other : ambSubscribers) {
                 other.unsubscribe();

--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -55,7 +55,7 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
         private final Subscriber<? super T> o;
         private final Iterator<? extends T> it;
 
-        private IterableProducer(Subscriber<? super T> o, Iterator<? extends T> it) {
+        IterableProducer(Subscriber<? super T> o, Iterator<? extends T> it) {
             this.o = o;
             this.it = it;
         }

--- a/src/main/java/rx/internal/operators/OnSubscribeRange.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRange.java
@@ -46,7 +46,7 @@ public final class OnSubscribeRange implements OnSubscribe<Integer> {
         private final int end;
         private long index;
 
-        private RangeProducer(Subscriber<? super Integer> o, int start, int end) {
+        RangeProducer(Subscriber<? super Integer> o, int start, int end) {
             this.o = o;
             this.index = start;
             this.end = end;

--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -67,7 +67,7 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
     };
 
     public static final class RedoFinite implements Func1<Observable<? extends Notification<?>>, Observable<?>> {
-        private final long count;
+        final long count;
 
         public RedoFinite(long count) {
             this.count = count;
@@ -98,7 +98,7 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
     }
 
     public static final class RetryWithPredicate implements Func1<Observable<? extends Notification<?>>, Observable<? extends Notification<?>>> {
-        private final Func2<Integer, Throwable, Boolean> predicate;
+        final Func2<Integer, Throwable, Boolean> predicate;
 
         public RetryWithPredicate(Func2<Integer, Throwable, Boolean> predicate) {
             this.predicate = predicate;
@@ -173,10 +173,10 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
         return create(new OnSubscribeRedo<T>(source, notificationHandler, false, false, scheduler));
     }
 
-    private final Observable<T> source;
+    final Observable<T> source;
     private final Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> controlHandlerFunction;
-    private final boolean stopOnComplete;
-    private final boolean stopOnError;
+    final boolean stopOnComplete;
+    final boolean stopOnError;
     private final Scheduler scheduler;
 
     private OnSubscribeRedo(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> f, boolean stopOnComplete, boolean stopOnError,

--- a/src/main/java/rx/internal/operators/OnSubscribeRefCount.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRefCount.java
@@ -38,13 +38,13 @@ import rx.subscriptions.Subscriptions;
 public final class OnSubscribeRefCount<T> implements OnSubscribe<T> {
 
     private final ConnectableObservable<? extends T> source;
-    private volatile CompositeSubscription baseSubscription = new CompositeSubscription();
-    private final AtomicInteger subscriptionCount = new AtomicInteger(0);
+    volatile CompositeSubscription baseSubscription = new CompositeSubscription();
+    final AtomicInteger subscriptionCount = new AtomicInteger(0);
 
     /**
      * Use this lock for every subscription and disconnect action.
      */
-    private final ReentrantLock lock = new ReentrantLock();
+    final ReentrantLock lock = new ReentrantLock();
 
     /**
      * Constructor.

--- a/src/main/java/rx/internal/operators/OnSubscribeToObservableFuture.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeToObservableFuture.java
@@ -41,7 +41,7 @@ public final class OnSubscribeToObservableFuture {
     }
 
     /* package accessible for unit tests */static class ToObservableFuture<T> implements OnSubscribe<T> {
-        private final Future<? extends T> that;
+        final Future<? extends T> that;
         private final long time;
         private final TimeUnit unit;
 

--- a/src/main/java/rx/internal/operators/OnSubscribeUsing.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeUsing.java
@@ -105,7 +105,7 @@ public final class OnSubscribeUsing<T, Resource> implements OnSubscribe<T> {
         private Action1<? super Resource> dispose;
         private Resource resource;
 
-        private DisposeAction(Action1<? super Resource> dispose, Resource resource) {
+        DisposeAction(Action1<? super Resource> dispose, Resource resource) {
             this.dispose = dispose;
             this.resource = resource;
             lazySet(false); // StoreStore barrier

--- a/src/main/java/rx/internal/operators/OperatorAll.java
+++ b/src/main/java/rx/internal/operators/OperatorAll.java
@@ -28,7 +28,7 @@ import rx.internal.producers.SingleDelayedProducer;
  * <img width="640" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/all.png" alt="">
  */
 public final class OperatorAll<T> implements Operator<Boolean, T> {
-    private final Func1<? super T, Boolean> predicate;
+    final Func1<? super T, Boolean> predicate;
 
     public OperatorAll(Func1<? super T, Boolean> predicate) {
         this.predicate = predicate;

--- a/src/main/java/rx/internal/operators/OperatorAny.java
+++ b/src/main/java/rx/internal/operators/OperatorAny.java
@@ -27,8 +27,8 @@ import rx.internal.producers.SingleDelayedProducer;
  * an observable sequence satisfies a condition, otherwise <code>false</code>.
  */
 public final class OperatorAny<T> implements Operator<Boolean, T> {
-    private final Func1<? super T, Boolean> predicate;
-    private final boolean returnOnEmpty;
+    final Func1<? super T, Boolean> predicate;
+    final boolean returnOnEmpty;
 
     public OperatorAny(Func1<? super T, Boolean> predicate, boolean returnOnEmpty) {
         this.predicate = predicate;

--- a/src/main/java/rx/internal/operators/OperatorAsObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorAsObservable.java
@@ -37,7 +37,7 @@ public final class OperatorAsObservable<T> implements Operator<T, T> {
     public static <T> OperatorAsObservable<T> instance() {
         return (OperatorAsObservable<T>)Holder.INSTANCE;
     }
-    private OperatorAsObservable() { }
+    OperatorAsObservable() { }
     @Override
     public Subscriber<? super T> call(Subscriber<? super T> s) {
         return s;

--- a/src/main/java/rx/internal/operators/OperatorCast.java
+++ b/src/main/java/rx/internal/operators/OperatorCast.java
@@ -24,7 +24,7 @@ import rx.Subscriber;
  */
 public class OperatorCast<T, R> implements Operator<R, T> {
 
-    private final Class<R> castClass;
+    final Class<R> castClass;
 
     public OperatorCast(Class<R> castClass) {
         this.castClass = castClass;

--- a/src/main/java/rx/internal/operators/OperatorConcat.java
+++ b/src/main/java/rx/internal/operators/OperatorConcat.java
@@ -50,7 +50,7 @@ public final class OperatorConcat<T> implements Operator<T, Observable<? extends
     public static <T> OperatorConcat<T> instance() {
         return (OperatorConcat<T>)Holder.INSTANCE;
     }
-    private OperatorConcat() { }
+    OperatorConcat() { }
     @Override
     public Subscriber<? super Observable<? extends T>> call(final Subscriber<? super T> child) {
         final SerializedSubscriber<T> s = new SerializedSubscriber<T>(child);

--- a/src/main/java/rx/internal/operators/OperatorDematerialize.java
+++ b/src/main/java/rx/internal/operators/OperatorDematerialize.java
@@ -42,7 +42,7 @@ public final class OperatorDematerialize<T> implements Operator<T, Notification<
     public static OperatorDematerialize instance() {
         return Holder.INSTANCE; // using raw types because the type inference is not good enough
     }
-    private OperatorDematerialize() { }
+    OperatorDematerialize() { }
     @Override
     public Subscriber<? super Notification<T>> call(final Subscriber<? super T> child) {
         return new Subscriber<Notification<T>>(child) {

--- a/src/main/java/rx/internal/operators/OperatorDoOnEach.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnEach.java
@@ -25,7 +25,7 @@ import rx.exceptions.*;
  * Converts the elements of an observable sequence to the specified type.
  */
 public class OperatorDoOnEach<T> implements Operator<T, T> {
-    private final Observer<? super T> doOnEachObserver;
+    final Observer<? super T> doOnEachObserver;
 
     public OperatorDoOnEach(Observer<? super T> doOnEachObserver) {
         this.doOnEachObserver = doOnEachObserver;

--- a/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
@@ -28,7 +28,7 @@ import rx.functions.Action1;
  */
 public class OperatorDoOnRequest<T> implements Operator<T, T> {
 
-    private final Action1<Long> request;
+    final Action1<Long> request;
 
     public OperatorDoOnRequest(Action1<Long> request) {
         this.request = request;
@@ -55,7 +55,7 @@ public class OperatorDoOnRequest<T> implements Operator<T, T> {
     private static final class ParentSubscriber<T> extends Subscriber<T> {
         private final Subscriber<? super T> child;
 
-        private ParentSubscriber(Subscriber<? super T> child) {
+        ParentSubscriber(Subscriber<? super T> child) {
             this.child = child;
         }
 

--- a/src/main/java/rx/internal/operators/OperatorElementAt.java
+++ b/src/main/java/rx/internal/operators/OperatorElementAt.java
@@ -26,9 +26,9 @@ import rx.Subscriber;
  */
 public final class OperatorElementAt<T> implements Operator<T, T> {
 
-    private final int index;
-    private final boolean hasDefault;
-    private final T defaultValue;
+    final int index;
+    final boolean hasDefault;
+    final T defaultValue;
 
     public OperatorElementAt(int index) {
         this(index, null, false);

--- a/src/main/java/rx/internal/operators/OperatorFilter.java
+++ b/src/main/java/rx/internal/operators/OperatorFilter.java
@@ -27,7 +27,7 @@ import rx.functions.Func1;
  */
 public final class OperatorFilter<T> implements Operator<T, T> {
 
-    private final Func1<? super T, Boolean> predicate;
+    final Func1<? super T, Boolean> predicate;
 
     public OperatorFilter(Func1<? super T, Boolean> predicate) {
         this.predicate = predicate;

--- a/src/main/java/rx/internal/operators/OperatorIgnoreElements.java
+++ b/src/main/java/rx/internal/operators/OperatorIgnoreElements.java
@@ -29,7 +29,7 @@ public class OperatorIgnoreElements<T> implements Operator<T, T> {
         return (OperatorIgnoreElements<T>) Holder.INSTANCE;
     }
 
-    private OperatorIgnoreElements() {
+    OperatorIgnoreElements() {
 
     }
 

--- a/src/main/java/rx/internal/operators/OperatorMap.java
+++ b/src/main/java/rx/internal/operators/OperatorMap.java
@@ -28,7 +28,7 @@ import rx.functions.Func1;
  */
 public final class OperatorMap<T, R> implements Operator<R, T> {
 
-    private final Func1<? super T, ? extends R> transformer;
+    final Func1<? super T, ? extends R> transformer;
 
     public OperatorMap(Func1<? super T, ? extends R> transformer) {
         this.transformer = transformer;

--- a/src/main/java/rx/internal/operators/OperatorMapNotification.java
+++ b/src/main/java/rx/internal/operators/OperatorMapNotification.java
@@ -34,9 +34,9 @@ import rx.internal.util.unsafe.*;
  */
 public final class OperatorMapNotification<T, R> implements Operator<R, T> {
 
-    private final Func1<? super T, ? extends R> onNext;
-    private final Func1<? super Throwable, ? extends R> onError;
-    private final Func0<? extends R> onCompleted;
+    final Func1<? super T, ? extends R> onNext;
+    final Func1<? super Throwable, ? extends R> onError;
+    final Func0<? extends R> onCompleted;
 
     public OperatorMapNotification(Func1<? super T, ? extends R> onNext, Func1<? super Throwable, ? extends R> onError, Func0<? extends R> onCompleted) {
         this.onNext = onNext;
@@ -58,8 +58,8 @@ public final class OperatorMapNotification<T, R> implements Operator<R, T> {
         private final Subscriber<? super R> o;
         private final ProducerArbiter pa;
         final SingleEmitter<R> emitter;
-        
-        private MapNotificationSubscriber(ProducerArbiter pa, Subscriber<? super R> o) {
+
+        MapNotificationSubscriber(ProducerArbiter pa, Subscriber<? super R> o) {
             this.pa = pa;
             this.o = o;
             this.emitter = new SingleEmitter<R>(o, pa, this);

--- a/src/main/java/rx/internal/operators/OperatorMaterialize.java
+++ b/src/main/java/rx/internal/operators/OperatorMaterialize.java
@@ -47,7 +47,7 @@ public final class OperatorMaterialize<T> implements Operator<Notification<T>, T
         return (OperatorMaterialize<T>) Holder.INSTANCE;
     }
 
-    private OperatorMaterialize() {
+    OperatorMaterialize() {
     }
 
     @Override

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -90,7 +90,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
     final boolean delayErrors;
     final int maxConcurrent;
 
-    private OperatorMerge(boolean delayErrors, int maxConcurrent) {
+    OperatorMerge(boolean delayErrors, int maxConcurrent) {
         this.delayErrors = delayErrors;
         this.maxConcurrent = maxConcurrent;
     }

--- a/src/main/java/rx/internal/operators/OperatorMulticast.java
+++ b/src/main/java/rx/internal/operators/OperatorMulticast.java
@@ -46,9 +46,9 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
     final List<Subscriber<? super R>> waitingForConnect;
 
     /** Guarded by guard. */
-    private Subscriber<T> subscription;
+    Subscriber<T> subscription;
     // wraps subscription above for unsubscription using guard
-    private Subscription guardedSubscription;
+    Subscription guardedSubscription;
 
     public OperatorMulticast(Observable<? extends T> source, final Func0<? extends Subject<? super T, ? extends R>> subjectFactory) {
         this(new Object(), new AtomicReference<Subject<? super T, ? extends R>>(), new ArrayList<Subscriber<? super R>>(), source, subjectFactory);

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -39,8 +39,8 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
     public static <T> OperatorOnBackpressureBuffer<T> instance() {
         return (OperatorOnBackpressureBuffer<T>) Holder.INSTANCE;
     }
-    
-    private OperatorOnBackpressureBuffer() {
+
+    OperatorOnBackpressureBuffer() {
         this.capacity = null;
         this.onOverflow = null;
     }

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureDrop.java
@@ -38,9 +38,9 @@ public class OperatorOnBackpressureDrop<T> implements Operator<T, T> {
         return (OperatorOnBackpressureDrop<T>)Holder.INSTANCE;
     }
 
-    private final Action1<? super T> onDrop;
+    final Action1<? super T> onDrop;
 
-    private OperatorOnBackpressureDrop() {
+    OperatorOnBackpressureDrop() {
         this(null);
     }
 

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureLatest.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureLatest.java
@@ -194,7 +194,7 @@ public final class OperatorOnBackpressureLatest<T> implements Operator<T, T> {
     static final class LatestSubscriber<T> extends Subscriber<T> {
         private final LatestEmitter<T> producer;
 
-        private LatestSubscriber(LatestEmitter<T> producer) {
+        LatestSubscriber(LatestEmitter<T> producer) {
             this.producer = producer;
         }
 

--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
@@ -43,7 +43,7 @@ import rx.subscriptions.SerialSubscription;
  */
 public final class OperatorOnErrorResumeNextViaFunction<T> implements Operator<T, T> {
 
-    private final Func1<Throwable, ? extends Observable<? extends T>> resumeFunction;
+    final Func1<Throwable, ? extends Observable<? extends T>> resumeFunction;
 
     public OperatorOnErrorResumeNextViaFunction(Func1<Throwable, ? extends Observable<? extends T>> f) {
         this.resumeFunction = f;

--- a/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/src/main/java/rx/internal/operators/OperatorScan.java
@@ -44,7 +44,7 @@ import rx.internal.util.unsafe.*;
 public final class OperatorScan<R, T> implements Operator<R, T> {
 
     private final Func0<R> initialValueFactory;
-    private final Func2<R, ? super T, R> accumulator;
+    final Func2<R, ? super T, R> accumulator;
     // sentinel if we don't receive an initial value
     private static final Object NO_INITIAL_VALUE = new Object();
 

--- a/src/main/java/rx/internal/operators/OperatorSequenceEqual.java
+++ b/src/main/java/rx/internal/operators/OperatorSequenceEqual.java
@@ -33,7 +33,7 @@ public final class OperatorSequenceEqual {
     }
 
     /** NotificationLite doesn't work as zip uses it. */
-    private static final Object LOCAL_ONCOMPLETED = new Object();
+    static final Object LOCAL_ONCOMPLETED = new Object();
     static <T> Observable<Object> materializeLite(Observable<T> source) {
         return concat(
                 source.map(new Func1<T, Object>() {

--- a/src/main/java/rx/internal/operators/OperatorSerialize.java
+++ b/src/main/java/rx/internal/operators/OperatorSerialize.java
@@ -32,7 +32,7 @@ public final class OperatorSerialize<T> implements Operator<T, T> {
     public static <T> OperatorSerialize<T> instance() {
         return (OperatorSerialize<T>)Holder.INSTANCE;
     }
-    private OperatorSerialize() { }
+    OperatorSerialize() { }
     @Override
     public Subscriber<? super T> call(final Subscriber<? super T> s) {
         return new SerializedSubscriber<T>(new Subscriber<T>(s) {

--- a/src/main/java/rx/internal/operators/OperatorSingle.java
+++ b/src/main/java/rx/internal/operators/OperatorSingle.java
@@ -46,8 +46,8 @@ public final class OperatorSingle<T> implements Operator<T, T> {
     public static <T> OperatorSingle<T> instance() {
         return (OperatorSingle<T>) Holder.INSTANCE;
     }
-    
-    private OperatorSingle() {
+
+    OperatorSingle() {
         this(false, null);
     }
 

--- a/src/main/java/rx/internal/operators/OperatorSkipLast.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipLast.java
@@ -26,7 +26,7 @@ import rx.Subscriber;
  */
 public class OperatorSkipLast<T> implements Operator<T, T> {
 
-    private final int count;
+    final int count;
 
     public OperatorSkipLast(int count) {
         if (count < 0) {

--- a/src/main/java/rx/internal/operators/OperatorSkipLastTimed.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipLastTimed.java
@@ -29,8 +29,8 @@ import rx.schedulers.Timestamped;
  */
 public class OperatorSkipLastTimed<T> implements Operator<T, T> {
 
-    private final long timeInMillis;
-    private final Scheduler scheduler;
+    final long timeInMillis;
+    final Scheduler scheduler;
 
     public OperatorSkipLastTimed(long time, TimeUnit unit, Scheduler scheduler) {
         this.timeInMillis = unit.toMillis(time);

--- a/src/main/java/rx/internal/operators/OperatorSkipWhile.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipWhile.java
@@ -25,7 +25,7 @@ import rx.functions.Func2;
  * as soon as the condition becomes false.
  */
 public final class OperatorSkipWhile<T> implements Operator<T, T> {
-    private final Func2<? super T, Integer, Boolean> predicate;
+    final Func2<? super T, Integer, Boolean> predicate;
 
     public OperatorSkipWhile(Func2<? super T, Integer, Boolean> predicate) {
         this.predicate = predicate;

--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -47,9 +47,9 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
     public static <T> OperatorSwitch<T> instance() {
         return (OperatorSwitch<T>)Holder.INSTANCE;
     }
-    
-    private OperatorSwitch() { }
-    
+
+    OperatorSwitch() { }
+
     @Override
     public Subscriber<? super Observable<? extends T>> call(final Subscriber<? super T> child) {
         SwitchSubscriber<T> sws = new SwitchSubscriber<T>(child);

--- a/src/main/java/rx/internal/operators/OperatorTakeLast.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLast.java
@@ -28,7 +28,7 @@ import rx.Subscriber;
  */
 public final class OperatorTakeLast<T> implements Operator<T, T> {
 
-    private final int count;
+    final int count;
 
     public OperatorTakeLast(int count) {
         if (count < 0) {

--- a/src/main/java/rx/internal/operators/OperatorTakeLastOne.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLastOne.java
@@ -18,7 +18,7 @@ public class OperatorTakeLastOne<T> implements Operator<T, T> {
         return (OperatorTakeLastOne<T>) Holder.INSTANCE;
     }
 
-    private OperatorTakeLastOne() {
+    OperatorTakeLastOne() {
 
     }
 

--- a/src/main/java/rx/internal/operators/OperatorTakeLastTimed.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLastTimed.java
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
  */
 public final class OperatorTakeLastTimed<T> implements Operator<T, T> {
 
-    private final long ageMillis;
-    private final Scheduler scheduler;
-    private final int count;
+    final long ageMillis;
+    final Scheduler scheduler;
+    final int count;
 
     public OperatorTakeLastTimed(long time, TimeUnit unit, Scheduler scheduler) {
         this.ageMillis = unit.toMillis(time);

--- a/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeUntilPredicate.java
@@ -31,7 +31,7 @@ public final class OperatorTakeUntilPredicate<T> implements Operator<T, T> {
         private final Subscriber<? super T> child;
         private boolean done = false;
 
-        private ParentSubscriber(Subscriber<? super T> child) {
+        ParentSubscriber(Subscriber<? super T> child) {
             this.child = child;
         }
 
@@ -73,7 +73,7 @@ public final class OperatorTakeUntilPredicate<T> implements Operator<T, T> {
         }
     }
 
-    private final Func1<? super T, Boolean> stopPredicate;
+    final Func1<? super T, Boolean> stopPredicate;
 
     public OperatorTakeUntilPredicate(final Func1<? super T, Boolean> stopPredicate) {
         this.stopPredicate = stopPredicate;

--- a/src/main/java/rx/internal/operators/OperatorTakeWhile.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeWhile.java
@@ -28,7 +28,7 @@ import rx.functions.*;
  */
 public final class OperatorTakeWhile<T> implements Operator<T, T> {
 
-    private final Func2<? super T, ? super Integer, Boolean> predicate;
+    final Func2<? super T, ? super Integer, Boolean> predicate;
 
     public OperatorTakeWhile(final Func1<? super T, Boolean> underlying) {
         this(new Func2<T, Integer, Boolean>() {

--- a/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
+++ b/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
@@ -25,8 +25,8 @@ import rx.Observable.Operator;
  */
 public final class OperatorThrottleFirst<T> implements Operator<T, T> {
 
-    private final long timeInMilliseconds;
-    private final Scheduler scheduler;
+    final long timeInMilliseconds;
+    final Scheduler scheduler;
 
     public OperatorThrottleFirst(long windowDuration, TimeUnit unit, Scheduler scheduler) {
         this.timeInMilliseconds = unit.toMillis(windowDuration);

--- a/src/main/java/rx/internal/operators/OperatorTimeInterval.java
+++ b/src/main/java/rx/internal/operators/OperatorTimeInterval.java
@@ -25,7 +25,7 @@ import rx.schedulers.TimeInterval;
  */
 public final class OperatorTimeInterval<T> implements Operator<TimeInterval<T>, T> {
 
-    private final Scheduler scheduler;
+    final Scheduler scheduler;
 
     public OperatorTimeInterval(Scheduler scheduler) {
         this.scheduler = scheduler;

--- a/src/main/java/rx/internal/operators/OperatorTimeoutBase.java
+++ b/src/main/java/rx/internal/operators/OperatorTimeoutBase.java
@@ -92,8 +92,8 @@ class OperatorTimeoutBase<T> implements Operator<T, T> {
         
         final AtomicInteger terminated = new AtomicInteger();
         final AtomicLong actual = new AtomicLong();
-        
-        private TimeoutSubscriber(
+
+        TimeoutSubscriber(
                 SerializedSubscriber<T> serializedSubscriber,
                 TimeoutStub<T> timeoutStub, SerialSubscription serial,
                 Observable<? extends T> other,

--- a/src/main/java/rx/internal/operators/OperatorTimestamp.java
+++ b/src/main/java/rx/internal/operators/OperatorTimestamp.java
@@ -27,7 +27,7 @@ import rx.schedulers.Timestamped;
  */
 public final class OperatorTimestamp<T> implements Operator<Timestamped<T>, T> {
 
-    private final Scheduler scheduler;
+    final Scheduler scheduler;
 
     public OperatorTimestamp(Scheduler scheduler) {
         this.scheduler = scheduler;

--- a/src/main/java/rx/internal/operators/OperatorToMap.java
+++ b/src/main/java/rx/internal/operators/OperatorToMap.java
@@ -45,9 +45,9 @@ public final class OperatorToMap<T, K, V> implements Operator<Map<K, V>, T> {
     }
 
 
-    private final Func1<? super T, ? extends K> keySelector;
+    final Func1<? super T, ? extends K> keySelector;
 
-    private final Func1<? super T, ? extends V> valueSelector;
+    final Func1<? super T, ? extends V> valueSelector;
 
     private final Func0<? extends Map<K, V>> mapFactory;
 

--- a/src/main/java/rx/internal/operators/OperatorToMultimap.java
+++ b/src/main/java/rx/internal/operators/OperatorToMultimap.java
@@ -58,10 +58,10 @@ public final class OperatorToMultimap<T, K, V> implements Operator<Map<K, Collec
         }
     }
 
-    private final Func1<? super T, ? extends K> keySelector;
-    private final Func1<? super T, ? extends V> valueSelector;
+    final Func1<? super T, ? extends K> keySelector;
+    final Func1<? super T, ? extends V> valueSelector;
     private final Func0<? extends Map<K, Collection<V>>> mapFactory;
-    private final Func1<? super K, ? extends Collection<V>> collectionFactory;
+    final Func1<? super K, ? extends Collection<V>> collectionFactory;
 
     /**
      * ToMultimap with key selector, custom value selector,

--- a/src/main/java/rx/internal/operators/OperatorToObservableList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableList.java
@@ -49,7 +49,7 @@ public final class OperatorToObservableList<T> implements Operator<List<T>, T> {
     public static <T> OperatorToObservableList<T> instance() {
         return (OperatorToObservableList<T>)Holder.INSTANCE;
     }
-    private OperatorToObservableList() { }
+    OperatorToObservableList() { }
     @Override
     public Subscriber<? super T> call(final Subscriber<? super List<T>> o) {
         final SingleDelayedProducer<List<T>> producer = new SingleDelayedProducer<List<T>>(o);

--- a/src/main/java/rx/internal/operators/OperatorToObservableSortedList.java
+++ b/src/main/java/rx/internal/operators/OperatorToObservableSortedList.java
@@ -34,8 +34,8 @@ import rx.internal.producers.SingleDelayedProducer;
  *          the type of the items emitted by the source and the resulting {@code Observable}s
  */
 public final class OperatorToObservableSortedList<T> implements Operator<List<T>, T> {
-    private final Comparator<? super T> sortFunction;
-    private final int initialCapacity;
+    final Comparator<? super T> sortFunction;
+    final int initialCapacity;
 
     @SuppressWarnings("unchecked")
     public OperatorToObservableSortedList(int initialCapacity) {
@@ -105,6 +105,8 @@ public final class OperatorToObservableSortedList<T> implements Operator<List<T>
     private static Comparator DEFAULT_SORT_FUNCTION = new DefaultComparableFunction();
 
     private static class DefaultComparableFunction implements Comparator<Object> {
+        DefaultComparableFunction() {
+        }
 
         // unchecked because we want to support Object for this default
         @SuppressWarnings("unchecked")

--- a/src/main/java/rx/internal/operators/OperatorUnsubscribeOn.java
+++ b/src/main/java/rx/internal/operators/OperatorUnsubscribeOn.java
@@ -27,7 +27,7 @@ import rx.subscriptions.Subscriptions;
  */
 public class OperatorUnsubscribeOn<T> implements Operator<T, T> {
 
-    private final Scheduler scheduler;
+    final Scheduler scheduler;
 
     public OperatorUnsubscribeOn(Scheduler scheduler) {
         this.scheduler = scheduler;

--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -178,7 +178,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
     }
 
     private static final class Zip<R> extends AtomicLong {
-        private final Observer<? super R> child;
+        final Observer<? super R> child;
         private final FuncN<? extends R> zipFunction;
         private final CompositeSubscription childSubscription = new CompositeSubscription();
 

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -26,8 +26,8 @@ import rx.subscriptions.*;
 public class EventLoopsScheduler extends Scheduler implements SchedulerLifecycle {
     /** Manages a fixed number of workers. */
     private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool-";
-    private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
-    /** 
+    static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
+    /**
      * Key to setting the maximum number of computation scheduler threads.
      * Zero or less is interpreted as use available. Capped by available.
      */
@@ -172,8 +172,8 @@ public class EventLoopsScheduler extends Scheduler implements SchedulerLifecycle
             return poolWorker.scheduleActual(action, delayTime, unit, timed);
         }
     }
-    
-    private static final class PoolWorker extends NewThreadWorker {
+
+    static final class PoolWorker extends NewThreadWorker {
         PoolWorker(ThreadFactory threadFactory) {
             super(threadFactory);
         }

--- a/src/main/java/rx/internal/schedulers/ScheduledAction.java
+++ b/src/main/java/rx/internal/schedulers/ScheduledAction.java
@@ -131,7 +131,7 @@ public final class ScheduledAction extends AtomicReference<Thread> implements Ru
     private final class FutureCompleter implements Subscription {
         private final Future<?> f;
 
-        private FutureCompleter(Future<?> f) {
+        FutureCompleter(Future<?> f) {
             this.f = f;
         }
 

--- a/src/main/java/rx/internal/util/IndexedRingBuffer.java
+++ b/src/main/java/rx/internal/util/IndexedRingBuffer.java
@@ -290,7 +290,7 @@ public final class IndexedRingBuffer<E> implements Subscription {
         releaseToPool();
     }
 
-    private IndexedRingBuffer() {
+    IndexedRingBuffer() {
     }
 
     /**
@@ -483,8 +483,11 @@ public final class IndexedRingBuffer<E> implements Subscription {
     }
 
     private static class ElementSection<E> {
-        private final AtomicReferenceArray<E> array = new AtomicReferenceArray<E>(SIZE);
-        private final AtomicReference<ElementSection<E>> next = new AtomicReference<ElementSection<E>>();
+        final AtomicReferenceArray<E> array = new AtomicReferenceArray<E>(SIZE);
+        final AtomicReference<ElementSection<E>> next = new AtomicReference<ElementSection<E>>();
+
+        ElementSection() {
+        }
 
         ElementSection<E> getNext() {
             if (next.get() != null) {
@@ -505,6 +508,9 @@ public final class IndexedRingBuffer<E> implements Subscription {
     private static class IndexSection {
 
         private final AtomicIntegerArray unsafeArray = new AtomicIntegerArray(SIZE);
+
+        IndexSection() {
+        }
 
         public int getAndSet(int expected, int newValue) {
             return unsafeArray.getAndSet(expected, newValue);

--- a/src/main/java/rx/internal/util/ObjectPool.java
+++ b/src/main/java/rx/internal/util/ObjectPool.java
@@ -28,9 +28,9 @@ import rx.internal.util.unsafe.*;
 import rx.schedulers.Schedulers;
 
 public abstract class ObjectPool<T> implements SchedulerLifecycle {
-    private Queue<T> pool;
-    private final int minSize;
-    private final int maxSize;
+    Queue<T> pool;
+    final int minSize;
+    final int maxSize;
     private final long validationInterval;
 
     private final AtomicReference<Worker> schedulerWorker;

--- a/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
+++ b/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
@@ -29,7 +29,7 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
         return new ScalarSynchronousObservable<T>(t);
     }
 
-    private final T t;
+    final T t;
 
     protected ScalarSynchronousObservable(final T t) {
         super(new OnSubscribe<T>() {
@@ -103,7 +103,7 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
         private final Subscriber<? super T> subscriber;
         private final T value;
 
-        private ScalarSynchronousAction(Subscriber<? super T> subscriber,
+        ScalarSynchronousAction(Subscriber<? super T> subscriber,
                 T value) {
             this.subscriber = subscriber;
             this.value = value;

--- a/src/main/java/rx/internal/util/UtilityFunctions.java
+++ b/src/main/java/rx/internal/util/UtilityFunctions.java
@@ -104,6 +104,9 @@ public final class UtilityFunctions {
             Func8<T0, T1, T2, T3, T4, T5, T6, T7, R>,
             Func9<T0, T1, T2, T3, T4, T5, T6, T7, T8, R>,
             FuncN<R> {
+        NullFunction() {
+        }
+
         @Override
         public R call() {
             return null;

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -264,7 +264,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
         private final Func3<? super S, Long, ? super Observer<Observable<? extends T>>, ? extends S> next;
         private final Action1<? super S> onUnsubscribe;
 
-        private AsyncOnSubscribeImpl(Func0<? extends S> generator, Func3<? super S, Long, ? super Observer<Observable<? extends T>>, ? extends S> next, Action1<? super S> onUnsubscribe) {
+        AsyncOnSubscribeImpl(Func0<? extends S> generator, Func3<? super S, Long, ? super Observer<Observable<? extends T>>, ? extends S> next, Action1<? super S> onUnsubscribe) {
             this.generator = generator;
             this.next = next;
             this.onUnsubscribe = onUnsubscribe;
@@ -355,7 +355,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
 
         private final AsyncOnSubscribe<S, T> parent;
         private final SerializedObserver<Observable<? extends T>> serializedSubscriber;
-        private final CompositeSubscription subscriptions = new CompositeSubscription();
+        final CompositeSubscription subscriptions = new CompositeSubscription();
 
         private boolean hasTerminated;
         private boolean onNextCalled;
@@ -647,7 +647,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
         }
 
         static final class State<T> implements OnSubscribe<T> {
-            private Subscriber<? super T> subscriber;
+            Subscriber<? super T> subscriber;
             @Override
             public void call(Subscriber<? super T> s) {
                 synchronized (this) {

--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -538,14 +538,14 @@ public final class BlockingObservable<T> {
     }
     
     /** Constant to indicate the onStart method should be called. */
-    private static final Object ON_START = new Object();
-    
+    static final Object ON_START = new Object();
+
     /** Constant indicating the setProducer method should be called. */
-    private static final Object SET_PRODUCER = new Object();
+    static final Object SET_PRODUCER = new Object();
 
     /** Indicates an unsubscripton happened */
-    private static final Object UNSUBSCRIBE = new Object();
-    
+    static final Object UNSUBSCRIBE = new Object();
+
     /**
      * Subscribes to the source and calls the Subscriber methods on the current thread.
      * <p>

--- a/src/main/java/rx/observables/SyncOnSubscribe.java
+++ b/src/main/java/rx/observables/SyncOnSubscribe.java
@@ -271,7 +271,7 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
         private final Func2<? super S, ? super Observer<? super T>, ? extends S> next;
         private final Action1<? super S> onUnsubscribe;
 
-        private SyncOnSubscribeImpl(Func0<? extends S> generator, Func2<? super S, ? super Observer<? super T>, ? extends S> next, Action1<? super S> onUnsubscribe) {
+        SyncOnSubscribeImpl(Func0<? extends S> generator, Func2<? super S, ? super Observer<? super T>, ? extends S> next, Action1<? super S> onUnsubscribe) {
             this.generator = generator;
             this.next = next;
             this.onUnsubscribe = onUnsubscribe;
@@ -322,8 +322,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
         private boolean hasTerminated;
         
         private S state;
-        
-        private SubscriptionProducer(final Subscriber<? super T> subscriber, SyncOnSubscribe<S, T> parent, S state) {
+
+        SubscriptionProducer(final Subscriber<? super T> subscriber, SyncOnSubscribe<S, T> parent, S state) {
             this.actualSubscriber = subscriber;
             this.parent = parent;
             this.state = state;

--- a/src/main/java/rx/schedulers/CachedThreadScheduler.java
+++ b/src/main/java/rx/schedulers/CachedThreadScheduler.java
@@ -26,11 +26,11 @@ import rx.subscriptions.*;
 
 /* package */final class CachedThreadScheduler extends Scheduler implements SchedulerLifecycle {
     private static final String WORKER_THREAD_NAME_PREFIX = "RxCachedThreadScheduler-";
-    private static final RxThreadFactory WORKER_THREAD_FACTORY =
+    static final RxThreadFactory WORKER_THREAD_FACTORY =
             new RxThreadFactory(WORKER_THREAD_NAME_PREFIX);
 
     private static final String EVICTOR_THREAD_NAME_PREFIX = "RxCachedWorkerPoolEvictor-";
-    private static final RxThreadFactory EVICTOR_THREAD_FACTORY =
+    static final RxThreadFactory EVICTOR_THREAD_FACTORY =
             new RxThreadFactory(EVICTOR_THREAD_NAME_PREFIX);
 
     private static final long KEEP_ALIVE_TIME = 60;

--- a/src/main/java/rx/schedulers/ImmediateScheduler.java
+++ b/src/main/java/rx/schedulers/ImmediateScheduler.java
@@ -45,6 +45,9 @@ public final class ImmediateScheduler extends Scheduler {
 
         final BooleanSubscription innerSubscription = new BooleanSubscription();
 
+        InnerImmediateScheduler() {
+        }
+
         @Override
         public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
             // since we are executing immediately on this thread we must cause this thread to sleep

--- a/src/main/java/rx/schedulers/TestScheduler.java
+++ b/src/main/java/rx/schedulers/TestScheduler.java
@@ -31,17 +31,17 @@ import rx.subscriptions.Subscriptions;
  * advancing the clock at whatever pace you choose.
  */
 public class TestScheduler extends Scheduler {
-    private final Queue<TimedAction> queue = new PriorityQueue<TimedAction>(11, new CompareActionsByTime());
-    private static long counter = 0;
+    final Queue<TimedAction> queue = new PriorityQueue<TimedAction>(11, new CompareActionsByTime());
+    static long counter = 0;
 
     private static final class TimedAction {
 
-        private final long time;
-        private final Action0 action;
-        private final Worker scheduler;
+        final long time;
+        final Action0 action;
+        final Worker scheduler;
         private final long count = counter++; // for differentiating tasks at same time
 
-        private TimedAction(Worker scheduler, long time, Action0 action) {
+        TimedAction(Worker scheduler, long time, Action0 action) {
             this.time = time;
             this.action = action;
             this.scheduler = scheduler;
@@ -54,6 +54,9 @@ public class TestScheduler extends Scheduler {
     }
 
     private static class CompareActionsByTime implements Comparator<TimedAction> {
+        CompareActionsByTime() {
+        }
+
         @Override
         public int compare(TimedAction action1, TimedAction action2) {
             if (action1.time == action2.time) {
@@ -65,7 +68,7 @@ public class TestScheduler extends Scheduler {
     }
 
     // Storing time in nanoseconds internally.
-    private long time;
+    long time;
 
     @Override
     public long now() {
@@ -131,6 +134,9 @@ public class TestScheduler extends Scheduler {
     private final class InnerTestScheduler extends Worker {
 
         private final BooleanSubscription s = new BooleanSubscription();
+
+        InnerTestScheduler() {
+        }
 
         @Override
         public void unsubscribe() {

--- a/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -47,9 +47,12 @@ public final class TrampolineScheduler extends Scheduler {
     private static class InnerCurrentThreadScheduler extends Scheduler.Worker implements Subscription {
 
         final AtomicInteger counter = new AtomicInteger();
-        private final PriorityBlockingQueue<TimedAction> queue = new PriorityBlockingQueue<TimedAction>();
+        final PriorityBlockingQueue<TimedAction> queue = new PriorityBlockingQueue<TimedAction>();
         private final BooleanSubscription innerSubscription = new BooleanSubscription();
         private final AtomicInteger wip = new AtomicInteger();
+
+        InnerCurrentThreadScheduler() {
+        }
 
         @Override
         public Subscription schedule(Action0 action) {
@@ -108,7 +111,7 @@ public final class TrampolineScheduler extends Scheduler {
         final Long execTime;
         final int count; // In case if time between enqueueing took less than 1ms
 
-        private TimedAction(Action0 action, Long execTime, int count) {
+        TimedAction(Action0 action, Long execTime, int count) {
             this.action = action;
             this.execTime = execTime;
             this.count = count;
@@ -125,7 +128,7 @@ public final class TrampolineScheduler extends Scheduler {
     }
 
     // because I can't use Integer.compare from Java 7
-    private static int compare(int x, int y) {
+    static int compare(int x, int y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 

--- a/src/main/java/rx/subjects/TestSubject.java
+++ b/src/main/java/rx/subjects/TestSubject.java
@@ -75,7 +75,7 @@ public final class TestSubject<T> extends Subject<T, T> {
         onCompleted(0);
     }
 
-    private void _onCompleted() {
+    void _onCompleted() {
         if (state.active) {
             for (SubjectObserver<T> bo : state.terminate(NotificationLite.instance().completed())) {
                 bo.onCompleted();
@@ -108,7 +108,7 @@ public final class TestSubject<T> extends Subject<T, T> {
         onError(e, 0);
     }
 
-    private void _onError(final Throwable e) {
+    void _onError(final Throwable e) {
         if (state.active) {
             for (SubjectObserver<T> bo : state.terminate(NotificationLite.instance().error(e))) {
                 bo.onError(e);
@@ -143,7 +143,7 @@ public final class TestSubject<T> extends Subject<T, T> {
         onNext(v, 0);
     }
 
-    private void _onNext(T v) {
+    void _onNext(T v) {
         for (Observer<? super T> o : state.observers()) {
             o.onNext(v);
         }

--- a/src/main/java/rx/subscriptions/Subscriptions.java
+++ b/src/main/java/rx/subscriptions/Subscriptions.java
@@ -120,7 +120,7 @@ public final class Subscriptions {
      */
     private static final Unsubscribed UNSUBSCRIBED = new Unsubscribed();
         /** Naming classes helps with debugging. */
-    private static final class Unsubscribed implements Subscription {
+    static final class Unsubscribed implements Subscription {
         @Override
         public void unsubscribe() {
         }


### PR DESCRIPTION
Outer classes accessing inner class private fields and methods (and vise versa) causes javac to generate package-scoped trampolines. These bloat the class files, adds overhead to the inliner analysis, and for Android create needless method that eat away at our fixed limit of methods in an application. By simply promoting the private interactions to package scope directly, the synthetic methods do not need generated.

2.5% of RxJava's methods were these needless generated trampolines accounting for 1.2% of jar size and 1.4% of dex size.

```
$ dex-method-count before.dex
5005

$ dex-method-count after.dex
4875
```
```
-rw-r--r--   1 jw  jw   699K Dec 25 03:08 after.dex
-rw-r--r--   1 jw  jw   952K Dec 25 03:08 after.jar
-rw-r--r--   1 jw  jw   709K Dec 25 03:06 before.dex
-rw-r--r--   1 jw  jw   964K Dec 25 03:06 before.jar
```