### PR TITLE
Fix the initialization order in GenericScheduledExecutorService

### DIFF
--- a/src/main/java/rx/internal/schedulers/GenericScheduledExecutorService.java
+++ b/src/main/java/rx/internal/schedulers/GenericScheduledExecutorService.java
@@ -35,18 +35,18 @@ public final class GenericScheduledExecutorService implements SchedulerLifecycle
 
     private static final String THREAD_NAME_PREFIX = "RxScheduledExecutorPool-";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
-    
-    /* Schedulers needs acces to this in order to work with the lifecycle. */
-    public final static GenericScheduledExecutorService INSTANCE = new GenericScheduledExecutorService();
-    
-    private final AtomicReference<ScheduledExecutorService> executor;
-    
-    static final ScheduledExecutorService NONE;
+
+    private static final ScheduledExecutorService NONE;
     static {
         NONE = Executors.newScheduledThreadPool(0);
         NONE.shutdownNow();
     }
+
+    /* Schedulers needs acces to this in order to work with the lifecycle. */
+    public final static GenericScheduledExecutorService INSTANCE = new GenericScheduledExecutorService();
     
+    private final AtomicReference<ScheduledExecutorService> executor;
+
     private GenericScheduledExecutorService() {
         executor = new AtomicReference<ScheduledExecutorService>(NONE);
         start();


### PR DESCRIPTION
The static `GenericScheduledExecutorService.None` should be initialized before creating any GenericScheduledExecutorService instance. Although the previous codes happen to work, it's sill worth to fix it.