### PR TITLE
1.x: concat reduce overhead when streaming a source

### DIFF
--- a/src/perf/java/rx/operators/ConcatPerf.java
+++ b/src/perf/java/rx/operators/ConcatPerf.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observable;
+import rx.jmh.LatchedObserver;
+
+/**
+ * Benchmark typical atomic operations on volatile fields and AtomicXYZ classes.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*ConcatPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*ConcatPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class ConcatPerf {
+
+    Observable<Integer> source;
+    
+    Observable<Integer> baseline;
+    
+    @Param({"1", "1000", "1000000"})
+    int count;
+    
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[count];
+        
+        for (int i = 0; i < count; i++) {
+            array[i] = 777;
+        }
+        
+        baseline = Observable.from(array);
+        
+        source = Observable.concat(baseline, Observable.<Integer>empty());
+    }
+    
+    @Benchmark
+    public void normal(Blackhole bh) {
+        source.subscribe(new LatchedObserver<Integer>(bh));
+    }
+
+    @Benchmark
+    public void baseline(Blackhole bh) {
+        baseline.subscribe(new LatchedObserver<Integer>(bh));
+    }
+}


### PR DESCRIPTION
This PR reduces the request tracking overhead of `concat` by tracking the produced item count in a plain field and subtracting it from the arbiter and requested values only before the inner source completes. So instead of N decrementAndGet call, we have 1 addAndGet(-N) per source. 

I've added a perf class to measure the difference.

(Intel Celeron 1005M @ 2GHz, Windows 7 x64, Java 8u66)

![image](https://cloud.githubusercontent.com/assets/1269832/12010270/d8af1660-ac9f-11e5-933c-ee96da7deda5.png)

The throughput increased considerably, although I would have expected more, especially in the 1M case where the subscription overhead doesn't matter.

I'll do further investigation on it and post a follow-up PR if this gets merged in the meantime.