### PR TITLE
1.x: fix counted buffer and window operators' backpressure behavior

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9654,8 +9654,8 @@ public class Observable<T> {
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window3.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>The operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
-     *  but each of them will emit at most {@code count} elements.</dd>
+     *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Observable uses an
+     *  unbounded buffer that may hold at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9664,6 +9664,7 @@ public class Observable<T> {
      *            the maximum size of each window before it should be emitted
      * @return an Observable that emits connected, non-overlapping windows, each containing at most
      *         {@code count} items from the source Observable
+     * @throws IllegalArgumentException if either count is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/window.html">ReactiveX operators documentation: Window</a>
      */
     public final Observable<Observable<T>> window(int count) {
@@ -9679,8 +9680,8 @@ public class Observable<T> {
      * <img width="640" height="365" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window4.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>The operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
-     *  but each of them will emit at most {@code count} elements.</dd>
+     *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Observable uses an
+     *  unbounded buffer that may hold at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9692,9 +9693,16 @@ public class Observable<T> {
      *            {@code count} are equal this is the same operation as {@link #window(int)}.
      * @return an Observable that emits windows every {@code skip} items containing at most {@code count} items
      *         from the source Observable
+     * @throws IllegalArgumentException if either count or skip is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/window.html">ReactiveX operators documentation: Window</a>
      */
     public final Observable<Observable<T>> window(int count, int skip) {
+        if (count <= 0) {
+            throw new IllegalArgumentException("count > 0 required but it was " + count);
+        }
+        if (skip <= 0) {
+            throw new IllegalArgumentException("skip > 0 required but it was " + skip);
+        }
         return lift(new OperatorWindowWithSize<T>(count, skip));
     }
 

--- a/src/main/java/rx/internal/operators/BackpressureUtils.java
+++ b/src/main/java/rx/internal/operators/BackpressureUtils.java
@@ -15,8 +15,10 @@
  */
 package rx.internal.operators;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import rx.Subscriber;
 
 /**
  * Utility functions for use with backpressure.
@@ -31,6 +33,8 @@ public final class BackpressureUtils {
      * Adds {@code n} to {@code requested} field and returns the value prior to
      * addition once the addition is successful (uses CAS semantics). If
      * overflows then sets {@code requested} field to {@code Long.MAX_VALUE}.
+     * 
+     * @param <T> the type of the target object on which the field updater operates
      * 
      * @param requested
      *            atomic field updater for a request count
@@ -103,4 +107,205 @@ public final class BackpressureUtils {
         return u;
     }
     
+    /**
+     * Masks the most significant bit, i.e., 0x8000_0000_0000_0000L.
+     */
+    static final long COMPLETED_MASK = Long.MIN_VALUE;
+    /**
+     * Masks the request amount bits, i.e., 0x7FFF_FFFF_FFFF_FFFF.
+     */
+    static final long REQUESTED_MASK = Long.MAX_VALUE;
+    
+    /**
+     * Signals the completion of the main sequence and switches to post-completion replay mode.
+     * 
+     * <p>
+     * Don't modify the queue after calling this method!
+     * 
+     * <p>
+     * Post-completion backpressure handles the case when a source produces values based on
+     * requests when it is active but more values are available even after its completion.
+     * In this case, the onCompleted() can't just emit the contents of the queue but has to
+     * coordinate with the requested amounts. This requires two distinct modes: active and
+     * completed. In active mode, requests flow through and the queue is not accessed but
+     * in completed mode, requests no-longer reach the upstream but help in draining the queue.
+     * <p>
+     * The algorithm utilizes the most significant bit (bit 63) of a long value (AtomicLong) since
+     * request amount only goes up to Long.MAX_VALUE (bits 0-62) and negative values aren't
+     * allowed.
+     * 
+     * @param <T> the value type to emit
+     * @param requested the holder of current requested amount
+     * @param queue the queue holding values to be emitted after completion
+     * @param actual the subscriber to receive the values
+     */
+    public static <T> void postCompleteDone(AtomicLong requested, Queue<T> queue, Subscriber<? super T> actual) {
+        for (;;) {
+            long r = requested.get();
+            
+            // switch to completed mode only once
+            if ((r & COMPLETED_MASK) != 0L) {
+                return;
+            }
+            
+            //
+            long u = r | COMPLETED_MASK;
+            
+            if (requested.compareAndSet(r, u)) {
+                // if we successfully switched to post-complete mode and there 
+                // are requests available start draining the queue
+                if (r != 0L) {
+                    // if the switch happened when there was outstanding requests, start draining
+                    postCompleteDrain(requested, queue, actual);
+                }
+                return;
+            }
+        }
+    }
+    
+    /**
+     * Accumulates requests (validated) and handles the completed mode draining of the queue based on the requests.
+     * 
+     * <p>
+     * Post-completion backpressure handles the case when a source produces values based on
+     * requests when it is active but more values are available even after its completion.
+     * In this case, the onCompleted() can't just emit the contents of the queue but has to
+     * coordinate with the requested amounts. This requires two distinct modes: active and
+     * completed. In active mode, requests flow through and the queue is not accessed but
+     * in completed mode, requests no-longer reach the upstream but help in draining the queue.
+     * 
+     * @param <T> the value type to emit
+     * @param requested the holder of current requested amount
+     * @param n the value requested;
+     * @param queue the queue holding values to be emitted after completion
+     * @param actual the subscriber to receive the values
+     * @return true if in the active mode and the request amount of n can be relayed to upstream, false if
+     * in the post-completed mode and the queue is draining.
+     */
+    public static <T> boolean postCompleteRequest(AtomicLong requested, long n, Queue<T> queue, Subscriber<? super T> actual) {
+        if (n < 0L) {
+            throw new IllegalArgumentException("n >= 0 required but it was " + n);
+        }
+        if (n == 0) {
+            return (requested.get() & COMPLETED_MASK) == 0;
+        }
+        
+        for (;;) {
+            long r = requested.get();
+            
+            // mask of the completed flag
+            long c = r & COMPLETED_MASK;
+            // mask of the requested amount
+            long u = r & REQUESTED_MASK;
+            
+            // add the current requested amount and the new requested amount
+            // cap at Long.MAX_VALUE;
+            long v = addCap(u, n);
+            
+            // restore the completed flag
+            v |= c;
+            
+            if (requested.compareAndSet(r, v)) {
+                // if there was no outstanding request before and in
+                // the post-completed state, start draining
+                if (r == COMPLETED_MASK) {
+                    postCompleteDrain(requested, queue, actual);
+                    return false;
+                }
+                // returns true for active mode and false if the completed flag was set
+                return c == 0L;
+            }
+        }
+    }
+    
+    /**
+     * Drains the queue based on the outstanding requests in post-completed mode (only!).
+     * 
+     * @param <T> the value type to emit
+     * @param requested the holder of current requested amount
+     * @param queue the queue holding values to be emitted after completion
+     * @param actual the subscriber to receive the values
+     */
+    static <T> void postCompleteDrain(AtomicLong requested, Queue<T> queue, Subscriber<? super T> subscriber) {
+        
+        long r = requested.get();
+        /*
+         * Since we are supposed to be in the post-complete state, 
+         * requested will have its top bit set.
+         * To allow direct comparison, we start with an emission value which has also
+         * this flag set, then increment it as usual.
+         * Since COMPLETED_MASK is essentially Long.MIN_VALUE, 
+         * there won't be any overflow or sign flip.
+         */
+        long e = COMPLETED_MASK;
+        
+        for (;;) {
+            
+            /*
+             * This is an improved queue-drain algorithm with a specialization 
+             * in which we know the queue won't change anymore (i.e., done is always true
+             * when looking at the classical algorithm and there is no error).
+             * 
+             * Note that we don't check for cancellation or emptyness upfront for two reasons:
+             * 1) if e != r, the loop will do this and we quit appropriately
+             * 2) if e == r, then either there was no outstanding requests or we emitted the requested amount
+             *    and the execution simply falls to the e == r check below which checks for emptyness anyway.
+             */
+            
+            while (e != r) {
+                if (subscriber.isUnsubscribed()) {
+                    return;
+                }
+                
+                T v = queue.poll();
+                
+                if (v == null) {
+                    subscriber.onCompleted();
+                    return;
+                }
+                
+                subscriber.onNext(v);
+                
+                e++;
+            }
+            
+            /*
+             * If the emission count reaches the requested amount the same time the queue becomes empty
+             * this will make sure the subscriber is completed immediately instead of on the next request.
+             * This is also true if there are no outstanding requests (this the while loop doesn't run)
+             * and the queue is empty from the start.
+             */
+            if (e == r) {
+                if (subscriber.isUnsubscribed()) {
+                    return;
+                }
+                if (queue.isEmpty()) {
+                    subscriber.onCompleted();
+                    return;
+                }
+            }
+            
+            /*
+             * Fast flow: see if more requests have arrived in the meantime.
+             * This avoids an atomic add (~40 cycles) and resumes the emission immediately.
+             */
+            r = requested.get();
+            
+            if (r == e) {
+                /* 
+                 * Atomically decrement the requested amount by the emission amount.
+                 * We can't use the full emission value because of the completed flag,
+                 * however, due to two's complement representation, the flag on requested
+                 * is preserved.
+                 */
+                r = requested.addAndGet(-(e & REQUESTED_MASK));
+                // The requested amount actually reached zero, quit
+                if (r == COMPLETED_MASK) {
+                    return;
+                }
+                // reset the emission count
+                e = COMPLETED_MASK;
+            }
+        }
+    }
 }

--- a/src/main/java/rx/internal/operators/OperatorBufferWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferWithSize.java
@@ -15,16 +15,13 @@
  */
 package rx.internal.operators;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.atomic.*;
 
+import rx.*;
 import rx.Observable;
 import rx.Observable.Operator;
-import rx.Producer;
-import rx.Subscriber;
-import rx.exceptions.Exceptions;
+import rx.exceptions.MissingBackpressureException;
 
 /**
  * This operation takes
@@ -66,167 +63,274 @@ public final class OperatorBufferWithSize<T> implements Operator<List<T>, T> {
 
     @Override
     public Subscriber<? super T> call(final Subscriber<? super List<T>> child) {
-        if (count == skip) {
-            return new Subscriber<T>(child) {
-                List<T> buffer;
+        if (skip == count) {
+            BufferExact<T> parent = new BufferExact<T>(child, count);
+            
+            child.add(parent);
+            child.setProducer(parent.createProducer());
+            
+            return parent;
+        }
+        if (skip > count) {
+            BufferSkip<T> parent = new BufferSkip<T>(child, count, skip);
+            
+            child.add(parent);
+            child.setProducer(parent.createProducer());
+            
+            return parent;
+        }
+        BufferOverlap<T> parent = new BufferOverlap<T>(child, count, skip);
+        
+        child.add(parent);
+        child.setProducer(parent.createProducer());
+        
+        return parent;
+    }
+    
+    static final class BufferExact<T> extends Subscriber<T> {
+        final Subscriber<? super List<T>> actual;
+        final int count;
 
+        List<T> buffer;
+        
+        public BufferExact(Subscriber<? super List<T>> actual, int count) {
+            this.actual = actual;
+            this.count = count;
+            this.request(0L);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            List<T> b = buffer;
+            if (b == null) {
+                b = new ArrayList<T>();
+                buffer = b;
+            }
+            
+            b.add(t);
+            
+            if (b.size() == count) {
+                buffer = null;
+                actual.onNext(b);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            buffer = null;
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            List<T> b = buffer;
+            if (b != null) {
+                actual.onNext(b);
+            }
+            actual.onCompleted();
+        }
+        
+        Producer createProducer() {
+            return new Producer() {
                 @Override
-                public void setProducer(final Producer producer) {
-                    child.setProducer(new Producer() {
-
-                        private volatile boolean infinite = false;
-
-                        @Override
-                        public void request(long n) {
-                            if (infinite) {
-                                return;
-                            }
-                            if (n >= Long.MAX_VALUE / count) {
-                                // n == Long.MAX_VALUE or n * count >= Long.MAX_VALUE
-                                infinite = true;
-                                producer.request(Long.MAX_VALUE);
-                            } else {
-                                producer.request(n * count);
-                            }
-                        }
-                    });
-                }
-
-                @Override
-                public void onNext(T t) {
-                    if (buffer == null) {
-                        buffer = new ArrayList<T>(count);
+                public void request(long n) {
+                    if (n < 0L) {
+                        throw new IllegalArgumentException("n >= required but it was " + n);
                     }
-                    buffer.add(t);
-                    if (buffer.size() == count) {
-                        List<T> oldBuffer = buffer;
-                        buffer = null;
-                        child.onNext(oldBuffer);
+                    if (n != 0L) {
+                        long u = BackpressureUtils.multiplyCap(n, count);
+                        BufferExact.this.request(u);
                     }
-                }
-
-                @Override
-                public void onError(Throwable e) {
-                    buffer = null;
-                    child.onError(e);
-                }
-
-                @Override
-                public void onCompleted() {
-                    List<T> oldBuffer = buffer;
-                    buffer = null;
-                    if (oldBuffer != null) {
-                        try {
-                            child.onNext(oldBuffer);
-                        } catch (Throwable t) {
-                            Exceptions.throwOrReport(t, this);
-                            return;
-                        }
-                    }
-                    child.onCompleted();
                 }
             };
         }
-        return new Subscriber<T>(child) {
-            final List<List<T>> chunks = new LinkedList<List<T>>();
-            int index;
+    }
+    
+    static final class BufferSkip<T> extends Subscriber<T> {
+        final Subscriber<? super List<T>> actual;
+        final int count;
+        final int skip;
+        
+        long index;
+        
+        List<T> buffer;
 
-            @Override
-            public void setProducer(final Producer producer) {
-                child.setProducer(new Producer() {
-
-                    private volatile boolean firstRequest = true;
-                    private volatile boolean infinite = false;
-
-                    private void requestInfinite() {
-                        infinite = true;
-                        producer.request(Long.MAX_VALUE);
-                    }
-
-                    @Override
-                    public void request(long n) {
-                        if (n == 0) {
-                            return;
-                        }
-                        if (n < 0) {
-                            throw new IllegalArgumentException("request a negative number: " + n);
-                        }
-                        if (infinite) {
-                            return;
-                        }
-                        if (n == Long.MAX_VALUE) {
-                            requestInfinite();
-                        } else {
-                            if (firstRequest) {
-                                firstRequest = false;
-                                if (n - 1 >= (Long.MAX_VALUE - count) / skip) {
-                                    // count + skip * (n - 1) >= Long.MAX_VALUE
-                                    requestInfinite();
-                                    return;
-                                }
-                                // count = 5, skip = 2, n = 3
-                                // * * * * *
-                                //     * * * * *
-                                //         * * * * *
-                                // request = 5 + 2 * ( 3 - 1)
-                                producer.request(count + skip * (n - 1));
-                            } else {
-                                if (n >= Long.MAX_VALUE / skip) {
-                                    // skip * n >= Long.MAX_VALUE
-                                    requestInfinite();
-                                    return;
-                                }
-                                // count = 5, skip = 2, n = 3
-                                // (* * *) * *
-                                // (    *) * * * *
-                                //           * * * * *
-                                // request = skip * n
-                                // "()" means the items already emitted before this request
-                                producer.request(skip * n);
-                            }
-                        }
-                    }
-                });
+        public BufferSkip(Subscriber<? super List<T>> actual, int count, int skip) {
+            this.actual = actual;
+            this.count = count;
+            this.skip = skip;
+            this.request(0L);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            long i = index;
+            List<T> b = buffer;
+            if (i == 0) {
+                b = new ArrayList<T>();
+                buffer = b;
             }
-
-            @Override
-            public void onNext(T t) {
-                if (index++ % skip == 0) {
-                    chunks.add(new ArrayList<T>(count));
-                }
+            i++;
+            if (i == skip) {
+                index = 0;
+            } else {
+                index = i;
+            }
+            
+            if (b != null) {
+                b.add(t);
                 
-                Iterator<List<T>> it = chunks.iterator();
-                while (it.hasNext()) {
-                    List<T> chunk = it.next();
-                    chunk.add(t);
-                    if (chunk.size() == count) {
-                        it.remove();
-                        child.onNext(chunk);
-                    }
+                if (b.size() == count) {
+                    buffer = null;
+                    actual.onNext(b);
                 }
             }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            buffer = null;
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            List<T> b = buffer;
+            if (b != null) {
+                buffer = null;
+                actual.onNext(b);
+            }
+            actual.onCompleted();
+        }
+        
+        Producer createProducer() {
+            return new BufferSkipProducer();
+        }
+        
+        final class BufferSkipProducer
+        extends AtomicBoolean
+        implements Producer {
+            /** */
+            private static final long serialVersionUID = 3428177408082367154L;
 
             @Override
-            public void onError(Throwable e) {
-                chunks.clear();
-                child.onError(e);
-            }
-            @Override
-            public void onCompleted() {
-                try {
-                    for (List<T> chunk : chunks) {
-                        try {
-                            child.onNext(chunk);
-                        } catch (Throwable t) {
-                            Exceptions.throwOrReport(t, this);
-                            return;
-                        }
+            public void request(long n) {
+                if (n < 0) {
+                    throw new IllegalArgumentException("n >= 0 required but it was " + n);
+                }
+                if (n != 0) {
+                    BufferSkip<T> parent = BufferSkip.this;
+                    if (!get() && compareAndSet(false, true)) {
+                        long u = BackpressureUtils.multiplyCap(n, parent.count);
+                        long v = BackpressureUtils.multiplyCap(parent.skip - parent.count, n - 1);
+                        long w = BackpressureUtils.addCap(u, v);
+                        parent.request(w);
+                    } else {
+                        long u = BackpressureUtils.multiplyCap(n, parent.skip);
+                        parent.request(u);
                     }
-                    child.onCompleted();
-                } finally {
-                    chunks.clear();
                 }
             }
-        };
+        }
+    }
+    
+    static final class BufferOverlap<T> extends Subscriber<T> {
+        final Subscriber<? super List<T>> actual;
+        final int count;
+        final int skip;
+        
+        long index;
+        
+        final ArrayDeque<List<T>> queue;
+        
+        final AtomicLong requested;
+        
+        long produced;
+
+        public BufferOverlap(Subscriber<? super List<T>> actual, int count, int skip) {
+            this.actual = actual;
+            this.count = count;
+            this.skip = skip;
+            this.queue = new ArrayDeque<List<T>>();
+            this.requested = new AtomicLong();
+            this.request(0L);
+        }
+
+        @Override
+        public void onNext(T t) {
+            long i = index;
+            if (i == 0) {
+                List<T> b = new ArrayList<T>();
+                queue.offer(b);
+            }
+            i++;
+            if (i == skip) {
+                index = 0;
+            } else {
+                index = i;
+            }
+            
+            for (List<T> list : queue) {
+                list.add(t);
+            }
+            
+            List<T> b = queue.peek();
+            if (b != null && b.size() == count) {
+                queue.poll();
+                produced++;
+                actual.onNext(b);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            queue.clear();
+            
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            long p = produced;
+            
+            if (p != 0L) {
+                if (p > requested.get()) {
+                    actual.onError(new MissingBackpressureException("More produced than requested? " + p));
+                    return;
+                }
+                requested.addAndGet(-p);
+            }
+            
+            BackpressureUtils.postCompleteDone(requested, queue, actual);
+        }
+        
+        Producer createProducer() {
+            return new BufferOverlapProducer();
+        }
+        
+        final class BufferOverlapProducer extends AtomicBoolean implements Producer {
+
+            /** */
+            private static final long serialVersionUID = -4015894850868853147L;
+
+            @Override
+            public void request(long n) {
+                BufferOverlap<T> parent = BufferOverlap.this;
+                if (BackpressureUtils.postCompleteRequest(parent.requested, n, parent.queue, parent.actual)) {
+                    if (n != 0L) {
+                        if (!get() && compareAndSet(false, true)) {
+                            long u = BackpressureUtils.multiplyCap(parent.skip, n - 1);
+                            long v = BackpressureUtils.addCap(u, parent.count);
+                            
+                            parent.request(v);
+                        } else {
+                            long u = BackpressureUtils.multiplyCap(parent.skip, n);
+                            parent.request(u);
+                        }
+                    }
+                }
+            }
+            
+        }
     }
 }

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -25,14 +25,13 @@ import rx.exceptions.CompositeException;
 /**
  * A {@code TestSubscriber} is a variety of {@link Subscriber} that you can use for unit testing, to perform
  * assertions, inspect received events, or wrap a mocked {@code Subscriber}.
+ * @param <T> the value type
  */
 public class TestSubscriber<T> extends Subscriber<T> {
 
     private final TestObserver<T> testObserver;
     private final CountDownLatch latch = new CountDownLatch(1);
     private volatile Thread lastSeenThread;
-    /** Holds the initial request value. */
-    private final long initialRequest;
     /** The shared no-op observer. */
     private static final Observer<Object> INERT = new Observer<Object>() {
 
@@ -78,7 +77,9 @@ public class TestSubscriber<T> extends Subscriber<T> {
             throw new NullPointerException();
         }
         this.testObserver = new TestObserver<T>(delegate);
-        this.initialRequest = initialRequest;
+        if (initialRequest >= 0L) {
+            this.request(initialRequest);
+        }
     }
 
     /**
@@ -112,6 +113,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
 
     /**
      * Factory method to construct a TestSubscriber with an initial request of Long.MAX_VALUE and no delegation.
+     * @param <T> the value type
      * @return the created TestSubscriber instance
      * @since 1.1.0
      */
@@ -121,6 +123,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     
     /**
      * Factory method to construct a TestSubscriber with the given initial request amount and no delegation.
+     * @param <T> the value type
      * @param initialRequest the initial request amount, negative values revert to the default unbounded mode
      * @return the created TestSubscriber instance
      * @since 1.1.0
@@ -132,6 +135,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Factory method to construct a TestSubscriber which delegates events to the given Observer and
      * issues the given initial request amount.
+     * @param <T> the value type
      * @param delegate the observer to delegate events to
      * @param initialRequest the initial request amount, negative values revert to the default unbounded mode
      * @return the created TestSubscriber instance
@@ -145,6 +149,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Factory method to construct a TestSubscriber which delegates events to the given Observer and
      * an issues an initial request of Long.MAX_VALUE.
+     * @param <T> the value type
      * @param delegate the observer to delegate events to
      * @return the created TestSubscriber instance
      * @throws NullPointerException if delegate is null
@@ -157,6 +162,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Factory method to construct a TestSubscriber which delegates events to the given Subscriber and
      * an issues an initial request of Long.MAX_VALUE.
+     * @param <T> the value type
      * @param delegate the subscriber to delegate events to
      * @return the created TestSubscriber instance
      * @throws NullPointerException if delegate is null
@@ -166,13 +172,6 @@ public class TestSubscriber<T> extends Subscriber<T> {
         return new TestSubscriber<T>(delegate);
     }
     
-    @Override
-    public void onStart() {
-        if (initialRequest >= 0) {
-            requestMore(initialRequest);
-        }
-    }
-
     /**
      * Notifies the Subscriber that the {@code Observable} has finished sending push-based notifications.
      * <p>


### PR DESCRIPTION
This PR fixes the backpressure behavior of the counted `buffer` and `window` operators and consists of several changes.

The main issue lies when `count > skip` in the operators, yielding overlapping buffers/windows. 

For `buffer`, when the upstream completed, the logic emitted all remaining partial buffers even if there was no request for new buffers, which can result in `MissingBackpressureException` somewhere. The proper handling of the final buffers required a new backpressure management algorithm which is now part of the `BackpressureUtils` class and consists of two new methods: `postCompleteDone` called from onComplete to take over the emission of queued values and `postCompleteRequest` which manages requests before and after the completed state.

For `window`, the new window opened was emitted regardless of requests which was common due to request-amplification (i.e., requesting n windows results in requesting `count + skip * (n - 1)` elements at first (then `skip * n` later) which opens `ceil(count / skip)` windows upfront. To avoid the overflow, the individual windows have to go through the usual queue/drain logic as well. I've also updated the Javadoc to reflect the backpressure behavior along with parameter validation.

In addition, the window case didn't manage cancellation properly. When the outer observable is unsubscribed, the inner subscribers may be still going and thus cancelling the upstream would stop/hang the inner windows. Instead, the open window count is tracked (also counting the outer as 1 window) and when all get unsubscribed (i.e., count reaches zero), the upstream is unsubscribed. To accomplish this, the `UnicastSubject` had to be retrofitted with a new optional callback `Action0` which gets called at most once whenever either `onError` or `onCompleted` is called or when the single `Subscriber` unsubscribes.

A secondary issue was with the `TestSubscriber`'s initial request; some upstream operators could get triggered with `Long.MAX_VALUE` despite the initial request amount was set. This PR changes it to be set at construction time instead of in `onStart`.