### PR TITLE
1.x: redo performance checker

### DIFF
--- a/src/perf/java/rx/operators/RedoPerf.java
+++ b/src/perf/java/rx/operators/RedoPerf.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observable;
+import rx.functions.Func1;
+import rx.internal.util.UtilityFunctions;
+import rx.jmh.LatchedObserver;
+
+/**
+ * Benchmark typical atomic operations on volatile fields and AtomicXYZ classes.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*RedoPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*RedoPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class RedoPerf {
+    @Param({"1,1", "1,1000", "1,1000000", "1000,1", "1000,1000", "1000000,1"})
+    public String params;
+    
+    public int len;
+    public int repeat;
+    
+    Observable<Integer> sourceRepeating;
+    
+    Observable<Integer> sourceRetrying;
+    
+    Observable<Integer> redoRepeating;
+    
+    Observable<Integer> redoRetrying;
+
+    Observable<Integer> baseline;
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Setup
+    public void setup() {
+        String[] ps = params.split(",");
+        len = Integer.parseInt(ps[0]);
+        repeat = Integer.parseInt(ps[1]);        
+    
+        Integer[] values = new Integer[len];
+        Arrays.fill(values, 777);
+        
+        Observable<Integer> source = Observable.from(values);
+        
+        Observable<Integer> error = source.concatWith(Observable.<Integer>error(new RuntimeException()));
+        
+        Integer[] values2 = new Integer[len * repeat];
+        Arrays.fill(values2, 777);
+        
+        baseline = Observable.from(values2); 
+        
+        sourceRepeating = source.repeat(repeat);
+        
+        sourceRetrying = error.retry(repeat);
+        
+        redoRepeating = source.repeatWhen((Func1)UtilityFunctions.identity()).take(len * repeat);
+
+        redoRetrying = error.retryWhen((Func1)UtilityFunctions.identity()).take(len * repeat);
+    }
+    
+    @Benchmark
+    public void baseline(Blackhole bh) {
+        baseline.subscribe(new LatchedObserver<Integer>(bh));
+    }
+    
+    @Benchmark
+    public void repeatCounted(Blackhole bh) {
+        sourceRepeating.subscribe(new LatchedObserver<Integer>(bh));
+    }
+    
+    @Benchmark
+    public void retryCounted(Blackhole bh) {
+        sourceRetrying.subscribe(new LatchedObserver<Integer>(bh));
+    }
+    
+    @Benchmark
+    public void repeatWhen(Blackhole bh) {
+        redoRepeating.subscribe(new LatchedObserver<Integer>(bh));
+    }
+    
+    @Benchmark
+    public void retryWhen(Blackhole bh) {
+        redoRetrying.subscribe(new LatchedObserver<Integer>(bh));
+    }
+}


### PR DESCRIPTION
This PR adds a perf test to measure the redo-based operators: repeat, repeatWhen, retry, retryWhen.

Results (Intel Celeron 1005M, Windows 7 x64, Java 8u72):
```
Benchmark                     (params)        Score  Score error
r.o.RedoPerf.baseline              1,1  9507538,496   384265,883
r.o.RedoPerf.baseline           1,1000   127236,123     6322,513
r.o.RedoPerf.baseline        1,1000000      131,491        7,443
r.o.RedoPerf.baseline           1000,1   126830,429     8161,593
r.o.RedoPerf.baseline        1000,1000      130,795        8,571
r.o.RedoPerf.baseline        1000000,1      130,097        0,936
r.o.RedoPerf.repeatCounted         1,1   473245,445    16574,938
r.o.RedoPerf.repeatCounted      1,1000     2039,161       64,254
r.o.RedoPerf.repeatCounted   1,1000000        2,304        0,376
r.o.RedoPerf.repeatCounted      1000,1    28622,433     2896,427
r.o.RedoPerf.repeatCounted   1000,1000       35,208        2,312
r.o.RedoPerf.repeatCounted   1000000,1       56,978        7,278
r.o.RedoPerf.repeatWhen            1,1   452640,724     5506,024
r.o.RedoPerf.repeatWhen         1,1000     2151,821      352,059
r.o.RedoPerf.repeatWhen      1,1000000        2,159        0,066
r.o.RedoPerf.repeatWhen         1000,1    23919,436      217,644
r.o.RedoPerf.repeatWhen      1000,1000       20,947        1,615
r.o.RedoPerf.repeatWhen      1000000,1       25,316        0,970
r.o.RedoPerf.retryCounted          1,1   176470,291     4570,641
r.o.RedoPerf.retryCounted       1,1000      588,985       38,103
r.o.RedoPerf.retryCounted    1,1000000        0,589        0,037
r.o.RedoPerf.retryCounted       1000,1     7178,699      123,423
r.o.RedoPerf.retryCounted    1000,1000       14,470        0,699
r.o.RedoPerf.retryCounted    1000000,1        7,842        0,252
r.o.RedoPerf.retryWhen             1,1   310407,136     8052,067
r.o.RedoPerf.retryWhen          1,1000      567,338       13,511
r.o.RedoPerf.retryWhen       1,1000000        0,587        0,036
r.o.RedoPerf.retryWhen          1000,1    10388,639      269,817
r.o.RedoPerf.retryWhen       1000,1000       10,657        1,471
r.o.RedoPerf.retryWhen       1000000,1       11,550        0,287
```

The `params` is a composite of number of elements and number of repetitions.