### PR TITLE
1.x: zip performance measure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ apply plugin: 'java'
 dependencies {
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
+
+    perfCompile 'org.openjdk.jmh:jmh-core:1.11.3'
+    perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.11.3'
 }
 
 javadoc {

--- a/src/perf/java/rx/operators/ZipPerf.java
+++ b/src/perf/java/rx/operators/ZipPerf.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observable;
+import rx.functions.Func2;
+import rx.jmh.LatchedObserver;
+import rx.schedulers.Schedulers;
+
+/**
+ * Benchmark the Zip operator.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*ZipPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*ZipPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class ZipPerf {
+    
+    @Param({"1", "1000", "1000000"})
+    public int firstLen;
+    @Param({"1", "1000", "1000000"})
+    public int secondLen;
+    
+    Observable<Integer> baseline;
+    
+    Observable<Integer> bothSync;
+    Observable<Integer> firstSync;
+    Observable<Integer> secondSync;
+    Observable<Integer> bothAsync;
+    
+    boolean small;
+    
+    @Setup
+    public void setup() {
+        Integer[] array1 = new Integer[firstLen];
+        Arrays.fill(array1, 777);
+        Integer[] array2 = new Integer[secondLen];
+        Arrays.fill(array2, 777);
+        
+        baseline = Observable.from(firstLen < secondLen? array2 : array1);
+    
+        Observable<Integer> o1 = Observable.from(array1);
+        
+        Observable<Integer> o2 = Observable.from(array2);
+        
+        Func2<Integer, Integer, Integer> plus = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer a, Integer b) {
+                return a + b;
+            }
+        };
+        
+        bothSync = Observable.zip(o1, o2, plus);
+
+        firstSync = Observable.zip(o1, o2.subscribeOn(Schedulers.computation()), plus);
+
+        secondSync = Observable.zip(o1.subscribeOn(Schedulers.computation()), o2, plus);
+
+        bothAsync = Observable.zip(o1.subscribeOn(Schedulers.computation()), o2.subscribeOn(Schedulers.computation()), plus);
+    
+        small = Math.min(firstLen, secondLen) < 100;
+    }
+    
+    @Benchmark
+    public void baseline(Blackhole bh) {
+        baseline.subscribe(new LatchedObserver<Integer>(bh));
+    }
+
+    @Benchmark
+    public void syncSync(Blackhole bh) {
+        bothSync.subscribe(new LatchedObserver<Integer>(bh));
+    }
+
+    @Benchmark
+    public void syncAsync(Blackhole bh) throws Exception {
+        LatchedObserver<Integer> o = new LatchedObserver<Integer>(bh);
+        firstSync.subscribe(o);
+        
+        if (small) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
+    }
+
+    @Benchmark
+    public void asyncSync(Blackhole bh) throws Exception {
+        LatchedObserver<Integer> o = new LatchedObserver<Integer>(bh);
+        secondSync.subscribe(o);
+        
+        if (small) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
+    }
+
+    @Benchmark
+    public void asyncAsync(Blackhole bh) throws Exception {
+        LatchedObserver<Integer> o = new LatchedObserver<Integer>(bh);
+        bothAsync.subscribe(o);
+        
+        if (small) {
+            while (o.latch.getCount() != 0);
+        } else {
+            o.latch.await();
+        }
+    }
+
+}


### PR DESCRIPTION
Performance measurement of `zip` and upgrade to JMH 1.11.3.

Results (Intel Celeron 1005M, Windows 7 x64, Java 8u72):

Overall throughput values:

![image](https://cloud.githubusercontent.com/assets/1269832/12523444/3e1893fc-c157-11e5-81bd-353031db4a91.png)

Comparing fully sync and fully async dual sources:

![image](https://cloud.githubusercontent.com/assets/1269832/12523464/5cc23074-c157-11e5-8231-5954eafd7d0e.png)

Comparing when either the first or the second is an async source:

![image](https://cloud.githubusercontent.com/assets/1269832/12523485/7bdf951e-c157-11e5-9f3c-f2f3b156ba03.png)

So the order of sources matter, having the async first allows it to start early and not after the synchronous source completes its prefetch run.
