### PR TITLE
handle predicate exceptions properly in skipWhile

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSkipWhile.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipWhile.java
@@ -17,6 +17,7 @@ package rx.internal.operators;
 
 import rx.Observable.Operator;
 import rx.Subscriber;
+import rx.exceptions.Exceptions;
 import rx.functions.Func1;
 import rx.functions.Func2;
 
@@ -40,7 +41,14 @@ public final class OperatorSkipWhile<T> implements Operator<T, T> {
                 if (!skipping) {
                     child.onNext(t);
                 } else {
-                    if (!predicate.call(t, index++)) {
+                    final boolean skip;
+                    try {
+                        skip = predicate.call(t,  index++);
+                    } catch (Throwable e) {
+                        Exceptions.throwOrReport(e, child, t);
+                        return;
+                    }
+                    if (!skip) {
                         skipping = false;
                         child.onNext(t);
                     } else {


### PR DESCRIPTION
A non-fatal exception thrown by `predicate.call()` in `OperatorSkipWhile` could result in the error being reported by an upstream operator. This PR ensures that the error is reported by the operator in which it occurs.

I've added a unit test for this scenario that failed with the original code, and a couple of other tests.

There are a few more of these floating around that I'll submit PRs for as well.