### PR TITLE
fix error handling in combineLatest

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -301,7 +301,14 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
 
         @Override
         public void onNext(T t) {
-            child.onNext(combinator.call(t));
+            final R value;
+            try {
+                value = combinator.call(t);
+            } catch (Throwable e) {
+                Exceptions.throwOrReport(e, child);
+                return;
+            }
+            child.onNext(value);
         }
 
         @Override

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -883,5 +884,32 @@ public class OnSubscribeCombineLatestTest {
             }});
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
+    
+    @Test
+    public void testNonFatalExceptionThrownByCombinatorForSingleSourceIsNotReportedByUpstreamOperator() {
+        final AtomicBoolean errorOccurred = new AtomicBoolean(false);
+        TestSubscriber<Integer> ts = TestSubscriber.create(1);
+        Observable<Integer> source = Observable.just(1)
+          // if haven't caught exception in combineLatest operator then would incorrectly
+          // be picked up by this call to doOnError
+          .doOnError(new Action1<Throwable>() {
+                @Override
+                public void call(Throwable t) {
+                    errorOccurred.set(true);
+                }
+            });
+        Observable
+          .combineLatest(Collections.singletonList(source), THROW_NON_FATAL)
+          .subscribe(ts);
+        assertFalse(errorOccurred.get());
+    }
+    
+    private static final FuncN<Integer> THROW_NON_FATAL = new FuncN<Integer>() {
+        @Override
+        public Integer call(Object... args) {
+            throw new RuntimeException();
+        }
+
+    }; 
 
 }


### PR DESCRIPTION
`combinator.call()` was not wrapped in an appropriate try catch to prevent the error from being reported from an upstream operator.

This PR includes a unit test that failed on the original code.