### PR TITLE
1.x: fix Amb sharing the choice among all subscribers

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeAmb.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeAmb.java
@@ -353,8 +353,6 @@ public final class OnSubscribeAmb<T> implements OnSubscribe<T>{
     //give default access instead of private as a micro-optimization 
     //for access from anonymous classes below
     final Iterable<? extends Observable<? extends T>> sources;
-    final Selection<T> selection = new Selection<T>();
-    final AtomicReference<AmbSubscriber<T>> choice = selection.choice;
     
     private OnSubscribeAmb(Iterable<? extends Observable<? extends T>> sources) {
         this.sources = sources;
@@ -362,6 +360,8 @@ public final class OnSubscribeAmb<T> implements OnSubscribe<T>{
 
     @Override
     public void call(final Subscriber<? super T> subscriber) {
+        final Selection<T> selection = new Selection<T>();
+        final AtomicReference<AmbSubscriber<T>> choice = selection.choice;
         
         //setup unsubscription of all the subscribers to the sources
         subscriber.add(Subscriptions.create(new Action0() {

--- a/src/test/java/rx/internal/operators/OnSubscribeAmbTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeAmbTest.java
@@ -288,5 +288,26 @@ public class OnSubscribeAmbTest {
         }).ambWith(Observable.just(2)).toBlocking().single();
         assertEquals(1, result);
     }
-    
+
+    @Test(timeout = 1000)
+    public void testMultipleUse() {
+        TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
+
+        Observable<Long> amb = Observable.timer(100, TimeUnit.MILLISECONDS).ambWith(Observable.timer(200, TimeUnit.MILLISECONDS));
+        
+        amb.subscribe(ts1);
+        amb.subscribe(ts2);
+        
+        ts1.awaitTerminalEvent();
+        ts2.awaitTerminalEvent();
+        
+        ts1.assertValue(0L);
+        ts1.assertCompleted();
+        ts1.assertNoErrors();
+
+        ts2.assertValue(0L);
+        ts2.assertCompleted();
+        ts2.assertNoErrors();
+    }
 }


### PR DESCRIPTION
The OnSubscribeAmb shared the choice variable among all of its subscribers which prevented reusing the same Observable.