### PR TITLE
2.x: Add support for concurrently inserting actions while advancing time

### DIFF
--- a/src/main/java/io/reactivex/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/schedulers/TestScheduler.java
@@ -14,6 +14,7 @@
 package io.reactivex.schedulers;
 
 import java.util.*;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Scheduler;
@@ -28,7 +29,7 @@ import io.reactivex.internal.functions.Objects;
  */
 public final class TestScheduler extends Scheduler {
     /** The ordered queue for the runnable tasks. */
-    private final Queue<TimedRunnable> queue = new PriorityQueue<TimedRunnable>(11);
+    private final Queue<TimedRunnable> queue = new PriorityBlockingQueue<TimedRunnable>(11);
     /** The per-scheduler global order counter. */
     long counter;
 
@@ -61,7 +62,7 @@ public final class TestScheduler extends Scheduler {
     }
 
     // Storing time in nanoseconds internally.
-    private long time;
+    private volatile long time;
 
     @Override
     public long now(TimeUnit unit) {

--- a/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
@@ -18,6 +18,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.*;
 
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -218,39 +221,4 @@ public class TestSchedulerTest {
         }
     }
 
-    @Test
-    public final void testConcurrentInsertionAndTimeChange() {
-        final TestScheduler scheduler = new TestScheduler();
-        new Thread() {
-            @Override public void run() {
-                while (true) {
-                    Thread.yield(); // Scheduling service lock is not fair
-                    final Scheduler.Worker inner = scheduler.createWorker();
-                    inner.schedule(new Runnable() {
-                        @Override
-                        public void run()
-                        {
-                            System.out.println(scheduler.now(TimeUnit.MILLISECONDS));
-                        }
-
-                    },1, TimeUnit.SECONDS);
-                }
-            }
-        }.start();
-        try
-        {
-            for (int i = 0; i < 10; i++) {
-                Thread.sleep(5);
-                scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-            }
-        } catch (InterruptedException e)
-        {
-            e.printStackTrace();
-        }
-        try
-        {
-        } catch(NullPointerException e) {
-            fail("unexpected NullPointerException : " + e);
-        }
-    }
 }

--- a/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.schedulers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.*;
 
@@ -214,6 +215,42 @@ public class TestSchedulerTest {
             inOrder.verify(calledOp, times(1)).run();
         } finally {
             inner.dispose();
+        }
+    }
+
+    @Test
+    public final void testConcurrentInsertionAndTimeChange() {
+        final TestScheduler scheduler = new TestScheduler();
+        new Thread() {
+            @Override public void run() {
+                while (true) {
+                    Thread.yield(); // Scheduling service lock is not fair
+                    final Scheduler.Worker inner = scheduler.createWorker();
+                    inner.schedule(new Runnable() {
+                        @Override
+                        public void run()
+                        {
+                            System.out.println(scheduler.now(TimeUnit.MILLISECONDS));
+                        }
+
+                    },1, TimeUnit.SECONDS);
+                }
+            }
+        }.start();
+        try
+        {
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(5);
+                scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+            }
+        } catch (InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+        try
+        {
+        } catch(NullPointerException e) {
+            fail("unexpected NullPointerException : " + e);
         }
     }
 }


### PR DESCRIPTION


This change is adding a bit of thread safety when some threads are trying to insert some actions while the time is changed in the TestScheduler