### PR TITLE
1.x: fix sample(Observable) not requesting Long.MAX_VALUE

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSampleWithObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorSampleWithObservable.java
@@ -69,7 +69,7 @@ public final class OperatorSampleWithObservable<T, U> implements Operator<T, T> 
             
         };
         
-        Subscriber<T> result = new Subscriber<T>(child) {
+        Subscriber<T> result = new Subscriber<T>() {
             @Override
             public void onNext(T t) {
                 value.set(t);
@@ -87,6 +87,8 @@ public final class OperatorSampleWithObservable<T, U> implements Operator<T, T> 
                 unsubscribe();
             }
         };
+        
+        child.add(result);
         
         sampler.unsafeSubscribe(samplerSub);
         

--- a/src/test/java/rx/internal/operators/OperatorSampleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSampleTest.java
@@ -16,21 +16,16 @@
 package rx.internal.operators;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.functions.Action0;
+import rx.functions.*;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
@@ -282,5 +277,39 @@ public class OperatorSampleTest {
         );
         o.throttleLast(1, TimeUnit.MILLISECONDS).subscribe().unsubscribe();
         verify(s).unsubscribe();
+    }
+    
+    @Test
+    public void testSampleOtherUnboundedIn() {
+        
+        final long[] requested = { -1 };
+        
+        PublishSubject.create()
+        .doOnRequest(new Action1<Long>() {
+            @Override
+            public void call(Long t) {
+                requested[0] = t;
+            }
+        })
+        .sample(PublishSubject.create()).subscribe();
+        
+        Assert.assertEquals(Long.MAX_VALUE, requested[0]);
+    }
+    
+    @Test
+    public void testSampleTimedUnboundedIn() {
+        
+        final long[] requested = { -1 };
+        
+        PublishSubject.create()
+        .doOnRequest(new Action1<Long>() {
+            @Override
+            public void call(Long t) {
+                requested[0] = t;
+            }
+        })
+        .sample(1, TimeUnit.SECONDS).subscribe().unsubscribe();
+        
+        Assert.assertEquals(Long.MAX_VALUE, requested[0]);
     }
 }


### PR DESCRIPTION
Reported on the rxjava discussion group.

Sample has to disconnect itself from the Producer chain and request Long.MAX_VALUE instead of whatever the downstream requests.