### PR TITLE
1.x: fix unsubscription and producer issues in sample(other)

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorSampleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSampleTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 import org.mockito.InOrder;
@@ -26,8 +27,10 @@ import org.mockito.InOrder;
 import rx.*;
 import rx.Observable.OnSubscribe;
 import rx.functions.*;
+import rx.observers.TestSubscriber;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
+import rx.subscriptions.Subscriptions;
 
 public class OperatorSampleTest {
     private TestScheduler scheduler;
@@ -311,5 +314,156 @@ public class OperatorSampleTest {
         .sample(1, TimeUnit.SECONDS).subscribe().unsubscribe();
         
         Assert.assertEquals(Long.MAX_VALUE, requested[0]);
+    }
+    
+    @Test
+    public void dontUnsubscribeChild1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        PublishSubject<Integer> sampler = PublishSubject.create();
+        
+        source.sample(sampler).unsafeSubscribe(ts);
+        
+        source.onCompleted();
+        
+        Assert.assertFalse("Source has subscribers?", source.hasObservers());
+        Assert.assertFalse("Sampler has subscribers?", sampler.hasObservers());
+        
+        Assert.assertFalse("TS unsubscribed?", ts.isUnsubscribed());
+    }
+
+    @Test
+    public void dontUnsubscribeChild2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        PublishSubject<Integer> source = PublishSubject.create();
+        
+        PublishSubject<Integer> sampler = PublishSubject.create();
+        
+        source.sample(sampler).unsafeSubscribe(ts);
+        
+        sampler.onCompleted();
+        
+        Assert.assertFalse("Source has subscribers?", source.hasObservers());
+        Assert.assertFalse("Sampler has subscribers?", sampler.hasObservers());
+        
+        Assert.assertFalse("TS unsubscribed?", ts.isUnsubscribed());
+    }
+    
+    @Test
+    public void neverSetProducer() {
+        Observable<Integer> neverBackpressure = Observable.create(new OnSubscribe<Integer>() {
+            @Override
+            public void call(Subscriber<? super Integer> t) {
+                t.setProducer(new Producer() {
+                    @Override
+                    public void request(long n) {
+                        // irrelevant in this test
+                    }
+                });
+            }
+        });
+        
+        final AtomicInteger count = new AtomicInteger();
+        
+        neverBackpressure.sample(neverBackpressure).unsafeSubscribe(new Subscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                // irrelevant
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                // irrelevant
+            }
+            
+            @Override
+            public void onCompleted() {
+                // irrelevant
+            }
+            
+            @Override
+            public void setProducer(Producer p) {
+                count.incrementAndGet();
+            }
+        });
+        
+        Assert.assertEquals(0, count.get());
+    }
+    
+    @Test
+    public void unsubscribeMainAfterCompleted() {
+        final AtomicBoolean unsubscribed = new AtomicBoolean();
+        
+        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+            @Override
+            public void call(Subscriber<? super Integer> t) {
+                t.add(Subscriptions.create(new Action0() {
+                    @Override
+                    public void call() {
+                        unsubscribed.set(true);
+                    }
+                }));
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onCompleted() {
+                if (unsubscribed.get()) {
+                    onError(new IllegalStateException("Resource unsubscribed!"));
+                } else {
+                    super.onCompleted();
+                }
+            }
+        };
+        
+        PublishSubject<Integer> sampler = PublishSubject.create();
+        
+        source.sample(sampler).unsafeSubscribe(ts);
+        
+        sampler.onCompleted();
+        
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void unsubscribeSamplerAfterCompleted() {
+        final AtomicBoolean unsubscribed = new AtomicBoolean();
+        
+        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+            @Override
+            public void call(Subscriber<? super Integer> t) {
+                t.add(Subscriptions.create(new Action0() {
+                    @Override
+                    public void call() {
+                        unsubscribed.set(true);
+                    }
+                }));
+            }
+        });
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onCompleted() {
+                if (unsubscribed.get()) {
+                    onError(new IllegalStateException("Resource unsubscribed!"));
+                } else {
+                    super.onCompleted();
+                }
+            }
+        };
+        
+        PublishSubject<Integer> sampled = PublishSubject.create();
+        
+        sampled.sample(source).unsafeSubscribe(ts);
+        
+        sampled.onCompleted();
+        
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 }


### PR DESCRIPTION
This PR fixes 2 bugs with `sample`

- Termination of the main or sampler subscriber unsubscribed the child subscriber which is not allowed.
- The sampler wrapped the child subscriber and thus it allowed setting a producer on the child (thus sampling based on request with some sources).

In addition, #3657 wants to emit the very last item on completion to which I marked the required changes in comments (to be uncommented in a separate PR if needed).