### PR TITLE
1.x: fix take(-1) not completing

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorTake.java
+++ b/src/main/java/rx/internal/operators/OperatorTake.java
@@ -36,6 +36,9 @@ public final class OperatorTake<T> implements Operator<T, T> {
     final int limit;
 
     public OperatorTake(int limit) {
+        if (limit < 0) {
+            throw new IllegalArgumentException("limit >= 0 required but it was " + limit);
+        }
         this.limit = limit;
     }
 

--- a/src/test/java/rx/internal/operators/OperatorTakeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeTest.java
@@ -438,4 +438,21 @@ public class OperatorTakeTest {
         ts.assertNoErrors();
         ts.assertCompleted();
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void takeNegative() {
+        Observable.range(1, 1000 * 1000 * 1000).take(-1);
+    }
+
+    @Test(timeout = 1000)
+    public void takeZero() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Observable.range(1, 1000 * 1000 * 1000).take(0).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
 }


### PR DESCRIPTION
Originally, only 0 was checked which resulted in `onCompleted()` but negative values weren't. When the downstream requested, c became -1 and was requested from the source. `range` ignores negative requests but other sources may throw IAE in that case.

With the fix, the operator will throw IAE in assembly time.