### PR TITLE
1.x: fix counted buffer and window backpressure

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9744,8 +9744,8 @@ public class Observable<T> {
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window3.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>The operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
-     *  but each of them will emit at most {@code count} elements.</dd>
+     *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Observable uses an
+     *  unbounded buffer that may hold at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9754,6 +9754,7 @@ public class Observable<T> {
      *            the maximum size of each window before it should be emitted
      * @return an Observable that emits connected, non-overlapping windows, each containing at most
      *         {@code count} items from the source Observable
+     * @throws IllegalArgumentException if either count is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/window.html">ReactiveX operators documentation: Window</a>
      */
     public final Observable<Observable<T>> window(int count) {
@@ -9769,8 +9770,8 @@ public class Observable<T> {
      * <img width="640" height="365" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window4.png" alt="">
      * <dl>
      *  <dt><b>Backpressure Support:</b></dt>
-     *  <dd>The operator honors backpressure on its outer subscriber, ignores backpressure in its inner Observables 
-     *  but each of them will emit at most {@code count} elements.</dd>
+     *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Observable uses an
+     *  unbounded buffer that may hold at most {@code count} elements.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9782,9 +9783,16 @@ public class Observable<T> {
      *            {@code count} are equal this is the same operation as {@link #window(int)}.
      * @return an Observable that emits windows every {@code skip} items containing at most {@code count} items
      *         from the source Observable
+     * @throws IllegalArgumentException if either count or skip is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/window.html">ReactiveX operators documentation: Window</a>
      */
     public final Observable<Observable<T>> window(int count, int skip) {
+        if (count <= 0) {
+            throw new IllegalArgumentException("count > 0 required but it was " + count);
+        }
+        if (skip <= 0) {
+            throw new IllegalArgumentException("skip > 0 required but it was " + skip);
+        }
         return lift(new OperatorWindowWithSize<T>(count, skip));
     }
 

--- a/src/main/java/rx/internal/operators/BackpressureUtils.java
+++ b/src/main/java/rx/internal/operators/BackpressureUtils.java
@@ -15,8 +15,10 @@
  */
 package rx.internal.operators;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import rx.Subscriber;
 
 /**
  * Utility functions for use with backpressure.
@@ -31,6 +33,8 @@ public final class BackpressureUtils {
      * Adds {@code n} to {@code requested} field and returns the value prior to
      * addition once the addition is successful (uses CAS semantics). If
      * overflows then sets {@code requested} field to {@code Long.MAX_VALUE}.
+     * 
+     * @param <T> the type of the target object on which the field updater operates
      * 
      * @param requested
      *            atomic field updater for a request count
@@ -103,6 +107,208 @@ public final class BackpressureUtils {
         return u;
     }
     
+    /**
+     * Masks the most significant bit, i.e., 0x8000_0000_0000_0000L.
+     */
+    static final long COMPLETED_MASK = Long.MIN_VALUE;
+    /**
+     * Masks the request amount bits, i.e., 0x7FFF_FFFF_FFFF_FFFF.
+     */
+    static final long REQUESTED_MASK = Long.MAX_VALUE;
+    
+    /**
+     * Signals the completion of the main sequence and switches to post-completion replay mode.
+     * 
+     * <p>
+     * Don't modify the queue after calling this method!
+     * 
+     * <p>
+     * Post-completion backpressure handles the case when a source produces values based on
+     * requests when it is active but more values are available even after its completion.
+     * In this case, the onCompleted() can't just emit the contents of the queue but has to
+     * coordinate with the requested amounts. This requires two distinct modes: active and
+     * completed. In active mode, requests flow through and the queue is not accessed but
+     * in completed mode, requests no-longer reach the upstream but help in draining the queue.
+     * <p>
+     * The algorithm utilizes the most significant bit (bit 63) of a long value (AtomicLong) since
+     * request amount only goes up to Long.MAX_VALUE (bits 0-62) and negative values aren't
+     * allowed.
+     * 
+     * @param <T> the value type to emit
+     * @param requested the holder of current requested amount
+     * @param queue the queue holding values to be emitted after completion
+     * @param actual the subscriber to receive the values
+     */
+    public static <T> void postCompleteDone(AtomicLong requested, Queue<T> queue, Subscriber<? super T> actual) {
+        for (;;) {
+            long r = requested.get();
+            
+            // switch to completed mode only once
+            if ((r & COMPLETED_MASK) != 0L) {
+                return;
+            }
+            
+            //
+            long u = r | COMPLETED_MASK;
+            
+            if (requested.compareAndSet(r, u)) {
+                // if we successfully switched to post-complete mode and there 
+                // are requests available start draining the queue
+                if (r != 0L) {
+                    // if the switch happened when there was outstanding requests, start draining
+                    postCompleteDrain(requested, queue, actual);
+                }
+                return;
+            }
+        }
+    }
+    
+    /**
+     * Accumulates requests (validated) and handles the completed mode draining of the queue based on the requests.
+     * 
+     * <p>
+     * Post-completion backpressure handles the case when a source produces values based on
+     * requests when it is active but more values are available even after its completion.
+     * In this case, the onCompleted() can't just emit the contents of the queue but has to
+     * coordinate with the requested amounts. This requires two distinct modes: active and
+     * completed. In active mode, requests flow through and the queue is not accessed but
+     * in completed mode, requests no-longer reach the upstream but help in draining the queue.
+     * 
+     * @param <T> the value type to emit
+     * @param requested the holder of current requested amount
+     * @param n the value requested;
+     * @param queue the queue holding values to be emitted after completion
+     * @param actual the subscriber to receive the values
+     * @return true if in the active mode and the request amount of n can be relayed to upstream, false if
+     * in the post-completed mode and the queue is draining.
+     */
+    public static <T> boolean postCompleteRequest(AtomicLong requested, long n, Queue<T> queue, Subscriber<? super T> actual) {
+        if (n < 0L) {
+            throw new IllegalArgumentException("n >= 0 required but it was " + n);
+        }
+        if (n == 0) {
+            return (requested.get() & COMPLETED_MASK) == 0;
+        }
+        
+        for (;;) {
+            long r = requested.get();
+            
+            // mask of the completed flag
+            long c = r & COMPLETED_MASK;
+            // mask of the requested amount
+            long u = r & REQUESTED_MASK;
+            
+            // add the current requested amount and the new requested amount
+            // cap at Long.MAX_VALUE;
+            long v = addCap(u, n);
+            
+            // restore the completed flag
+            v |= c;
+            
+            if (requested.compareAndSet(r, v)) {
+                // if there was no outstanding request before and in
+                // the post-completed state, start draining
+                if (r == COMPLETED_MASK) {
+                    postCompleteDrain(requested, queue, actual);
+                    return false;
+                }
+                // returns true for active mode and false if the completed flag was set
+                return c == 0L;
+            }
+        }
+    }
+    
+    /**
+     * Drains the queue based on the outstanding requests in post-completed mode (only!).
+     * 
+     * @param <T> the value type to emit
+     * @param requested the holder of current requested amount
+     * @param queue the queue holding values to be emitted after completion
+     * @param actual the subscriber to receive the values
+     */
+    static <T> void postCompleteDrain(AtomicLong requested, Queue<T> queue, Subscriber<? super T> subscriber) {
+        
+        long r = requested.get();
+        /*
+         * Since we are supposed to be in the post-complete state, 
+         * requested will have its top bit set.
+         * To allow direct comparison, we start with an emission value which has also
+         * this flag set, then increment it as usual.
+         * Since COMPLETED_MASK is essentially Long.MIN_VALUE, 
+         * there won't be any overflow or sign flip.
+         */
+        long e = COMPLETED_MASK;
+        
+        for (;;) {
+            
+            /*
+             * This is an improved queue-drain algorithm with a specialization 
+             * in which we know the queue won't change anymore (i.e., done is always true
+             * when looking at the classical algorithm and there is no error).
+             * 
+             * Note that we don't check for cancellation or emptyness upfront for two reasons:
+             * 1) if e != r, the loop will do this and we quit appropriately
+             * 2) if e == r, then either there was no outstanding requests or we emitted the requested amount
+             *    and the execution simply falls to the e == r check below which checks for emptyness anyway.
+             */
+            
+            while (e != r) {
+                if (subscriber.isUnsubscribed()) {
+                    return;
+                }
+                
+                T v = queue.poll();
+                
+                if (v == null) {
+                    subscriber.onCompleted();
+                    return;
+                }
+                
+                subscriber.onNext(v);
+                
+                e++;
+            }
+            
+            /*
+             * If the emission count reaches the requested amount the same time the queue becomes empty
+             * this will make sure the subscriber is completed immediately instead of on the next request.
+             * This is also true if there are no outstanding requests (this the while loop doesn't run)
+             * and the queue is empty from the start.
+             */
+            if (e == r) {
+                if (subscriber.isUnsubscribed()) {
+                    return;
+                }
+                if (queue.isEmpty()) {
+                    subscriber.onCompleted();
+                    return;
+                }
+            }
+            
+            /*
+             * Fast flow: see if more requests have arrived in the meantime.
+             * This avoids an atomic add (~40 cycles) and resumes the emission immediately.
+             */
+            r = requested.get();
+            
+            if (r == e) {
+                /* 
+                 * Atomically decrement the requested amount by the emission amount.
+                 * We can't use the full emission value because of the completed flag,
+                 * however, due to two's complement representation, the flag on requested
+                 * is preserved.
+                 */
+                r = requested.addAndGet(-(e & REQUESTED_MASK));
+                // The requested amount actually reached zero, quit
+                if (r == COMPLETED_MASK) {
+                    return;
+                }
+                // reset the emission count
+                e = COMPLETED_MASK;
+            }
+        }
+    }
+
     /**
      * Atomically subtracts a value from the requested amount unless it's at Long.MAX_VALUE.
      * @param requested the requested amount holder

--- a/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
@@ -16,12 +16,14 @@
 package rx.internal.operators;
 
 import java.util.*;
+import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.Observable.Operator;
 import rx.Observable;
-import rx.Observer;
+import rx.Observable.Operator;
 import rx.functions.Action0;
+import rx.internal.util.atomic.SpscLinkedArrayQueue;
+import rx.subjects.Subject;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -48,215 +50,455 @@ public final class OperatorWindowWithSize<T> implements Operator<Observable<T>, 
     @Override
     public Subscriber<? super T> call(Subscriber<? super Observable<T>> child) {
         if (skip == size) {
-            ExactSubscriber e = new ExactSubscriber(child);
-            e.init();
-            return e;
+            WindowExact<T> parent = new WindowExact<T>(child, size);
+            
+            child.add(parent.cancel);
+            child.setProducer(parent.createProducer());
+            
+            return parent;
+        } else
+        if (skip > size) {
+            WindowSkip<T> parent = new WindowSkip<T>(child, size, skip);
+            
+            child.add(parent.cancel);
+            child.setProducer(parent.createProducer());
+            
+            return parent;
         }
-        InexactSubscriber ie = new InexactSubscriber(child);
-        ie.init();
-        return ie;
-    }
-    /** Subscriber with exact, non-overlapping window bounds. */
-    final class ExactSubscriber extends Subscriber<T> {
-        final Subscriber<? super Observable<T>> child;
-        int count;
-        UnicastSubject<T> window;
-        volatile boolean noWindow = true;
-        public ExactSubscriber(Subscriber<? super Observable<T>> child) {
-            /**
-             * See https://github.com/ReactiveX/RxJava/issues/1546
-             * We cannot compose through a Subscription because unsubscribing
-             * applies to the outer, not the inner.
-             */
-            this.child = child;
-            /*
-             * Add unsubscribe hook to child to get unsubscribe on outer (unsubscribing on next window, not on the inner window itself)
-             */
-        }
-        void init() {
-            child.add(Subscriptions.create(new Action0() {
 
+        WindowOverlap<T> parent = new WindowOverlap<T>(child, size, skip);
+        
+        child.add(parent.cancel);
+        child.setProducer(parent.createProducer());
+        
+        return parent;
+        
+    }
+    
+    static final class WindowExact<T> extends Subscriber<T> implements Action0 {
+        final Subscriber<? super Observable<T>> actual;
+        
+        final int size;
+        
+        final AtomicInteger wip;
+        
+        final Subscription cancel;
+        
+        int index;
+        
+        Subject<T, T> window;
+        
+        public WindowExact(Subscriber<? super Observable<T>> actual, int size) {
+            this.actual = actual;
+            this.size = size;
+            this.wip = new AtomicInteger(1);
+            this.cancel = Subscriptions.create(this);
+            this.add(cancel);
+            this.request(0);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            int i = index;
+            
+            Subject<T, T> w = window;
+            if (i == 0) {
+                wip.getAndIncrement();
+                
+                w = UnicastSubject.create(size, this);
+                window = w;
+                
+                actual.onNext(w);
+            }
+            i++;
+            
+            w.onNext(t);
+            
+            if (i == size) {
+                index = 0;
+                window = null;
+                w.onCompleted();
+            } else {
+                index = i;
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            Subject<T, T> w = window;
+            
+            if (w != null) {
+                window = null;
+                w.onError(e);
+            }
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            Subject<T, T> w = window;
+            
+            if (w != null) {
+                window = null;
+                w.onCompleted();
+            }
+            actual.onCompleted();
+        }
+        
+        Producer createProducer() {
+            return new Producer() {
                 @Override
-                public void call() {
-                    // if no window we unsubscribe up otherwise wait until window ends
-                    if (noWindow) {
-                        unsubscribe();
+                public void request(long n) {
+                    if (n < 0L) {
+                        throw new IllegalArgumentException("n >= 0 required but it was " + n);
+                    }
+                    if (n != 0L) {
+                        long u = BackpressureUtils.multiplyCap(size, n);
+                        WindowExact.this.request(u);
+                    }
+                }
+            };
+        }
+        
+        @Override
+        public void call() {
+            if (wip.decrementAndGet() == 0) {
+                unsubscribe();
+            }
+        }
+    }
+    
+    static final class WindowSkip<T> extends Subscriber<T> implements Action0 {
+        final Subscriber<? super Observable<T>> actual;
+        
+        final int size;
+        
+        final int skip;
+        
+        final AtomicInteger wip;
+        
+        final Subscription cancel;
+        
+        int index;
+        
+        Subject<T, T> window;
+        
+        public WindowSkip(Subscriber<? super Observable<T>> actual, int size, int skip) {
+            this.actual = actual;
+            this.size = size;
+            this.skip = skip;
+            this.wip = new AtomicInteger(1);
+            this.cancel = Subscriptions.create(this);
+            this.add(cancel);
+            this.request(0);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            int i = index;
+            
+            Subject<T, T> w = window;
+            if (i == 0) {
+                wip.getAndIncrement();
+                
+                w = UnicastSubject.create(size, this);
+                window = w;
+                
+                actual.onNext(w);
+            }
+            i++;
+            
+            if (w != null) {
+                w.onNext(t);
+            }
+            
+            if (i == size) {
+                index = i;
+                window = null;
+                w.onCompleted();
+            } else
+            if (i == skip) {
+                index = 0;
+            } else {
+                index = i;
+            }
+            
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            Subject<T, T> w = window;
+            
+            if (w != null) {
+                window = null;
+                w.onError(e);
+            }
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            Subject<T, T> w = window;
+            
+            if (w != null) {
+                window = null;
+                w.onCompleted();
+            }
+            actual.onCompleted();
+        }
+        
+        Producer createProducer() {
+            return new WindowSkipProducer();
+        }
+        
+        @Override
+        public void call() {
+            if (wip.decrementAndGet() == 0) {
+                unsubscribe();
+            }
+        }
+        
+        final class WindowSkipProducer extends AtomicBoolean implements Producer {
+            /** */
+            private static final long serialVersionUID = 4625807964358024108L;
+
+            @Override
+            public void request(long n) {
+                if (n < 0L) {
+                    throw new IllegalArgumentException("n >= 0 required but it was " + n);
+                }
+                if (n != 0L) {
+                    WindowSkip<T> parent = WindowSkip.this;
+                    if (!get() && compareAndSet(false, true)) {
+                        long u = BackpressureUtils.multiplyCap(n, parent.size);
+                        long v = BackpressureUtils.multiplyCap(parent.skip - parent.size, n - 1);
+                        long w = BackpressureUtils.addCap(u, v);
+                        parent.request(w);
+                    } else {
+                        long u = BackpressureUtils.multiplyCap(n, parent.skip);
+                        parent.request(u);
+                    }
+                }
+            }
+        }
+    }
+    
+    static final class WindowOverlap<T> extends Subscriber<T> implements Action0 {
+        final Subscriber<? super Observable<T>> actual;
+        
+        final int size;
+        
+        final int skip;
+        
+        final AtomicInteger wip;
+        
+        final Subscription cancel;
+
+        final ArrayDeque<Subject<T, T>> windows;
+
+        final AtomicLong requested;
+        
+        final AtomicInteger drainWip;
+        
+        final Queue<Subject<T, T>> queue;
+        
+        Throwable error;
+        
+        volatile boolean done;
+        
+        int index;
+        
+        int produced;
+        
+        public WindowOverlap(Subscriber<? super Observable<T>> actual, int size, int skip) {
+            this.actual = actual;
+            this.size = size;
+            this.skip = skip;
+            this.wip = new AtomicInteger(1);
+            this.windows = new ArrayDeque<Subject<T, T>>();
+            this.drainWip = new AtomicInteger();
+            this.requested = new AtomicLong();
+            this.cancel = Subscriptions.create(this);
+            this.add(cancel);
+            this.request(0);
+            int maxWindows = (size + (skip - 1)) / skip;
+            this.queue = new SpscLinkedArrayQueue<Subject<T, T>>(maxWindows);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            int i = index;
+            
+            ArrayDeque<Subject<T, T>> q = windows;
+            
+            if (i == 0 && !actual.isUnsubscribed()) {
+                wip.getAndIncrement();
+                
+                Subject<T, T> w = UnicastSubject.create(16, this);
+                q.offer(w);
+                
+                queue.offer(w);
+                drain();
+            }
+
+            for (Subject<T, T> w : windows) {
+                w.onNext(t);
+            }
+
+            int p = produced + 1;
+            
+            if (p == size) {
+                produced = p - skip;
+                
+                Subject<T, T> w = q.poll();
+                if (w != null) {
+                    w.onCompleted();
+                }
+            } else {
+                produced = p;
+            }
+            
+            i++;
+            if (i == skip) {
+                index = 0;
+            } else {
+                index = i;
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            for (Subject<T, T> w : windows) {
+                w.onError(e);
+            }
+            windows.clear();
+            
+            error = e;
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void onCompleted() {
+            for (Subject<T, T> w : windows) {
+                w.onCompleted();
+            }
+            windows.clear();
+            
+            done = true;
+            drain();
+        }
+        
+        Producer createProducer() {
+            return new WindowOverlapProducer();
+        }
+        
+        @Override
+        public void call() {
+            if (wip.decrementAndGet() == 0) {
+                unsubscribe();
+            }
+        }
+        
+        void drain() {
+            AtomicInteger dw = drainWip;
+            if (dw.getAndIncrement() != 0) {
+                return;
+            }
+
+            final Subscriber<? super Subject<T, T>> a = actual;
+            final Queue<Subject<T, T>> q = queue;
+            
+            int missed = 1;
+            
+            for (;;) {
+                
+                long r = requested.get();
+                long e = 0L;
+                
+                while (e != r) {
+                    boolean d = done;
+                    Subject<T, T> v = q.poll();
+                    boolean empty = v == null;
+                    
+                    if (checkTerminated(d, empty, a, q)) {
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(v);
+                    
+                    e++;
+                }
+                
+                if (e == r) {
+                    if (checkTerminated(done, q.isEmpty(), a, q)) {
+                        return;
                     }
                 }
                 
-            }));
-            child.setProducer(new Producer() {
-                @Override
-                public void request(long n) {
-                    if (n > 0) {
-                        long u = n * size;
-                        if (((u >>> 31) != 0) && (u / n != size)) {
-                            u = Long.MAX_VALUE;
-                        }
-                        requestMore(u);
-                    }
+                if (e != 0 && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
                 }
-            });
+                
+                missed = dw.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
         }
         
-        void requestMore(long n) {
-            request(n);
-        }
-
-        @Override
-        public void onNext(T t) {
-            if (window == null) {
-                noWindow = false;
-                window = UnicastSubject.create();
-                child.onNext(window);
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super Subject<T, T>> a, Queue<Subject<T, T>> q) {
+            if (a.isUnsubscribed()) {
+                q.clear();
+                return true;
             }
-            window.onNext(t);
-            if (++count % size == 0) {
-                window.onCompleted();
-                window = null;
-                noWindow = true;
-                if (child.isUnsubscribed()) {
-                    unsubscribe();
+            if (d) {
+                Throwable e = error;
+                if (e != null) {
+                    q.clear();
+                    a.onError(e);
+                    return true;
+                } else
+                if (empty) {
+                    a.onCompleted();
+                    return true;
                 }
             }
-        }
-
-        @Override
-        public void onError(Throwable e) {
-            if (window != null) {
-                window.onError(e);
-            }
-            child.onError(e);
-        }
-
-        @Override
-        public void onCompleted() {
-            if (window != null) {
-                window.onCompleted();
-            }
-            child.onCompleted();
-        }
-    }
-
-    /** Subscriber with inexact, possibly overlapping or skipping windows. */
-    final class InexactSubscriber extends Subscriber<T> {
-        final Subscriber<? super Observable<T>> child;
-        int count;
-        final List<CountedSubject<T>> chunks = new LinkedList<CountedSubject<T>>();
-        volatile boolean noWindow = true;
-
-        public InexactSubscriber(Subscriber<? super Observable<T>> child) {
-            /**
-             * See https://github.com/ReactiveX/RxJava/issues/1546
-             * We cannot compose through a Subscription because unsubscribing
-             * applies to the outer, not the inner.
-             */
-            this.child = child;
-        }
-
-        void init() {
-            /*
-             * Add unsubscribe hook to child to get unsubscribe on outer (unsubscribing on next window, not on the inner window itself)
-             */
-            child.add(Subscriptions.create(new Action0() {
-
-                @Override
-                public void call() {
-                    // if no window we unsubscribe up otherwise wait until window ends
-                    if (noWindow) {
-                        unsubscribe();
-                    }
-                }
-
-            }));
-            
-            child.setProducer(new Producer() {
-                @Override
-                public void request(long n) {
-                    if (n > 0) {
-                        long u = n * size;
-                        if (((u >>> 31) != 0) && (u / n != size)) {
-                            u = Long.MAX_VALUE;
-                        }
-                        requestMore(u);
-                    }
-                }
-            });
+            return false;
         }
         
-        void requestMore(long n) {
-            request(n);
-        }
+        final class WindowOverlapProducer extends AtomicBoolean implements Producer {
+            /** */
+            private static final long serialVersionUID = 4625807964358024108L;
 
-        @Override
-        public void onNext(T t) {
-            if (count++ % skip == 0) {
-                if (!child.isUnsubscribed()) {
-                    if (chunks.isEmpty()) {
-                        noWindow = false;
+            @Override
+            public void request(long n) {
+                if (n < 0L) {
+                    throw new IllegalArgumentException("n >= 0 required but it was " + n);
+                }
+                if (n != 0L) {
+                    
+                    WindowOverlap<T> parent = WindowOverlap.this;
+                    
+                    if (!get() && compareAndSet(false, true)) {
+                        long u = BackpressureUtils.multiplyCap(parent.skip, n - 1);
+                        long v = BackpressureUtils.addCap(u, parent.size);
+                        
+                        parent.request(v);
+                    } else {
+                        long u = BackpressureUtils.multiplyCap(parent.skip, n);
+                        WindowOverlap.this.request(u);
                     }
-                    CountedSubject<T> cs = createCountedSubject();
-                    chunks.add(cs);
-                    child.onNext(cs.producer);
+                    
+                    BackpressureUtils.getAndAddRequest(parent.requested, n);
+                    parent.drain();
                 }
             }
-
-            Iterator<CountedSubject<T>> it = chunks.iterator();
-            while (it.hasNext()) {
-                CountedSubject<T> cs = it.next();
-                cs.consumer.onNext(t);
-                if (++cs.count == size) {
-                    it.remove();
-                    cs.consumer.onCompleted();
-                }
-            }
-            if (chunks.isEmpty()) {
-                noWindow = true;
-                if (child.isUnsubscribed()) {
-                    unsubscribe();
-                }
-            }
-        }
-
-        @Override
-        public void onError(Throwable e) {
-            List<CountedSubject<T>> list = new ArrayList<CountedSubject<T>>(chunks);
-            chunks.clear();
-            noWindow = true;
-            for (CountedSubject<T> cs : list) {
-                cs.consumer.onError(e);
-            }
-            child.onError(e);
-        }
-
-        @Override
-        public void onCompleted() {
-            List<CountedSubject<T>> list = new ArrayList<CountedSubject<T>>(chunks);
-            chunks.clear();
-            noWindow = true;
-            for (CountedSubject<T> cs : list) {
-                cs.consumer.onCompleted();
-            }
-            child.onCompleted();
-        }
-
-        CountedSubject<T> createCountedSubject() {
-            final UnicastSubject<T> bus = UnicastSubject.create();
-            return new CountedSubject<T>(bus, bus);
         }
     }
-    /** 
-     * Record to store the subject and the emission count. 
-     * @param <T> the subject's in-out type
-     */
-    static final class CountedSubject<T> {
-        final Observer<T> consumer;
-        final Observable<T> producer;
-        int count;
 
-        public CountedSubject(Observer<T> consumer, Observable<T> producer) {
-            this.consumer = consumer;
-            this.producer = producer;
-        }
-    }
 }

--- a/src/main/java/rx/internal/operators/UnicastSubject.java
+++ b/src/main/java/rx/internal/operators/UnicastSubject.java
@@ -32,12 +32,15 @@ import rx.subscriptions.Subscriptions;
  * amount. In this case, the buffered values are no longer retained. If the Subscriber
  * requests a limited amount, queueing is involved and only those values are retained which
  * weren't requested by the Subscriber at that time.
+ * 
+ * @param <T> the input and output value type
  */
 public final class UnicastSubject<T> extends Subject<T, T> {
 
     /**
      * Constructs an empty UnicastSubject instance with the default capacity hint of 16 elements.
      * 
+     * @param <T> the input and output value type
      * @return the created UnicastSubject instance
      */
     public static <T> UnicastSubject<T> create() {
@@ -48,14 +51,34 @@ public final class UnicastSubject<T> extends Subject<T, T> {
      * <p>The capacity hint determines the internal queue's island size: the larger
      * it is the less frequent allocation will happen if there is no subscriber
      * or the subscriber hasn't caught up.
+     * @param <T> the input and output value type
      * @param capacityHint the capacity hint for the internal queue
      * @return the created BufferUntilSubscriber instance
      */
     public static <T> UnicastSubject<T> create(int capacityHint) {
-        State<T> state = new State<T>(capacityHint);
+        State<T> state = new State<T>(capacityHint, null);
         return new UnicastSubject<T>(state);
     }
-    
+
+    /**
+     * Constructs an empty UnicastSubject instance with a capacity hint and
+     * an Action0 instance to call if the subject reaches its terminal state
+     * or the single Subscriber unsubscribes mid-sequence.
+     * <p>The capacity hint determines the internal queue's island size: the larger
+     * it is the less frequent allocation will happen if there is no subscriber
+     * or the subscriber hasn't caught up.
+     * @param <T> the input and output value type
+     * @param capacityHint the capacity hint for the internal queue
+     * @param onTerminated the optional callback to call when subject reaches its terminal state
+     *                      or the single Subscriber unsubscribes mid-sequence. It will be called
+     *                      at most once.
+     * @return the created BufferUntilSubscriber instance
+     */
+    public static <T> UnicastSubject<T> create(int capacityHint, Action0 onTerminated) {
+        State<T> state = new State<T>(capacityHint, onTerminated);
+        return new UnicastSubject<T>(state);
+    }
+
     final State<T> state;
 
     private UnicastSubject(State<T> state) {
@@ -97,6 +120,8 @@ public final class UnicastSubject<T> extends Subject<T, T> {
         final Queue<Object> queue;
         /** JCTools queues don't accept nulls. */
         final NotificationLite<T> nl;
+        /** Atomically set to true on terminal condition. */
+        final AtomicReference<Action0> terminateOnce;
         /** In case the source emitted an error. */
         Throwable error;
         /** Indicates the source has terminated. */
@@ -111,10 +136,14 @@ public final class UnicastSubject<T> extends Subject<T, T> {
          * Constructor.
          * @param capacityHint indicates how large each island in the Spsc queue should be to
          * reduce allocation frequency
+         * @param onTerminated the action to call when the subject reaches its terminal state or
+         * the single subscriber unsubscribes.
          */
-        public State(int capacityHint) {
+        public State(int capacityHint, Action0 onTerminated) {
             this.nl = NotificationLite.instance();
             this.subscriber = new AtomicReference<Subscriber<? super T>>();
+            this.terminateOnce = onTerminated != null ? new AtomicReference<Action0>(onTerminated) : null;
+            
             Queue<Object> q;
             if (capacityHint > 1) {
                 q = UnsafeAccess.isUnsafeAvailable()
@@ -161,6 +190,9 @@ public final class UnicastSubject<T> extends Subject<T, T> {
         @Override
         public void onError(Throwable e) {
             if (!done) {
+                
+                doTerminate();
+                
                 error = e;
                 done = true;
                 if (!caughtUp) {
@@ -179,6 +211,9 @@ public final class UnicastSubject<T> extends Subject<T, T> {
         @Override
         public void onCompleted() {
             if (!done) {
+
+                doTerminate();
+
                 done = true;
                 if (!caughtUp) {
                     boolean stillReplay = false;
@@ -292,6 +327,9 @@ public final class UnicastSubject<T> extends Subject<T, T> {
          */
         @Override
         public void call() {
+
+            doTerminate();
+
             done = true;
             synchronized (this) {
                 if (emitting) {
@@ -327,6 +365,19 @@ public final class UnicastSubject<T> extends Subject<T, T> {
                 }
             }
             return false;
+        }
+        
+        /**
+         * Call the optional termination action at most once.
+         */
+        void doTerminate() {
+            AtomicReference<Action0> ref = this.terminateOnce;
+            if (ref != null) {
+                Action0 a = ref.get();
+                if (a != null && ref.compareAndSet(a, null)) {
+                    a.call();
+                }
+            }
         }
     }
 }

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -25,14 +25,13 @@ import rx.exceptions.CompositeException;
 /**
  * A {@code TestSubscriber} is a variety of {@link Subscriber} that you can use for unit testing, to perform
  * assertions, inspect received events, or wrap a mocked {@code Subscriber}.
+ * @param <T> the value type
  */
 public class TestSubscriber<T> extends Subscriber<T> {
 
     private final TestObserver<T> testObserver;
     private final CountDownLatch latch = new CountDownLatch(1);
     private volatile Thread lastSeenThread;
-    /** Holds the initial request value. */
-    private final long initialRequest;
     /** The shared no-op observer. */
     private static final Observer<Object> INERT = new Observer<Object>() {
 
@@ -78,7 +77,9 @@ public class TestSubscriber<T> extends Subscriber<T> {
             throw new NullPointerException();
         }
         this.testObserver = new TestObserver<T>(delegate);
-        this.initialRequest = initialRequest;
+        if (initialRequest >= 0L) {
+            this.request(initialRequest);
+        }
     }
 
     /**
@@ -112,6 +113,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
 
     /**
      * Factory method to construct a TestSubscriber with an initial request of Long.MAX_VALUE and no delegation.
+     * @param <T> the value type
      * @return the created TestSubscriber instance
      * @since 1.1.0
      */
@@ -121,6 +123,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     
     /**
      * Factory method to construct a TestSubscriber with the given initial request amount and no delegation.
+     * @param <T> the value type
      * @param initialRequest the initial request amount, negative values revert to the default unbounded mode
      * @return the created TestSubscriber instance
      * @since 1.1.0
@@ -132,6 +135,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Factory method to construct a TestSubscriber which delegates events to the given Observer and
      * issues the given initial request amount.
+     * @param <T> the value type
      * @param delegate the observer to delegate events to
      * @param initialRequest the initial request amount, negative values revert to the default unbounded mode
      * @return the created TestSubscriber instance
@@ -145,6 +149,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Factory method to construct a TestSubscriber which delegates events to the given Observer and
      * an issues an initial request of Long.MAX_VALUE.
+     * @param <T> the value type
      * @param delegate the observer to delegate events to
      * @return the created TestSubscriber instance
      * @throws NullPointerException if delegate is null
@@ -157,6 +162,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Factory method to construct a TestSubscriber which delegates events to the given Subscriber and
      * an issues an initial request of Long.MAX_VALUE.
+     * @param <T> the value type
      * @param delegate the subscriber to delegate events to
      * @return the created TestSubscriber instance
      * @throws NullPointerException if delegate is null
@@ -166,13 +172,6 @@ public class TestSubscriber<T> extends Subscriber<T> {
         return new TestSubscriber<T>(delegate);
     }
     
-    @Override
-    public void onStart() {
-        if (initialRequest >= 0) {
-            requestMore(initialRequest);
-        }
-    }
-
     /**
      * Notifies the Subscriber that the {@code Observable} has finished sending push-based notifications.
      * <p>


### PR DESCRIPTION
This PR fixes the backpressure behavior of the counted `buffer` and `window` operators and consists of several changes.

The main issue lies when `count > skip` in the operators, yielding overlapping buffers/windows. 

For `buffer`, when the upstream completed, the logic emitted all remaining partial buffers even if there was no request for new buffers, which can result in `MissingBackpressureException` somewhere. The proper handling of the final buffers required a new backpressure management algorithm which is now part of the `BackpressureUtils` class and consists of two new methods: `postCompleteDone` called from onComplete to take over the emission of queued values and `postCompleteRequest` which manages requests before and after the completed state.

For `window`, the new window opened was emitted regardless of requests which was common due to request-amplification (i.e., requesting n windows results in requesting `count + skip * (n - 1)` elements at first (then `skip * n` later) which opens `ceil(count / skip)` windows upfront. To avoid the overflow, the individual windows have to go through the usual queue/drain logic as well. I've also updated the Javadoc to reflect the backpressure behavior along with parameter validation.

In addition, the window case didn't manage cancellation properly. When the outer observable is unsubscribed, the inner subscribers may be still going and thus cancelling the upstream would stop/hang the inner windows. Instead, the open window count is tracked (also counting the outer as 1 window) and when all get unsubscribed (i.e., count reaches zero), the upstream is unsubscribed. To accomplish this, the `UnicastSubject` had to be retrofitted with a new optional callback `Action0` which gets called at most once whenever either `onError` or `onCompleted` is called or when the single `Subscriber` unsubscribes.

A secondary issue was with the `TestSubscriber`'s initial request; some upstream operators could get triggered with `Long.MAX_VALUE` despite the initial request amount was set. This PR changes it to be set at construction time instead of in `onStart`.