### PR TITLE
1.x: fix observeOn resource handling, add delayError capability

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5999,7 +5999,9 @@ public class Observable<T> {
     
     /**
      * Modifies an Observable to perform its emissions and notifications on a specified {@link Scheduler},
-     * asynchronously with an unbounded buffer.
+     * asynchronously with a bounded buffer.
+     * <p>Note that onError notifications will cut ahead of onNext notifications on the emission thread if Scheduler is truly
+     * asynchronous. If strict event ordering is required, consider using the {@link #observeOn(Scheduler, boolean)} overload.
      * <p>
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
      * <dl>
@@ -6014,12 +6016,43 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
+     * @see #observeOn(Scheduler, boolean)
      */
     public final Observable<T> observeOn(Scheduler scheduler) {
         if (this instanceof ScalarSynchronousObservable) {
             return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
         }
-        return lift(new OperatorObserveOn<T>(scheduler));
+        return lift(new OperatorObserveOn<T>(scheduler, false));
+    }
+
+    /**
+     * Modifies an Observable to perform its emissions and notifications on a specified {@link Scheduler},
+     * asynchronously with a bounded buffer and optionally delays onError notifications.
+     * <p>
+     * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     * 
+     * @param scheduler
+     *            the {@link Scheduler} to notify {@link Observer}s on
+     * @param delayError
+     *            indicates if the onError notification may not cut ahead of onNext notification on the other side of the
+     *            scheduling boundary. If true a sequence ending in onError will be replayed in the same order as was received
+     *            from upstream
+     * @return the source Observable modified so that its {@link Observer}s are notified on the specified
+     *         {@link Scheduler}
+     * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
+     * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
+     * @see #subscribeOn
+     * @see #observeOn(Scheduler)
+     */
+    public final Observable<T> observeOn(Scheduler scheduler, boolean delayError) {
+        if (this instanceof ScalarSynchronousObservable) {
+            return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
+        }
+        return lift(new OperatorObserveOn<T>(scheduler, delayError));
     }
 
     /**

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1381,7 +1381,9 @@ public class Single<T> {
         if (this instanceof ScalarSynchronousSingle) {
             return ((ScalarSynchronousSingle<T>)this).scalarScheduleOn(scheduler);
         }
-        return lift(new OperatorObserveOn<T>(scheduler));
+        // Note that since Single emits onSuccess xor onError, 
+        // there is no cut-ahead possible like with regular Observable sequences.
+        return lift(new OperatorObserveOn<T>(scheduler, false));
     }
 
     /**

--- a/src/main/java/rx/internal/util/atomic/SpscAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscAtomicArrayQueue.java
@@ -107,6 +107,11 @@ public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> 
         }
     }
 
+    @Override
+    public boolean isEmpty() {
+        return lvProducerIndex() == lvConsumerIndex();
+    }
+
     private void soProducerIndex(long newIndex) {
         producerIndex.lazySet(newIndex);
     }

--- a/src/main/java/rx/internal/util/unsafe/SpscArrayQueue.java
+++ b/src/main/java/rx/internal/util/unsafe/SpscArrayQueue.java
@@ -162,6 +162,11 @@ public final class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E> {
             }
         }
     }
+    
+    @Override
+    public boolean isEmpty() {
+        return lvProducerIndex() == lvConsumerIndex();
+    }
 
     private void soProducerIndex(long v) {
         UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, v);


### PR DESCRIPTION
This PR fixes the "messing around" reported in #3002 and adds an overload to `observeOn` that allows delaying errors without the need for wrapping (see #3542 and maybe there are other reports).

In addition, this PR adds a proper override of the `isEmpty` method to simply compare the two indexes for emptiness directly instead of `size() == 0` to avoid looping, multi-reading and casting.

Benchmark comparison (i7 4790, Windows 7 x64, Java 8u66):

![image](https://cloud.githubusercontent.com/assets/1269832/11442154/3f4f104a-9513-11e5-9b0c-00cef5a6bb10.png)

Note that the benchmark is generally quite noisy, yielding hectic results (i.e., firing up a thread with newThread may take quite some random microseconds). For example, `observeOnImmediate` shouldn't be affected by any of the changes yet the run-to-run variance is +/- 10%. I'm fine with the results of the benchmark.