### PR TITLE
1.x: onErrorResumeNext(Func1) should not call plugin handler there

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
@@ -70,11 +70,11 @@ public final class OperatorOnErrorResumeNextViaFunction<T> implements Operator<T
             public void onError(Throwable e) {
                 if (done) {
                     Exceptions.throwIfFatal(e);
+                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     return;
                 }
                 done = true;
                 try {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     unsubscribe();
                     Subscriber<T> next = new Subscriber<T>() {
                         @Override

--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservable.java
@@ -68,10 +68,10 @@ public final class OperatorOnErrorResumeNextViaObservable<T> implements Operator
             public void onError(Throwable e) {
                 if (done) {
                     Exceptions.throwIfFatal(e);
+                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     return;
                 }
                 done = true;
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                 unsubscribe();
                 resumeSequence.unsafeSubscribe(child);
             }

--- a/src/main/java/rx/internal/operators/OperatorOnErrorReturn.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorReturn.java
@@ -69,11 +69,11 @@ public final class OperatorOnErrorReturn<T> implements Operator<T, T> {
             public void onError(Throwable e) {
                 if (done) {
                     Exceptions.throwIfFatal(e);
+                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     return;
                 }
                 done = true;
                 try {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     unsubscribe();
                     T result = resultFunction.call(e);
                     child.onNext(result);

--- a/src/main/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservable.java
@@ -72,11 +72,11 @@ public final class OperatorOnExceptionResumeNextViaObservable<T> implements Oper
             public void onError(Throwable e) {
                 if (done) {
                     Exceptions.throwIfFatal(e);
+                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     return;
                 }
                 done = true;
                 if (e instanceof Exception) {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
                     unsubscribe();
                     resumeSequence.unsafeSubscribe(child);
                 } else {


### PR DESCRIPTION
When the operator switches to the other, that counts as a handled error. 

See also #3347.