### PR TITLE
1.x: make Completable.subscribe() report isUnsubscribed consistently

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -1828,12 +1828,13 @@ public class Completable {
         subscribe(new CompletableSubscriber() {
             @Override
             public void onCompleted() {
-                // nothing to do
+                mad.unsubscribe();
             }
             
             @Override
             public void onError(Throwable e) {
                 ERROR_HANDLER.handleError(e);
+                mad.unsubscribe();
             }
             
             @Override
@@ -1864,11 +1865,13 @@ public class Completable {
                 } catch (Throwable e) {
                     ERROR_HANDLER.handleError(e);
                 }
+                mad.unsubscribe();
             }
             
             @Override
             public void onError(Throwable e) {
                 ERROR_HANDLER.handleError(e);
+                mad.unsubscribe();
             }
             
             @Override
@@ -1900,7 +1903,9 @@ public class Completable {
                     onComplete.call();
                 } catch (Throwable e) {
                     onError(e);
+                    return;
                 }
+                mad.unsubscribe();
             }
             
             @Override
@@ -1911,6 +1916,7 @@ public class Completable {
                     e = new CompositeException(Arrays.asList(e, ex));
                     ERROR_HANDLER.handleError(e);
                 }
+                mad.unsubscribe();
             }
             
             @Override

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -3604,4 +3604,142 @@ public class CompletableTest {
         assertTrue(listEx.get(1).toString(), listEx.get(1) instanceof TestException);
     }
 
+    @Test
+    public void subscribeReportsUnsubscribed() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        Subscription completableSubscription = completable.subscribe();
+        
+        stringSubject.onCompleted();
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+    }
+
+    @Test
+    public void subscribeReportsUnsubscribedOnError() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        Subscription completableSubscription = completable.subscribe();
+        
+        stringSubject.onError(new TestException());
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+    }
+
+    @Test
+    public void subscribeActionReportsUnsubscribed() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        Subscription completableSubscription = completable.subscribe(Actions.empty());
+        
+        stringSubject.onCompleted();
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+    }
+
+    @Test
+    public void subscribeActionReportsUnsubscribedAfter() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        final AtomicReference<Subscription> subscriptionRef = new AtomicReference<Subscription>();
+        Subscription completableSubscription = completable.subscribe(new Action0() {
+            @Override
+            public void call() {
+                if (subscriptionRef.get().isUnsubscribed()) {
+                    subscriptionRef.set(null);
+                }
+            }
+        });
+        subscriptionRef.set(completableSubscription);
+        
+        stringSubject.onCompleted();
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+        assertNotNull("Unsubscribed before the call to onCompleted", subscriptionRef.get());
+    }
+
+    @Test
+    public void subscribeActionReportsUnsubscribedOnError() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        Subscription completableSubscription = completable.subscribe(Actions.empty());
+        
+        stringSubject.onError(new TestException());
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+    }
+
+    @Test
+    public void subscribeAction2ReportsUnsubscribed() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        Subscription completableSubscription = completable.subscribe(Actions.empty(), Actions.empty());
+        
+        stringSubject.onCompleted();
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+    }
+
+    @Test
+    public void subscribeAction2ReportsUnsubscribedOnError() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        Subscription completableSubscription = completable.subscribe(Actions.empty(), Actions.empty());
+        
+        stringSubject.onError(new TestException());
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+    }
+
+    @Test
+    public void subscribeAction2ReportsUnsubscribedAfter() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        final AtomicReference<Subscription> subscriptionRef = new AtomicReference<Subscription>();
+        Subscription completableSubscription = completable.subscribe(Actions.empty(), new Action0() {
+            @Override
+            public void call() {
+                if (subscriptionRef.get().isUnsubscribed()) {
+                    subscriptionRef.set(null);
+                }
+            }
+        });
+        subscriptionRef.set(completableSubscription);
+        
+        stringSubject.onCompleted();
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+        assertNotNull("Unsubscribed before the call to onCompleted", subscriptionRef.get());
+    }
+
+    @Test
+    public void subscribeAction2ReportsUnsubscribedOnErrorAfter() {
+        PublishSubject<String> stringSubject = PublishSubject.create();
+        Completable completable = stringSubject.toCompletable();
+        
+        final AtomicReference<Subscription> subscriptionRef = new AtomicReference<Subscription>();
+        Subscription completableSubscription = completable.subscribe(new Action1<Throwable>() {
+            @Override
+            public void call(Throwable e) {
+                if (subscriptionRef.get().isUnsubscribed()) {
+                    subscriptionRef.set(null);
+                }
+            }
+        }, Actions.empty());
+        subscriptionRef.set(completableSubscription);
+        
+        stringSubject.onError(new TestException());
+        
+        assertTrue("Not unsubscribed?", completableSubscription.isUnsubscribed());
+        assertNotNull("Unsubscribed before the call to onError", subscriptionRef.get());
+    }
+
 }


### PR DESCRIPTION
The empty and lambda-based `Completable.subscribe()` returns a `Subscription` whose `isUnsubscribed` should be consistent with the rest of the reactive objects by returning true if the sequence terminated (not just when one truly cancelled it).