### PR TITLE
Add takeUntil support in Single

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -12,6 +12,9 @@
  */
 package rx;
 
+import java.util.Collection;
+import java.util.concurrent.*;
+
 import rx.Observable.Operator;
 import rx.annotations.Beta;
 import rx.annotations.Experimental;
@@ -23,14 +26,12 @@ import rx.internal.producers.SingleDelayedProducer;
 import rx.internal.util.ScalarSynchronousSingle;
 import rx.internal.util.UtilityFunctions;
 import rx.observers.SafeSubscriber;
+import rx.observers.SerializedSubscriber;
 import rx.plugins.RxJavaObservableExecutionHook;
 import rx.plugins.RxJavaPlugins;
 import rx.schedulers.Schedulers;
 import rx.singles.BlockingSingle;
 import rx.subscriptions.Subscriptions;
-
-import java.util.Collection;
-import java.util.concurrent.*;
 
 /**
  * The Single class implements the Reactive Pattern for a single value response. See {@link Observable} for the
@@ -1797,6 +1798,156 @@ public class Single<T> {
                         Single.this.subscribe(ssub);
                     }
                 });
+            }
+        });
+    }
+
+    /**
+     * Returns a Single that emits the item emitted by the source Single until an Observable emits an item. Upon
+     * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
+     * {@link SingleSubscriber#onSuccess(Object)}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Observable whose first emitted item will cause {@code takeUntil} to emit the item from the source
+     *            Single
+     * @param <E>
+     *            the type of items emitted by {@code other}
+     * @return a Single that emits the item emitted by the source Single until such time as {@code other} emits
+     * its first item
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    public final <E> Single<T> takeUntil(final Observable<? extends E> other) {
+        return lift(new Operator<T, T>() {
+            @Override
+            public Subscriber<? super T> call(Subscriber<? super T> child) {
+                final Subscriber<T> serial = new SerializedSubscriber<T>(child, false);
+
+                final Subscriber<T> main = new Subscriber<T>(serial, false) {
+                    @Override
+                    public void onNext(T t) {
+                        serial.onNext(t);
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        try {
+                            serial.onError(e);
+                        } finally {
+                            serial.unsubscribe();
+                        }
+                    }
+                    @Override
+                    public void onCompleted() {
+                        try {
+                            serial.onCompleted();
+                        } finally {
+                            serial.unsubscribe();
+                        }
+                    }
+                };
+
+                final Subscriber<E> so = new Subscriber<E>() {
+
+                    @Override
+                    public void onCompleted() {
+                        onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        main.onError(e);
+                    }
+
+                    @Override
+                    public void onNext(E e) {
+                        onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+                    }
+                };
+
+                serial.add(main);
+                serial.add(so);
+
+                child.add(serial);
+
+                other.unsafeSubscribe(so);
+
+                return main;
+            }
+        });
+    }
+
+    /**
+     * Returns a Single that emits the item emitted by the source Single until a second Single emits an item. Upon
+     * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
+     * {@link SingleSubscriber#onSuccess(Object)}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Single whose emitted item will cause {@code takeUntil} to emit the item from the source Single
+     * @param <E>
+     *            the type of item emitted by {@code other}
+     * @return a Single that emits the item emitted by the source Single until such time as {@code other} emits its item
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    public final <E> Single<T> takeUntil(final Single<? extends E> other) {
+        return lift(new Operator<T, T>() {
+            @Override
+            public Subscriber<? super T> call(Subscriber<? super T> child) {
+                final Subscriber<T> serial = new SerializedSubscriber<T>(child, false);
+
+                final Subscriber<T> main = new Subscriber<T>(serial, false) {
+                    @Override
+                    public void onNext(T t) {
+                        serial.onNext(t);
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        try {
+                            serial.onError(e);
+                        } finally {
+                            serial.unsubscribe();
+                        }
+                    }
+                    @Override
+                    public void onCompleted() {
+                        try {
+                            serial.onCompleted();
+                        } finally {
+                            serial.unsubscribe();
+                        }
+                    }
+                };
+
+                final SingleSubscriber<E> so = new SingleSubscriber<E>() {
+                    @Override
+                    public void onSuccess(E value) {
+                        onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        main.onError(e);
+                    }
+                };
+
+                serial.add(main);
+                serial.add(so);
+
+                child.add(serial);
+
+                other.subscribe(so);
+
+                return main;
             }
         });
     }

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1803,6 +1803,79 @@ public class Single<T> {
     }
 
     /**
+     * Returns a Single that emits the item emitted by the source Single until a Completable terminates. Upon
+     * termination of {@code other}, this will emit a {@link CancellationException} rather than go to
+     * {@link SingleSubscriber#onSuccess(Object)}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Completable whose termination will cause {@code takeUntil} to emit the item from the source
+     *            Single
+     * @return a Single that emits the item emitted by the source Single until such time as {@code other} terminates.
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    public final Single<T> takeUntil(final Completable other) {
+        return lift(new Operator<T, T>() {
+            @Override
+            public Subscriber<? super T> call(Subscriber<? super T> child) {
+                final Subscriber<T> serial = new SerializedSubscriber<T>(child, false);
+
+                final Subscriber<T> main = new Subscriber<T>(serial, false) {
+                    @Override
+                    public void onNext(T t) {
+                        serial.onNext(t);
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        try {
+                            serial.onError(e);
+                        } finally {
+                            serial.unsubscribe();
+                        }
+                    }
+                    @Override
+                    public void onCompleted() {
+                        try {
+                            serial.onCompleted();
+                        } finally {
+                            serial.unsubscribe();
+                        }
+                    }
+                };
+
+                final Completable.CompletableSubscriber so = new Completable.CompletableSubscriber() {
+                    @Override
+                    public void onCompleted() {
+                        onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        main.onError(e);
+                    }
+
+                    @Override
+                    public void onSubscribe(Subscription d) {
+                        serial.add(d);
+                    }
+                };
+
+                serial.add(main);
+                child.add(serial);
+
+                other.subscribe(so);
+
+                return main;
+            }
+        });
+    }
+
+    /**
      * Returns a Single that emits the item emitted by the source Single until an Observable emits an item. Upon
      * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
      * {@link SingleSubscriber#onSuccess(Object)}.

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -1357,252 +1357,28 @@ public class SingleTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilSuccess() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestSingle other = new TestSingle(sOther);
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Single.create(other));
-        stringSingle.subscribe(result);
-        other.sendOnSuccess("one");
-
-        result.assertError(CancellationException.class);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilSourceSuccess() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestSingle other = new TestSingle(sOther);
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Single.create(other));
-        stringSingle.subscribe(result);
-        source.sendOnSuccess("one");
-
-        result.assertValue("one");
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilNext() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestObservable other = new TestObservable(sOther);
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Observable.create(other));
-        stringSingle.subscribe(result);
-        other.sendOnNext("one");
-
-        result.assertError(CancellationException.class);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilSourceSuccessObservable() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestObservable other = new TestObservable(sOther);
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Observable.create(other));
-        stringSingle.subscribe(result);
-        source.sendOnSuccess("one");
-
-        result.assertValue("one");
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilSourceError() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestSingle other = new TestSingle(sOther);
-        Throwable error = new Throwable();
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Single.create(other));
-        stringSingle.subscribe(result);
-        source.sendOnError(error);
-
-        result.assertError(error);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilSourceErrorObservable() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestObservable other = new TestObservable(sOther);
-        Throwable error = new Throwable();
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Observable.create(other));
-        stringSingle.subscribe(result);
-        source.sendOnError(error);
-
-        result.assertError(error);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilOtherError() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestSingle other = new TestSingle(sOther);
-        Throwable error = new Throwable();
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Single.create(other));
-        stringSingle.subscribe(result);
-        other.sendOnError(error);
-
-        result.assertError(error);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilOtherErrorObservable() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestObservable other = new TestObservable(sOther);
-        Throwable error = new Throwable();
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Observable.create(other));
-        stringSingle.subscribe(result);
-        other.sendOnError(error);
-
-        result.assertError(error);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void takeUntilOtherCompleted() {
-        Subscription sSource = mock(Subscription.class);
-        Subscription sOther = mock(Subscription.class);
-        TestSingle source = new TestSingle(sSource);
-        TestObservable other = new TestObservable(sOther);
-
-        TestSubscriber<String> result = new TestSubscriber<String>();
-        Single<String> stringSingle = Single.create(source).takeUntil(Observable.create(other));
-        stringSingle.subscribe(result);
-        other.sendOnCompleted();
-
-        result.assertError(CancellationException.class);
-        verify(sSource).unsubscribe();
-        verify(sOther).unsubscribe();
-
-    }
-
-    private static class TestObservable implements Observable.OnSubscribe<String> {
-
-        Observer<? super String> observer = null;
-        Subscription s;
-
-        public TestObservable(Subscription s) {
-            this.s = s;
-        }
-
-        /* used to simulate subscription */
-        public void sendOnCompleted() {
-            observer.onCompleted();
-        }
-
-        /* used to simulate subscription */
-        public void sendOnNext(String value) {
-            observer.onNext(value);
-        }
-
-        /* used to simulate subscription */
-        public void sendOnError(Throwable e) {
-            observer.onError(e);
-        }
-
-        @Override
-        public void call(Subscriber<? super String> observer) {
-            this.observer = observer;
-            observer.add(s);
-        }
-    }
-
-    private static class TestSingle implements Single.OnSubscribe<String> {
-
-        SingleSubscriber<? super String> subscriber = null;
-        Subscription s;
-
-        public TestSingle(Subscription s) {
-            this.s = s;
-        }
-
-        /* used to simulate subscription */
-        public void sendOnSuccess(String value) {
-            subscriber.onSuccess(value);
-        }
-
-        /* used to simulate subscription */
-        public void sendOnError(Throwable e) {
-            subscriber.onError(e);
-        }
-
-        @Override
-        public void call(SingleSubscriber<? super String> observer) {
-            this.subscriber = observer;
-            observer.add(s);
-        }
-    }
-
-    @Test
-    public void takeUntilFires() {
+    public void takeUntilCompletableFires() {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        source.take(1).toSingle().takeUntil(until.take(1).toSingle()).unsafeSubscribe(ts);
+        source.take(1).toSingle().takeUntil(until.toCompletable()).unsafeSubscribe(ts);
 
         assertTrue(source.hasObservers());
         assertTrue(until.hasObservers());
 
-        until.onNext(1);
+        until.onCompleted();
 
         ts.assertError(CancellationException.class);
 
-        assertFalse("Source still has observers", source.hasObservers());
-        assertFalse("Until still has observers", until.hasObservers());
-        assertFalse("TestSubscriber is unsubscribed", ts.isUnsubscribed());
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
     }
 
     @Test
-    public void takeUntilFiresObservable() {
+    public void takeUntilObservableFires() {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
@@ -1617,13 +1393,78 @@ public class SingleTest {
 
         ts.assertError(CancellationException.class);
 
-        assertFalse("Source still has observers", source.hasObservers());
-        assertFalse("Until still has observers", until.hasObservers());
-        assertFalse("TestSubscriber is unsubscribed", ts.isUnsubscribed());
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
     }
 
     @Test
-    public void takeUntilDownstreamUnsubscribes() {
+    public void takeUntilSingleFires() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.take(1).toSingle()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        until.onNext(1);
+
+        ts.assertError(CancellationException.class);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilObservableCompletes() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.take(1)).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        until.onCompleted();
+
+        ts.assertError(CancellationException.class);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilSourceUnsubscribes_withCompletable() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.toCompletable()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        source.onNext(1);
+
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertTerminalEvent();
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilSourceUnsubscribes_withObservable() {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
@@ -1640,13 +1481,13 @@ public class SingleTest {
         ts.assertNoErrors();
         ts.assertTerminalEvent();
 
-        assertFalse("Source still has observers", source.hasObservers());
-        assertFalse("Until still has observers", until.hasObservers());
-        assertFalse("TestSubscriber is unsubscribed", ts.isUnsubscribed());
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
     }
 
     @Test
-    public void takeUntilDownstreamUnsubscribesObservable() {
+    public void takeUntilSourceUnsubscribes_withSingle() {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
@@ -1663,54 +1504,144 @@ public class SingleTest {
         ts.assertNoErrors();
         ts.assertTerminalEvent();
 
-        assertFalse("Source still has observers", source.hasObservers());
-        assertFalse("Until still has observers", until.hasObservers());
-        assertFalse("TestSubscriber is unsubscribed", ts.isUnsubscribed());
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
     }
 
     @Test
-    public void takeUntilSimple() {
-        PublishSubject<String> stringSubject = PublishSubject.create();
-        Single<String> single = stringSubject.toSingle();
+    public void takeUntilSourceErrorUnsubscribes_withCompletable() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
 
-        Subscription singleSubscription = single.takeUntil(Single.just("Hello")).subscribe(
-                new Action1<String>() {
-                    @Override
-                    public void call(String s) {
-                        fail();
-                    }
-                },
-                new Action1<Throwable>() {
-                    @Override
-                    public void call(Throwable throwable) {
-                        assertTrue(throwable instanceof CancellationException);
-                    }
-                }
-        );
-        assertTrue(singleSubscription.isUnsubscribed());
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.toCompletable()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        Exception e = new Exception();
+        source.onError(e);
+
+        ts.assertNoValues();
+        ts.assertError(e);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
     }
 
     @Test
-    public void takeUntilObservable() {
-        PublishSubject<String> stringSubject = PublishSubject.create();
-        Single<String> single = stringSubject.toSingle();
-        PublishSubject<String> otherSubject = PublishSubject.create();
+    public void takeUntilSourceErrorUnsubscribes_withObservable() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
 
-        Subscription singleSubscription = single.takeUntil(otherSubject.asObservable()).subscribe(
-                new Action1<String>() {
-                    @Override
-                    public void call(String s) {
-                        fail();
-                    }
-                },
-                new Action1<Throwable>() {
-                    @Override
-                    public void call(Throwable throwable) {
-                        assertTrue(throwable instanceof CancellationException);
-                    }
-                }
-        );
-        otherSubject.onNext("Hello");
-        assertTrue(singleSubscription.isUnsubscribed());
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        source.onError(new Throwable());
+
+        ts.assertNoValues();
+        ts.assertError(Throwable.class);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilSourceErrorUnsubscribes_withSingle() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.take(1).toSingle()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        source.onError(new Throwable());
+
+        ts.assertNoValues();
+        ts.assertError(Throwable.class);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilError_withCompletable_shouldMatch() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.toCompletable()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        Exception e = new Exception();
+        until.onError(e);
+
+        ts.assertNoValues();
+        ts.assertError(e);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilError_withObservable_shouldMatch() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.asObservable()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        Exception e = new Exception();
+        until.onError(e);
+
+        ts.assertNoValues();
+        ts.assertError(e);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
+    }
+
+    @Test
+    public void takeUntilError_withSingle_shouldMatch() {
+        PublishSubject<Integer> source = PublishSubject.create();
+        PublishSubject<Integer> until = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        source.take(1).toSingle().takeUntil(until.take(1).toSingle()).unsafeSubscribe(ts);
+
+        assertTrue(source.hasObservers());
+        assertTrue(until.hasObservers());
+
+        Exception e = new Exception();
+        until.onError(e);
+
+        ts.assertNoValues();
+        ts.assertError(e);
+
+        assertFalse(source.hasObservers());
+        assertFalse(until.hasObservers());
+        assertFalse(ts.isUnsubscribed());
     }
 }


### PR DESCRIPTION
As discussed in #3708

This adds `takeUntil(Observable)` and `takeUntil(Single)` support in `Single`. It was mostly just adapting the logic from the existing `OperatorTakeUntil` and adjusting it for accepting a `Single` and sending a `CancelattionException` in the event of a submission from `other` prior to a terminal event in the source `Single`.

Any feedback is appreciated it, this is my first time contributing an implementation to this project. Particularly wondering if it's worth keeping both overloads or if the user should just coerce their `other` to one type or ther other. Also particularly looking for feedback on what information to include in the `CancellationException`.