### PR TITLE
scan should pass upstream a request of Long.MAX_VALUE

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/src/main/java/rx/internal/operators/OperatorScan.java
@@ -268,8 +268,12 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                 if (producer != null) {
                     throw new IllegalStateException("Can't set more than one Producer!");
                 }
+                mr = missedRequested;
                 // request one less because of the initial value, this happens once
-                mr = missedRequested - 1;
+                // and is performed only if the request is not at MAX_VALUE already
+                if (mr != Long.MAX_VALUE) {
+                    mr -= 1;
+                }
                 missedRequested = 0L;
                 producer = p;
             }

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -451,4 +451,22 @@ public class OperatorScanTest {
             }
         });
     }
+    
+    @Test
+    public void scanShouldPassUpstreamARequestForMaxValue() {
+        final List<Long> requests = new ArrayList<Long>();
+        Observable.just(1,2,3).doOnRequest(new Action1<Long>() {
+            @Override
+            public void call(Long n) {
+                requests.add(n);
+            }
+        })
+        .scan(new Func2<Integer,Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return 0;
+            }}).count().subscribe();
+        
+        assertEquals(Arrays.asList(Long.MAX_VALUE), requests);
+    }
 }


### PR DESCRIPTION
Changes in 1.1.1. for the `scan` operator introduced a bug in requesting where when the initial request was for max value the `scan` operator requested one less than that value of upstream (which affects fast-path producers).

I believe this bug only affects 1.1.1 (haven't looked at 2.x).

This PR includes a test that failed on the original code.