### PR TITLE
Avoid swallowing errors in Completable

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -1835,6 +1835,7 @@ public class Completable {
             public void onError(Throwable e) {
                 ERROR_HANDLER.handleError(e);
                 mad.unsubscribe();
+                deliverUncaughtException(e);
             }
             
             @Override
@@ -1864,14 +1865,17 @@ public class Completable {
                     onComplete.call();
                 } catch (Throwable e) {
                     ERROR_HANDLER.handleError(e);
+                    deliverUncaughtException(e);
+                } finally {
+                    mad.unsubscribe();
                 }
-                mad.unsubscribe();
             }
             
             @Override
             public void onError(Throwable e) {
                 ERROR_HANDLER.handleError(e);
                 mad.unsubscribe();
+                deliverUncaughtException(e);
             }
             
             @Override
@@ -1915,8 +1919,10 @@ public class Completable {
                 } catch (Throwable ex) {
                     e = new CompositeException(Arrays.asList(e, ex));
                     ERROR_HANDLER.handleError(e);
+                    deliverUncaughtException(e);
+                } finally {
+                    mad.unsubscribe();
                 }
-                mad.unsubscribe();
             }
             
             @Override
@@ -1927,7 +1933,12 @@ public class Completable {
         
         return mad;
     }
-    
+
+    private static void deliverUncaughtException(Throwable e) {
+        Thread thread = Thread.currentThread();
+        thread.getUncaughtExceptionHandler().uncaughtException(thread, e);
+    }
+
     /**
      * Subscribes the given CompletableSubscriber to this Completable instance.
      * @param s the CompletableSubscriber, not null

--- a/src/test/java/rx/CapturingUncaughtExceptionHandler.java
+++ b/src/test/java/rx/CapturingUncaughtExceptionHandler.java
@@ -1,0 +1,16 @@
+package rx;
+
+import java.util.concurrent.CountDownLatch;
+
+public final class CapturingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+    public int count = 0;
+    public Throwable caught;
+    public CountDownLatch completed = new CountDownLatch(1);
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        count++;
+        caught = e;
+        completed.countDown();
+    }
+}

--- a/src/test/java/rx/schedulers/SchedulerTests.java
+++ b/src/test/java/rx/schedulers/SchedulerTests.java
@@ -1,5 +1,6 @@
 package rx.schedulers;
 
+import rx.CapturingUncaughtExceptionHandler;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
@@ -84,19 +85,6 @@ final class SchedulerTests {
             assertEquals("Our error should have been delivered to the observer", error, cause);
         } finally {
             Thread.setDefaultUncaughtExceptionHandler(originalHandler);
-        }
-    }
-
-    private static final class CapturingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
-        int count = 0;
-        Throwable caught;
-        CountDownLatch completed = new CountDownLatch(1);
-
-        @Override
-        public void uncaughtException(Thread t, Throwable e) {
-            count++;
-            caught = e;
-            completed.countDown();
         }
     }
 


### PR DESCRIPTION
Instead, deliver them up to the thread's uncaught exception handler.

Fixes reactivex/rxjava#3726