### PR TITLE
1.x: new operators buffer(While/Until) with predicate-based boundary

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -3722,6 +3722,116 @@ public class Observable<T> {
     }
 
     /**
+     * Buffers the elements into continuous, non-overlapping Lists where the boundary is
+     * determined by a predicate receiving each item, after being buffered, and returns true to
+     * indicate a new buffer should start.
+     * 
+     * <p>
+     * The operator won't return an empty first or last buffer.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator supports backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param predicate the Func1 that receives each item, after being buffered, and should
+     * return true to indicate a new buffer has to start.
+     * @return the new Observable instance
+     * @see #bufferWhile(Func1)
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
+     *        with the release number)
+     */
+    @Experimental
+    public final Observable<List<T>> bufferUntil(Func1<? super T, Boolean> predicate) {
+        return bufferUntil(predicate, 10);
+    }
+
+    /**
+     * Buffers the elements into continuous, non-overlapping Lists where the boundary is
+     * determined by a predicate receiving each item, after being buffered, and returns true to
+     * indicate a new buffer should start.
+     * 
+     * <p>
+     * The operator won't return an empty first or last buffer.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator supports backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param predicate the Func1 that receives each item, after being buffered, and should
+     * return true to indicate a new buffer has to start.
+     * @param capacityHint the expected number of items in each buffer
+     * @return the new Observable instance
+     * @see #bufferWhile(Func1)
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
+     *        with the release number)
+     */
+    @Experimental
+    public final Observable<List<T>> bufferUntil(Func1<? super T, Boolean> predicate, int capacityHint) {
+        return lift(new OperatorBufferPredicateBoundary<T>(predicate, RxRingBuffer.SIZE, capacityHint, true));
+    }
+
+    /**
+     * Buffers the elements into continuous, non-overlapping Lists where the boundary is
+     * determined by a predicate receiving each item, before or after being buffered, and returns true to
+     * indicate a new buffer should start.
+     * 
+     * <p>
+     * The operator won't return an empty first or last buffer.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator supports backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param predicate the Func1 that receives each item, before being buffered, and should
+     * return true to indicate a new buffer has to start.
+     * @return the new Observable instance
+     * @see #bufferWhile(Func1)
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
+     *        with the release number)
+     */
+    @Experimental
+    public final Observable<List<T>> bufferWhile(Func1<? super T, Boolean> predicate) {
+        return bufferWhile(predicate, 10);
+    }
+
+    /**
+     * Buffers the elements into continuous, non-overlapping Lists where the boundary is
+     * determined by a predicate receiving each item, before being buffered, and returns true to
+     * indicate a new buffer should start.
+     * 
+     * <p>
+     * The operator won't return an empty first or last buffer.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator supports backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param predicate the Func1 that receives each item, before being buffered, and should
+     * return true to indicate a new buffer has to start.
+     * @param capacityHint the expected number of items in each buffer
+     * @return the new Observable instance
+     * @see #bufferWhile(Func1)
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
+     *        with the release number)
+     */
+    @Experimental
+    public final Observable<List<T>> bufferWhile(Func1<? super T, Boolean> predicate, int capacityHint) {
+        return lift(new OperatorBufferPredicateBoundary<T>(predicate, RxRingBuffer.SIZE, capacityHint, false));
+    }
+
+    /**
      * Caches the emissions from the source Observable and replays them in order to any subsequent Subscribers.
      * This method has similar behavior to {@link #replay} except that this auto-subscribes to the source
      * Observable rather than returning a {@link ConnectableObservable} for which you must call

--- a/src/main/java/rx/internal/operators/OperatorBufferPredicateBoundary.java
+++ b/src/main/java/rx/internal/operators/OperatorBufferPredicateBoundary.java
@@ -1,0 +1,408 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import rx.*;
+import rx.Observable.Operator;
+import rx.exceptions.*;
+import rx.functions.Func1;
+import rx.internal.util.atomic.SpscAtomicArrayQueue;
+import rx.internal.util.unsafe.*;
+
+/**
+ * Buffers values into a continuous, non-overlapping Lists where the boundary is determined
+ * by a predicate returning true.
+ *
+ * @param <T> the source and List element type
+ */
+public final class OperatorBufferPredicateBoundary<T> implements Operator<List<T>, T> {
+
+    final Func1<? super T, Boolean> predicate;
+    
+    final int prefetch;
+    
+    final int capacityHint;
+    
+    final boolean after;
+    
+    public OperatorBufferPredicateBoundary(Func1<? super T, Boolean> predicate, int prefetch, int capacityHint, boolean after) {
+        if (predicate == null) {
+            throw new NullPointerException("predicate");
+        }
+        if (prefetch <= 0) {
+            throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+        }
+        if (capacityHint <= 0) {
+            throw new IllegalArgumentException("capacityHint > 0 required but it was " + capacityHint);
+        }
+        this.predicate = predicate;
+        this.prefetch = prefetch;
+        this.capacityHint = capacityHint;
+        this.after = after;
+    }
+
+    @Override
+    public Subscriber<? super T> call(Subscriber<? super List<T>> child) {
+        final BoundedSubscriber<T> parent = after 
+                ? new BoundedAfterSubscriber<T>(child, capacityHint, predicate, prefetch)
+                : new BoundedBeforeSubscriber<T>(child, capacityHint, predicate, prefetch);
+                
+        child.add(parent);
+        child.setProducer(new Producer() {
+            @Override
+            public void request(long n) {
+                parent.requestMore(n);
+            }
+        });
+        
+        return parent;
+    }
+    
+    static abstract class BoundedSubscriber<T> extends Subscriber<T> {
+        final Subscriber<? super List<T>> actual;
+        
+        final int capacityHint;
+        
+        final Func1<? super T, Boolean> predicate;
+        
+        final Queue<Object> queue;
+        
+        final AtomicLong requested;
+
+        final AtomicInteger wip;
+        
+        final NotificationLite<T> nl;
+        
+        final int limit;
+
+        List<T> buffer;
+        
+        long upstreamConsumed;
+        
+        volatile boolean done;
+        Throwable error;
+
+        public BoundedSubscriber(Subscriber<? super List<T>> actual, int capacityHint,
+                Func1<? super T, Boolean> predicate, int prefetch) {
+            this.actual = actual;
+            this.capacityHint = capacityHint;
+            this.predicate = predicate;
+            Queue<Object> q;
+            if (UnsafeAccess.isUnsafeAvailable()) {
+                q = new SpscArrayQueue<Object>(prefetch);
+            } else {
+                q = new SpscAtomicArrayQueue<Object>(prefetch);
+            }
+            queue = q;
+            buffer = new ArrayList<T>(capacityHint);
+            requested = new AtomicLong();
+            wip = new AtomicInteger();
+            nl = NotificationLite.instance();
+            limit = prefetch - (prefetch >> 2);
+            if (prefetch == Integer.MAX_VALUE) {
+                request(Long.MAX_VALUE);
+            } else {
+                request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!queue.offer(nl.next(t))) {
+                unsubscribe();
+                onError(new MissingBackpressureException());
+            } else {
+                drain();
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            error = e;
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void onCompleted() {
+            done = true;
+            drain();
+        }
+        
+        void requestMore(long n) {
+            if (n > 0) {
+                BackpressureUtils.getAndAddRequest(requested, n);
+                drain();
+            } else
+            if (n < 0) {
+                throw new IllegalArgumentException("n >= 0 required but it was " + n);
+            }
+        }
+
+        abstract void drain();
+    }
+    
+    static final class BoundedAfterSubscriber<T> extends BoundedSubscriber<T> {
+
+        public BoundedAfterSubscriber(Subscriber<? super List<T>> actual, int capacityHint,
+                Func1<? super T, Boolean> predicate, int prefetch) {
+            super(actual, capacityHint, predicate, prefetch);
+        }
+        
+        @Override
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+            
+            final Subscriber<? super List<T>> localSubscriber = actual;
+            final Queue<Object> localQueue = queue;
+            int missed = 1;
+            
+            for (;;) {
+
+                long localRequested = requested.get();
+                long localEmission = 0L;
+                long localConsumption = 0L;
+                List<T> localBuffer = buffer;
+                
+                while (localEmission != localRequested) {
+                    if (localSubscriber.isUnsubscribed()) {
+                        return;
+                    }
+                    
+                    boolean mainDone = done;
+                    
+                    if (mainDone) {
+                        Throwable exception = error;
+                        if (exception != null) {
+                            buffer = null;
+                            localSubscriber.onError(exception);
+                            return;
+                        }
+                    }
+                    
+                    Object notification = localQueue.poll();
+                    boolean empty = notification == null;
+                    
+                    if (mainDone && empty) {
+                        buffer = null;
+                        if (!localBuffer.isEmpty()) {
+                            localSubscriber.onNext(localBuffer);
+                        }
+                        localSubscriber.onCompleted();
+                        return;
+                    }
+                    if (empty) {
+                        break;
+                    }
+                    
+                    T value = nl.getValue(notification);
+                    
+                    localBuffer.add(value);
+                    localConsumption++;
+                    
+                    boolean emit;
+                    
+                    try {
+                        emit = predicate.call(value);
+                    } catch (Throwable ex) {
+                        unsubscribe();
+                        buffer = null;
+                        Exceptions.throwOrReport(ex, localSubscriber, value);
+                        return;
+                    }
+                    
+                    if (emit) {
+                        localSubscriber.onNext(localBuffer);
+                        localBuffer = new ArrayList<T>(capacityHint);
+                        buffer = localBuffer;
+                        
+                        localEmission++;
+                    }
+                }
+                
+                if (localEmission == localRequested) {
+                    if (localSubscriber.isUnsubscribed()) {
+                        return;
+                    }
+                    
+                    boolean mainDone = done;
+
+                    if (mainDone) {
+                        Throwable exception = error;
+                        if (exception != null) {
+                            buffer = null;
+                            localSubscriber.onError(exception);
+                            return;
+                        } else
+                        if (localQueue.isEmpty() && localBuffer.isEmpty()) {
+                            buffer = null;
+                            localSubscriber.onCompleted();
+                            return;
+                        }
+                    }
+                }
+                
+                if (localEmission != 0L) {
+                    BackpressureUtils.produced(requested, localEmission);
+                }
+                if (localConsumption != 0L) {
+                    long p = upstreamConsumed + localConsumption;
+                    if (p >= limit) {
+                        upstreamConsumed = 0L;
+                        request(p);
+                    } else {
+                        upstreamConsumed = p;
+                    }
+                }
+                
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    static final class BoundedBeforeSubscriber<T> extends BoundedSubscriber<T> {
+        public BoundedBeforeSubscriber(Subscriber<? super List<T>> actual, int capacityHint,
+                Func1<? super T, Boolean> predicate, int prefetch) {
+            super(actual, capacityHint, predicate, prefetch);
+        }
+
+        @Override
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+            
+            final Subscriber<? super List<T>> localSubscriber = actual;
+            final Queue<Object> localQueue = queue;
+            int missed = 1;
+            
+            for (;;) {
+
+                long localRequested = requested.get();
+                long localEmission = 0L;
+                long localConsumption = 0L;
+                List<T> localBuffer = buffer;
+                
+                while (localEmission != localRequested) {
+                    if (localSubscriber.isUnsubscribed()) {
+                        return;
+                    }
+                    
+                    boolean mainDone = done;
+                    
+                    if (mainDone) {
+                        Throwable exception = error;
+                        if (exception != null) {
+                            buffer = null;
+                            localSubscriber.onError(exception);
+                            return;
+                        }
+                    }
+                    
+                    Object o = localQueue.poll();
+                    boolean empty = o == null;
+                    
+                    if (mainDone && empty) {
+                        buffer = null;
+                        if (!localBuffer.isEmpty()) {
+                            localSubscriber.onNext(localBuffer);
+                        }
+                        localSubscriber.onCompleted();
+                        return;
+                    }
+                    if (empty) {
+                        break;
+                    }
+                    
+                    T value = nl.getValue(o);
+                    
+                    boolean emit;
+                    
+                    try {
+                        emit = predicate.call(value);
+                    } catch (Throwable ex) {
+                        unsubscribe();
+                        buffer = null;
+                        Exceptions.throwOrReport(ex, localSubscriber, value);
+                        return;
+                    }
+                    
+                    if (emit && !localBuffer.isEmpty()) {
+                        localSubscriber.onNext(localBuffer);
+                        localBuffer = new ArrayList<T>(capacityHint);
+                        buffer = localBuffer;
+                        
+                        localEmission++;
+                    }
+                    
+                    localBuffer.add(value);
+                    
+                    localConsumption++;
+                }
+                
+                if (localEmission == localRequested) {
+                    if (localSubscriber.isUnsubscribed()) {
+                        return;
+                    }
+                    
+                    boolean mainDone = done;
+
+                    if (mainDone) {
+                        Throwable exception = error;
+                        if (exception != null) {
+                            buffer = null;
+                            localSubscriber.onError(exception);
+                            return;
+                        } else
+                        if (localQueue.isEmpty() && localBuffer.isEmpty()) {
+                            buffer = null;
+                            localSubscriber.onCompleted();
+                            return;
+                        }
+                    }
+                }
+                
+                if (localEmission != 0L) {
+                    BackpressureUtils.produced(requested, localEmission);
+                }
+                
+                if (localConsumption != 0L) {
+                    long produced = upstreamConsumed + localConsumption;
+                    if (produced >= limit) {
+                        upstreamConsumed = 0L;
+                        request(produced);
+                    } else {
+                        upstreamConsumed = produced;
+                    }
+                }
+                
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/OperatorBufferPredicateBoundaryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorBufferPredicateBoundaryTest.java
@@ -1,0 +1,473 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.*;
+
+import org.junit.*;
+
+import rx.Observable;
+import rx.exceptions.TestException;
+import rx.functions.Func1;
+import rx.internal.util.*;
+import rx.observers.TestSubscriber;
+
+public class OperatorBufferPredicateBoundaryTest {
+
+    @Test
+    public void bufferWhilePredicateNull() {
+        try {
+            Observable.empty().bufferWhile(null);
+            Assert.fail("Didn't throw NullPointerException");
+        } catch (NullPointerException ex) {
+            Assert.assertEquals("predicate", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void bufferUntilPredicateNull() {
+        try {
+            Observable.empty().bufferUntil(null);
+            Assert.fail("Didn't throw NullPointerException");
+        } catch (NullPointerException ex) {
+            Assert.assertEquals("predicate", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void bufferWhileCapacityHintInvalid() {
+        try {
+            Observable.empty().bufferWhile(UtilityFunctions.alwaysTrue(), -99);
+            Assert.fail("Didn't throw IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("capacityHint > 0 required but it was -99", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void bufferUntilCapacityHintInvalid() {
+        try {
+            Observable.empty().bufferUntil(UtilityFunctions.alwaysTrue(), -99);
+            Assert.fail("Didn't throw IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("capacityHint > 0 required but it was -99", ex.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferWhileWith1() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.range(1, 10)
+        .bufferWhile(UtilityFunctions.alwaysTrue())
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1),
+                Arrays.asList(2),
+                Arrays.asList(3),
+                Arrays.asList(4),
+                Arrays.asList(5),
+                Arrays.asList(6),
+                Arrays.asList(7),
+                Arrays.asList(8),
+                Arrays.asList(9),
+                Arrays.asList(10)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferWhileWith5() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.range(1, 10)
+        .bufferWhile(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v == 5;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1, 2, 3, 4),
+                Arrays.asList(5, 6, 7, 8, 9, 10)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferWhileWith20() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.range(1, 10)
+        .bufferWhile(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v == 20;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferUntilWith1() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.range(1, 10)
+        .bufferUntil(UtilityFunctions.alwaysTrue())
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1),
+                Arrays.asList(2),
+                Arrays.asList(3),
+                Arrays.asList(4),
+                Arrays.asList(5),
+                Arrays.asList(6),
+                Arrays.asList(7),
+                Arrays.asList(8),
+                Arrays.asList(9),
+                Arrays.asList(10)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferUntilWith5() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.range(1, 10)
+        .bufferUntil(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v == 5;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1, 2, 3, 4, 5),
+                Arrays.asList(6, 7, 8, 9, 10)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferUntilWith20() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.range(1, 10)
+        .bufferUntil(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v == 20;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferWhileSomeNull() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.just(1, 2, 3, null, 4, 5)
+        .bufferUntil(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v != null && v == 20;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1, 2, 3, null, 4, 5)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferUntilSomeNull() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.just(1, 2, 3, null, 4, 5)
+        .bufferUntil(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v != null && v == 20;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValues(
+                Arrays.asList(1, 2, 3, null, 4, 5)
+            );
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void bufferWhilePredicateThrows() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.just(1, 2, 3, null, 4, 5)
+        .bufferWhile(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v == 20;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(NullPointerException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void bufferUntilPredicateThrows() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        Observable.just(1, 2, 3, null, 4, 5)
+        .bufferUntil(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v == 20;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(NullPointerException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void emptySourceBufferWhile() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+        Observable.<Integer>empty()
+        .bufferWhile(UtilityFunctions.alwaysTrue())
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void emptySourceBufferUntil() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+        Observable.<Integer>empty()
+        .bufferUntil(UtilityFunctions.alwaysTrue())
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void errorSourceBufferWhile() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+        Observable.<Integer>error(new TestException())
+        .bufferWhile(UtilityFunctions.alwaysTrue())
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void errorSourceBufferUntil() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+        Observable.<Integer>error(new TestException())
+        .bufferUntil(UtilityFunctions.alwaysTrue())
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferWhileBackpressure() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create(0);
+        
+        Observable.range(1, RxRingBuffer.SIZE * 4)
+        .bufferWhile(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return (v % 3) == 0;
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        
+        ts.assertValue(Arrays.asList(1, 2));
+
+        ts.requestMore(1);
+        ts.assertValues(
+                Arrays.asList(1, 2),
+                Arrays.asList(3, 4, 5)
+        );
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        ts.assertValues(
+                Arrays.asList(1, 2),
+                Arrays.asList(3, 4, 5),
+                Arrays.asList(6, 7, 8)
+        );
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(Long.MAX_VALUE);
+        
+        ts.assertValueCount((RxRingBuffer.SIZE * 4) / 3 + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferUntilBackpressure() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create(0);
+        
+        Observable.range(1, RxRingBuffer.SIZE * 4)
+        .bufferUntil(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return (v % 3) == 0;
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        
+        ts.assertValue(Arrays.asList(1, 2, 3));
+
+        ts.requestMore(1);
+        ts.assertValues(
+                Arrays.asList(1, 2, 3),
+                Arrays.asList(4, 5, 6)
+        );
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        ts.assertValues(
+                Arrays.asList(1, 2, 3),
+                Arrays.asList(4, 5, 6),
+                Arrays.asList(7, 8, 9)
+        );
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(Long.MAX_VALUE);
+        
+        ts.assertValueCount((RxRingBuffer.SIZE * 4) / 3 + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void bufferWhileBackpressureFullBuffer() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create(0);
+        
+        int count = RxRingBuffer.SIZE * 4;
+        
+        Observable.range(1, count)
+        .bufferWhile(UtilityFunctions.alwaysFalse())
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        
+        ts.assertValueCount(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertEquals(count, ts.getOnNextEvents().get(0).size());
+    }
+
+    @Test
+    public void bufferUntilBackpressureFullBuffer() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create(0);
+        
+        int count = RxRingBuffer.SIZE * 4;
+        
+        Observable.range(1, count)
+        .bufferUntil(UtilityFunctions.alwaysFalse())
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        
+        ts.assertValueCount(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertEquals(count, ts.getOnNextEvents().get(0).size());
+    }
+
+}


### PR DESCRIPTION
The need for a buffer operator that splits the source sequence into continuous non-overlapping buffers based on the values in the sequence comes up from time to time. For, me, it reached the point where I'd consider adding operator(s) with this functionality into RxJava.

There are two variants of the required functionality: split before the element is added to the buffer: `bufferWhile`; and split after the element has been added to the buffer: `bufferUntil`.  Both cases, the predicate has to return `true` to trigger a split and emission of the current buffer.

I've added 2-2 overloads of these methods to `Observable` where the second overloads allow specifying the expected capacity use of the buffers (for performance reasons). These operators don't support backpressure and go unbounded, just like `buffer(Observable)` and others.

In the operator itself, I've added backpressured versions of `bufferWhile` and `bufferUntil`, which use a prefetch queue and a request-dependent queue-drain approach. It is up for a discussion what to do with these (provided this PR is of interest at all): 1) use them as the basis for the methods instead, 2) expose them through a different name and 3) drop them.

