### PR TITLE
1.x: Fix the test Issue1685 not waiting long enough.

### DIFF
--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1108,7 +1108,9 @@ public class ObservableTests {
             subject.subscribe();
             subject.materialize().toBlocking().first();
 
-            Thread.sleep(1000); // the uncaught exception comes after the terminal event reaches toBlocking
+            for (int i = 0; i < 20 && err.get() == null; i++) {
+                Thread.sleep(100); // the uncaught exception comes after the terminal event reaches toBlocking
+            }
             
             assertNotNull("UncaughtExceptionHandler didn't get anything.", err.get());
             


### PR DESCRIPTION
The tests started regularly failing on travis. This PR increases the waiting time to 2 seconds in total.