### PR TITLE
1.x: measure flatMap/concatMap performance when used as filter

### DIFF
--- a/src/perf/java/rx/operators/FlatMapAsFilterPerf.java
+++ b/src/perf/java/rx/operators/FlatMapAsFilterPerf.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.operators;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observable;
+import rx.functions.Func1;
+import rx.jmh.LatchedObserver;
+
+/**
+ * Benchmark flatMap running over a mixture of normal and empty Observables.
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*FlatMapAsFilterPerf.*"
+ * <p>
+ * gradlew benchmarks "-Pjmh=-f 1 -tu ns -bm avgt -wi 5 -i 5 -r 1 .*FlatMapAsFilterPerf.*"
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class FlatMapAsFilterPerf {
+
+    @Param({"1", "1000", "1000000"})
+    public int count;
+    
+    @Param({"0", "1", "3", "7"})
+    public int mask;
+    
+    public Observable<Integer> justEmptyFlatMap;
+    
+    public Observable<Integer> rangeEmptyFlatMap;
+
+    public Observable<Integer> justEmptyConcatMap;
+    
+    public Observable<Integer> rangeEmptyConcatMap;
+
+    @Setup
+    public void setup() {
+        if (count == 1 && mask != 0) {
+            throw new RuntimeException("Force skip");
+        }
+        Integer[] values = new Integer[count];
+        for (int i = 0; i < count; i++) {
+            values[i] = i;
+        }
+        final Observable<Integer> just = Observable.just(1);
+        
+        final Observable<Integer> range = Observable.range(1, 2);
+        
+        final Observable<Integer> empty = Observable.empty();
+        
+        final int m = mask;
+        
+        justEmptyFlatMap = Observable.from(values).flatMap(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer v) {
+                return (v & m) == 0 ? empty : just;
+            }
+        });
+        
+        rangeEmptyFlatMap = Observable.from(values).flatMap(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer v) {
+                return (v & m) == 0 ? empty : range;
+            }
+        });
+
+        justEmptyConcatMap = Observable.from(values).concatMap(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer v) {
+                return (v & m) == 0 ? empty : just;
+            }
+        });
+        
+        rangeEmptyConcatMap = Observable.from(values).concatMap(new Func1<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Integer v) {
+                return (v & m) == 0 ? empty : range;
+            }
+        });
+    }
+
+    @Benchmark
+    public void justEmptyFlatMap(Blackhole bh) {
+        justEmptyFlatMap.subscribe(new LatchedObserver<Integer>(bh));
+    }
+    
+    @Benchmark
+    public void rangeEmptyFlatMap(Blackhole bh) {
+        rangeEmptyFlatMap.subscribe(new LatchedObserver<Integer>(bh));
+    }
+
+    @Benchmark
+    public void justEmptyConcatMap(Blackhole bh) {
+        justEmptyConcatMap.subscribe(new LatchedObserver<Integer>(bh));
+    }
+    
+    @Benchmark
+    public void rangeEmptyConcatMap(Blackhole bh) {
+        rangeEmptyConcatMap.subscribe(new LatchedObserver<Integer>(bh));
+    }
+}


### PR DESCRIPTION
This PR adds a perf class to measure the overhead of using `empty()` when the `flatMap`/`concatMap` emulates `filter`.

This will establish the comparison baseline for `flatMap`/`concatMap` optimization as requested in #1653.

The baseline [numbers](https://gist.github.com/akarnokd/243a09e28edfc27aeb0d) (i7 4770K, Windows 7 x64, Java 8u72):

![image](https://cloud.githubusercontent.com/assets/1269832/13731994/629ce62c-e977-11e5-9f32-82dc404c792f.png)

Comparing `flatMap` against `concatMap`:

![image](https://cloud.githubusercontent.com/assets/1269832/13731998/a15586b2-e977-11e5-82c5-b33e458cb5a9.png)

Here, mask indicates the and-mask that makes emitting `empty` less frequent: 0 = always, 1 = every other, 3 = every fourth, 7 = every eighth. This also means that `rangeEmpty` starts emitting more and more values with higher mask value hence the different throughput values.
