### PR TITLE
1.x: Operator sample emits last sampled value before termination.

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSampleWithObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorSampleWithObservable.java
@@ -66,7 +66,7 @@ public final class OperatorSampleWithObservable<T, U> implements Operator<T, T> 
 
             @Override
             public void onCompleted() {
-                // onNext(null); // emit the very last value?
+                onNext(null);
                 s.onCompleted();
                 // no need to null check, main is assigned before any of the two gets subscribed
                 main.get().unsubscribe();
@@ -88,7 +88,7 @@ public final class OperatorSampleWithObservable<T, U> implements Operator<T, T> 
 
             @Override
             public void onCompleted() {
-                // samplerSub.onNext(null); // emit the very last value?
+                samplerSub.onNext(null);
                 s.onCompleted();
 
                 samplerSub.unsubscribe();

--- a/src/main/java/rx/internal/operators/OperatorSampleWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorSampleWithTime.java
@@ -89,12 +89,17 @@ public final class OperatorSampleWithTime<T> implements Operator<T, T> {
 
         @Override
         public void onCompleted() {
+            emitIfNonEmpty();
             subscriber.onCompleted();
             unsubscribe();
         }
 
         @Override
         public void call() {
+            emitIfNonEmpty();
+        }
+
+        private void emitIfNonEmpty() {
             Object localValue = value.getAndSet(EMPTY_TOKEN);
             if (localValue != EMPTY_TOKEN) {
                 try {


### PR DESCRIPTION
Changes:
- `OperatorSampleWithTime` emits last stored value if it is set before `onCompleted`
- `OperatorSampleWithObservable` emits last sampled value if source or sample complete.

As discussed in https://github.com/ReactiveX/RxJava/issues/3657.