### PR TITLE
1.x: optimize merge/flatMap for empty sources

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -237,6 +237,9 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             if (t == null) {
                 return;
             }
+            if (t == Observable.empty()) {
+                emitEmpty();
+            } else
             if (t instanceof ScalarSynchronousObservable) {
                 tryEmit(((ScalarSynchronousObservable<? extends T>)t).get());
             } else {
@@ -244,6 +247,16 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 addInner(inner);
                 t.unsafeSubscribe(inner);
                 emit();
+            }
+        }
+        
+        void emitEmpty() {
+            int produced = scalarEmissionCount + 1;
+            if (produced == scalarEmissionLimit) {
+                scalarEmissionCount = 0;
+                this.requestMore(produced);
+            } else {
+                scalarEmissionCount = produced;
             }
         }
         


### PR DESCRIPTION
This PR improves the overhead when one merges/flatMaps `empty()` sequences.

Benchmark results: (i7 4770K, Windows 7 x64, Java 8u72):

![image](https://cloud.githubusercontent.com/assets/1269832/13749421/a04a35c6-ea01-11e5-8b02-53ad07517453.png)

For rare `empty()`, the overhead seems to be around the noise level.
