### PR TITLE
1.x: Deprecate CompositeException constructor with message prefix

### DIFF
--- a/src/main/java/rx/exceptions/CompositeException.java
+++ b/src/main/java/rx/exceptions/CompositeException.java
@@ -41,6 +41,8 @@ public final class CompositeException extends RuntimeException {
     private final List<Throwable> exceptions;
     private final String message;
 
+    /** @deprecated please use {@link #CompositeException(Collection)} */
+    @Deprecated
     public CompositeException(String messagePrefix, Collection<? extends Throwable> errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();
         List<Throwable> _exceptions = new ArrayList<Throwable>();

--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -171,8 +171,7 @@ public final class Exceptions {
                     throw new RuntimeException(t);
                 }
             }
-            throw new CompositeException(
-                    "Multiple exceptions", exceptions);
+            throw new CompositeException(exceptions);
         }
     }
     

--- a/src/test/java/rx/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/rx/exceptions/CompositeExceptionTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class CompositeExceptionTest {
         Throwable e1 = new Throwable("1", rootCause);
         Throwable e2 = new Throwable("2", rootCause);
         Throwable e3 = new Throwable("3", rootCause);
-        CompositeException ce = new CompositeException("3 failures with same root cause", Arrays.asList(e1, e2, e3));
+        CompositeException ce = new CompositeException(Arrays.asList(e1, e2, e3));
 
         System.err.println("----------------------------- print composite stacktrace");
         ce.printStackTrace();
@@ -174,7 +175,7 @@ public class CompositeExceptionTest {
     }
     @Test
     public void testNullElement() {
-        CompositeException composite = new CompositeException(Arrays.asList((Throwable)null));
+        CompositeException composite = new CompositeException(Collections.singletonList((Throwable) null));
         composite.getCause();
         composite.printStackTrace();
     }
@@ -219,5 +220,17 @@ public class CompositeExceptionTest {
 
         System.err.println("----------------------------- print cause stacktrace");
         cex.getCause().printStackTrace();
+    }
+
+    @Test
+    public void messageCollection() {
+        CompositeException compositeException = new CompositeException(Arrays.asList(ex1, ex3));
+        assertEquals("2 exceptions occurred. ", compositeException.getMessage());
+    }
+
+    @Test
+    public void messageVarargs() {
+        CompositeException compositeException = new CompositeException(ex1, ex2, ex3);
+        assertEquals("3 exceptions occurred. ", compositeException.getMessage());
     }
 }


### PR DESCRIPTION
Before this PR messagePrefix was never used :dancer: 

If you guys want I can revert the change on CompositeExceptionTest.java:177. I just thought that way it' be nicer.

About the message is there any reason for having a space after the dot?