### PR TITLE
1.x: combineLatestDelayError

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -907,6 +907,33 @@ public class Observable<T> {
     }
 
     /**
+     * Combines a collection of source Observables by emitting an item that aggregates the latest values of each of
+     * the source Observables each time an item is received from any of the source Observables, where this
+     * aggregation is defined by a specified function and delays any error from the sources until
+     * all source Observables terminate.
+     * 
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T>
+     *            the common base type of source values
+     * @param <R>
+     *            the result type
+     * @param sources
+     *            the collection of source Observables
+     * @param combineFunction
+     *            the aggregation function used to combine the items emitted by the source Observables
+     * @return an Observable that emits items that are the result of combining the items emitted by the source
+     *         Observables by means of the given aggregation function
+     * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
+     */
+    public static <T, R> Observable<R> combineLatestDelayError(Iterable<? extends Observable<? extends T>> sources, FuncN<? extends R> combineFunction) {
+        return create(new OnSubscribeCombineLatest<T, R>(null, sources, combineFunction, RxRingBuffer.SIZE, true));
+    }
+
+    /**
      * Returns an Observable that emits the items emitted by each of the Observables emitted by the source
      * Observable, one after the other, without interleaving them.
      * <p>

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -213,7 +213,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
                     if (value != null && allSourcesFinished) {
                         queue.offer(combinerSubscriber, latest.clone());
                     } else
-                    if (value == null && error.get() != null) {
+                    if (value == null && error.get() != null && (o == MISSING || !delayError)) {
                         done = true; // if this source completed without a value
                     }
                 } else {


### PR DESCRIPTION
This PR exposes the `delayError` option in `combineLatest` as `combineLatestDelayError`.

(Note that we have convenience overloads with 2-9 sources that could also use an overload, but that just expands the API surface drastically.)