### PR TITLE
1.x: observeOn - fix in-sequence termination/unsubscription

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -834,4 +834,27 @@ public class OperatorObserveOnTest {
         ts.assertError(TestException.class);
         ts.assertNotCompleted();
     }
+    
+    @Test
+    public void requestExactCompletesImmediately() {
+TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        TestScheduler test = Schedulers.test();
+
+        Observable.range(1, 10).observeOn(test).subscribe(ts);
+
+        test.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(10);
+
+        test.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        ts.assertValueCount(10);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }


### PR DESCRIPTION
This fixes `observeOn` not completing immediately if the downstream requested exactly the remaining amount. The original version required a new request from downstream to trigger the delivery of the terminal event.

This also fixes the rare failure in `testNoMoreRequestsAfterUnsubscribe` because the unsubscription is now checked in-sequence and doesn't trigger the unwanted replenishment request.