### PR TITLE
observeOn: allow configurable buffer size

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -6291,7 +6291,8 @@ public class Observable<T> {
     
     /**
      * Modifies an Observable to perform its emissions and notifications on a specified {@link Scheduler},
-     * asynchronously with a bounded buffer.
+     * asynchronously with a bounded buffer of {@link RxRingBuffer.SIZE} slots.
+     *
      * <p>Note that onError notifications will cut ahead of onNext notifications on the emission thread if Scheduler is truly
      * asynchronous. If strict event ordering is required, consider using the {@link #observeOn(Scheduler, boolean)} overload.
      * <p>
@@ -6308,13 +6309,41 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
+     * @see #observeOn(Scheduler, int)
      * @see #observeOn(Scheduler, boolean)
+     * @see #observeOn(Scheduler, boolean, int)
      */
     public final Observable<T> observeOn(Scheduler scheduler) {
-        if (this instanceof ScalarSynchronousObservable) {
-            return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
-        }
-        return lift(new OperatorObserveOn<T>(scheduler, false));
+        return observeOn(scheduler, RxRingBuffer.SIZE);
+    }
+
+    /**
+     * Modifies an Observable to perform its emissions and notifications on a specified {@link Scheduler},
+     * asynchronously with a bounded buffer of configurable size other than the {@link RxRingBuffer.SIZE}
+     * default.
+     *
+     * <p>Note that onError notifications will cut ahead of onNext notifications on the emission thread if Scheduler is truly
+     * asynchronous. If strict event ordering is required, consider using the {@link #observeOn(Scheduler, boolean)} overload.
+     * <p>
+     * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     *
+     * @param scheduler the {@link Scheduler} to notify {@link Observer}s on
+     * @param bufferSize the size of the buffer.
+     * @return the source Observable modified so that its {@link Observer}s are notified on the specified
+     *         {@link Scheduler}
+     * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
+     * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
+     * @see #subscribeOn
+     * @see #observeOn(Scheduler)
+     * @see #observeOn(Scheduler, boolean)
+     * @see #observeOn(Scheduler, boolean, int)
+     */
+    public final Observable<T> observeOn(Scheduler scheduler, int bufferSize) {
+        return observeOn(scheduler, false, bufferSize);
     }
 
     /**
@@ -6339,12 +6368,45 @@ public class Observable<T> {
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
      * @see #observeOn(Scheduler)
+     * @see #observeOn(Scheduler, int)
+     * @see #observeOn(Scheduler, boolean, int)
      */
     public final Observable<T> observeOn(Scheduler scheduler, boolean delayError) {
+        return observeOn(scheduler, delayError, RxRingBuffer.SIZE);
+    }
+
+    /**
+     * Modifies an Observable to perform its emissions and notifications on a specified {@link Scheduler},
+     * asynchronously with a bounded buffer of configurable size other than the {@link RxRingBuffer.SIZE}
+     * default, and optionally delays onError notifications.
+     * <p>
+     * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     *
+     * @param scheduler
+     *            the {@link Scheduler} to notify {@link Observer}s on
+     * @param delayError
+     *            indicates if the onError notification may not cut ahead of onNext notification on the other side of the
+     *            scheduling boundary. If true a sequence ending in onError will be replayed in the same order as was received
+     *            from upstream
+     * @param bufferSize the size of the buffer.
+     * @return the source Observable modified so that its {@link Observer}s are notified on the specified
+     *         {@link Scheduler}
+     * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
+     * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
+     * @see #subscribeOn
+     * @see #observeOn(Scheduler)
+     * @see #observeOn(Scheduler, int)
+     * @see #observeOn(Scheduler, boolean)
+     */
+    public final Observable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
         if (this instanceof ScalarSynchronousObservable) {
             return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
         }
-        return lift(new OperatorObserveOn<T>(scheduler, delayError));
+        return lift(new OperatorObserveOn<T>(scheduler, delayError, bufferSize));
     }
 
     /**

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -581,6 +581,69 @@ public class OperatorObserveOnTest {
     }
 
     @Test
+    public void testQueueFullEmitsErrorWithVaryingBufferSize() {
+        final CountDownLatch latch = new CountDownLatch(1);
+        // randomize buffer size, note that underlying implementations may be tuning the real size to a power of 2
+        // which can lead to unexpected results when adding excess capacity (e.g.: see ConcurrentCircularArrayQueue)
+        for (int i = 1; i <= 1024; i = i * 2) {
+            final int capacity = i;
+            Observable<Integer> observable = Observable.create(new OnSubscribe<Integer>() {
+
+                @Override
+                public void call(Subscriber<? super Integer> o) {
+                    for (int i = 0; i < capacity + 10; i++) {
+                        o.onNext(i);
+                    }
+                    latch.countDown();
+                    o.onCompleted();
+                }
+
+            });
+
+            TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>(new Observer<Integer>() {
+
+                @Override
+                public void onCompleted() {
+
+                }
+
+                @Override
+                public void onError(Throwable e) {
+
+                }
+
+                @Override
+                public void onNext(Integer t) {
+                    try {
+                        // force it to be slow wait until we have queued everything
+                        latch.await(500, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+
+            });
+            System.out.println("Using capacity " + capacity); // for post-failure debugging
+            observable.observeOn(Schedulers.newThread(), capacity).subscribe(testSubscriber);
+
+            testSubscriber.awaitTerminalEvent();
+            List<Throwable> errors = testSubscriber.getOnErrorEvents();
+            assertEquals(1, errors.size());
+            System.out.println("Errors: " + errors);
+            Throwable t = errors.get(0);
+            if (t instanceof MissingBackpressureException) {
+                // success, we expect this
+            } else {
+                if (t.getCause() instanceof MissingBackpressureException) {
+                    // this is also okay
+                } else {
+                    fail("Expecting MissingBackpressureException");
+                }
+            }
+        }
+    }
+
+    @Test
     public void testAsyncChild() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Observable.range(0, 100000).observeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(ts);


### PR DESCRIPTION
The observeOn operator is backed by a small queue of 128 slots that may
overflow quickly on slow producers.  This could only be avoided by
adding a backpressure operator before the observeOn (not only
inconvenient, but also taking a perf. hit as it forces hops between two
queues).

This patch allows modifying the default queue size on the observeOn
operator.

Fixes: #3751
Signed-off-by: Galo Navarro <anglorvaroa@gmail.com>