### PR TITLE
1.x: fix GroupBy delaying group completion till all groups were emitted

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -219,6 +219,12 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             if (done) {
                 return;
             }
+
+            for (GroupedUnicast<K, V> e : groups.values()) {
+                e.onComplete();
+            }
+            groups.clear();
+
             done = true;
             GROUP_COUNT.decrementAndGet(this);
             drain();
@@ -328,13 +334,6 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                     return true;
                 } else
                 if (empty) {
-                    List<GroupedUnicast<K, V>> list = new ArrayList<GroupedUnicast<K, V>>(groups.values());
-                    groups.clear();
-                    
-                    for (GroupedUnicast<K, V> e : list) {
-                        e.onComplete();
-                    }
-                    
                     actual.onCompleted();
                     return true;
                 }

--- a/src/test/java/rx/GroupByTests.java
+++ b/src/test/java/rx/GroupByTests.java
@@ -21,6 +21,7 @@ import rx.EventStream.Event;
 import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.observables.GroupedObservable;
+import rx.observers.TestSubscriber;
 
 public class GroupByTests {
 
@@ -89,5 +90,28 @@ public class GroupByTests {
                 });
 
         System.out.println("**** finished");
+    }
+    
+    @Test
+    public void groupsCompleteAsSoonAsMainCompletes() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(0, 20)
+        .groupBy(new Func1<Integer, Integer>() {
+            @Override
+            public Integer call(Integer i) {
+                return i % 5;
+            }
+        })
+        .concatMap(new Func1<GroupedObservable<Integer, Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(GroupedObservable<Integer, Integer> v) {
+                return v;
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(0, 5, 10, 15, 1, 6, 11, 16, 2, 7, 12, 17, 3, 8, 13, 18, 4, 9, 14, 19);
+        ts.assertCompleted();
+        ts.assertNoErrors();
     }
 }


### PR DESCRIPTION
In 1.1.1, `groupBy` was fixed to properly honor backpressure on the outer `Observable`. The change included a drain loop that emitted `onCompleted()` to the groups only when all `GroupedObservable`s were drained from the main queue. This delayed the group's completion unnecessarily causing the `concat` operator to hang in some source-consumer cases such as #3775.

This PR fixes the behavior by signalling `onCompleted()` to the groups the moment the main completes. 

Note, however, that concatenating groups is eventually prone to hangs due to the groups not completing until the source completes, thus `concat` can't switch to the next source. One should use `flatMap` or `concatMapEager` instead.