### PR TITLE
1.x: observeOn now replenishes with constant rate

### DIFF
--- a/src/test/java/rx/observables/AsyncOnSubscribeTest.java
+++ b/src/test/java/rx/observables/AsyncOnSubscribeTest.java
@@ -383,7 +383,8 @@ public class AsyncOnSubscribeTest {
                                     }}));
                         break;
                     case 2:
-                        observer.onNext(Observable.<Integer>never()
+                        observer.onNext(Observable.just(1)
+                                .concatWith(Observable.<Integer>never())
                                 .subscribeOn(scheduler)
                                 .doOnUnsubscribe(new Action0(){
                                     @Override
@@ -397,7 +398,7 @@ public class AsyncOnSubscribeTest {
                     return state + 1;
                 }});
         Subscription subscription = Observable.create(os)
-            .observeOn(scheduler)
+            .observeOn(scheduler, 1)
             .subscribe(subscriber);
         sub.set(subscription);
         subscriber.assertNoValues();


### PR DESCRIPTION
This PR makes sure `observeOn` requests replenishments in a fixed and predictable quantity of 75% of the `bufferSize`, that is, if an emission counter reaches `0.75 * bufferSize`, that amount is requested and the emission counter is reset to zero. This requires saving the emission count between drain runs. If the bufferSize is 1 or 2, the replenishment will trigger after every 1 or 2 items.

Note that there is only one sensitive operator-builder, `AsyncOnSubscribe`, which is mostly affected by the request pattern as it facilitates user code to respond with an Observable sequence of the requested amount.

In addition, since `observeOn` now supports setting the buffer size, it can act as a rebatching operator via the help of `Schedulers.immediate()`.