### PR TITLE
2.x: add ConsumableX to the base types, update method signatures

### DIFF
--- a/src/main/java/io/reactivex/CompletableSubscriber.java
+++ b/src/main/java/io/reactivex/CompletableSubscriber.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * Represents the subscription API callbacks when subscribing to a Completable instance.
+ */
+public interface CompletableSubscriber {
+    /**
+     * Called once the deferred computation completes normally.
+     */
+    void onComplete();
+    
+    /**
+     * Called once if the deferred computation 'throws' an exception.
+     * @param e the exception, not null.
+     */
+    void onError(Throwable e);
+    
+    /**
+     * Called once by the Completable to set a Disposable on this instance which
+     * then can be used to cancel the subscription at any time.
+     * @param d the Disposable instance to call dispose on for cancellation, not null
+     */
+    void onSubscribe(Disposable d);
+}

--- a/src/main/java/io/reactivex/ConsumableCompletable.java
+++ b/src/main/java/io/reactivex/ConsumableCompletable.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+/**
+ * A ConsumableCompletable represents the provider of exactly one completion or exactly one error signal
+ * and is mainly useful for composing side-effecting computation that don't generate values.
+ * <p>
+ * A ConsumableCompletable can serve multiple CompletableSubscriber subscribed via subscribe(CompletableSubscriber) dynamically
+ * at various points in time.
+ * <p>
+ * A ConsumableCompletable signalling events to its CompletableSubscribers has to and will follow the following protocol:
+ *  onSubscribe (onError | onComplete)?
+ */
+public interface ConsumableCompletable {
+    
+    /**
+     * Request the ConsumableCompletable to signal a completion or an error signal.
+     * 
+     * @param subscriber The CompletableSubscriber instance that will receive either the completion
+     * signal or the error signal.
+     */
+    void subscribe(CompletableSubscriber subscriber);
+}

--- a/src/main/java/io/reactivex/ConsumableFlowable.java
+++ b/src/main/java/io/reactivex/ConsumableFlowable.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+package io.reactivex;
+
+import org.reactivestreams.Subscriber;
+
+/**
+ * A ConsumableFlowable represents a backpressured sequence of values optionally followed
+ * by a teraminal signal.
+ *
+ * A ConsumableFlowable can serve multiple Subscribers subscribed via subscribe(Subscriber) dynamically
+ * at various points in time.
+ * <p>
+ * A ConsumableFlowable signalling events to its Subscriber has to and will follow the following protocol:
+ *  onSubscribe onNext* (onError | onComplete)?
+ *  
+ * @param <T> The type of the element received from an ConsumableFlowable
+ */
+public interface ConsumableFlowable<T> {
+    /**
+     * Request the ConsumableFlowable to start streaming data.
+     * 
+     * @param subscriber The Subscriber that will consume signals from this ConsumableFlowable.
+     */
+    void subscribe(Subscriber<? super T> subscriber);
+}

--- a/src/main/java/io/reactivex/ConsumableObservable.java
+++ b/src/main/java/io/reactivex/ConsumableObservable.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+package io.reactivex;
+
+/**
+ * A ConsumableObservable represents a non-backpressured and unbounded sequence of values optionally followed
+ * by a teraminal signal.
+ *
+ * A ConsumableObservable can serve multiple Observers subscribed via subscribe(Observer) dynamically
+ * at various points in time.
+ * <p>
+ * A ConsumableObservable signalling events to its Observer has to and will follow the following protocol:
+ *  onSubscribe onNext* (onError | onComplete)?
+ *  
+ * @param <T> The type of the element received from an ConsumableObservable
+ */
+public interface ConsumableObservable<T> {
+    /**
+     * Request the ConsumableObservable to start streaming data.
+     * 
+     * @param observer The Observer that will consume signals from this ConsumableObservable.
+     */
+    void subscribe(Observer<? super T> observer);
+}

--- a/src/main/java/io/reactivex/ConsumableSingle.java
+++ b/src/main/java/io/reactivex/ConsumableSingle.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+/**
+ * A ConsumableSingle represents a provider of exactly one element or exactly one Exception to its
+ * SingleSubscribers.
+ *
+ * A ConsumableSingle can serve multiple SingleSubscribers subscribed via subscribe(SingleSubscriber) dynamically
+ * at various points in time.
+ * 
+ * A ConsumableSingle signalling events to its SingleSubscribers has to and will follow the following protocol:
+ * onSubscribe (onSuccess | onError)?
+ * 
+ * @param <T> The type of the element signalled to the SingleSubscriber
+ */
+public interface ConsumableSingle<T> {
+    /**
+     * Request the ConsumableSingle to signal an element or Exception.
+     * 
+     * @param subscriber The SingleSubscriber instance that will receive the element or Exception.
+     */
+    void subscribe(SingleSubscriber<? super T> subscriber);
+}

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 
-public class Flowable<T> implements Publisher<T> {
+public class Flowable<T> implements Publisher<T>, ConsumableFlowable<T> {
     /**
      * Interface to map/wrap a downstream subscriber to an upstream subscriber.
      *
@@ -1190,7 +1190,7 @@ public class Flowable<T> implements Publisher<T> {
 
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Flowable<T> asObservable() {
+    public final Flowable<T> asFlowable() {
         return create(new Publisher<T>() {
             @Override
             public void subscribe(Subscriber<? super T> s) {
@@ -1876,6 +1876,8 @@ public class Flowable<T> implements Publisher<T> {
         }
         return concatArray(this, fromArray);
     }
+    
+    
 
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
@@ -2942,6 +2944,13 @@ public class Flowable<T> implements Publisher<T> {
         subscribeActual(s);
     }
     
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerKind.NONE)
+//    @Override
+    public final void subscribe(Observer<? super T> o) {
+        toObservable().subscribe(o);
+    }
+    
     private void subscribeActual(Subscriber<? super T> s) {
         try {
             s = RxJavaPlugins.onSubscribe(s);
@@ -3491,7 +3500,7 @@ public class Flowable<T> implements Publisher<T> {
     
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> toNbpObservable() {
+    public final Observable<T> toObservable() {
         return Observable.fromPublisher(this);
     }
     
@@ -3746,5 +3755,4 @@ public class Flowable<T> implements Publisher<T> {
     public final <U, R> Flowable<R> zipWith(Publisher<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zip(this, other, zipper, delayError, bufferSize);
     }
-
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -38,8 +38,9 @@ import io.reactivex.schedulers.*;
  * Observable for delivering a sequence of values without backpressure. 
  * @param <T>
  */
-public class Observable<T> {
+public class Observable<T> implements ConsumableObservable<T> {
 
+    // FIXME maybe use ConsumableObservable directly?
     public interface NbpOnSubscribe<T> extends Consumer<Observer<? super T>> {
         
     }
@@ -71,21 +72,34 @@ public class Observable<T> {
     
     static final Object OBJECT = new Object();
     
-    public static <T> Observable<T> amb(Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> amb(Iterable<? extends ConsumableObservable<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return create(new NbpOnSubscribeAmb<T>(null, sources));
     }
     
     @SuppressWarnings("unchecked")
+    public static <T> Observable<T> wrap(final ConsumableObservable<? extends T> consumable) {
+        if (consumable instanceof Observable) {
+            return (Observable<T>)consumable;
+        }
+        Objects.requireNonNull(consumable, "consumable is null");
+        return create(new NbpOnSubscribe<T>() {
+            @Override
+            public void accept(Observer<? super T> s) {
+                consumable.subscribe(s);
+            }
+        });
+    }
+    
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> amb(Observable<? extends T>... sources) {
+    public static <T> Observable<T> amb(ConsumableObservable<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
             return empty();
         } else
         if (len == 1) {
-            return (Observable<T>)sources[0];
+            return wrap(sources[0]);
         }
         return create(new NbpOnSubscribeAmb<T>(sources, null));
     }
@@ -99,22 +113,22 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize, Observable<? extends T>... sources) {
+    public static <T, R> Observable<R> combineLatest(Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize, ConsumableObservable<? extends T>... sources) {
         return combineLatest(sources, combiner, delayError, bufferSize);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> combiner) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ConsumableObservable<? extends T>> sources, Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, false, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ConsumableObservable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
         return combineLatest(sources, combiner, delayError, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ConsumableObservable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         validateBufferSize(bufferSize);
@@ -125,17 +139,17 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Observable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
+    public static <T, R> Observable<R> combineLatest(ConsumableObservable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, false, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Observable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
+    public static <T, R> Observable<R> combineLatest(ConsumableObservable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
         return combineLatest(sources, combiner, delayError, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Observable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(ConsumableObservable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
         validateBufferSize(bufferSize);
         Objects.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
@@ -149,7 +163,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2);
     }
@@ -157,8 +171,8 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, 
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, 
             Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3);
     }
@@ -166,8 +180,8 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, ConsumableObservable<? extends T4> p4,
             Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4);
     }
@@ -175,9 +189,9 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, ConsumableObservable<? extends T4> p4,
+            ConsumableObservable<? extends T5> p5,
             Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5);
     }
@@ -185,9 +199,9 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, ConsumableObservable<? extends T4> p4,
+            ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
             Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6);
     }
@@ -195,10 +209,10 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, ConsumableObservable<? extends T4> p4,
+            ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
+            ConsumableObservable<? extends T7> p7,
             Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7);
     }
@@ -206,10 +220,10 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, ConsumableObservable<? extends T4> p4,
+            ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
+            ConsumableObservable<? extends T7> p7, ConsumableObservable<? extends T8> p8,
             Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8);
     }
@@ -217,68 +231,68 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8,
-            Observable<? extends T9> p9,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
+            ConsumableObservable<? extends T3> p3, ConsumableObservable<? extends T4> p4,
+            ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
+            ConsumableObservable<? extends T7> p7, ConsumableObservable<? extends T8> p8,
+            ConsumableObservable<? extends T9> p9,
             Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concat(int prefetch, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> concat(int prefetch, Iterable<? extends ConsumableObservable<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMap((Function)Functions.identity(), prefetch);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concat(Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> concat(Iterable<? extends ConsumableObservable<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMap((Function)Functions.identity());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static final <T> Observable<T> concat(Observable<? extends Observable<? extends T>> sources) {
+    public static final <T> Observable<T> concat(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources) {
         return concat(sources, bufferSize());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static final <T> Observable<T> concat(Observable<? extends Observable<? extends T>> sources, int bufferSize) {
-        return sources.concatMap((Function)Functions.identity());
+    public static final <T> Observable<T> concat(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources, int bufferSize) {
+        return wrap(sources).concatMap((Function)Functions.identity());
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concat(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<T> concat(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2) {
         return concatArray(p1, p2);
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2,
-            Observable<? extends T> p3) {
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2,
+            ConsumableObservable<? extends T> p3) {
         return concatArray(p1, p2, p3);
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2,
-            Observable<? extends T> p3, Observable<? extends T> p4) {
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2,
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4) {
         return concatArray(p1, p2, p3, p4);
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, 
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4,
+            ConsumableObservable<? extends T> p5
     ) {
         return concatArray(p1, p2, p3, p4, p5);
     }
@@ -286,9 +300,9 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, 
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4,
+            ConsumableObservable<? extends T> p5, ConsumableObservable<? extends T> p6
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6);
     }
@@ -296,10 +310,10 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2,
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6,
-            Observable<? extends T> p7
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2,
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4,
+            ConsumableObservable<? extends T> p5, ConsumableObservable<? extends T> p6,
+            ConsumableObservable<? extends T> p7
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6, p7);
     }
@@ -307,10 +321,10 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6,
-            Observable<? extends T> p7, Observable<? extends T> p8
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, 
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4,
+            ConsumableObservable<? extends T> p5, ConsumableObservable<? extends T> p6,
+            ConsumableObservable<? extends T> p7, ConsumableObservable<? extends T> p8
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6, p7, p8);
     }
@@ -318,18 +332,18 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6,
-            Observable<? extends T> p7, Observable<? extends T> p8,
-            Observable<? extends T> p9
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, 
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4,
+            ConsumableObservable<? extends T> p5, ConsumableObservable<? extends T> p6,
+            ConsumableObservable<? extends T> p7, ConsumableObservable<? extends T> p8,
+            ConsumableObservable<? extends T> p9
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concatArray(int prefetch, Observable<? extends T>... sources) {
+    public static <T> Observable<T> concatArray(int prefetch, ConsumableObservable<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromArray(sources).concatMap((Function)Functions.identity(), prefetch);
     }
@@ -345,7 +359,7 @@ public class Observable<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concatArray(Observable<? extends T>... sources) {
+    public static <T> Observable<T> concatArray(ConsumableObservable<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         } else
@@ -362,7 +376,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> defer(Supplier<? extends Observable<? extends T>> supplier) {
+    public static <T> Observable<T> defer(Supplier<? extends ConsumableObservable<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return create(new NbpOnSubscribeDefer<T>(supplier));
     }
@@ -694,50 +708,50 @@ public class Observable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, Iterable<? extends ConsumableObservable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, Observable<? extends T>... sources) {
+    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, ConsumableObservable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(int maxConcurrency, Observable<? extends T>... sources) {
+    public static <T> Observable<T> merge(int maxConcurrency, ConsumableObservable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> merge(Iterable<? extends ConsumableObservable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends Observable<? extends T>> sources, int maxConcurrency) {
+    public static <T> Observable<T> merge(Iterable<? extends ConsumableObservable<? extends T>> sources, int maxConcurrency) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> merge(Observable<? extends Observable<? extends T>> sources) {
-        return sources.flatMap((Function)Functions.identity());
+    public static <T> Observable<T> merge(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources) {
+        return wrap(sources).flatMap((Function)Functions.identity());
     }
 
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends Observable<? extends T>> sources, int maxConcurrency) {
-        return sources.flatMap((Function)Functions.identity(), maxConcurrency);
+    public static <T> Observable<T> merge(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources, int maxConcurrency) {
+        return wrap(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<T> merge(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), false, 2);
@@ -746,7 +760,7 @@ public class Observable<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends T> p1, Observable<? extends T> p2, Observable<? extends T> p3) {
+    public static <T> Observable<T> merge(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, ConsumableObservable<? extends T> p3) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -757,8 +771,8 @@ public class Observable<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> merge(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4) {
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, 
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -768,55 +782,55 @@ public class Observable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends T>... sources) {
+    public static <T> Observable<T> merge(ConsumableObservable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), sources.length);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(boolean delayErrors, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> mergeDelayError(boolean delayErrors, Iterable<? extends ConsumableObservable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, Iterable<? extends ConsumableObservable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, Observable<? extends T>... sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, ConsumableObservable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, Iterable<? extends ConsumableObservable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, Observable<? extends T>... sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, ConsumableObservable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> mergeDelayError(Observable<? extends Observable<? extends T>> sources) {
-        return sources.flatMap((Function)Functions.identity(), true);
+    public static <T> Observable<T> mergeDelayError(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources) {
+        return wrap(sources).flatMap((Function)Functions.identity(), true);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends Observable<? extends T>> sources, int maxConcurrency) {
-        return sources.flatMap((Function)Functions.identity(), true, maxConcurrency);
+    public static <T> Observable<T> mergeDelayError(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources, int maxConcurrency) {
+        return wrap(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<T> mergeDelayError(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), true, 2);
@@ -825,7 +839,7 @@ public class Observable<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends T> p1, Observable<? extends T> p2, Observable<? extends T> p3) {
+    public static <T> Observable<T> mergeDelayError(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, ConsumableObservable<? extends T> p3) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -836,8 +850,8 @@ public class Observable<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> mergeDelayError(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4) {
+            ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, 
+            ConsumableObservable<? extends T> p3, ConsumableObservable<? extends T> p4) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -847,7 +861,7 @@ public class Observable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends T>... sources) {
+    public static <T> Observable<T> mergeDelayError(ConsumableObservable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, sources.length);
     }
 
@@ -889,17 +903,17 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<Boolean> sequenceEqual(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2) {
         return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual) {
+    public static <T> Observable<Boolean> sequenceEqual(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual) {
         return sequenceEqual(p1, p2, isEqual, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
+    public static <T> Observable<Boolean> sequenceEqual(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(isEqual, "isEqual is null");
@@ -908,21 +922,21 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2, int bufferSize) {
+    public static <T> Observable<Boolean> sequenceEqual(ConsumableObservable<? extends T> p1, ConsumableObservable<? extends T> p2, int bufferSize) {
         return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> switchOnNext(int bufferSize, Observable<? extends Observable<? extends T>> sources) {
-        return sources.switchMap((Function)Functions.identity(), bufferSize);
+    public static <T> Observable<T> switchOnNext(int bufferSize, ConsumableObservable<? extends ConsumableObservable<? extends T>> sources) {
+        return wrap(sources).switchMap((Function)Functions.identity(), bufferSize);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> switchOnNext(Observable<? extends Observable<? extends T>> sources) {
-        return sources.switchMap((Function)Functions.identity());
+    public static <T> Observable<T> switchOnNext(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources) {
+        return wrap(sources).switchMap((Function)Functions.identity());
     }
 
     @SchedulerSupport(SchedulerKind.COMPUTATION)
@@ -942,12 +956,12 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends Observable<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
+    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ConsumableObservable<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
         return using(resourceSupplier, sourceSupplier, disposer, true);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends Observable<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
+    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ConsumableObservable<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
         Objects.requireNonNull(disposer, "disposer is null");
@@ -961,18 +975,18 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> zip(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Observable<R> zip(Iterable<? extends ConsumableObservable<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return create(new NbpOnSubscribeZip<T, R>(null, sources, zipper, bufferSize(), false));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> zip(Observable<? extends Observable<? extends T>> sources, final Function<Object[], R> zipper) {
+    public static <T, R> Observable<R> zip(ConsumableObservable<? extends ConsumableObservable<? extends T>> sources, final Function<Object[], R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
-        return sources.toList().flatMap(new Function<List<? extends Observable<? extends T>>, Observable<R>>() {
+        return wrap(sources).toList().flatMap(new Function<List<? extends ConsumableObservable<? extends T>>, Observable<R>>() {
             @Override
-            public Observable<R> apply(List<? extends Observable<? extends T>> list) {
+            public Observable<R> apply(List<? extends ConsumableObservable<? extends T>> list) {
                 return zipIterable(zipper, false, bufferSize(), list);
             }
         });
@@ -981,7 +995,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2);
     }
@@ -989,7 +1003,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize(), p1, p2);
     }
@@ -997,7 +1011,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize, p1, p2);
     }
@@ -1005,7 +1019,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3, 
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3, 
             Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3);
     }
@@ -1013,8 +1027,8 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3,
+            ConsumableObservable<? extends T4> p4,
             Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4);
     }
@@ -1022,8 +1036,8 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3,
+            ConsumableObservable<? extends T4> p4, ConsumableObservable<? extends T5> p5,
             Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5);
     }
@@ -1031,8 +1045,8 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3,
+            ConsumableObservable<? extends T4> p4, ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
             Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6);
     }
@@ -1040,9 +1054,9 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3,
+            ConsumableObservable<? extends T4> p4, ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
+            ConsumableObservable<? extends T7> p7,
             Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7);
     }
@@ -1050,9 +1064,9 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3,
+            ConsumableObservable<? extends T4> p4, ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
+            ConsumableObservable<? extends T7> p7, ConsumableObservable<? extends T8> p8,
             Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8);
     }
@@ -1060,16 +1074,16 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8, Observable<? extends T9> p9,
+            ConsumableObservable<? extends T1> p1, ConsumableObservable<? extends T2> p2, ConsumableObservable<? extends T3> p3,
+            ConsumableObservable<? extends T4> p4, ConsumableObservable<? extends T5> p5, ConsumableObservable<? extends T6> p6,
+            ConsumableObservable<? extends T7> p7, ConsumableObservable<? extends T8> p8, ConsumableObservable<? extends T9> p9,
             Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> Observable<R> zipArray(Function<? super Object[], ? extends R> zipper, 
-            boolean delayError, int bufferSize, Observable<? extends T>... sources) {
+            boolean delayError, int bufferSize, ConsumableObservable<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
@@ -1081,7 +1095,7 @@ public class Observable<T> {
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> Observable<R> zipIterable(Function<? super Object[], ? extends R> zipper,
             boolean delayError, int bufferSize, 
-            Iterable<? extends Observable<? extends T>> sources) {
+            Iterable<? extends ConsumableObservable<? extends T>> sources) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         validateBufferSize(bufferSize);
@@ -1232,7 +1246,7 @@ public class Observable<T> {
     @SchedulerSupport(SchedulerKind.NONE)
     public final <TOpening, TClosing> Observable<List<T>> buffer(
             Observable<? extends TOpening> bufferOpenings, 
-            Function<? super TOpening, ? extends Observable<? extends TClosing>> bufferClosingSelector) {
+            Function<? super TOpening, ? extends ConsumableObservable<? extends TClosing>> bufferClosingSelector) {
         return buffer(bufferOpenings, bufferClosingSelector, new Supplier<List<T>>() {
             @Override
             public List<T> get() {
@@ -1244,7 +1258,7 @@ public class Observable<T> {
     @SchedulerSupport(SchedulerKind.NONE)
     public final <TOpening, TClosing, U extends Collection<? super T>> Observable<U> buffer(
             Observable<? extends TOpening> bufferOpenings, 
-            Function<? super TOpening, ? extends Observable<? extends TClosing>> bufferClosingSelector,
+            Function<? super TOpening, ? extends ConsumableObservable<? extends TClosing>> bufferClosingSelector,
             Supplier<U> bufferSupplier) {
         Objects.requireNonNull(bufferOpenings, "bufferOpenings is null");
         Objects.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
@@ -1253,7 +1267,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<List<T>> buffer(Observable<B> boundary) {
+    public final <B> Observable<List<T>> buffer(ConsumableObservable<B> boundary) {
         /*
          * XXX: javac complains if this is not manually cast, Eclipse is fine
          */
@@ -1266,7 +1280,7 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<List<T>> buffer(Observable<B> boundary, final int initialCapacity) {
+    public final <B> Observable<List<T>> buffer(ConsumableObservable<B> boundary, final int initialCapacity) {
         return buffer(boundary, new Supplier<List<T>>() {
             @Override
             public List<T> get() {
@@ -1276,14 +1290,14 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(Observable<B> boundary, Supplier<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(ConsumableObservable<B> boundary, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundary, "boundary is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return lift(new NbpOperatorBufferExactBoundary<T, U, B>(boundary, bufferSupplier));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<List<T>> buffer(Supplier<? extends Observable<B>> boundarySupplier) {
+    public final <B> Observable<List<T>> buffer(Supplier<? extends ConsumableObservable<B>> boundarySupplier) {
         return buffer(boundarySupplier, new Supplier<List<T>>() {
             @Override
             public List<T> get() {
@@ -1294,7 +1308,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends Observable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends ConsumableObservable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundarySupplier, "boundarySupplier is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return lift(new NbpOperatorBufferBoundarySupplier<T, U, B>(boundarySupplier, bufferSupplier));
@@ -1339,17 +1353,17 @@ public class Observable<T> {
         }, collector);
     }
 
-    public final <R> Observable<R> compose(Function<? super Observable<T>, ? extends Observable<R>> convert) {
-        return to(convert);
+    public final <R> Observable<R> compose(Function<? super Observable<T>, ? extends ConsumableObservable<R>> convert) {
+        return wrap(to(convert));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends Observable<? extends R>> mapper) {
+    public final <R> Observable<R> concatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper) {
         return concatMap(mapper, 2);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends Observable<? extends R>> mapper, int prefetch) {
+    public final <R> Observable<R> concatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (prefetch <= 0) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
@@ -1379,7 +1393,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> concatWith(Observable<? extends T> other) {
+    public final Observable<T> concatWith(ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concat(this, other);
     }
@@ -1401,7 +1415,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> debounce(Function<? super T, ? extends Observable<U>> debounceSelector) {
+    public final <U> Observable<T> debounce(Function<? super T, ? extends ConsumableObservable<U>> debounceSelector) {
         Objects.requireNonNull(debounceSelector, "debounceSelector is null");
         return lift(new NbpOperatorDebounce<T, U>(debounceSelector));
     }
@@ -1427,12 +1441,12 @@ public class Observable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     // TODO a more efficient implementation if necessary
-    public final <U> Observable<T> delay(final Function<? super T, ? extends Observable<U>> itemDelay) {
+    public final <U> Observable<T> delay(final Function<? super T, ? extends ConsumableObservable<U>> itemDelay) {
         Objects.requireNonNull(itemDelay, "itemDelay is null");
         return flatMap(new Function<T, Observable<T>>() {
             @Override
             public Observable<T> apply(final T v) {
-                return itemDelay.apply(v).take(1).map(new Function<U, T>() {
+                return wrap(itemDelay.apply(v)).take(1).map(new Function<U, T>() {
                     @Override
                     public T apply(U u) {
                         return v;
@@ -1466,7 +1480,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, V> Observable<T> delay(Supplier<? extends Observable<U>> delaySupplier,
+    public final <U, V> Observable<T> delay(Supplier<? extends ConsumableObservable<U>> delaySupplier,
             Function<? super T, ? extends Observable<V>> itemDelay) {
         return delaySubscription(delaySupplier).delay(itemDelay);
     }
@@ -1490,7 +1504,7 @@ public class Observable<T> {
      *         until the other Observable emits an element or completes normally.
      */
     @Experimental
-    public final <U> Observable<T> delaySubscription(Observable<U> other) {
+    public final <U> Observable<T> delaySubscription(ConsumableObservable<U> other) {
         Objects.requireNonNull(other, "other is null");
         return create(new NbpOnSubscribeDelaySubscriptionOther<T, U>(this, other));
     }
@@ -1516,11 +1530,11 @@ public class Observable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> delaySubscription(final Supplier<? extends Observable<U>> delaySupplier) {
+    public final <U> Observable<T> delaySubscription(final Supplier<? extends ConsumableObservable<U>> delaySupplier) {
         Objects.requireNonNull(delaySupplier, "delaySupplier is null");
-        return fromCallable(new Callable<Observable<U>>() {
+        return fromCallable(new Callable<ConsumableObservable<U>>() {
             @Override
-            public Observable<U> call() throws Exception {
+            public ConsumableObservable<U> call() throws Exception {
                 return delaySupplier.get();
             }
         })
@@ -1710,7 +1724,7 @@ public class Observable<T> {
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> endWith(Observable<? extends T> other) {
+    public final Observable<T> endWith(ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(this, other);
     }
@@ -1753,22 +1767,22 @@ public class Observable<T> {
         return take(1).single(defaultValue);
     }
 
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper) {
         return flatMap(mapper, false);
     }
 
 
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, boolean delayError) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, boolean delayError) {
         return flatMap(mapper, delayError, Integer.MAX_VALUE);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, delayErrors, maxConcurrency, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, 
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, 
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (maxConcurrency <= 0) {
@@ -1784,9 +1798,9 @@ public class Observable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <R> Observable<R> flatMap(
-            Function<? super T, ? extends Observable<? extends R>> onNextMapper, 
-            Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper, 
-            Supplier<? extends Observable<? extends R>> onCompleteSupplier) {
+            Function<? super T, ? extends ConsumableObservable<? extends R>> onNextMapper, 
+            Function<? super Throwable, ? extends ConsumableObservable<? extends R>> onErrorMapper, 
+            Supplier<? extends ConsumableObservable<? extends R>> onCompleteSupplier) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
@@ -1795,9 +1809,9 @@ public class Observable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <R> Observable<R> flatMap(
-            Function<? super T, ? extends Observable<? extends R>> onNextMapper, 
-            Function<Throwable, ? extends Observable<? extends R>> onErrorMapper, 
-            Supplier<? extends Observable<? extends R>> onCompleteSupplier, 
+            Function<? super T, ? extends ConsumableObservable<? extends R>> onNextMapper, 
+            Function<Throwable, ? extends ConsumableObservable<? extends R>> onErrorMapper, 
+            Supplier<? extends ConsumableObservable<? extends R>> onCompleteSupplier, 
             int maxConcurrency) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
@@ -1806,27 +1820,27 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, int maxConcurrency) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, int maxConcurrency) {
         return flatMap(mapper, false, maxConcurrency, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> resultSelector) {
         return flatMap(mapper, resultSelector, false, bufferSize(), bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError) {
         return flatMap(mapper, combiner, delayError, bufferSize(), bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency) {
         return flatMap(mapper, combiner, delayError, maxConcurrency, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends Observable<? extends U>> mapper, final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
+    public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(combiner, "combiner is null");
         return flatMap(new Function<T, Observable<R>>() {
@@ -1845,7 +1859,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
         return flatMap(mapper, combiner, false, maxConcurrency, bufferSize());
     }
 
@@ -2037,7 +2051,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> mergeWith(Observable<? extends T> other) {
+    public final Observable<T> mergeWith(ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
@@ -2077,7 +2091,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends Observable<? extends T>> resumeFunction) {
+    public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends ConsumableObservable<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
         return lift(new NbpOperatorOnErrorNext<T>(resumeFunction, false));
     }
@@ -2112,11 +2126,11 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> onExceptionResumeNext(final Observable<? extends T> next) {
+    public final Observable<T> onExceptionResumeNext(final ConsumableObservable<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
-        return lift(new NbpOperatorOnErrorNext<T>(new Function<Throwable, Observable<? extends T>>() {
+        return lift(new NbpOperatorOnErrorNext<T>(new Function<Throwable, ConsumableObservable<? extends T>>() {
             @Override
-            public Observable<? extends T> apply(Throwable e) {
+            public ConsumableObservable<? extends T> apply(Throwable e) {
                 return next;
             }
         }, true));
@@ -2128,12 +2142,12 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends Observable<R>> selector) {
+    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector) {
         return publish(selector, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends Observable<R>> selector, int bufferSize) {
+    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, int bufferSize) {
         validateBufferSize(bufferSize);
         Objects.requireNonNull(selector, "selector is null");
         return NbpOperatorPublish.create(this, selector, bufferSize);
@@ -2184,12 +2198,12 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends Observable<?>> handler) {
+    public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends ConsumableObservable<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
         
-        Function<Observable<Try<Optional<Object>>>, Observable<?>> f = new Function<Observable<Try<Optional<Object>>>, Observable<?>>() {
+        Function<Observable<Try<Optional<Object>>>, ConsumableObservable<?>> f = new Function<Observable<Try<Optional<Object>>>, ConsumableObservable<?>>() {
             @Override
-            public Observable<?> apply(Observable<Try<Optional<Object>>> no) {
+            public ConsumableObservable<?> apply(Observable<Try<Optional<Object>>> no) {
                 return handler.apply(no.map(new Function<Try<Optional<Object>>, Object>() {
                     @Override
                     public Object apply(Try<Optional<Object>> v) {
@@ -2209,7 +2223,7 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
             @Override
@@ -2220,7 +2234,7 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, final int bufferSize) {
         Objects.requireNonNull(selector, "selector is null");
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
             @Override
@@ -2231,12 +2245,12 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.COMPUTATION)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, int bufferSize, long time, TimeUnit unit) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, int bufferSize, long time, TimeUnit unit) {
         return replay(selector, bufferSize, time, unit, Schedulers.computation());
     }
     
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
@@ -2250,7 +2264,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, final int bufferSize, final Scheduler scheduler) {
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
             @Override
             public ConnectableObservable<T> get() {
@@ -2260,18 +2274,18 @@ public class Observable<T> {
         new Function<Observable<T>, Observable<R>>() {
             @Override
             public Observable<R> apply(Observable<T> t) {
-                return selector.apply(t).observeOn(scheduler);
+                return wrap(selector.apply(t)).observeOn(scheduler);
             }
         });
     }
 
     @SchedulerSupport(SchedulerKind.COMPUTATION)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, long time, TimeUnit unit) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, long time, TimeUnit unit) {
         return replay(selector, time, unit, Schedulers.computation());
     }
     
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -2284,7 +2298,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends Observable<R>> selector, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, final Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
@@ -2296,7 +2310,7 @@ public class Observable<T> {
         new Function<Observable<T>, Observable<R>>() {
             @Override
             public Observable<R> apply(Observable<T> t) {
-                return selector.apply(t).observeOn(scheduler);
+                return wrap(selector.apply(t)).observeOn(scheduler);
             }
         });
     }
@@ -2390,12 +2404,12 @@ public class Observable<T> {
     
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> retryWhen(
-            final Function<? super Observable<? extends Throwable>, ? extends Observable<?>> handler) {
+            final Function<? super Observable<? extends Throwable>, ? extends ConsumableObservable<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
         
-        Function<Observable<Try<Optional<Object>>>, Observable<?>> f = new Function<Observable<Try<Optional<Object>>>, Observable<?>>() {
+        Function<Observable<Try<Optional<Object>>>, ConsumableObservable<?>> f = new Function<Observable<Try<Optional<Object>>>, ConsumableObservable<?>>() {
             @Override
-            public Observable<?> apply(Observable<Try<Optional<Object>>> no) {
+            public ConsumableObservable<?> apply(Observable<Try<Optional<Object>>> no) {
                 return handler.apply(no
                         .takeWhile(new Predicate<Try<Optional<Object>>>() {
                             @Override
@@ -2441,7 +2455,7 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> sample(Observable<U> sampler) {
+    public final <U> Observable<T> sample(ConsumableObservable<U> sampler) {
         Objects.requireNonNull(sampler, "sampler is null");
         return lift(new NbpOperatorSampleWithObservable<T>(sampler));
     }
@@ -2557,7 +2571,7 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> skipUntil(Observable<U> other) {
+    public final <U> Observable<T> skipUntil(ConsumableObservable<U> other) {
         Objects.requireNonNull(other, "other is null");
         return lift(new NbpOperatorSkipUntil<T, U>(other));
     }
@@ -2576,7 +2590,7 @@ public class Observable<T> {
     
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> startWith(Observable<? extends T> other) {
+    public final Observable<T> startWith(ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
@@ -2634,8 +2648,10 @@ public class Observable<T> {
         return ls;
     }
 
+    @Override
     public final void subscribe(Observer<? super T> subscriber) {
         Objects.requireNonNull(subscriber, "subscriber is null");
+        // TODO plugin
         onSubscribe.accept(subscriber);
     }
 
@@ -2646,18 +2662,18 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> switchIfEmpty(Observable<? extends T> other) {
+    public final Observable<T> switchIfEmpty(ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return lift(new NbpOperatorSwitchIfEmpty<T>(other));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> switchMap(Function<? super T, ? extends Observable<? extends R>> mapper) {
+    public final <R> Observable<R> switchMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper) {
         return switchMap(mapper, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> switchMap(Function<? super T, ? extends Observable<? extends R>> mapper, int bufferSize) {
+    public final <R> Observable<R> switchMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         validateBufferSize(bufferSize);
         return lift(new NbpOperatorSwitchMap<T, R>(mapper, bufferSize));
@@ -2773,7 +2789,7 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> takeUntil(Observable<U> other) {
+    public final <U> Observable<T> takeUntil(ConsumableObservable<U> other) {
         Objects.requireNonNull(other, "other is null");
         return lift(new NbpOperatorTakeUntil<T, U>(other));
     }
@@ -2845,12 +2861,12 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends Observable<V>> timeoutSelector) {
+    public final <V> Observable<T> timeout(Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector) {
         return timeout0(null, timeoutSelector, null);
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends Observable<V>> timeoutSelector, Observable<? extends T> other) {
+    public final <V> Observable<T> timeout(Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector, ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(null, timeoutSelector, other);
     }
@@ -2861,13 +2877,13 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.COMPUTATION)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Observable<? extends T> other) {
+    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, Schedulers.computation());
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Observable<? extends T> other, Scheduler scheduler) {
+    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ConsumableObservable<? extends T> other, Scheduler scheduler) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
@@ -2877,23 +2893,23 @@ public class Observable<T> {
         return timeout0(timeout, timeUnit, null, scheduler);
     }
     
-    public final <U, V> Observable<T> timeout(Supplier<? extends Observable<U>> firstTimeoutSelector, 
-            Function<? super T, ? extends Observable<V>> timeoutSelector) {
+    public final <U, V> Observable<T> timeout(Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector, 
+            Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector) {
         Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, null);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<T> timeout(
-            Supplier<? extends Observable<U>> firstTimeoutSelector, 
-            Function<? super T, ? extends Observable<V>> timeoutSelector, 
-                    Observable<? extends T> other) {
+            Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector, 
+            Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector, 
+                    ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
         Objects.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, other);
     }
     
-    private Observable<T> timeout0(long timeout, TimeUnit timeUnit, Observable<? extends T> other, 
+    private Observable<T> timeout0(long timeout, TimeUnit timeUnit, ConsumableObservable<? extends T> other, 
             Scheduler scheduler) {
         Objects.requireNonNull(timeUnit, "timeUnit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -2901,9 +2917,9 @@ public class Observable<T> {
     }
 
     private <U, V> Observable<T> timeout0(
-            Supplier<? extends Observable<U>> firstTimeoutSelector, 
-            Function<? super T, ? extends Observable<V>> timeoutSelector, 
-                    Observable<? extends T> other) {
+            Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector, 
+            Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector, 
+                    ConsumableObservable<? extends T> other) {
         Objects.requireNonNull(timeoutSelector, "timeoutSelector is null");
         return lift(new NbpOperatorTimeout<T, U, V>(firstTimeoutSelector, timeoutSelector, other));
     }
@@ -3325,45 +3341,45 @@ public class Observable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Observable<B> boundary) {
+    public final <B> Observable<Observable<T>> window(ConsumableObservable<B> boundary) {
         return window(boundary, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Observable<B> boundary, int bufferSize) {
+    public final <B> Observable<Observable<T>> window(ConsumableObservable<B> boundary, int bufferSize) {
         Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundary<T, B>(boundary, bufferSize));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<Observable<T>> window(
-            Observable<U> windowOpen, 
-            Function<? super U, ? extends Observable<V>> windowClose) {
+            ConsumableObservable<U> windowOpen, 
+            Function<? super U, ? extends ConsumableObservable<V>> windowClose) {
         return window(windowOpen, windowClose, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<Observable<T>> window(
-            Observable<U> windowOpen, 
-            Function<? super U, ? extends Observable<V>> windowClose, int bufferSize) {
+            ConsumableObservable<U> windowOpen, 
+            Function<? super U, ? extends ConsumableObservable<V>> windowClose, int bufferSize) {
         Objects.requireNonNull(windowOpen, "windowOpen is null");
         Objects.requireNonNull(windowClose, "windowClose is null");
         return lift(new NbpOperatorWindowBoundarySelector<T, U, V>(windowOpen, windowClose, bufferSize));
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Supplier<? extends Observable<B>> boundary) {
+    public final <B> Observable<Observable<T>> window(Supplier<? extends ConsumableObservable<B>> boundary) {
         return window(boundary, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Supplier<? extends Observable<B>> boundary, int bufferSize) {
+    public final <B> Observable<Observable<T>> window(Supplier<? extends ConsumableObservable<B>> boundary, int bufferSize) {
         Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundarySupplier<T, B>(boundary, bufferSize));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> withLatestFrom(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
+    public final <U, R> Observable<R> withLatestFrom(ConsumableObservable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(combiner, "combiner is null");
 
@@ -3378,18 +3394,18 @@ public class Observable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> zipWith(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+    public final <U, R> Observable<R> zipWith(ConsumableObservable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> zipWith(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
+    public final <U, R> Observable<R> zipWith(ConsumableObservable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
         return zip(this, other, zipper, delayError);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> zipWith(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
+    public final <U, R> Observable<R> zipWith(ConsumableObservable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zip(this, other, zipper, delayError, bufferSize);
     }
 

--- a/src/main/java/io/reactivex/SingleSubscriber.java
+++ b/src/main/java/io/reactivex/SingleSubscriber.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A SingleSubscriber represents a consumer of exactly one value or exactly one exception
+ * while allowing synchronous cancellation via a shared Disposable instance between it
+ * and the ConsumableSingle producer.
+ *
+ * @param <T> the value type
+ */
+public interface SingleSubscriber<T> {
+    
+    /**
+     * Invoked by the ConsumableSingle after the SingleSubscriber has been subscribed 
+     * to it via ConsumableSingle.subscribe() method and receives an Disposable instance 
+     * that can be used for cancelling the subscription.
+     * @param d The IDisposable instance used for cancelling the subscription to the ConsumableSingle.
+     */
+    void onSubscribe(Disposable d);
+
+    /**
+     * Invoked by the ConsumableSingle when it produced the exactly one element.
+     * <p>
+     * The call to this method is mutually exclusive with onError.
+     * 
+     * @param value The element produced by the source Single.
+     */
+    void onSuccess(T value);
+
+    /**
+     * Invoked by the ConsumableSingle when it produced the exaclty one Exception.
+     * <p>
+     * The call to this method is mutually exclusive with onSuccess.
+     * 
+     * @param e The Exception produced by the source ConsumableSingle
+     */
+    void onError(Throwable e);
+}

--- a/src/main/java/io/reactivex/flowables/BlockingFlowable.java
+++ b/src/main/java/io/reactivex/flowables/BlockingFlowable.java
@@ -29,7 +29,7 @@ import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.subscribers.flowable.*;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public final class BlockingFlowable<T> implements Publisher<T>, Iterable<T> {
     final Publisher<? extends T> o;
@@ -544,7 +544,7 @@ public final class BlockingFlowable<T> implements Publisher<T>, Iterable<T> {
      * @param onComplete the callback action for the completion event.
      */
     public void subscribe(final Consumer<? super T> onNext, final Consumer<? super Throwable> onError, final Runnable onComplete) {
-        subscribe(new DefaultObserver<T>() {
+        subscribe(new DefaultSubscriber<T>() {
             @Override
             public void onNext(T t) {
                 onNext.accept(t);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeConcat.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeConcat.java
@@ -27,10 +27,10 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableOnSubscribeConcat implements CompletableOnSubscribe {
-    final Flowable<? extends Completable> sources;
+    final Flowable<? extends ConsumableCompletable> sources;
     final int prefetch;
     
-    public CompletableOnSubscribeConcat(Flowable<? extends Completable> sources, int prefetch) {
+    public CompletableOnSubscribeConcat(Flowable<? extends ConsumableCompletable> sources, int prefetch) {
         this.sources = sources;
         this.prefetch = prefetch;
     }
@@ -43,14 +43,14 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
     
     static final class CompletableConcatSubscriber
     extends AtomicInteger
-    implements Subscriber<Completable>, Disposable {
+    implements Subscriber<ConsumableCompletable>, Disposable {
         /** */
         private static final long serialVersionUID = 7412667182931235013L;
         final CompletableSubscriber actual;
         final int prefetch;
         final SerialResource<Disposable> sr;
         
-        final SpscArrayQueue<Completable> queue;
+        final SpscArrayQueue<ConsumableCompletable> queue;
         
         Subscription s;
         
@@ -63,7 +63,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
         public CompletableConcatSubscriber(CompletableSubscriber actual, int prefetch) {
             this.actual = actual;
             this.prefetch = prefetch;
-            this.queue = new SpscArrayQueue<Completable>(prefetch);
+            this.queue = new SpscArrayQueue<ConsumableCompletable>(prefetch);
             this.sr = new SerialResource<Disposable>(Disposables.consumeAndDispose());
             this.inner = new ConcatInnerSubscriber();
         }
@@ -79,7 +79,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
         }
         
         @Override
-        public void onNext(Completable t) {
+        public void onNext(ConsumableCompletable t) {
             if (!queue.offer(t)) {
                 onError(new MissingBackpressureException());
                 return;
@@ -131,7 +131,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
         
         void next() {
             boolean d = done;
-            Completable c = queue.poll();
+            ConsumableCompletable c = queue.poll();
             if (c == null) {
                 if (d) {
                     if (once.compareAndSet(false, true)) {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeConcatArray.java
@@ -15,14 +15,14 @@ package io.reactivex.internal.operators.completable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Completable;
+import io.reactivex.*;
 import io.reactivex.Completable.*;
 import io.reactivex.disposables.*;
 
 public final class CompletableOnSubscribeConcatArray implements CompletableOnSubscribe {
-    final Completable[] sources;
+    final ConsumableCompletable[] sources;
     
-    public CompletableOnSubscribeConcatArray(Completable[] sources) {
+    public CompletableOnSubscribeConcatArray(ConsumableCompletable[] sources) {
         this.sources = sources;
     }
     
@@ -38,13 +38,13 @@ public final class CompletableOnSubscribeConcatArray implements CompletableOnSub
         private static final long serialVersionUID = -7965400327305809232L;
 
         final CompletableSubscriber actual;
-        final Completable[] sources;
+        final ConsumableCompletable[] sources;
         
         int index;
         
         final SerialDisposable sd;
         
-        public ConcatInnerSubscriber(CompletableSubscriber actual, Completable[] sources) {
+        public ConcatInnerSubscriber(CompletableSubscriber actual, ConsumableCompletable[] sources) {
             this.actual = actual;
             this.sources = sources;
             this.sd = new SerialDisposable();
@@ -74,7 +74,7 @@ public final class CompletableOnSubscribeConcatArray implements CompletableOnSub
                 return;
             }
 
-            Completable[] a = sources;
+            ConsumableCompletable[] a = sources;
             do {
                 if (sd.isDisposed()) {
                     return;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeConcatIterable.java
@@ -16,22 +16,22 @@ package io.reactivex.internal.operators.completable;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Completable;
+import io.reactivex.*;
 import io.reactivex.Completable.*;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class CompletableOnSubscribeConcatIterable implements CompletableOnSubscribe {
-    final Iterable<? extends Completable> sources;
+    final Iterable<? extends ConsumableCompletable> sources;
     
-    public CompletableOnSubscribeConcatIterable(Iterable<? extends Completable> sources) {
+    public CompletableOnSubscribeConcatIterable(Iterable<? extends ConsumableCompletable> sources) {
         this.sources = sources;
     }
     
     @Override
     public void accept(CompletableSubscriber s) {
         
-        Iterator<? extends Completable> it;
+        Iterator<? extends ConsumableCompletable> it;
         
         try {
             it = sources.iterator();
@@ -57,13 +57,13 @@ public final class CompletableOnSubscribeConcatIterable implements CompletableOn
         private static final long serialVersionUID = -7965400327305809232L;
 
         final CompletableSubscriber actual;
-        final Iterator<? extends Completable> sources;
+        final Iterator<? extends ConsumableCompletable> sources;
         
         int index;
         
         final SerialDisposable sd;
         
-        public ConcatInnerSubscriber(CompletableSubscriber actual, Iterator<? extends Completable> sources) {
+        public ConcatInnerSubscriber(CompletableSubscriber actual, Iterator<? extends ConsumableCompletable> sources) {
             this.actual = actual;
             this.sources = sources;
             this.sd = new SerialDisposable();
@@ -93,7 +93,7 @@ public final class CompletableOnSubscribeConcatIterable implements CompletableOn
                 return;
             }
 
-            Iterator<? extends Completable> a = sources;
+            Iterator<? extends ConsumableCompletable> a = sources;
             do {
                 if (sd.isDisposed()) {
                     return;
@@ -112,7 +112,7 @@ public final class CompletableOnSubscribeConcatIterable implements CompletableOn
                     return;
                 }
                 
-                Completable c;
+                ConsumableCompletable c;
                 
                 try {
                     c = a.next();

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMerge.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMerge.java
@@ -28,11 +28,11 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe {
-    final Flowable<? extends Completable> source;
+    final Publisher<? extends ConsumableCompletable> source;
     final int maxConcurrency;
     final boolean delayErrors;
     
-    public CompletableOnSubscribeMerge(Flowable<? extends Completable> source, int maxConcurrency, boolean delayErrors) {
+    public CompletableOnSubscribeMerge(Publisher<? extends ConsumableCompletable> source, int maxConcurrency, boolean delayErrors) {
         this.source = source;
         this.maxConcurrency = maxConcurrency;
         this.delayErrors = delayErrors;
@@ -46,7 +46,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
     
     static final class CompletableMergeSubscriber
     extends AtomicInteger
-    implements Subscriber<Completable>, Disposable {
+    implements Subscriber<ConsumableCompletable>, Disposable {
         /** */
         private static final long serialVersionUID = -2108443387387077490L;
         
@@ -107,7 +107,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
         }
 
         @Override
-        public void onNext(Completable t) {
+        public void onNext(ConsumableCompletable t) {
             if (done) {
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeArray.java
@@ -15,15 +15,15 @@ package io.reactivex.internal.operators.completable;
 
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.Completable;
+import io.reactivex.*;
 import io.reactivex.Completable.*;
 import io.reactivex.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableOnSubscribeMergeArray implements CompletableOnSubscribe {
-    final Completable[] sources;
+    final ConsumableCompletable[] sources;
     
-    public CompletableOnSubscribeMergeArray(Completable[] sources) {
+    public CompletableOnSubscribeMergeArray(ConsumableCompletable[] sources) {
         this.sources = sources;
     }
     
@@ -35,7 +35,7 @@ public final class CompletableOnSubscribeMergeArray implements CompletableOnSubs
         
         s.onSubscribe(set);
         
-        for (Completable c : sources) {
+        for (ConsumableCompletable c : sources) {
             if (set.isDisposed()) {
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeDelayErrorArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeDelayErrorArray.java
@@ -17,14 +17,14 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Completable;
+import io.reactivex.*;
 import io.reactivex.Completable.*;
 import io.reactivex.disposables.*;
 
 public final class CompletableOnSubscribeMergeDelayErrorArray implements CompletableOnSubscribe {
-    final Completable[] sources;
+    final ConsumableCompletable[] sources;
     
-    public CompletableOnSubscribeMergeDelayErrorArray(Completable[] sources) {
+    public CompletableOnSubscribeMergeDelayErrorArray(ConsumableCompletable[] sources) {
         this.sources = sources;
     }
     
@@ -37,7 +37,7 @@ public final class CompletableOnSubscribeMergeDelayErrorArray implements Complet
         
         s.onSubscribe(set);
         
-        for (Completable c : sources) {
+        for (ConsumableCompletable c : sources) {
             if (set.isDisposed()) {
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeDelayErrorIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeDelayErrorIterable.java
@@ -16,15 +16,15 @@ package io.reactivex.internal.operators.completable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Completable;
+import io.reactivex.*;
 import io.reactivex.Completable.*;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 
 public final class CompletableOnSubscribeMergeDelayErrorIterable implements CompletableOnSubscribe {
-    final Iterable<? extends Completable> sources;
+    final Iterable<? extends ConsumableCompletable> sources;
     
-    public CompletableOnSubscribeMergeDelayErrorIterable(Iterable<? extends Completable> sources) {
+    public CompletableOnSubscribeMergeDelayErrorIterable(Iterable<? extends ConsumableCompletable> sources) {
         this.sources = sources;
     }
     
@@ -37,7 +37,7 @@ public final class CompletableOnSubscribeMergeDelayErrorIterable implements Comp
         
         s.onSubscribe(set);
         
-        Iterator<? extends Completable> iterator;
+        Iterator<? extends ConsumableCompletable> iterator;
         
         try {
             iterator = sources.iterator();
@@ -79,7 +79,7 @@ public final class CompletableOnSubscribeMergeDelayErrorIterable implements Comp
                 return;
             }
             
-            Completable c;
+            ConsumableCompletable c;
             
             try {
                 c = iterator.next();

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeMergeIterable.java
@@ -16,15 +16,15 @@ package io.reactivex.internal.operators.completable;
 import java.util.Iterator;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.Completable;
+import io.reactivex.*;
 import io.reactivex.Completable.*;
 import io.reactivex.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableOnSubscribeMergeIterable implements CompletableOnSubscribe {
-    final Iterable<? extends Completable> sources;
+    final Iterable<? extends ConsumableCompletable> sources;
     
-    public CompletableOnSubscribeMergeIterable(Iterable<? extends Completable> sources) {
+    public CompletableOnSubscribeMergeIterable(Iterable<? extends ConsumableCompletable> sources) {
         this.sources = sources;
     }
     
@@ -36,7 +36,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
         
         s.onSubscribe(set);
         
-        Iterator<? extends Completable> iterator;
+        Iterator<? extends ConsumableCompletable> iterator;
         
         try {
             iterator = sources.iterator();
@@ -76,7 +76,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
                 return;
             }
             
-            Completable c;
+            ConsumableCompletable c;
             
             try {
                 c = iterator.next();

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnSubscribeTimeout.java
@@ -27,10 +27,10 @@ public final class CompletableOnSubscribeTimeout implements CompletableOnSubscri
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;
-    final Completable other;
+    final ConsumableCompletable other;
 
     public CompletableOnSubscribeTimeout(Completable source, long timeout, 
-            TimeUnit unit, Scheduler scheduler, Completable other) {
+            TimeUnit unit, Scheduler scheduler, ConsumableCompletable other) {
         this.source = source;
         this.timeout = timeout;
         this.unit = unit;

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingOperatorMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingOperatorMostRecent.java
@@ -18,7 +18,7 @@ import java.util.*;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.internal.util.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 /**
  * Returns an Iterable that always returns the item most recently emitted by an Observable, or a
@@ -57,7 +57,7 @@ public enum BlockingOperatorMostRecent {
         };
     }
 
-    private static final class MostRecentObserver<T> extends DefaultObserver<T> {
+    private static final class MostRecentObserver<T> extends DefaultSubscriber<T> {
         volatile Object value;
         
         private MostRecentObserver(T value) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpObservableScalarSource.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpObservableScalarSource.java
@@ -39,11 +39,11 @@ public final class NbpObservableScalarSource<T> extends Observable<T> {
         return value;
     }
     
-    public <U> NbpOnSubscribe<U> scalarFlatMap(final Function<? super T, ? extends Observable<? extends U>> mapper) {
+    public <U> NbpOnSubscribe<U> scalarFlatMap(final Function<? super T, ? extends ConsumableObservable<? extends U>> mapper) {
         return new NbpOnSubscribe<U>() {
             @Override
             public void accept(Observer<? super U> s) {
-                Observable<? extends U> other;
+                ConsumableObservable<? extends U> other;
                 try {
                     other = mapper.apply(value);
                 } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeAmb.java
@@ -16,17 +16,17 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.Observable.*;
+import io.reactivex.Observable.NbpOnSubscribe;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeAmb<T> implements NbpOnSubscribe<T> {
-    final Observable<? extends T>[] sources;
-    final Iterable<? extends Observable<? extends T>> sourcesIterable;
+    final ConsumableObservable<? extends T>[] sources;
+    final Iterable<? extends ConsumableObservable<? extends T>> sourcesIterable;
     
-    public NbpOnSubscribeAmb(Observable<? extends T>[] sources, Iterable<? extends Observable<? extends T>> sourcesIterable) {
+    public NbpOnSubscribeAmb(ConsumableObservable<? extends T>[] sources, Iterable<? extends ConsumableObservable<? extends T>> sourcesIterable) {
         this.sources = sources;
         this.sourcesIterable = sourcesIterable;
     }
@@ -34,13 +34,13 @@ public final class NbpOnSubscribeAmb<T> implements NbpOnSubscribe<T> {
     @Override
     @SuppressWarnings("unchecked")
     public void accept(Observer<? super T> s) {
-        Observable<? extends T>[] sources = this.sources;
+        ConsumableObservable<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
-            sources = new Observable[8];
-            for (Observable<? extends T> p : sourcesIterable) {
+            sources = new ConsumableObservable[8];
+            for (ConsumableObservable<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
-                    Observable<? extends T>[] b = new Observable[count + (count >> 2)];
+                    ConsumableObservable<? extends T>[] b = new ConsumableObservable[count + (count >> 2)];
                     System.arraycopy(sources, 0, b, 0, count);
                     sources = b;
                 }
@@ -55,7 +55,7 @@ public final class NbpOnSubscribeAmb<T> implements NbpOnSubscribe<T> {
             return;
         } else
         if (count == 1) {
-            sources[0].subscribe(s);
+            Observable.wrap(sources[0]).subscribe(s);
             return;
         }
 
@@ -75,7 +75,7 @@ public final class NbpOnSubscribeAmb<T> implements NbpOnSubscribe<T> {
             this.subscribers = new AmbInnerSubscriber[count];
         }
         
-        public void subscribe(Observable<? extends T>[] sources) {
+        public void subscribe(ConsumableObservable<? extends T>[] sources) {
             AmbInnerSubscriber<T>[] as = subscribers;
             int len = as.length;
             for (int i = 0; i < len; i++) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeCombineLatest.java
@@ -16,9 +16,9 @@ package io.reactivex.internal.operators.observable;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.ConsumableObservable;
+import io.reactivex.Observable.NbpOnSubscribe;
 import io.reactivex.Observer;
-import io.reactivex.Observable;
-import io.reactivex.Observable.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Function;
@@ -28,14 +28,14 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeCombineLatest<T, R> implements NbpOnSubscribe<R> {
-    final Observable<? extends T>[] sources;
-    final Iterable<? extends Observable<? extends T>> sourcesIterable;
+    final ConsumableObservable<? extends T>[] sources;
+    final Iterable<? extends ConsumableObservable<? extends T>> sourcesIterable;
     final Function<? super Object[], ? extends R> combiner;
     final int bufferSize;
     final boolean delayError;
     
-    public NbpOnSubscribeCombineLatest(Observable<? extends T>[] sources,
-            Iterable<? extends Observable<? extends T>> sourcesIterable,
+    public NbpOnSubscribeCombineLatest(ConsumableObservable<? extends T>[] sources,
+            Iterable<? extends ConsumableObservable<? extends T>> sourcesIterable,
             Function<? super Object[], ? extends R> combiner, int bufferSize,
             boolean delayError) {
         this.sources = sources;
@@ -49,13 +49,13 @@ public final class NbpOnSubscribeCombineLatest<T, R> implements NbpOnSubscribe<R
     @Override
     @SuppressWarnings("unchecked")
     public void accept(Observer<? super R> s) {
-        Observable<? extends T>[] sources = this.sources;
+        ConsumableObservable<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
-            sources = new Observable[8];
-            for (Observable<? extends T> p : sourcesIterable) {
+            sources = new ConsumableObservable[8];
+            for (ConsumableObservable<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
-                    Observable<? extends T>[] b = new Observable[count + (count >> 2)];
+                    ConsumableObservable<? extends T>[] b = new ConsumableObservable[count + (count >> 2)];
                     System.arraycopy(sources, 0, b, 0, count);
                     sources = b;
                 }
@@ -109,7 +109,7 @@ public final class NbpOnSubscribeCombineLatest<T, R> implements NbpOnSubscribe<R
             this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
         }
         
-        public void subscribe(Observable<? extends T>[] sources) {
+        public void subscribe(ConsumableObservable<? extends T>[] sources) {
             Observer<T>[] as = subscribers;
             int len = as.length;
             for (int i = 0; i < len; i++) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDefer.java
@@ -19,13 +19,13 @@ import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class NbpOnSubscribeDefer<T> implements NbpOnSubscribe<T> {
-    final Supplier<? extends Observable<? extends T>> supplier;
-    public NbpOnSubscribeDefer(Supplier<? extends Observable<? extends T>> supplier) {
+    final Supplier<? extends ConsumableObservable<? extends T>> supplier;
+    public NbpOnSubscribeDefer(Supplier<? extends ConsumableObservable<? extends T>> supplier) {
         this.supplier = supplier;
     }
     @Override
     public void accept(Observer<? super T> s) {
-        Observable<? extends T> pub;
+        ConsumableObservable<? extends T> pub;
         try {
             pub = supplier.get();
         } catch (Throwable t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDelaySubscriptionOther.java
@@ -25,10 +25,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <U> the other value type, ignored
  */
 public final class NbpOnSubscribeDelaySubscriptionOther<T, U> implements NbpOnSubscribe<T> {
-    final Observable<? extends T> main;
-    final Observable<U> other;
+    final ConsumableObservable<? extends T> main;
+    final ConsumableObservable<U> other;
     
-    public NbpOnSubscribeDelaySubscriptionOther(Observable<? extends T> main, Observable<U> other) {
+    public NbpOnSubscribeDelaySubscriptionOther(ConsumableObservable<? extends T> main, ConsumableObservable<U> other) {
         this.main = main;
         this.other = other;
     }
@@ -67,7 +67,7 @@ public final class NbpOnSubscribeDelaySubscriptionOther<T, U> implements NbpOnSu
                 }
                 done = true;
                 
-                main.unsafeSubscribe(new Observer<T>() {
+                main.subscribe(new Observer<T>() {
                     @Override
                     public void onSubscribe(Disposable d) {
                         serial.set(d);
@@ -91,6 +91,6 @@ public final class NbpOnSubscribeDelaySubscriptionOther<T, U> implements NbpOnSu
             }
         };
         
-        other.unsafeSubscribe(otherSubscriber);
+        other.subscribe(otherSubscriber);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeRedo.java
@@ -23,11 +23,11 @@ import io.reactivex.internal.subscribers.observable.NbpToNotificationSubscriber;
 import io.reactivex.subjects.BehaviorSubject;
 
 public final class NbpOnSubscribeRedo<T> implements NbpOnSubscribe<T> {
-    final Observable<? extends T> source;
-    final Function<? super Observable<Try<Optional<Object>>>, ? extends Observable<?>> manager;
+    final ConsumableObservable<? extends T> source;
+    final Function<? super Observable<Try<Optional<Object>>>, ? extends ConsumableObservable<?>> manager;
 
     public NbpOnSubscribeRedo(Observable<? extends T> source,
-            Function<? super Observable<Try<Optional<Object>>>, ? extends Observable<?>> manager) {
+            Function<? super Observable<Try<Optional<Object>>>, ? extends ConsumableObservable<?>> manager) {
         this.source = source;
         this.manager = manager;
     }
@@ -42,7 +42,7 @@ public final class NbpOnSubscribeRedo<T> implements NbpOnSubscribe<T> {
 
         s.onSubscribe(parent.arbiter);
 
-        Observable<?> action = manager.apply(subject);
+        ConsumableObservable<?> action = manager.apply(subject);
         
         action.subscribe(new NbpToNotificationSubscriber<Object>(new Consumer<Try<Optional<Object>>>() {
             @Override
@@ -60,12 +60,12 @@ public final class NbpOnSubscribeRedo<T> implements NbpOnSubscribe<T> {
         private static final long serialVersionUID = -1151903143112844287L;
         final Observer<? super T> actual;
         final BehaviorSubject<Try<Optional<Object>>> subject;
-        final Observable<? extends T> source;
+        final ConsumableObservable<? extends T> source;
         final MultipleAssignmentDisposable arbiter;
         
         final AtomicInteger wip = new AtomicInteger();
         
-        public RedoSubscriber(Observer<? super T> actual, BehaviorSubject<Try<Optional<Object>>> subject, Observable<? extends T> source) {
+        public RedoSubscriber(Observer<? super T> actual, BehaviorSubject<Try<Optional<Object>>> subject, ConsumableObservable<? extends T> source) {
             this.actual = actual;
             this.subject = subject;
             this.source = source;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeSequenceEqual.java
@@ -24,12 +24,12 @@ import io.reactivex.internal.disposables.ArrayCompositeResource;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 
 public final class NbpOnSubscribeSequenceEqual<T> implements NbpOnSubscribe<Boolean> {
-    final Observable<? extends T> first;
-    final Observable<? extends T> second;
+    final ConsumableObservable<? extends T> first;
+    final ConsumableObservable<? extends T> second;
     final BiPredicate<? super T, ? super T> comparer;
     final int bufferSize;
     
-    public NbpOnSubscribeSequenceEqual(Observable<? extends T> first, Observable<? extends T> second,
+    public NbpOnSubscribeSequenceEqual(ConsumableObservable<? extends T> first, ConsumableObservable<? extends T> second,
             BiPredicate<? super T, ? super T> comparer, int bufferSize) {
         this.first = first;
         this.second = second;
@@ -49,14 +49,14 @@ public final class NbpOnSubscribeSequenceEqual<T> implements NbpOnSubscribe<Bool
         final Observer<? super Boolean> actual;
         final BiPredicate<? super T, ? super T> comparer;
         final ArrayCompositeResource<Disposable> resources;
-        final Observable<? extends T> first;
-        final Observable<? extends T> second;
+        final ConsumableObservable<? extends T> first;
+        final ConsumableObservable<? extends T> second;
         final EqualSubscriber<T>[] subscribers;
         
         volatile boolean cancelled;
         
         public EqualCoordinator(Observer<? super Boolean> actual, int bufferSize,
-                Observable<? extends T> first, Observable<? extends T> second,
+                ConsumableObservable<? extends T> first, ConsumableObservable<? extends T> second,
                 BiPredicate<? super T, ? super T> comparer) {
             this.actual = actual;
             this.first = first;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeUsing.java
@@ -26,12 +26,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeUsing<T, D> implements NbpOnSubscribe<T> {
     final Supplier<? extends D> resourceSupplier;
-    final Function<? super D, ? extends Observable<? extends T>> sourceSupplier;
+    final Function<? super D, ? extends ConsumableObservable<? extends T>> sourceSupplier;
     final Consumer<? super D> disposer;
     final boolean eager;
     
     public NbpOnSubscribeUsing(Supplier<? extends D> resourceSupplier,
-            Function<? super D, ? extends Observable<? extends T>> sourceSupplier, 
+            Function<? super D, ? extends ConsumableObservable<? extends T>> sourceSupplier, 
             Consumer<? super D> disposer,
             boolean eager) {
         this.resourceSupplier = resourceSupplier;
@@ -51,7 +51,7 @@ public final class NbpOnSubscribeUsing<T, D> implements NbpOnSubscribe<T> {
             return;
         }
         
-        Observable<? extends T> source;
+        ConsumableObservable<? extends T> source;
         try {
             source = sourceSupplier.apply(resource);
         } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeZip.java
@@ -26,14 +26,14 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeZip<T, R> implements NbpOnSubscribe<R> {
     
-    final Observable<? extends T>[] sources;
-    final Iterable<? extends Observable<? extends T>> sourcesIterable;
+    final ConsumableObservable<? extends T>[] sources;
+    final Iterable<? extends ConsumableObservable<? extends T>> sourcesIterable;
     final Function<? super Object[], ? extends R> zipper;
     final int bufferSize;
     final boolean delayError;
     
-    public NbpOnSubscribeZip(Observable<? extends T>[] sources,
-            Iterable<? extends Observable<? extends T>> sourcesIterable,
+    public NbpOnSubscribeZip(ConsumableObservable<? extends T>[] sources,
+            Iterable<? extends ConsumableObservable<? extends T>> sourcesIterable,
             Function<? super Object[], ? extends R> zipper,
             int bufferSize,
             boolean delayError) {
@@ -47,13 +47,13 @@ public final class NbpOnSubscribeZip<T, R> implements NbpOnSubscribe<R> {
     @Override
     @SuppressWarnings("unchecked")
     public void accept(Observer<? super R> s) {
-        Observable<? extends T>[] sources = this.sources;
+        ConsumableObservable<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
-            sources = new Observable[8];
-            for (Observable<? extends T> p : sourcesIterable) {
+            sources = new ConsumableObservable[8];
+            for (ConsumableObservable<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
-                    Observable<? extends T>[] b = new Observable[count + (count >> 2)];
+                    ConsumableObservable<? extends T>[] b = new ConsumableObservable[count + (count >> 2)];
                     System.arraycopy(sources, 0, b, 0, count);
                     sources = b;
                 }
@@ -94,7 +94,7 @@ public final class NbpOnSubscribeZip<T, R> implements NbpOnSubscribe<R> {
             this.delayError = delayError;
         }
         
-        public void subscribe(Observable<? extends T>[] sources, int bufferSize) {
+        public void subscribe(ConsumableObservable<? extends T>[] sources, int bufferSize) {
             ZipSubscriber<T, R>[] s = subscribers;
             int len = s.length;
             for (int i = 0; i < len; i++) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundary.java
@@ -16,9 +16,9 @@ package io.reactivex.internal.operators.observable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.ConsumableObservable;
+import io.reactivex.Observable.NbpOperator;
 import io.reactivex.Observer;
-import io.reactivex.Observable;
-import io.reactivex.Observable.*;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.SetCompositeResource;
@@ -31,11 +31,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>, Open, Close> implements NbpOperator<U, T> {
     final Supplier<U> bufferSupplier;
-    final Observable<? extends Open> bufferOpen;
-    final Function<? super Open, ? extends Observable<? extends Close>> bufferClose;
+    final ConsumableObservable<? extends Open> bufferOpen;
+    final Function<? super Open, ? extends ConsumableObservable<? extends Close>> bufferClose;
 
-    public NbpOperatorBufferBoundary(Observable<? extends Open> bufferOpen,
-            Function<? super Open, ? extends Observable<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
+    public NbpOperatorBufferBoundary(ConsumableObservable<? extends Open> bufferOpen,
+            Function<? super Open, ? extends ConsumableObservable<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
         this.bufferOpen = bufferOpen;
         this.bufferClose = bufferClose;
         this.bufferSupplier = bufferSupplier;
@@ -51,8 +51,8 @@ public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>,
     
     static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, Open, Close>
     extends NbpQueueDrainSubscriber<T, U, U> implements Disposable {
-        final Observable<? extends Open> bufferOpen;
-        final Function<? super Open, ? extends Observable<? extends Close>> bufferClose;
+        final ConsumableObservable<? extends Open> bufferOpen;
+        final Function<? super Open, ? extends ConsumableObservable<? extends Close>> bufferClose;
         final Supplier<U> bufferSupplier;
         final SetCompositeResource<Disposable> resources;
         
@@ -63,8 +63,8 @@ public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>,
         final AtomicInteger windows = new AtomicInteger();
 
         public BufferBoundarySubscriber(Observer<? super U> actual, 
-                Observable<? extends Open> bufferOpen,
-                Function<? super Open, ? extends Observable<? extends Close>> bufferClose,
+                ConsumableObservable<? extends Open> bufferOpen,
+                Function<? super Open, ? extends ConsumableObservable<? extends Close>> bufferClose,
                 Supplier<U> bufferSupplier) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferOpen = bufferOpen;
@@ -164,7 +164,7 @@ public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>,
                 return;
             }
 
-            Observable<? extends Close> p;
+            ConsumableObservable<? extends Close> p;
             
             try {
                 p = bufferClose.apply(window);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundarySupplier.java
@@ -29,10 +29,10 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? super T>, B> implements NbpOperator<U, T> {
-    final Supplier<? extends Observable<B>> boundarySupplier;
+    final Supplier<? extends ConsumableObservable<B>> boundarySupplier;
     final Supplier<U> bufferSupplier;
     
-    public NbpOperatorBufferBoundarySupplier(Supplier<? extends Observable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
+    public NbpOperatorBufferBoundarySupplier(Supplier<? extends ConsumableObservable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         this.boundarySupplier = boundarySupplier;
         this.bufferSupplier = bufferSupplier;
     }
@@ -46,7 +46,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
     extends NbpQueueDrainSubscriber<T, U, U> implements Observer<T>, Disposable {
         /** */
         final Supplier<U> bufferSupplier;
-        final Supplier<? extends Observable<B>> boundarySupplier;
+        final Supplier<? extends ConsumableObservable<B>> boundarySupplier;
         
         Disposable s;
         
@@ -60,7 +60,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
         U buffer;
         
         public BufferBondarySupplierSubscriber(Observer<? super U> actual, Supplier<U> bufferSupplier,
-                Supplier<? extends Observable<B>> boundarySupplier) {
+                Supplier<? extends ConsumableObservable<B>> boundarySupplier) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
             this.boundarySupplier = boundarySupplier;
@@ -94,7 +94,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
             }
             buffer = b;
             
-            Observable<B> boundary;
+            ConsumableObservable<B> boundary;
             
             try {
                 boundary = boundarySupplier.get();
@@ -199,7 +199,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
                 return;
             }
             
-            Observable<B> boundary;
+            ConsumableObservable<B> boundary;
             
             try {
                 boundary = boundarySupplier.get();

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferExactBoundary.java
@@ -27,10 +27,10 @@ import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorBufferExactBoundary<T, U extends Collection<? super T>, B> implements NbpOperator<U, T> {
-    final Observable<B> boundary;
+    final ConsumableObservable<B> boundary;
     final Supplier<U> bufferSupplier;
     
-    public NbpOperatorBufferExactBoundary(Observable<B> boundary, Supplier<U> bufferSupplier) {
+    public NbpOperatorBufferExactBoundary(ConsumableObservable<B> boundary, Supplier<U> bufferSupplier) {
         this.boundary = boundary;
         this.bufferSupplier = bufferSupplier;
     }
@@ -44,7 +44,7 @@ public final class NbpOperatorBufferExactBoundary<T, U extends Collection<? supe
     extends NbpQueueDrainSubscriber<T, U, U> implements Observer<T>, Disposable {
         /** */
         final Supplier<U> bufferSupplier;
-        final Observable<B> boundary;
+        final ConsumableObservable<B> boundary;
         
         Disposable s;
         
@@ -53,7 +53,7 @@ public final class NbpOperatorBufferExactBoundary<T, U extends Collection<? supe
         U buffer;
         
         public BufferExactBondarySubscriber(Observer<? super U> actual, Supplier<U> bufferSupplier,
-                Observable<B> boundary) {
+                ConsumableObservable<B> boundary) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
             this.boundary = boundary;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorConcatMap.java
@@ -25,9 +25,9 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
-    final Function<? super T, ? extends Observable<? extends U>> mapper;
+    final Function<? super T, ? extends ConsumableObservable<? extends U>> mapper;
     final int bufferSize;
-    public NbpOperatorConcatMap(Function<? super T, ? extends Observable<? extends U>> mapper, int bufferSize) {
+    public NbpOperatorConcatMap(Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, int bufferSize) {
         this.mapper = mapper;
         this.bufferSize = Math.max(8, bufferSize);
     }
@@ -44,7 +44,7 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
         private static final long serialVersionUID = 8828587559905699186L;
         final Observer<? super U> actual;
         final SerialDisposable sa;
-        final Function<? super T, ? extends Observable<? extends U>> mapper;
+        final Function<? super T, ? extends ConsumableObservable<? extends U>> mapper;
         final Observer<U> inner;
         final Queue<T> queue;
         final int bufferSize;
@@ -56,7 +56,7 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
         volatile long index;
         
         public SourceSubscriber(Observer<? super U> actual, SerialDisposable sa,
-                Function<? super T, ? extends Observable<? extends U>> mapper, int bufferSize) {
+                Function<? super T, ? extends ConsumableObservable<? extends U>> mapper, int bufferSize) {
             this.actual = actual;
             this.sa = sa;
             this.mapper = mapper;
@@ -129,7 +129,7 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
                 RxJavaPlugins.onError(new IllegalStateException("Queue is empty?!"));
                 return;
             }
-            Observable<? extends U> p;
+            ConsumableObservable<? extends U> p;
             try {
                 p = mapper.apply(o);
             } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorDebounce.java
@@ -25,9 +25,9 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
-    final Function<? super T, ? extends Observable<U>> debounceSelector;
+    final Function<? super T, ? extends ConsumableObservable<U>> debounceSelector;
 
-    public NbpOperatorDebounce(Function<? super T, ? extends Observable<U>> debounceSelector) {
+    public NbpOperatorDebounce(Function<? super T, ? extends ConsumableObservable<U>> debounceSelector) {
         this.debounceSelector = debounceSelector;
     }
     
@@ -39,7 +39,7 @@ public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
     static final class DebounceSubscriber<T, U> 
     implements Observer<T>, Disposable {
         final Observer<? super T> actual;
-        final Function<? super T, ? extends Observable<U>> debounceSelector;
+        final Function<? super T, ? extends ConsumableObservable<U>> debounceSelector;
         
         volatile boolean gate;
 
@@ -57,7 +57,7 @@ public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
         boolean done;
 
         public DebounceSubscriber(Observer<? super T> actual,
-                Function<? super T, ? extends Observable<U>> debounceSelector) {
+                Function<? super T, ? extends ConsumableObservable<U>> debounceSelector) {
             this.actual = actual;
             this.debounceSelector = debounceSelector;
         }
@@ -86,7 +86,7 @@ public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
                 d.dispose();
             }
             
-            Observable<U> p;
+            ConsumableObservable<U> p;
             
             try {
                 p = debounceSelector.apply(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorFlatMap.java
@@ -16,9 +16,9 @@ package io.reactivex.internal.operators.observable;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.ConsumableObservable;
+import io.reactivex.Observable.NbpOperator;
 import io.reactivex.Observer;
-import io.reactivex.Observable;
-import io.reactivex.Observable.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -27,13 +27,13 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.Pow2;
 
 public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
-    final Function<? super T, ? extends Observable<? extends U>> mapper;
+    final Function<? super T, ? extends ConsumableObservable<? extends U>> mapper;
     final boolean delayErrors;
     final int maxConcurrency;
     final int bufferSize;
     
     public NbpOperatorFlatMap( 
-            Function<? super T, ? extends Observable<? extends U>> mapper,
+            Function<? super T, ? extends ConsumableObservable<? extends U>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         this.mapper = mapper;
         this.delayErrors = delayErrors;
@@ -51,7 +51,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
         private static final long serialVersionUID = -2117620485640801370L;
         
         final Observer<? super U> actual;
-        final Function<? super T, ? extends Observable<? extends U>> mapper;
+        final Function<? super T, ? extends ConsumableObservable<? extends U>> mapper;
         final boolean delayErrors;
         final int maxConcurrency;
         final int bufferSize;
@@ -78,11 +78,11 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
         long lastId;
         int lastIndex;
         
-        Queue<Observable<? extends U>> sources;
+        Queue<ConsumableObservable<? extends U>> sources;
         
         int wip;
         
-        public MergeSubscriber(Observer<? super U> actual, Function<? super T, ? extends Observable<? extends U>> mapper,
+        public MergeSubscriber(Observer<? super U> actual, Function<? super T, ? extends ConsumableObservable<? extends U>> mapper,
                 boolean delayErrors, int maxConcurrency, int bufferSize) {
             this.actual = actual;
             this.mapper = mapper;
@@ -90,7 +90,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
             this.maxConcurrency = maxConcurrency;
             this.bufferSize = bufferSize;
             if (maxConcurrency != Integer.MAX_VALUE) {
-                sources = new ArrayDeque<Observable<? extends U>>(maxConcurrency);
+                sources = new ArrayDeque<ConsumableObservable<? extends U>>(maxConcurrency);
             }
             this.subscribers = new AtomicReference<InnerSubscriber<?, ?>[]>(EMPTY);
         }
@@ -110,7 +110,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
             if (done) {
                 return;
             }
-            Observable<? extends U> p;
+            ConsumableObservable<? extends U> p;
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {
@@ -135,7 +135,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
             }
         }
         
-        void subscribeInner(Observable<? extends U> p) {
+        void subscribeInner(ConsumableObservable<? extends U> p) {
             InnerSubscriber<T, U> inner = new InnerSubscriber<T, U>(this, uniqueId++);
             addInner(inner);
             p.subscribe(inner);
@@ -413,7 +413,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
                 
                 if (innerCompleted) {
                     if (maxConcurrency != Integer.MAX_VALUE) {
-                        Observable<? extends U> p;
+                        ConsumableObservable<? extends U> p;
                         synchronized (this) {
                             p = sources.poll();
                             if (p == null) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorMapNotification.java
@@ -19,31 +19,31 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Observable<? extends R>, T>{
+public final class NbpOperatorMapNotification<T, R> implements NbpOperator<ConsumableObservable<? extends R>, T>{
 
-    final Function<? super T, ? extends Observable<? extends R>> onNextMapper;
-    final Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper;
-    final Supplier<? extends Observable<? extends R>> onCompleteSupplier;
+    final Function<? super T, ? extends ConsumableObservable<? extends R>> onNextMapper;
+    final Function<? super Throwable, ? extends ConsumableObservable<? extends R>> onErrorMapper;
+    final Supplier<? extends ConsumableObservable<? extends R>> onCompleteSupplier;
 
-    public NbpOperatorMapNotification(Function<? super T, ? extends Observable<? extends R>> onNextMapper, 
-            Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper, 
-            Supplier<? extends Observable<? extends R>> onCompleteSupplier) {
+    public NbpOperatorMapNotification(Function<? super T, ? extends ConsumableObservable<? extends R>> onNextMapper, 
+            Function<? super Throwable, ? extends ConsumableObservable<? extends R>> onErrorMapper, 
+            Supplier<? extends ConsumableObservable<? extends R>> onCompleteSupplier) {
         this.onNextMapper = onNextMapper;
         this.onErrorMapper = onErrorMapper;
         this.onCompleteSupplier = onCompleteSupplier;
     }
     
     @Override
-    public Observer<? super T> apply(Observer<? super Observable<? extends R>> t) {
+    public Observer<? super T> apply(Observer<? super ConsumableObservable<? extends R>> t) {
         return new MapNotificationSubscriber<T, R>(t, onNextMapper, onErrorMapper, onCompleteSupplier);
     }
     
     static final class MapNotificationSubscriber<T, R>
     implements Observer<T> {
-        final Observer<? super Observable<? extends R>> actual;
-        final Function<? super T, ? extends Observable<? extends R>> onNextMapper;
-        final Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper;
-        final Supplier<? extends Observable<? extends R>> onCompleteSupplier;
+        final Observer<? super ConsumableObservable<? extends R>> actual;
+        final Function<? super T, ? extends ConsumableObservable<? extends R>> onNextMapper;
+        final Function<? super Throwable, ? extends ConsumableObservable<? extends R>> onErrorMapper;
+        final Supplier<? extends ConsumableObservable<? extends R>> onCompleteSupplier;
         
         Disposable s;
         
@@ -51,10 +51,10 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         volatile boolean done;
 
-        public MapNotificationSubscriber(Observer<? super Observable<? extends R>> actual,
-                Function<? super T, ? extends Observable<? extends R>> onNextMapper,
-                Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper,
-                Supplier<? extends Observable<? extends R>> onCompleteSupplier) {
+        public MapNotificationSubscriber(Observer<? super ConsumableObservable<? extends R>> actual,
+                Function<? super T, ? extends ConsumableObservable<? extends R>> onNextMapper,
+                Function<? super Throwable, ? extends ConsumableObservable<? extends R>> onErrorMapper,
+                Supplier<? extends ConsumableObservable<? extends R>> onCompleteSupplier) {
             this.actual = actual;
             this.onNextMapper = onNextMapper;
             this.onErrorMapper = onErrorMapper;
@@ -72,7 +72,7 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         @Override
         public void onNext(T t) {
-            Observable<? extends R> p;
+            ConsumableObservable<? extends R> p;
             
             try {
                 p = onNextMapper.apply(t);
@@ -91,7 +91,7 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         @Override
         public void onError(Throwable t) {
-            Observable<? extends R> p;
+            ConsumableObservable<? extends R> p;
             
             try {
                 p = onErrorMapper.apply(t);
@@ -111,7 +111,7 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         @Override
         public void onComplete() {
-            Observable<? extends R> p;
+            ConsumableObservable<? extends R> p;
             
             try {
                 p = onCompleteSupplier.get();

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorOnErrorNext.java
@@ -21,10 +21,10 @@ import io.reactivex.functions.Function;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
-    final Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier;
+    final Function<? super Throwable, ? extends ConsumableObservable<? extends T>> nextSupplier;
     final boolean allowFatal;
     
-    public NbpOperatorOnErrorNext(Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier, boolean allowFatal) {
+    public NbpOperatorOnErrorNext(Function<? super Throwable, ? extends ConsumableObservable<? extends T>> nextSupplier, boolean allowFatal) {
         this.nextSupplier = nextSupplier;
         this.allowFatal = allowFatal;
     }
@@ -38,7 +38,7 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
     
     static final class OnErrorNextSubscriber<T> implements Observer<T> {
         final Observer<? super T> actual;
-        final Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier;
+        final Function<? super Throwable, ? extends ConsumableObservable<? extends T>> nextSupplier;
         final boolean allowFatal;
         final MultipleAssignmentDisposable arbiter;
         
@@ -46,7 +46,7 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
         
         boolean done;
         
-        public OnErrorNextSubscriber(Observer<? super T> actual, Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier, boolean allowFatal) {
+        public OnErrorNextSubscriber(Observer<? super T> actual, Function<? super Throwable, ? extends ConsumableObservable<? extends T>> nextSupplier, boolean allowFatal) {
             this.actual = actual;
             this.nextSupplier = nextSupplier;
             this.allowFatal = allowFatal;
@@ -83,7 +83,7 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
                 return;
             }
             
-            Observable<? extends T> p;
+            ConsumableObservable<? extends T> p;
             
             try {
                 p = nextSupplier.apply(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorPublish.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorPublish.java
@@ -31,7 +31,7 @@ import io.reactivex.observables.ConnectableObservable;
  */
 public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
     /** The source observable. */
-    final Observable<? extends T> source;
+    final ConsumableObservable<? extends T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
     final AtomicReference<PublishSubscriber<T>> current;
     
@@ -45,7 +45,7 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
      * @param bufferSize the size of the prefetch buffer
      * @return the connectable observable
      */
-    public static <T> ConnectableObservable<T> create(Observable<? extends T> source, final int bufferSize) {
+    public static <T> ConnectableObservable<T> create(ConsumableObservable<? extends T> source, final int bufferSize) {
         // the current connection to source needs to be shared between the operator and its onSubscribe call
         final AtomicReference<PublishSubscriber<T>> curr = new AtomicReference<PublishSubscriber<T>>();
         NbpOnSubscribe<T> onSubscribe = new NbpOnSubscribe<T>() {
@@ -115,8 +115,8 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
         return new NbpOperatorPublish<T>(onSubscribe, source, curr, bufferSize);
     }
 
-    public static <T, R> Observable<R> create(final Observable<? extends T> source, 
-            final Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize) {
+    public static <T, R> Observable<R> create(final ConsumableObservable<? extends T> source, 
+            final Function<? super Observable<T>, ? extends ConsumableObservable<R>> selector, final int bufferSize) {
         return create(new NbpOnSubscribe<R>() {
             @Override
             public void accept(Observer<? super R> sr) {
@@ -136,7 +136,7 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
         });
     }
 
-    private NbpOperatorPublish(NbpOnSubscribe<T> onSubscribe, Observable<? extends T> source, 
+    private NbpOperatorPublish(NbpOnSubscribe<T> onSubscribe, ConsumableObservable<? extends T> source, 
             final AtomicReference<PublishSubscriber<T>> current, int bufferSize) {
         super(onSubscribe);
         this.source = source;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorReplay.java
@@ -17,9 +17,9 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.Scheduler;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
@@ -55,12 +55,12 @@ public final class NbpOperatorReplay<T> extends ConnectableObservable<T> {
      */
     public static <U, R> Observable<R> multicastSelector(
             final Supplier<? extends ConnectableObservable<U>> connectableFactory,
-            final Function<? super Observable<U>, ? extends Observable<R>> selector) {
+            final Function<? super Observable<U>, ? extends ConsumableObservable<R>> selector) {
         return Observable.create(new NbpOnSubscribe<R>() {
             @Override
             public void accept(Observer<? super R> child) {
                 ConnectableObservable<U> co;
-                Observable<R> observable;
+                ConsumableObservable<R> observable;
                 try {
                     co = connectableFactory.get();
                     observable = selector.apply(co);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSampleWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSampleWithObservable.java
@@ -22,9 +22,9 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorSampleWithObservable<T> implements NbpOperator<T, T> {
-    final Observable<?> other;
+    final ConsumableObservable<?> other;
     
-    public NbpOperatorSampleWithObservable(Observable<?> other) {
+    public NbpOperatorSampleWithObservable(ConsumableObservable<?> other) {
         this.other = other;
     }
     
@@ -40,7 +40,7 @@ public final class NbpOperatorSampleWithObservable<T> implements NbpOperator<T, 
         private static final long serialVersionUID = -3517602651313910099L;
 
         final Observer<? super T> actual;
-        final Observable<?> sampler;
+        final ConsumableObservable<?> sampler;
         
         final AtomicReference<Disposable> other = new AtomicReference<Disposable>();
         
@@ -51,7 +51,7 @@ public final class NbpOperatorSampleWithObservable<T> implements NbpOperator<T, 
         
         Disposable s;
         
-        public SamplePublisherSubscriber(Observer<? super T> actual, Observable<?> other) {
+        public SamplePublisherSubscriber(Observer<? super T> actual, ConsumableObservable<?> other) {
             this.actual = actual;
             this.sampler = other;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSkipUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSkipUntil.java
@@ -23,8 +23,8 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorSkipUntil<T, U> implements NbpOperator<T, T> {
-    final Observable<U> other;
-    public NbpOperatorSkipUntil(Observable<U> other) {
+    final ConsumableObservable<U> other;
+    public NbpOperatorSkipUntil(ConsumableObservable<U> other) {
         this.other = other;
     }
     

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchIfEmpty.java
@@ -18,8 +18,8 @@ import io.reactivex.Observable.*;
 import io.reactivex.disposables.*;
 
 public final class NbpOperatorSwitchIfEmpty<T> implements NbpOperator<T, T> {
-    final Observable<? extends T> other;
-    public NbpOperatorSwitchIfEmpty(Observable<? extends T> other) {
+    final ConsumableObservable<? extends T> other;
+    public NbpOperatorSwitchIfEmpty(ConsumableObservable<? extends T> other) {
         this.other = other;
     }
     
@@ -32,12 +32,12 @@ public final class NbpOperatorSwitchIfEmpty<T> implements NbpOperator<T, T> {
     
     static final class SwitchIfEmptySubscriber<T> implements Observer<T> {
         final Observer<? super T> actual;
-        final Observable<? extends T> other;
+        final ConsumableObservable<? extends T> other;
         final SerialDisposable arbiter;
         
         boolean empty;
         
-        public SwitchIfEmptySubscriber(Observer<? super T> actual, Observable<? extends T> other) {
+        public SwitchIfEmptySubscriber(Observer<? super T> actual, ConsumableObservable<? extends T> other) {
             this.actual = actual;
             this.other = other;
             this.empty = true;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchMap.java
@@ -28,10 +28,10 @@ import io.reactivex.internal.util.Pow2;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
-    final Function<? super T, ? extends Observable<? extends R>> mapper;
+    final Function<? super T, ? extends ConsumableObservable<? extends R>> mapper;
     final int bufferSize;
 
-    public NbpOperatorSwitchMap(Function<? super T, ? extends Observable<? extends R>> mapper, int bufferSize) {
+    public NbpOperatorSwitchMap(Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, int bufferSize) {
         this.mapper = mapper;
         this.bufferSize = bufferSize;
     }
@@ -45,7 +45,7 @@ public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
         /** */
         private static final long serialVersionUID = -3491074160481096299L;
         final Observer<? super R> actual;
-        final Function<? super T, ? extends Observable<? extends R>> mapper;
+        final Function<? super T, ? extends ConsumableObservable<? extends R>> mapper;
         final int bufferSize;
         
         
@@ -66,7 +66,7 @@ public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
         
         volatile long unique;
         
-        public SwitchMapSubscriber(Observer<? super R> actual, Function<? super T, ? extends Observable<? extends R>> mapper, int bufferSize) {
+        public SwitchMapSubscriber(Observer<? super R> actual, Function<? super T, ? extends ConsumableObservable<? extends R>> mapper, int bufferSize) {
             this.actual = actual;
             this.mapper = mapper;
             this.bufferSize = bufferSize;
@@ -91,7 +91,7 @@ public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
                 inner.cancel();
             }
             
-            Observable<? extends R> p;
+            ConsumableObservable<? extends R> p;
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTakeUntil.java
@@ -23,8 +23,8 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorTakeUntil<T, U> implements NbpOperator<T, T> {
-    final Observable<? extends U> other;
-    public NbpOperatorTakeUntil(Observable<? extends U> other) {
+    final ConsumableObservable<? extends U> other;
+    public NbpOperatorTakeUntil(ConsumableObservable<? extends U> other) {
         this.other = other;
     }
     @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeout.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
-import io.reactivex.Observable.*;
+import io.reactivex.Observable.NbpOperator;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
@@ -28,12 +28,12 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
-    final Supplier<? extends Observable<U>> firstTimeoutSelector; 
-    final Function<? super T, ? extends Observable<V>> timeoutSelector; 
-    final Observable<? extends T> other;
+    final Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector; 
+    final Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector; 
+    final ConsumableObservable<? extends T> other;
 
-    public NbpOperatorTimeout(Supplier<? extends Observable<U>> firstTimeoutSelector,
-            Function<? super T, ? extends Observable<V>> timeoutSelector, Observable<? extends T> other) {
+    public NbpOperatorTimeout(Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector,
+            Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector, ConsumableObservable<? extends T> other) {
         this.firstTimeoutSelector = firstTimeoutSelector;
         this.timeoutSelector = timeoutSelector;
         this.other = other;
@@ -51,8 +51,8 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
     
     static final class TimeoutSubscriber<T, U, V> implements Observer<T>, Disposable, OnTimeout {
         final Observer<? super T> actual;
-        final Supplier<? extends Observable<U>> firstTimeoutSelector; 
-        final Function<? super T, ? extends Observable<V>> timeoutSelector; 
+        final Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector; 
+        final Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector; 
 
         Disposable s;
         
@@ -68,8 +68,8 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
         };
 
         public TimeoutSubscriber(Observer<? super T> actual, 
-                Supplier<? extends Observable<U>> firstTimeoutSelector,
-                Function<? super T, ? extends Observable<V>> timeoutSelector) {
+                Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector,
+                Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector) {
             this.actual = actual;
             this.firstTimeoutSelector = firstTimeoutSelector;
             this.timeoutSelector = timeoutSelector;
@@ -84,7 +84,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
             
             Observer<? super T> a = actual;
             
-            Observable<U> p;
+            ConsumableObservable<U> p;
             
             if (firstTimeoutSelector != null) {
                 try {
@@ -124,7 +124,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
                 d.dispose();
             }
             
-            Observable<V> p;
+            ConsumableObservable<V> p;
             
             try {
                 p = timeoutSelector.apply(t);
@@ -228,9 +228,9 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
     
     static final class TimeoutOtherSubscriber<T, U, V> implements Observer<T>, Disposable, OnTimeout {
         final Observer<? super T> actual;
-        final Supplier<? extends Observable<U>> firstTimeoutSelector; 
-        final Function<? super T, ? extends Observable<V>> timeoutSelector;
-        final Observable<? extends T> other;
+        final Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector; 
+        final Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector;
+        final ConsumableObservable<? extends T> other;
         final NbpFullArbiter<T> arbiter;
         
         Disposable s;
@@ -249,8 +249,8 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
         };
 
         public TimeoutOtherSubscriber(Observer<? super T> actual,
-                Supplier<? extends Observable<U>> firstTimeoutSelector,
-                Function<? super T, ? extends Observable<V>> timeoutSelector, Observable<? extends T> other) {
+                Supplier<? extends ConsumableObservable<U>> firstTimeoutSelector,
+                Function<? super T, ? extends ConsumableObservable<V>> timeoutSelector, ConsumableObservable<? extends T> other) {
             this.actual = actual;
             this.firstTimeoutSelector = firstTimeoutSelector;
             this.timeoutSelector = timeoutSelector;
@@ -271,7 +271,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
             Observer<? super T> a = actual;
             
             if (firstTimeoutSelector != null) {
-                Observable<U> p;
+                ConsumableObservable<U> p;
                 
                 try {
                     p = firstTimeoutSelector.get();
@@ -315,7 +315,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
                 d.dispose();
             }
             
-            Observable<V> p;
+            ConsumableObservable<V> p;
             
             try {
                 p = timeoutSelector.apply(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeoutTimed.java
@@ -30,9 +30,9 @@ public final class NbpOperatorTimeoutTimed<T> implements NbpOperator<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;
-    final Observable<? extends T> other;
+    final ConsumableObservable<? extends T> other;
     
-    public NbpOperatorTimeoutTimed(long timeout, TimeUnit unit, Scheduler scheduler, Observable<? extends T> other) {
+    public NbpOperatorTimeoutTimed(long timeout, TimeUnit unit, Scheduler scheduler, ConsumableObservable<? extends T> other) {
         this.timeout = timeout;
         this.unit = unit;
         this.scheduler = scheduler;
@@ -56,7 +56,7 @@ public final class NbpOperatorTimeoutTimed<T> implements NbpOperator<T, T> {
         final long timeout;
         final TimeUnit unit;
         final Scheduler.Worker worker;
-        final Observable<? extends T> other;
+        final ConsumableObservable<? extends T> other;
         
         Disposable s; 
         
@@ -79,7 +79,7 @@ public final class NbpOperatorTimeoutTimed<T> implements NbpOperator<T, T> {
         volatile boolean done;
         
         public TimeoutTimedOtherSubscriber(Observer<? super T> actual, long timeout, TimeUnit unit, Worker worker,
-                Observable<? extends T> other) {
+                ConsumableObservable<? extends T> other) {
             this.actual = actual;
             this.timeout = timeout;
             this.unit = unit;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundary.java
@@ -28,10 +28,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class NbpOperatorWindowBoundary<T, B> implements NbpOperator<Observable<T>, T> {
-    final Observable<B> other;
+    final ConsumableObservable<B> other;
     final int bufferSize;
     
-    public NbpOperatorWindowBoundary(Observable<B> other, int bufferSize) {
+    public NbpOperatorWindowBoundary(ConsumableObservable<B> other, int bufferSize) {
         this.other = other;
         this.bufferSize = bufferSize;
     }
@@ -45,7 +45,7 @@ public final class NbpOperatorWindowBoundary<T, B> implements NbpOperator<Observ
     extends NbpQueueDrainSubscriber<T, Object, Observable<T>> 
     implements Disposable {
         
-        final Observable<B> other;
+        final ConsumableObservable<B> other;
         final int bufferSize;
         
         Disposable s;
@@ -63,7 +63,7 @@ public final class NbpOperatorWindowBoundary<T, B> implements NbpOperator<Observ
         
         final AtomicLong windows = new AtomicLong();
         
-        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, Observable<B> other,
+        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, ConsumableObservable<B> other,
                 int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
             this.other = other;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySelector.java
@@ -16,9 +16,10 @@ package io.reactivex.internal.operators.observable;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.Observer;
+import io.reactivex.ConsumableObservable;
 import io.reactivex.Observable;
-import io.reactivex.Observable.*;
+import io.reactivex.Observable.NbpOperator;
+import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.SetCompositeResource;
@@ -31,11 +32,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOperator<Observable<T>, T> {
-    final Observable<B> open;
-    final Function<? super B, ? extends Observable<V>> close;
+    final ConsumableObservable<B> open;
+    final Function<? super B, ? extends ConsumableObservable<V>> close;
     final int bufferSize;
     
-    public NbpOperatorWindowBoundarySelector(Observable<B> open, Function<? super B, ? extends Observable<V>> close,
+    public NbpOperatorWindowBoundarySelector(ConsumableObservable<B> open, Function<? super B, ? extends ConsumableObservable<V>> close,
             int bufferSize) {
         this.open = open;
         this.close = close;
@@ -52,8 +53,8 @@ public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOper
     static final class WindowBoundaryMainSubscriber<T, B, V>
     extends NbpQueueDrainSubscriber<T, Object, Observable<T>>
     implements Disposable {
-        final Observable<B> open;
-        final Function<? super B, ? extends Observable<V>> close;
+        final ConsumableObservable<B> open;
+        final Function<? super B, ? extends ConsumableObservable<V>> close;
         final int bufferSize;
         final SetCompositeResource<Disposable> resources;
 
@@ -71,7 +72,7 @@ public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOper
         final AtomicLong windows = new AtomicLong();
 
         public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual,
-                Observable<B> open, Function<? super B, ? extends Observable<V>> close, int bufferSize) {
+                ConsumableObservable<B> open, Function<? super B, ? extends ConsumableObservable<V>> close, int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
             this.open = open;
             this.close = close;
@@ -259,7 +260,7 @@ public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOper
                         ws.add(w);
                         a.onNext(w);
                         
-                        Observable<V> p;
+                        ConsumableObservable<V> p;
                         
                         try {
                             p = close.apply(wo.open);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySupplier.java
@@ -29,10 +29,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperator<Observable<T>, T> {
-    final Supplier<? extends Observable<B>> other;
+    final Supplier<? extends ConsumableObservable<B>> other;
     final int bufferSize;
     
-    public NbpOperatorWindowBoundarySupplier(Supplier<? extends Observable<B>> other, int bufferSize) {
+    public NbpOperatorWindowBoundarySupplier(Supplier<? extends ConsumableObservable<B>> other, int bufferSize) {
         this.other = other;
         this.bufferSize = bufferSize;
     }
@@ -46,7 +46,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
     extends NbpQueueDrainSubscriber<T, Object, Observable<T>> 
     implements Disposable {
         
-        final Supplier<? extends Observable<B>> other;
+        final Supplier<? extends ConsumableObservable<B>> other;
         final int bufferSize;
         
         Disposable s;
@@ -64,7 +64,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
         
         final AtomicLong windows = new AtomicLong();
 
-        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, Supplier<? extends Observable<B>> other,
+        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, Supplier<? extends ConsumableObservable<B>> other,
                 int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
             this.other = other;
@@ -86,7 +86,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
                 return;
             }
             
-            Observable<B> p;
+            ConsumableObservable<B> p;
             
             try {
                 p = other.get();
@@ -230,7 +230,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
                             continue;
                         }
                         
-                        Observable<B> p;
+                        ConsumableObservable<B> p;
 
                         try {
                             p = other.get();

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWithLatestFrom.java
@@ -26,8 +26,8 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorWithLatestFrom<T, U, R> implements NbpOperator<R, T> {
     final BiFunction<? super T, ? super U, ? extends R> combiner;
-    final Observable<? extends U> other;
-    public NbpOperatorWithLatestFrom(BiFunction<? super T, ? super U, ? extends R> combiner, Observable<? extends U> other) {
+    final ConsumableObservable<? extends U> other;
+    public NbpOperatorWithLatestFrom(BiFunction<? super T, ? super U, ? extends R> combiner, ConsumableObservable<? extends U> other) {
         this.combiner = combiner;
         this.other = other;
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOperatorFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOperatorFlatMap.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.single;
 
-import io.reactivex.Single;
+import io.reactivex.*;
 import io.reactivex.Single.*;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
 
 public final class SingleOperatorFlatMap<T, R> implements SingleOperator<R, T> {
-    final Function<? super T, ? extends Single<? extends R>> mapper;
+    final Function<? super T, ? extends ConsumableSingle<? extends R>> mapper;
 
-    public SingleOperatorFlatMap(Function<? super T, ? extends Single<? extends R>> mapper) {
+    public SingleOperatorFlatMap(Function<? super T, ? extends ConsumableSingle<? extends R>> mapper) {
         this.mapper = mapper;
     }
     
@@ -32,12 +32,12 @@ public final class SingleOperatorFlatMap<T, R> implements SingleOperator<R, T> {
     
     static final class SingleFlatMapCallback<T, R> implements SingleSubscriber<T> {
         final SingleSubscriber<? super R> actual;
-        final Function<? super T, ? extends Single<? extends R>> mapper;
+        final Function<? super T, ? extends ConsumableSingle<? extends R>> mapper;
         
         final MultipleAssignmentDisposable mad;
 
         public SingleFlatMapCallback(SingleSubscriber<? super R> actual,
-                Function<? super T, ? extends Single<? extends R>> mapper) {
+                Function<? super T, ? extends ConsumableSingle<? extends R>> mapper) {
             this.actual = actual;
             this.mapper = mapper;
             this.mad = new MultipleAssignmentDisposable();
@@ -50,7 +50,7 @@ public final class SingleOperatorFlatMap<T, R> implements SingleOperator<R, T> {
         
         @Override
         public void onSuccess(T value) {
-            Single<? extends R> o;
+            ConsumableSingle<? extends R> o;
             
             try {
                 o = mapper.apply(value);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOperatorMap.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOperatorMap.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.Single.*;
+import io.reactivex.SingleSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 

--- a/src/main/java/io/reactivex/subscribers/AsyncSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/AsyncSubscriber.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.util.BackpressureHelper;
  * An abstract Subscriber implementation that allows asynchronous cancellation of its
  * subscription.
  * 
- * <p>This implementation let's you chose if the AsyncObserver manages resources or not,
+ * <p>This implementation let's you chose if the AsyncSubscriber manages resources or not,
  * thus saving memory on cases where there is no need for that.
  * 
  * <p>All pre-implemented final methods are thread-safe.
@@ -58,14 +58,14 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
     };
     
     /**
-     * Constructs an AsyncObserver with resource support.
+     * Constructs an AsyncSubscriber with resource support.
      */
     public AsyncSubscriber() {
         this(true);
     }
 
     /**
-     * Constructs an AsyncObserver and allows specifying if it should support resources or not.
+     * Constructs an AsyncSubscriber and allows specifying if it should support resources or not.
      * @param withResources true if resource support should be on.
      */
     public AsyncSubscriber(boolean withResources) {
@@ -75,16 +75,16 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
     }
 
     /**
-     * Adds a resource to this AsyncObserver.
+     * Adds a resource to this AsyncSubscriber.
      * 
-     * <p>Note that if the AsyncObserver doesn't manage resources, this method will
+     * <p>Note that if the AsyncSubscriber doesn't manage resources, this method will
      * throw an IllegalStateException. Use {@link #supportsResources()} to determine if
-     * this AsyncObserver manages resources or not.
+     * this AsyncSubscriber manages resources or not.
      * 
      * @param resource the resource to add
      * 
      * @throws NullPointerException if resource is null
-     * @throws IllegalStateException if this AsyncObserver doesn't manage resources
+     * @throws IllegalStateException if this AsyncSubscriber doesn't manage resources
      * @see #supportsResources()
      */
     public final void add(Disposable resource) {
@@ -93,13 +93,13 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
             add(resource);
         } else {
             resource.dispose();
-            throw new IllegalStateException("This AsyncObserver doesn't manage additional resources");
+            throw new IllegalStateException("This AsyncSubscriber doesn't manage additional resources");
         }
     }
     
     /**
-     * Returns true if this AsyncObserver supports resources added via the add() method. 
-     * @return true if this AsyncObserver supports resources added via the add() method
+     * Returns true if this AsyncSubscriber supports resources added via the add() method. 
+     * @return true if this AsyncSubscriber supports resources added via the add() method
      * @see #add(Disposable)
      */
     public final boolean supportsResources() {
@@ -124,7 +124,7 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
     }
     
     /**
-     * Called once the upstream sets a Subscription on this AsyncObserver.
+     * Called once the upstream sets a Subscription on this AsyncSubscriber.
      * 
      * <p>You can perform initialization at this moment. The default
      * implementation requests Long.MAX_VALUE from upstream.
@@ -162,7 +162,7 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
     
     /**
      * Cancels the subscription (if any) and disposes the resources associated with
-     * this AsyncObserver (if any).
+     * this AsyncSubscriber (if any).
      * 
      * <p>This method can be called before the upstream calls onSubscribe at which
      * case the Subscription will be immediately cancelled.
@@ -186,8 +186,8 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
     }
     
     /**
-     * Returns true if this AsyncObserver has been disposed/cancelled.
-     * @return true if this AsyncObserver has been disposed/cancelled
+     * Returns true if this AsyncSubscriber has been disposed/cancelled.
+     * @return true if this AsyncSubscriber has been disposed/cancelled
      */
     public final boolean isDisposed() {
         return s == CANCELLED;

--- a/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public abstract class DefaultObserver<T> implements Subscriber<T> {
+public abstract class DefaultSubscriber<T> implements Subscriber<T> {
     private Subscription s;
     @Override
     public final void onSubscribe(Subscription s) {

--- a/src/main/java/io/reactivex/subscribers/Subscribers.java
+++ b/src/main/java/io/reactivex/subscribers/Subscribers.java
@@ -285,7 +285,7 @@ public final class Subscribers {
         };
     }
     
-    public static <T> DefaultObserver<T> create(
+    public static <T> DefaultSubscriber<T> create(
             final Consumer<? super T> onNext, 
             final Consumer<? super Throwable> onError, 
             final Runnable onComplete, 
@@ -294,7 +294,7 @@ public final class Subscribers {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
         Objects.requireNonNull(onStart, "onStart is null");
-        return new DefaultObserver<T>() {
+        return new DefaultSubscriber<T>() {
             boolean done;
             @Override
             protected void onStart() {

--- a/src/main/java/io/reactivex/subscribers/completable/CompletableSerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/completable/CompletableSerializedSubscriber.java
@@ -15,7 +15,7 @@ package io.reactivex.subscribers.completable;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.reactivex.Completable.CompletableSubscriber;
+import io.reactivex.CompletableSubscriber;
 import io.reactivex.disposables.Disposable;
 
 public final class CompletableSerializedSubscriber implements CompletableSubscriber {

--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -20,7 +20,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.EmptySubscription;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 /**
  * Exposes an Observable and Observer that increments n Integers and consumes them in a Blackhole.
@@ -83,7 +83,7 @@ public abstract class InputWithIncrementingInteger {
     }
 
     public Subscriber<Integer> newSubscriber() {
-        return new DefaultObserver<Integer>() {
+        return new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {

--- a/src/perf/java/io/reactivex/LatchedObserver.java
+++ b/src/perf/java/io/reactivex/LatchedObserver.java
@@ -17,9 +17,9 @@ import java.util.concurrent.CountDownLatch;
 
 import org.openjdk.jmh.infra.Blackhole;
 
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
-public class LatchedObserver<T> extends DefaultObserver<T> {
+public class LatchedObserver<T> extends DefaultSubscriber<T> {
 
     public CountDownLatch latch = new CountDownLatch(1);
     private final Blackhole bh;

--- a/src/perf/java/io/reactivex/LatchedSingleObserver.java
+++ b/src/perf/java/io/reactivex/LatchedSingleObserver.java
@@ -17,7 +17,6 @@ import java.util.concurrent.CountDownLatch;
 
 import org.openjdk.jmh.infra.Blackhole;
 
-import io.reactivex.Single.SingleSubscriber;
 import io.reactivex.disposables.Disposable;
 
 public final class LatchedSingleObserver<T> implements SingleSubscriber<T> {

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -575,12 +575,12 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void fromNbpObservableNull() {
-        Completable.fromNbpObservable(null);
+        Completable.fromObservable(null);
     }
     
     @Test(timeout = 1000)
     public void fromNbpObservableEmpty() {
-        Completable c = Completable.fromNbpObservable(Observable.empty());
+        Completable c = Completable.fromObservable(Observable.empty());
         
         c.await();
     }
@@ -588,7 +588,7 @@ public class CompletableTest {
     @Test(timeout = 5000)
     public void fromNbpObservableSome() {
         for (int n = 1; n < 10000; n *= 10) {
-            Completable c = Completable.fromNbpObservable(Observable.range(1, n));
+            Completable c = Completable.fromObservable(Observable.range(1, n));
             
             c.await();
         }
@@ -596,7 +596,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void fromNbpObservableError() {
-        Completable c = Completable.fromNbpObservable(Observable.error(new Supplier<Throwable>() {
+        Completable c = Completable.fromObservable(Observable.error(new Supplier<Throwable>() {
             @Override
             public Throwable get() {
                 return new TestException();
@@ -2859,12 +2859,12 @@ public class CompletableTest {
 
     @Test(timeout = 1000)
     public void toNbpObservableNormal() {
-        normal.completable.toNbpObservable().toBlocking().forEach(Functions.emptyConsumer());
+        normal.completable.toObservable().toBlocking().forEach(Functions.emptyConsumer());
     }
     
     @Test(timeout = 1000, expected = TestException.class)
     public void toNbpObservableError() {
-        error.completable.toNbpObservable().toBlocking().forEach(Functions.emptyConsumer());
+        error.completable.toObservable().toBlocking().forEach(Functions.emptyConsumer());
     }
     
     @Test(timeout = 1000)
@@ -3459,7 +3459,7 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void startWithFlowableNull() {
-        normal.completable.startWith((Flowable<Object>)null);
+        normal.completable.startWith((Publisher<Object>)null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -3469,24 +3469,24 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void endWithCompletableNull() {
-        normal.completable.endWith((Completable)null);
+        normal.completable.andThen((Completable)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void endWithFlowableNull() {
-        normal.completable.endWith((Flowable<Object>)null);
+        normal.completable.andThen((Publisher<Object>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void endWithNbpObservableNull() {
-        normal.completable.endWith((Observable<Object>)null);
+        normal.completable.andThen((Observable<Object>)null);
     }
     
     @Test(timeout = 1000)
     public void endWithCompletableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         Completable c = normal.completable
-                .endWith(Completable.fromCallable(new Callable<Object>() {
+                .andThen(Completable.fromCallable(new Callable<Object>() {
                     @Override
                     public Object call() throws Exception {
                         run.set(normal.get() == 0);
@@ -3502,7 +3502,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000)
     public void endWithCompletableError() {
-        Completable c = normal.completable.endWith(error.completable);
+        Completable c = normal.completable.andThen(error.completable);
         
         try {
             c.await();
@@ -3517,7 +3517,7 @@ public class CompletableTest {
     public void endWithFlowableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         Flowable<Object> c = normal.completable
-                .endWith(Flowable.fromCallable(new Callable<Object>() {
+                .andThen(Flowable.fromCallable(new Callable<Object>() {
                     @Override
                     public Object call() throws Exception {
                         run.set(normal.get() == 0);
@@ -3540,7 +3540,7 @@ public class CompletableTest {
     @Test(timeout = 1000)
     public void endWithFlowableError() {
         Flowable<Object> c = normal.completable
-                .endWith(Flowable.error(new TestException()));
+                .andThen(Flowable.error(new TestException()));
         
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
         
@@ -3557,7 +3557,7 @@ public class CompletableTest {
     public void endWithNbpObservableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         Observable<Object> c = normal.completable
-                .endWith(Observable.fromCallable(new Callable<Object>() {
+                .andThen(Observable.fromCallable(new Callable<Object>() {
                     @Override
                     public Object call() throws Exception {
                         run.set(normal.get() == 0);
@@ -3580,7 +3580,7 @@ public class CompletableTest {
     @Test(timeout = 1000)
     public void endWithNbpObservableError() {
         Observable<Object> c = normal.completable
-                .endWith(Observable.error(new TestException()));
+                .andThen(Observable.error(new TestException()));
         
         TestObserver<Object> ts = new TestObserver<Object>();
         

--- a/src/test/java/io/reactivex/flowable/ErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/flowable/ErrorHandlingTests.java
@@ -23,7 +23,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class ErrorHandlingTests {
 
@@ -36,7 +36,7 @@ public class ErrorHandlingTests {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
         Flowable<Long> o = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> observer = new DefaultObserver<Long>() {
+        Subscriber<Long> observer = new DefaultSubscriber<Long>() {
 
             @Override
             public void onComplete() {
@@ -72,7 +72,7 @@ public class ErrorHandlingTests {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
         Flowable<Long> o = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> observer = new DefaultObserver<Long>() {
+        Subscriber<Long> observer = new DefaultSubscriber<Long>() {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/flowable/ObservableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/ObservableConversionTest.java
@@ -25,7 +25,7 @@ import io.reactivex.Flowable.Operator;
 import io.reactivex.functions.*;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class ObservableConversionTest {
@@ -139,7 +139,7 @@ public class ObservableConversionTest {
     
     @Test
     public void testConversionBetweenObservableClasses() {
-        final TestSubscriber<String> subscriber = new TestSubscriber<String>(new DefaultObserver<String>() {
+        final TestSubscriber<String> subscriber = new TestSubscriber<String>(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -221,7 +221,7 @@ public class ObservableConversionTest {
                         @Override
                         public ConcurrentLinkedQueue<Integer> apply(Flowable<Integer> onSubscribe) {
                             final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<Integer>();
-                            onSubscribe.subscribe(new DefaultObserver<Integer>(){
+                            onSubscribe.subscribe(new DefaultSubscriber<Integer>(){
                                 @Override
                                 public void onComplete() {
                                     isFinished.set(true);

--- a/src/test/java/io/reactivex/flowable/ObservableTests.java
+++ b/src/test/java/io/reactivex/flowable/ObservableTests.java
@@ -33,7 +33,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class ObservableTests {
@@ -318,7 +318,7 @@ public class ObservableTests {
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
         .subscribeOn(Schedulers.newThread())
-        .safeSubscribe(new DefaultObserver<String>() {
+        .safeSubscribe(new DefaultSubscriber<String>() {
             @Override
             public void onComplete() {
                 System.out.println("completed");
@@ -365,7 +365,7 @@ public class ObservableTests {
         
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
-        .safeSubscribe(new DefaultObserver<String>() {
+        .safeSubscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -412,7 +412,7 @@ public class ObservableTests {
                 return new NumberFormatException();
             }
         }))
-        .subscribe(new DefaultObserver<String>() {
+        .subscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -687,7 +687,7 @@ public class ObservableTests {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         Flowable.just("1", "2", "three", "4").take(3)
-        .safeSubscribe(new DefaultObserver<String>() {
+        .safeSubscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/flowable/SubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/SubscriberTest.java
@@ -26,7 +26,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Flowable.Operator;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.subscribers.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class SubscriberTest {
 
@@ -363,7 +363,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartCalledOnceViaSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultObserver<Integer>() {
+        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -394,7 +394,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartCalledOnceViaUnsafeSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).take(2).unsafeSubscribe(new DefaultObserver<Integer>() {
+        Flowable.just(1, 2, 3, 4).take(2).unsafeSubscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -429,7 +429,7 @@ public class SubscriberTest {
 
             @Override
             public Subscriber<? super Integer> apply(final Subscriber<? super Integer> child) {
-                return new DefaultObserver<Integer>() {
+                return new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {
@@ -466,7 +466,7 @@ public class SubscriberTest {
     public void testNegativeRequestThrowsIllegalArgumentException() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
-        Flowable.just(1,2,3,4).subscribe(new DefaultObserver<Integer>() {
+        Flowable.just(1,2,3,4).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -497,7 +497,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartRequestsAreAdditive() {
         final List<Integer> list = new ArrayList<Integer>();
-        Flowable.just(1,2,3,4,5).subscribe(new DefaultObserver<Integer>() {
+        Flowable.just(1,2,3,4,5).subscribe(new DefaultSubscriber<Integer>() {
             @Override
             public void onStart() {
                 request(3);
@@ -524,7 +524,7 @@ public class SubscriberTest {
     @Test
     public void testOnStartRequestsAreAdditiveAndOverflowBecomesMaxValue() {
         final List<Integer> list = new ArrayList<Integer>();
-        Flowable.just(1,2,3,4,5).subscribe(new DefaultObserver<Integer>() {
+        Flowable.just(1,2,3,4,5).subscribe(new DefaultSubscriber<Integer>() {
             @Override
             public void onStart() {
                 request(2);

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeAmbTest.java
@@ -101,7 +101,7 @@ public class OnSubscribeAmbTest {
                 observable2, observable3);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         o.subscribe(observer);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
@@ -131,7 +131,7 @@ public class OnSubscribeAmbTest {
                 observable2, observable3);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         o.subscribe(observer);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
@@ -159,7 +159,7 @@ public class OnSubscribeAmbTest {
                 observable2, observable3);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         o.subscribe(observer);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeCombineLatestTest.java
@@ -31,7 +31,7 @@ import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OnSubscribeCombineLatestTest {
@@ -481,7 +481,7 @@ public class OnSubscribeCombineLatestTest {
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Subscriber<List<Object>> s = new DefaultObserver<List<Object>>() {
+            Subscriber<List<Object>> s = new DefaultSubscriber<List<Object>>() {
 
                 @Override
                 public void onNext(List<Object> t) {
@@ -812,7 +812,7 @@ public class OnSubscribeCombineLatestTest {
             }});
         //should get at least 4
         final CountDownLatch latch = new CountDownLatch(4);
-        o.subscribeOn(Schedulers.computation()).subscribe(new DefaultObserver<Integer>() {
+        o.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
             
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeDeferTest.java
@@ -23,7 +23,7 @@ import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.Supplier;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 @SuppressWarnings("unchecked")
 public class OnSubscribeDeferTest {
@@ -71,7 +71,7 @@ public class OnSubscribeDeferTest {
         
         Flowable<String> result = Flowable.defer(factory);
         
-        DefaultObserver<String> o = mock(DefaultObserver.class);
+        DefaultSubscriber<String> o = mock(DefaultSubscriber.class);
         
         result.subscribe(o);
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeFromIterableTest.java
@@ -28,7 +28,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OnSubscribeFromIterableTest {
@@ -174,7 +174,7 @@ public class OnSubscribeFromIterableTest {
         final CountDownLatch latch = new CountDownLatch(expectedCount);
         
         o.subscribeOn(Schedulers.computation())
-        .subscribe(new DefaultObserver<Integer>() {
+        .subscribe(new DefaultSubscriber<Integer>() {
             
             @Override
             public void onStart() {
@@ -204,7 +204,7 @@ public class OnSubscribeFromIterableTest {
         
         final AtomicBoolean completed = new AtomicBoolean(false);
         
-        Flowable.fromIterable(Collections.emptyList()).subscribe(new DefaultObserver<Object>() {
+        Flowable.fromIterable(Collections.emptyList()).subscribe(new DefaultSubscriber<Object>() {
 
             @Override
             public void onStart() {
@@ -298,7 +298,7 @@ public class OnSubscribeFromIterableTest {
                 };
             }
         };
-        Flowable.fromIterable(iterable).subscribe(new DefaultObserver<Integer>() {
+        Flowable.fromIterable(iterable).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeRangeTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.Consumer;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OnSubscribeRangeTest {
@@ -198,7 +198,7 @@ public class OnSubscribeRangeTest {
     public void testRequestOverflow() {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        Flowable.range(1, n).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(1, n).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -226,7 +226,7 @@ public class OnSubscribeRangeTest {
     @Test
     public void testEmptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Flowable.range(1, 0).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(1, 0).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeTimerTest.java
@@ -226,7 +226,7 @@ public class OnSubscribeTimerTest {
     public void testOnceObserverThrows() {
         Flowable<Long> source = Flowable.timer(100, TimeUnit.MILLISECONDS, scheduler);
         
-        source.safeSubscribe(new DefaultObserver<Long>() {
+        source.safeSubscribe(new DefaultSubscriber<Long>() {
 
             @Override
             public void onNext(Long t) {
@@ -256,7 +256,7 @@ public class OnSubscribeTimerTest {
         
         InOrder inOrder = inOrder(observer);
         
-        source.safeSubscribe(new DefaultObserver<Long>() {
+        source.safeSubscribe(new DefaultSubscriber<Long>() {
 
             @Override
             public void onNext(Long t) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorAsObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorAsObservableTest.java
@@ -24,14 +24,14 @@ import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class OperatorAsObservableTest {
     @Test
     public void testHiding() {
         PublishProcessor<Integer> src = PublishProcessor.create();
         
-        Flowable<Integer> dst = src.asObservable();
+        Flowable<Integer> dst = src.asFlowable();
         
         assertFalse(dst instanceof PublishProcessor);
         
@@ -50,12 +50,12 @@ public class OperatorAsObservableTest {
     public void testHidingError() {
         PublishProcessor<Integer> src = PublishProcessor.create();
         
-        Flowable<Integer> dst = src.asObservable();
+        Flowable<Integer> dst = src.asFlowable();
         
         assertFalse(dst instanceof PublishProcessor);
         
         @SuppressWarnings("unchecked")
-        DefaultObserver<Object> o = mock(DefaultObserver.class);
+        DefaultSubscriber<Object> o = mock(DefaultSubscriber.class);
         
         dst.subscribe(o);
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorBufferTest.java
@@ -33,7 +33,7 @@ import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class OperatorBufferTest {
 
@@ -961,7 +961,7 @@ public class OperatorBufferTest {
                 });
             }
 
-        }).buffer(3, 2).subscribe(new DefaultObserver<List<Integer>>() {
+        }).buffer(3, 2).subscribe(new DefaultSubscriber<List<Integer>>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorConcatTest.java
@@ -32,7 +32,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorConcatTest {
@@ -741,7 +741,7 @@ public class OperatorConcatTest {
         int n = 5000;
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable.range(1, n).concatMap(func).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(1, n).concatMap(func).subscribe(new DefaultSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -777,7 +777,7 @@ public class OperatorConcatTest {
         Flowable<Integer> o1 = Flowable.just(1,2,3);
         Flowable<Integer> o2 = Flowable.just(4,5,6);
         final AtomicBoolean completed = new AtomicBoolean(false);
-        o1.concatWith(o2).subscribe(new DefaultObserver<Integer>() {
+        o1.concatWith(o2).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorDefaultIfEmptyTest.java
@@ -62,7 +62,7 @@ public class OperatorDefaultIfEmptyTest {
     public void testEmptyButClientThrows() {
         final Subscriber<Integer> o = TestHelper.mockSubscriber();
         
-        Flowable.<Integer>empty().defaultIfEmpty(1).subscribe(new DefaultObserver<Integer>() {
+        Flowable.<Integer>empty().defaultIfEmpty(1).subscribe(new DefaultSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorDoOnRequestTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.LongConsumer;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class OperatorDoOnRequestTest {
 
@@ -61,7 +61,7 @@ public class OperatorDoOnRequestTest {
                     }
                 })
                 //
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorFlatMapTest.java
@@ -483,7 +483,7 @@ public class OperatorFlatMapTest {
                 public Flowable<Integer> apply(Integer t) {
                     Flowable<Integer> r = Flowable.just(t);
                     if (rnd.nextBoolean()) {
-                        r = r.asObservable();
+                        r = r.asFlowable();
                     }
                     return r;
                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorGroupByTest.java
@@ -32,7 +32,7 @@ import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorGroupByTest {
@@ -118,7 +118,7 @@ public class OperatorGroupByTest {
                     }
                 });
             }
-        }).subscribe(new DefaultObserver<String>() {
+        }).subscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -229,7 +229,7 @@ public class OperatorGroupByTest {
                 });
 
             }
-        }).subscribe(new DefaultObserver<String>() {
+        }).subscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -311,7 +311,7 @@ public class OperatorGroupByTest {
                                 });
 
                     }
-                }).subscribe(new DefaultObserver<String>() {
+                }).subscribe(new DefaultSubscriber<String>() {
 
                     @Override
                     public void onComplete() {
@@ -470,7 +470,7 @@ public class OperatorGroupByTest {
                         }
                     }
                 })
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onComplete() {
@@ -510,7 +510,7 @@ public class OperatorGroupByTest {
                         return i % 2;
                     }
                 })
-                .subscribe(new DefaultObserver<GroupedFlowable<Integer, Integer>>() {
+                .subscribe(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() {
 
                     @Override
                     public void onComplete() {
@@ -993,9 +993,9 @@ public class OperatorGroupByTest {
 
         // create two observers
         @SuppressWarnings("unchecked")
-        DefaultObserver<GroupedFlowable<Boolean, Long>> o1 = mock(DefaultObserver.class);
+        DefaultSubscriber<GroupedFlowable<Boolean, Long>> o1 = mock(DefaultSubscriber.class);
         @SuppressWarnings("unchecked")
-        DefaultObserver<GroupedFlowable<Boolean, Long>> o2 = mock(DefaultObserver.class);
+        DefaultSubscriber<GroupedFlowable<Boolean, Long>> o2 = mock(DefaultSubscriber.class);
 
         // subscribe with the observers
         stream.subscribe(o1);
@@ -1222,7 +1222,7 @@ public class OperatorGroupByTest {
         inner.get().subscribe();
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o2 = mock(DefaultObserver.class);
+        DefaultSubscriber<Integer> o2 = mock(DefaultSubscriber.class);
 
         inner.get().subscribe(o2);
 
@@ -1410,7 +1410,7 @@ public class OperatorGroupByTest {
         final TestSubscriber<Integer> inner2 = new TestSubscriber<Integer>();
 
         final TestSubscriber<GroupedFlowable<Integer, Integer>> outer
-                = new TestSubscriber<GroupedFlowable<Integer, Integer>>(new DefaultObserver<GroupedFlowable<Integer, Integer>>() {
+                = new TestSubscriber<GroupedFlowable<Integer, Integer>>(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() {
 
             @Override
             public void onComplete() {
@@ -1470,7 +1470,7 @@ public class OperatorGroupByTest {
                         return g;
                     }
                 })
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
                     
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorIgnoreElementsTest.java
@@ -113,7 +113,7 @@ public class OperatorIgnoreElementsTest {
                     }
                 })
                 //
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorMaterializeTest.java
@@ -26,7 +26,7 @@ import io.reactivex.Optional;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorMaterializeTest {
@@ -197,7 +197,7 @@ public class OperatorMaterializeTest {
 //        ts.assertUnsubscribed();
     }
 
-    private static class TestObserver extends DefaultObserver<Try<Optional<String>>> {
+    private static class TestObserver extends DefaultSubscriber<Try<Optional<String>>> {
 
         boolean onCompleted = false;
         boolean onError = false;

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorMergeDelayErrorTest.java
@@ -29,7 +29,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.LongConsumer;
 import io.reactivex.internal.subscriptions.EmptySubscription;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorMergeDelayErrorTest {
@@ -295,7 +295,7 @@ public class OperatorMergeDelayErrorTest {
         final Flowable<Flowable<String>> o1 = Flowable.error(new RuntimeException("unit test"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        Flowable.mergeDelayError(o1).subscribe(new DefaultObserver<String>() {
+        Flowable.mergeDelayError(o1).subscribe(new DefaultSubscriber<String>() {
             @Override
             public void onComplete() {
                 fail("Expected onError path");
@@ -417,7 +417,7 @@ public class OperatorMergeDelayErrorTest {
         }
     }
 
-    private static class CaptureObserver extends DefaultObserver<String> {
+    private static class CaptureObserver extends DefaultSubscriber<String> {
         volatile Throwable e;
 
         @Override
@@ -458,7 +458,7 @@ public class OperatorMergeDelayErrorTest {
         final Subscriber<Integer> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);
         
-        result.unsafeSubscribe(new DefaultObserver<Integer>() {
+        result.unsafeSubscribe(new DefaultSubscriber<Integer>() {
             int calls;
             @Override
             public void onNext(Integer t) {
@@ -563,7 +563,7 @@ public class OperatorMergeDelayErrorTest {
     public void testDelayErrorMaxConcurrent() {
         final List<Long> requests = new ArrayList<Long>();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(
-                Flowable.just(1).asObservable(), 
+                Flowable.just(1).asFlowable(), 
                 Flowable.<Integer>error(new TestException()))
                 .doOnRequest(new LongConsumer() {
                     @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorMergeTest.java
@@ -31,7 +31,7 @@ import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorMergeTest {
@@ -228,7 +228,7 @@ public class OperatorMergeTest {
         final AtomicInteger totalCounter = new AtomicInteger();
 
         Flowable<String> m = Flowable.merge(Flowable.create(o1), Flowable.create(o2));
-        m.subscribe(new DefaultObserver<String>() {
+        m.subscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -1258,7 +1258,7 @@ public class OperatorMergeTest {
                 .mergeWith(Flowable.fromIterable(Arrays.asList(3,4)));
         final int expectedCount = 4;
         final CountDownLatch latch = new CountDownLatch(expectedCount);
-        o.subscribeOn(Schedulers.computation()).subscribe(new DefaultObserver<Integer>() {
+        o.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
             
             @Override
             public void onStart() {
@@ -1319,7 +1319,7 @@ public class OperatorMergeTest {
     Function<Integer, Flowable<Integer>> toHiddenScalar = new Function<Integer, Flowable<Integer>>() {
         @Override
         public Flowable<Integer> apply(Integer t) {
-            return Flowable.just(t).asObservable();
+            return Flowable.just(t).asFlowable();
         }
     };
     ;

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorObserveOnTest.java
@@ -33,7 +33,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorObserveOnTest {
@@ -147,9 +147,9 @@ public class OperatorObserveOnTest {
         Flowable<Integer> o2 = o.observeOn(scheduler);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<Object> observer1 = mock(DefaultObserver.class);
+        DefaultSubscriber<Object> observer1 = mock(DefaultSubscriber.class);
         @SuppressWarnings("unchecked")
-        DefaultObserver<Object> observer2 = mock(DefaultObserver.class);
+        DefaultSubscriber<Object> observer2 = mock(DefaultSubscriber.class);
 
         InOrder inOrder1 = inOrder(observer1);
         InOrder inOrder2 = inOrder(observer2);
@@ -317,7 +317,7 @@ public class OperatorObserveOnTest {
         final CountDownLatch nextLatch = new CountDownLatch(1);
         final AtomicLong completeTime = new AtomicLong();
         // use subscribeOn to make async, observeOn to move
-        Flowable.range(1, 2).subscribeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(1, 2).subscribeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -370,7 +370,7 @@ public class OperatorObserveOnTest {
         Flowable<Integer> source = Flowable.concat(Flowable.<Integer> error(new TestException()), Flowable.just(1));
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        DefaultSubscriber<Integer> o = mock(DefaultSubscriber.class);
         InOrder inOrder = inOrder(o);
 
         source.observeOn(testScheduler).subscribe(o);
@@ -552,7 +552,7 @@ public class OperatorObserveOnTest {
 
         });
 
-        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>(new DefaultObserver<Integer>() {
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -607,7 +607,7 @@ public class OperatorObserveOnTest {
             final PublishProcessor<Long> subject = PublishProcessor.create();
     
             final AtomicLong counter = new AtomicLong();
-            TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultObserver<Long>() {
+            TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
     
                 @Override
                 public void onComplete() {
@@ -724,7 +724,7 @@ public class OperatorObserveOnTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100).observeOn(Schedulers.computation())
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     boolean first = true;
                     
@@ -772,7 +772,7 @@ public class OperatorObserveOnTest {
                     }
                 })
                 .observeOn(Schedulers.io())
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnBackpressureBufferTest.java
@@ -44,7 +44,7 @@ public class OperatorOnBackpressureBufferTest {
     public void testFixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultObserver<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {
@@ -101,7 +101,7 @@ public class OperatorOnBackpressureBufferTest {
     public void testFixBackpressureBoundedBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch backpressureCallback = new CountDownLatch(1);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultObserver<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnBackpressureDropTest.java
@@ -51,7 +51,7 @@ public class OperatorOnBackpressureDropTest {
     public void testFixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultObserver<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {
@@ -93,7 +93,7 @@ public class OperatorOnBackpressureDropTest {
     public void testRequestOverflow() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        range(n).onBackpressureDrop().subscribe(new DefaultObserver<Long>() {
+        range(n).onBackpressureDrop().subscribe(new DefaultSubscriber<Long>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnErrorResumeNextViaFunctionTest.java
@@ -127,7 +127,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
         Flowable<String> observable = Flowable.create(w).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         observable.subscribe(observer);
 
         try {
@@ -259,7 +259,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         
         TestSubscriber<String> ts = new TestSubscriber<String>(observer, Long.MAX_VALUE);
         observable.subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnErrorResumeNextViaObservableTest.java
@@ -135,7 +135,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
         Flowable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         TestSubscriber<String> ts = new TestSubscriber<String>(observer, Long.MAX_VALUE);
         observable.subscribe(ts);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorOnErrorReturnTest.java
@@ -48,7 +48,7 @@ public class OperatorOnErrorReturnTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         observable.subscribe(observer);
 
         try {
@@ -84,7 +84,7 @@ public class OperatorOnErrorReturnTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         observable.subscribe(observer);
 
         try {
@@ -129,7 +129,7 @@ public class OperatorOnErrorReturnTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
         TestSubscriber<String> ts = new TestSubscriber<String>(observer, Long.MAX_VALUE);
         observable.subscribe(ts);
         ts.awaitTerminalEvent();

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorRetryTest.java
@@ -33,7 +33,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorRetryTest {
@@ -615,7 +615,7 @@ public class OperatorRetryTest {
     }
 
     /** Observer for listener on seperate thread */
-    static final class AsyncObserver<T> extends DefaultObserver<T> {
+    static final class AsyncObserver<T> extends DefaultSubscriber<T> {
 
         protected CountDownLatch latch = new CountDownLatch(1);
 
@@ -662,7 +662,7 @@ public class OperatorRetryTest {
     public void testUnsubscribeAfterError() {
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<Long> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<Long> observer = mock(DefaultSubscriber.class);
 
         // Observable that always fails after 100ms
         SlowObservable so = new SlowObservable(100, 0);
@@ -687,7 +687,7 @@ public class OperatorRetryTest {
     public void testTimeoutWithRetry() {
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<Long> observer = mock(DefaultObserver.class);
+        DefaultSubscriber<Long> observer = mock(DefaultSubscriber.class);
 
         // Observable that sends every 100ms (timeout fails instead)
         SlowObservable so = new SlowObservable(100, 10);

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorRetryWithPredicateTest.java
@@ -33,7 +33,7 @@ import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorRetryWithPredicateTest {
@@ -91,7 +91,7 @@ public class OperatorRetryWithPredicateTest {
         });
         
         @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        DefaultSubscriber<Integer> o = mock(DefaultSubscriber.class);
         InOrder inOrder = inOrder(o);
         
         source.retry(retryTwice).subscribe(o);
@@ -119,7 +119,7 @@ public class OperatorRetryWithPredicateTest {
         });
         
         @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        DefaultSubscriber<Integer> o = mock(DefaultSubscriber.class);
         InOrder inOrder = inOrder(o);
         
         source.retry(retryTwice).subscribe(o);
@@ -155,7 +155,7 @@ public class OperatorRetryWithPredicateTest {
         });
         
         @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        DefaultSubscriber<Integer> o = mock(DefaultSubscriber.class);
         InOrder inOrder = inOrder(o);
         
         source.retry(retryOnTestException).subscribe(o);
@@ -192,7 +192,7 @@ public class OperatorRetryWithPredicateTest {
         });
         
         @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        DefaultSubscriber<Integer> o = mock(DefaultSubscriber.class);
         InOrder inOrder = inOrder(o);
         
         source.retry(retryOnTestException).subscribe(o);

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorScanTest.java
@@ -27,7 +27,7 @@ import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorScanTest {
@@ -143,7 +143,7 @@ public class OperatorScanTest {
                     }
 
                 })
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {
@@ -184,7 +184,7 @@ public class OperatorScanTest {
                     }
 
                 })
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {
@@ -225,7 +225,7 @@ public class OperatorScanTest {
                     }
 
                 })
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorSerializeTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.internal.subscriptions.EmptySubscription;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class OperatorSerializeTest {
 
@@ -146,10 +146,10 @@ public class OperatorSerializeTest {
      */
     public static class OnNextThread implements Runnable {
 
-        private final DefaultObserver<String> observer;
+        private final DefaultSubscriber<String> observer;
         private final int numStringsToSend;
 
-        OnNextThread(DefaultObserver<String> observer, int numStringsToSend) {
+        OnNextThread(DefaultSubscriber<String> observer, int numStringsToSend) {
             this.observer = observer;
             this.numStringsToSend = numStringsToSend;
         }
@@ -167,11 +167,11 @@ public class OperatorSerializeTest {
      */
     public static class CompletionThread implements Runnable {
 
-        private final DefaultObserver<String> observer;
+        private final DefaultSubscriber<String> observer;
         private final TestConcurrencyobserverEvent event;
         private final Future<?>[] waitOnThese;
 
-        CompletionThread(DefaultObserver<String> observer, TestConcurrencyobserverEvent event, Future<?>... waitOnThese) {
+        CompletionThread(DefaultSubscriber<String> observer, TestConcurrencyobserverEvent event, Future<?>... waitOnThese) {
             this.observer = observer;
             this.event = event;
             this.waitOnThese = waitOnThese;
@@ -340,7 +340,7 @@ public class OperatorSerializeTest {
         }
     }
 
-    private static class BusyObserver extends DefaultObserver<String> {
+    private static class BusyObserver extends DefaultSubscriber<String> {
         volatile boolean onCompleted = false;
         volatile boolean onError = false;
         AtomicInteger onNextCount = new AtomicInteger();

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorSingleTest.java
@@ -27,7 +27,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class OperatorSingleTest {
 
@@ -129,7 +129,7 @@ public class OperatorSingleTest {
                 //
                 .single()
                 //
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {
@@ -169,7 +169,7 @@ public class OperatorSingleTest {
                 //
                 .single()
                 //
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {
@@ -208,7 +208,7 @@ public class OperatorSingleTest {
                 //
                 .single()
                 //
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onStart() {
@@ -403,7 +403,7 @@ public class OperatorSingleTest {
     public void testSingleWithBackpressure() {
         Flowable<Integer> observable = Flowable.just(1, 2).single();
 
-        Subscriber<Integer> subscriber = spy(new DefaultObserver<Integer>() {
+        Subscriber<Integer> subscriber = spy(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorSubscribeOnTest.java
@@ -188,7 +188,7 @@ public class OperatorSubscribeOnTest {
     @Test
     public void testBackpressureReschedulesCorrectly() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(10);
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new DefaultObserver<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -239,7 +239,7 @@ public class OperatorSubscribeOnTest {
                     }
 
                 });
-                Subscriber<Integer> parent = new DefaultObserver<Integer>() {
+                Subscriber<Integer> parent = new DefaultSubscriber<Integer>() {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorSwitchIfEmptyTest.java
@@ -101,7 +101,7 @@ public class OperatorSwitchIfEmptyTest {
                 .lift(new Flowable.Operator<Long, Long>() {
             @Override
             public Subscriber<? super Long> apply(final Subscriber<? super Long> child) {
-                return new DefaultObserver<Long>() {
+                return new DefaultSubscriber<Long>() {
                     @Override
                     public void onComplete() {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorSwitchTest.java
@@ -32,7 +32,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorSwitchTest {
@@ -450,7 +450,7 @@ public class OperatorSwitchTest {
 
         
         final TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
-        Flowable.switchOnNext(o).subscribe(new DefaultObserver<String>() {
+        Flowable.switchOnNext(o).subscribe(new DefaultSubscriber<String>() {
 
             private int requested = 0;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorTakeLastOneTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorTakeLastOneTest {
@@ -98,7 +98,7 @@ public class OperatorTakeLastOneTest {
         assertEquals(0L, count);
     }
     
-    private static class MySubscriber<T> extends DefaultObserver<T> {
+    private static class MySubscriber<T> extends DefaultSubscriber<T> {
 
         private long initialRequest;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorTakeLastTest.java
@@ -28,7 +28,7 @@ import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorTakeLastTest {
@@ -162,7 +162,7 @@ public class OperatorTakeLastTest {
     @Test
     public void testIgnoreRequest1() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -188,7 +188,7 @@ public class OperatorTakeLastTest {
     @Test
     public void testIgnoreRequest2() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -213,7 +213,7 @@ public class OperatorTakeLastTest {
     @Test(timeout = 30000)
     public void testIgnoreRequest3() {
         // If `takeLast` does not ignore `request` properly, it will enter an infinite loop.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -240,7 +240,7 @@ public class OperatorTakeLastTest {
     @Test
     public void testIgnoreRequest4() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -266,7 +266,7 @@ public class OperatorTakeLastTest {
     @Test
     public void testUnsubscribeTakesEffectEarlyOnFastPath() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -294,7 +294,7 @@ public class OperatorTakeLastTest {
     @Test(timeout=10000)
     public void testRequestOverflow() {
         final List<Integer> list = new ArrayList<Integer>();
-        Flowable.range(1, 100).takeLast(50).subscribe(new DefaultObserver<Integer>() {
+        Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithObservableTest.java
@@ -28,7 +28,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.Supplier;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorWindowWithObservableTest {
@@ -42,7 +42,7 @@ public class OperatorWindowWithObservableTest {
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultObserver<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -100,7 +100,7 @@ public class OperatorWindowWithObservableTest {
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultObserver<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -156,7 +156,7 @@ public class OperatorWindowWithObservableTest {
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultObserver<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -206,7 +206,7 @@ public class OperatorWindowWithObservableTest {
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultObserver<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithSizeTest.java
@@ -29,7 +29,7 @@ import io.reactivex.flowable.TestHelper;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorWindowWithSizeTest {
@@ -207,14 +207,14 @@ public class OperatorWindowWithSizeTest {
         
         final Subscriber<Integer> o = TestHelper.mockSubscriber();
         
-        source.subscribe(new DefaultObserver<Flowable<Integer>>() {
+        source.subscribe(new DefaultSubscriber<Flowable<Integer>>() {
             @Override
             public void onStart() {
                 request(1);
             }
             @Override
             public void onNext(Flowable<Integer> t) {
-                t.subscribe(new DefaultObserver<Integer>() {
+                t.subscribe(new DefaultSubscriber<Integer>() {
                     @Override
                     public void onNext(Integer t) {
                         list.add(t);

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithStartEndObservableTest.java
@@ -26,7 +26,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorWindowWithStartEndObservableTest {
@@ -171,7 +171,7 @@ public class OperatorWindowWithStartEndObservableTest {
         return new Consumer<Flowable<String>>() {
             @Override
             public void accept(Flowable<String> stringObservable) {
-                stringObservable.subscribe(new DefaultObserver<String>() {
+                stringObservable.subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onComplete() {
                         lists.add(new ArrayList<String>(list));

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorWindowWithTimeTest.java
@@ -26,7 +26,7 @@ import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 
@@ -135,7 +135,7 @@ public class OperatorWindowWithTimeTest {
         return new Consumer<Flowable<T>>() {
             @Override
             public void accept(Flowable<T> stringObservable) {
-                stringObservable.subscribe(new DefaultObserver<T>() {
+                stringObservable.subscribe(new DefaultSubscriber<T>() {
                     @Override
                     public void onComplete() {
                         lists.add(new ArrayList<T>(list));

--- a/src/test/java/io/reactivex/internal/operators/flowable/OperatorZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OperatorZipTest.java
@@ -33,7 +33,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class OperatorZipTest {
@@ -732,7 +732,7 @@ public class OperatorZipTest {
                     public Integer apply(Integer a, Integer b) {
                         return a + b;
                     }
-                }).subscribe(new DefaultObserver<Integer>() {
+                }).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -821,7 +821,7 @@ public class OperatorZipTest {
                 });
 
         final ArrayList<String> list = new ArrayList<String>();
-        os.subscribe(new DefaultObserver<String>() {
+        os.subscribe(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/processors/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorSubjectTest.java
@@ -253,7 +253,7 @@ public class BehaviorSubjectTest {
                         return Flowable.just(t1 + ", " + t1);
                     }
                 })
-                .subscribe(new DefaultObserver<String>() {
+                .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
                         o.onNext(t);
@@ -427,7 +427,7 @@ public class BehaviorSubjectTest {
                 final AtomicReference<Object> o = new AtomicReference<Object>();
                 
                 rs.subscribeOn(s).observeOn(Schedulers.io())
-                .subscribe(new DefaultObserver<Object>() {
+                .subscribe(new DefaultSubscriber<Object>() {
     
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/processors/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/processors/PublishSubjectTest.java
@@ -308,7 +308,7 @@ public class PublishSubjectTest {
                         return Flowable.just(t1 + ", " + t1);
                     }
                 })
-                .subscribe(new DefaultObserver<String>() {
+                .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
                         o.onNext(t);

--- a/src/test/java/io/reactivex/processors/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplaySubjectBoundedConcurrencyTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.functions.Consumer;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class ReplaySubjectBoundedConcurrencyTest {
@@ -62,7 +62,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
             @Override
             public void run() {
-                Subscriber<Long> slow = new DefaultObserver<Long>() {
+                Subscriber<Long> slow = new DefaultSubscriber<Long>() {
 
                     @Override
                     public void onComplete() {
@@ -103,7 +103,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
             @Override
             public void run() {
                 final CountDownLatch fastLatch = new CountDownLatch(1);
-                Subscriber<Long> fast = new DefaultObserver<Long>() {
+                Subscriber<Long> fast = new DefaultSubscriber<Long>() {
 
                     @Override
                     public void onComplete() {
@@ -356,7 +356,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
                 .subscribeOn(s)
                 .observeOn(Schedulers.io())
 //                .doOnNext(e -> System.out.println(">>> " + j))
-                .subscribe(new DefaultObserver<Object>() {
+                .subscribe(new DefaultSubscriber<Object>() {
     
                     @Override
                     protected void onStart() {

--- a/src/test/java/io/reactivex/processors/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplaySubjectConcurrencyTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.functions.Consumer;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class ReplaySubjectConcurrencyTest {
@@ -62,7 +62,7 @@ public class ReplaySubjectConcurrencyTest {
 
             @Override
             public void run() {
-                Subscriber<Long> slow = new DefaultObserver<Long>() {
+                Subscriber<Long> slow = new DefaultSubscriber<Long>() {
 
                     @Override
                     public void onComplete() {
@@ -103,7 +103,7 @@ public class ReplaySubjectConcurrencyTest {
             @Override
             public void run() {
                 final CountDownLatch fastLatch = new CountDownLatch(1);
-                Subscriber<Long> fast = new DefaultObserver<Long>() {
+                Subscriber<Long> fast = new DefaultSubscriber<Long>() {
 
                     @Override
                     public void onComplete() {
@@ -348,7 +348,7 @@ public class ReplaySubjectConcurrencyTest {
                 final AtomicReference<Object> o = new AtomicReference<Object>();
                 
                 rs.subscribeOn(s).observeOn(Schedulers.io())
-                .subscribe(new DefaultObserver<Object>() {
+                .subscribe(new DefaultSubscriber<Object>() {
     
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/processors/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/processors/ReplaySubjectTest.java
@@ -251,7 +251,7 @@ public class ReplaySubjectTest {
     public void testNewSubscriberDoesntBlockExisting() throws InterruptedException {
 
         final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<String>();
-        Subscriber<String> observer1 = new DefaultObserver<String>() {
+        Subscriber<String> observer1 = new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -275,7 +275,7 @@ public class ReplaySubjectTest {
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
-        Subscriber<String> observer2 = new DefaultObserver<String>() {
+        Subscriber<String> observer2 = new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -374,7 +374,7 @@ public class ReplaySubjectTest {
                         return Flowable.just(t1 + ", " + t1);
                     }
                 })
-                .subscribe(new DefaultObserver<String>() {
+                .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
                         System.out.println(t);
@@ -405,7 +405,7 @@ public class ReplaySubjectTest {
         
         final Subscriber<Integer> o = TestHelper.mockSubscriber();
         
-        source.unsafeSubscribe(new DefaultObserver<Integer>() {
+        source.unsafeSubscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -55,7 +55,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                 })
                 .subscribeOn(getScheduler())
                 .observeOn(getScheduler())
-                .subscribe(new DefaultObserver<Long>() {
+                .subscribe(new DefaultSubscriber<Long>() {
                     @Override
                     public void onComplete() {
                         System.out.println("--- completed");

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -29,7 +29,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 /**
  * Base tests for all schedulers including Immediate/Current.
@@ -457,7 +457,7 @@ public abstract class AbstractSchedulerTests {
      * 
      * @param <T>
      */
-    private static class ConcurrentObserverValidator<T> extends DefaultObserver<T> {
+    private static class ConcurrentObserverValidator<T> extends DefaultSubscriber<T> {
 
         final AtomicInteger concurrentCounter = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();

--- a/src/test/java/io/reactivex/schedulers/SchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTests.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.util.concurrent.*;
 
 import io.reactivex.*;
-import io.reactivex.subscribers.DefaultObserver;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 final class SchedulerTests {
     private SchedulerTests() {
@@ -110,7 +110,7 @@ final class SchedulerTests {
         }
     }
 
-    private static final class CapturingObserver<T> extends DefaultObserver<T> {
+    private static final class CapturingObserver<T> extends DefaultSubscriber<T> {
         CountDownLatch completed = new CountDownLatch(1);
         int errorCount = 0;
         int nextCount = 0;

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -98,7 +98,7 @@ public class SingleNullTests {
         for (int argCount = 2; argCount < 10; argCount++) {
             for (int argNull = 1; argNull <= argCount; argNull++) {
                 Class<?>[] params = new Class[argCount];
-                Arrays.fill(params, Single.class);
+                Arrays.fill(params, ConsumableSingle.class);
 
                 Object[] values = new Object[argCount];
                 Arrays.fill(values, just1);
@@ -260,7 +260,7 @@ public class SingleNullTests {
         for (int argCount = 2; argCount < 10; argCount++) {
             for (int argNull = 1; argNull <= argCount; argNull++) {
                 Class<?>[] params = new Class[argCount];
-                Arrays.fill(params, Single.class);
+                Arrays.fill(params, ConsumableSingle.class);
 
                 Object[] values = new Object[argCount];
                 Arrays.fill(values, just1);
@@ -411,7 +411,7 @@ public class SingleNullTests {
         for (int argCount = 3; argCount < 10; argCount++) {
             for (int argNull = 1; argNull <= argCount; argNull++) {
                 Class<?>[] params = new Class[argCount + 1];
-                Arrays.fill(params, Single.class);
+                Arrays.fill(params, ConsumableSingle.class);
                 Class<?> fniClass = Class.forName("io.reactivex.functions.Function" + argCount);
                 params[argCount] = fniClass;
 
@@ -454,7 +454,7 @@ public class SingleNullTests {
             }
             
             Class<?>[] params = new Class[argCount + 1];
-            Arrays.fill(params, Single.class);
+            Arrays.fill(params, ConsumableSingle.class);
             Class<?> fniClass = Class.forName("io.reactivex.functions.Function" + argCount);
             params[argCount] = fniClass;
 

--- a/src/test/java/io/reactivex/subscribers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeObserverTest.java
@@ -321,7 +321,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_SUCCESS() {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -342,7 +342,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_SUCCESS(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -363,7 +363,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -384,7 +384,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -405,7 +405,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_ONERROR_FAIL() {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -426,7 +426,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_ONERROR_NOTIMPLEMENTED() {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -447,7 +447,7 @@ public class SafeObserverTest {
     }
 
     private static Subscriber<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() {
+        return new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -478,7 +478,7 @@ public class SafeObserverTest {
     @Ignore("Subscribers can't throw")
     public void testOnCompletedThrows() {
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(new DefaultObserver<Integer>() {
+        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(new DefaultSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 
@@ -503,7 +503,7 @@ public class SafeObserverTest {
     
     @Test
     public void testActual() {
-        Subscriber<Integer> actual = new DefaultObserver<Integer>() {
+        Subscriber<Integer> actual = new DefaultSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
             }

--- a/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
@@ -268,7 +268,7 @@ public class SerializedObserverTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final CountDownLatch running = new CountDownLatch(2);
 
-                TestSubscriber<String> to = new TestSubscriber<String>(new DefaultObserver<String>() {
+                TestSubscriber<String> to = new TestSubscriber<String>(new DefaultSubscriber<String>() {
 
                     @Override
                     public void onComplete() {
@@ -349,7 +349,7 @@ public class SerializedObserverTest {
     @Test
     public void testThreadStarvation() throws InterruptedException {
 
-        TestSubscriber<String> to = new TestSubscriber<String>(new DefaultObserver<String>() {
+        TestSubscriber<String> to = new TestSubscriber<String>(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -519,7 +519,7 @@ public class SerializedObserverTest {
         onCompleted, onError, onNext
     }
 
-    private static class TestConcurrencySubscriber extends DefaultObserver<String> {
+    private static class TestConcurrencySubscriber extends DefaultSubscriber<String> {
 
         /**
          * used to store the order and number of events received
@@ -752,7 +752,7 @@ public class SerializedObserverTest {
         }
     }
 
-    private static class BusySubscriber extends DefaultObserver<String> {
+    private static class BusySubscriber extends DefaultSubscriber<String> {
         volatile boolean onCompleted = false;
         volatile boolean onError = false;
         AtomicInteger onNextCount = new AtomicInteger();

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -162,7 +162,7 @@ public class TestSubscriberTest {
 
     @Test(expected = NullPointerException.class)
     public void testNullDelegate1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((DefaultObserver<Integer>)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((DefaultSubscriber<Integer>)null);
         ts.onComplete();
     }
     


### PR DESCRIPTION
This PR factors out the `XSubscriber` types, makes sure the base types implement `ConsumableX`
and methods accepting X in some way now accept `ConsumableX` type.

Wrapping into the base types are not yet eliminated.