### PR TITLE
1.x: Fix prolonged Producer retention in switchOnNext

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -20,7 +20,7 @@ import java.util.*;
 import rx.*;
 import rx.Observable;
 import rx.Observable.Operator;
-import rx.exceptions.CompositeException;
+import rx.exceptions.*;
 import rx.internal.producers.ProducerArbiter;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.SerialSubscription;
@@ -211,7 +211,12 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                 emitting = true;
             }
             
-            child.onNext(value);
+            try {
+                child.onNext(value);
+            } catch (Throwable ex) {
+                Exceptions.throwOrReport(ex, child, value);
+                return;
+            }
             
             arbiter.produced(1);
             
@@ -258,7 +263,12 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                             return;
                         }
 
-                        child.onNext(v);
+                        try {
+                            child.onNext(v);
+                        } catch (Throwable ex) {
+                            Exceptions.throwOrReport(ex, child, v);
+                            return;
+                        }
                         n++;
                     }
                     

--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -107,7 +107,9 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                 @Override
                 public void request(long n) {
                     if (n > 0) {
-                        arbiter.request(n);
+                        synchronized (this) {
+                            arbiter.request(n);
+                        }
                     }
                 }
             });

--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -45,6 +45,9 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
         static final OperatorSwitch<Object> INSTANCE = new OperatorSwitch<Object>(true);
     }
     /**
+     * Returns a singleton instance of the operator based on the delayError parameter.
+     * @param <T> the value type
+     * @param delayError should the errors of the inner sources delayed until the main sequence completes?
      * @return a singleton instance of this stateless operator.
      */
     @SuppressWarnings({ "unchecked" })
@@ -117,6 +120,8 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                 long id = ++index;
                 inner = new InnerSubscriber<T>(id, this);
                 innerActive = true;
+                
+                arbiter.setProducer(null);
             }
             ssub.set(inner);
             
@@ -135,6 +140,10 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                 }
                 if (delayError && innerActive) {
                     return;
+                }
+                if (!delayError) {
+                    index = Long.MAX_VALUE;
+                    arbiter.setProducer(null);
                 }
                 emitting = true;
             }
@@ -225,6 +234,7 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                     localMainDone = mainDone;
                     localQueue = queue;
                     localActive = innerActive;
+                    queue = null;
                 }
                 
                 if (!delayError && localError != null) {
@@ -261,6 +271,8 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
             boolean drop;
             synchronized (this) {
                 if (id == index) {
+                    arbiter.setProducer(null);
+
                     innerActive = false;
                     
                     e = updateError(e);
@@ -293,6 +305,9 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                 if (id != index) {
                     return;
                 }
+                
+                arbiter.setProducer(null);
+                
                 innerActive = false;
                 
                 if (emitting) {
@@ -317,6 +332,14 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
         void pluginError(Throwable e) {
             RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
         }
+        
+        void innerProducer(Producer p, long id) {
+            synchronized (this) {
+                if (this.index == id) {
+                    arbiter.setProducer(p);
+                }
+            }
+        }
     }
     
     private static final class InnerSubscriber<T> extends Subscriber<T> {
@@ -332,7 +355,7 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
         
         @Override
         public void setProducer(Producer p) {
-            parent.arbiter.setProducer(p);
+            parent.innerProducer(p, id);
         }
 
         @Override

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -831,6 +831,13 @@ public class OperatorSwitchTest {
     }
 
     @Test
+    public void switchAsyncHeavilyLoop() {
+        for (int i = 0; i < 1000; i++) {
+            switchAsyncHeavily();
+        }
+    }
+    
+    @Test
     public void switchAsyncHeavily() {
         for (int i = 1; i < 1024; i *= 2) {
             System.out.println("switchAsyncHeavily >> " + i);


### PR DESCRIPTION
There are two cases when the operator `switchOnNext` / `switchMap` retained parts of an earlier source through its `Producer` via the arbiter structure:

  - when a backpressure-supporting source was followed by a unsupporting source which never sets a new Producer, keeping the old one there indefinitely
  - when a backpressure-supporting source terminated but was not followed by any other source for longer period of time

The fix swaps in a null-producer when a new source is encountered and when an old source terminates. The swap is guarded by the current index so outdated events won't interfere with newer sequences.

**Edit**

Fixed a `ConcurrentModificationException` because the `queue` wasn't nulled out after assigning it to `localQueue`. Plus, I've added a test to check the async-source and async-inner doesn't cause backpressure exceptions.