### PR TITLE
1.x Provide public constant instead of UnsafeAccess.isUnsafeAvailable()

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
@@ -125,7 +125,7 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
             this.wip = new AtomicInteger();
             this.error = new AtomicReference<Throwable>();
             Queue<Object> q;
-            if (UnsafeAccess.isUnsafeAvailable()) {
+            if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
                 q = new SpscArrayQueue<Object>(prefetch);
             } else {
                 q = new SpscAtomicArrayQueue<Object>(prefetch);

--- a/src/main/java/rx/internal/operators/OnSubscribePublishMulticast.java
+++ b/src/main/java/rx/internal/operators/OnSubscribePublishMulticast.java
@@ -104,7 +104,7 @@ implements Observable.OnSubscribe<T>, Observer<T>, Subscription {
         }
         this.prefetch = prefetch;
         this.delayError = delayError;
-        if (UnsafeAccess.isUnsafeAvailable()) {
+        if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             this.queue = new SpscArrayQueue<T>(prefetch);
         } else {
             this.queue = new SpscAtomicArrayQueue<T>(prefetch);

--- a/src/main/java/rx/internal/operators/OperatorEagerConcatMap.java
+++ b/src/main/java/rx/internal/operators/OperatorEagerConcatMap.java
@@ -282,7 +282,7 @@ public final class OperatorEagerConcatMap<T, R> implements Operator<R, T> {
             super();
             this.parent = parent;
             Queue<Object> q;
-            if (UnsafeAccess.isUnsafeAvailable()) {
+            if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
                 q = new SpscArrayQueue<Object>(bufferSize);
             } else {
                 q = new SpscAtomicArrayQueue<Object>(bufferSize);

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -464,7 +464,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                     q = new SpscUnboundedAtomicArrayQueue<Object>(RxRingBuffer.SIZE);
                 } else {
                     if (Pow2.isPowerOfTwo(mc)) {
-                        if (UnsafeAccess.isUnsafeAvailable()) {
+                        if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
                             q = new SpscArrayQueue<Object>(mc);
                         } else {
                             q = new SpscAtomicArrayQueue<Object>(mc);

--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -106,7 +106,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
             this.delayError = delayError;
             this.on = NotificationLite.instance();
             this.bufferSize = (bufferSize > 0) ? bufferSize : RxRingBuffer.SIZE;
-            if (UnsafeAccess.isUnsafeAvailable()) {
+            if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
                 queue = new SpscArrayQueue<Object>(this.bufferSize);
             } else {
                 queue = new SpscAtomicArrayQueue<Object>(this.bufferSize);

--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -244,7 +244,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
         boolean missed;
         
         public PublishSubscriber(AtomicReference<PublishSubscriber<T>> current) {
-            this.queue = UnsafeAccess.isUnsafeAvailable() 
+            this.queue = UnsafeAccess.IS_UNSAFE_AVAILABLE
                     ? new SpscArrayQueue<Object>(RxRingBuffer.SIZE) 
                     : new SynchronizedQueue<Object>(RxRingBuffer.SIZE);
             

--- a/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/src/main/java/rx/internal/operators/OperatorScan.java
@@ -186,7 +186,7 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
             this.child = child;
             Queue<Object> q;
             // TODO switch to the linked-array based queue once available
-            if (UnsafeAccess.isUnsafeAvailable()) {
+            if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
                 q = new SpscLinkedQueue<Object>(); // new SpscUnboundedArrayQueue<R>(8);
             } else {
                 q = new SpscLinkedAtomicQueue<Object>();  // new SpscUnboundedAtomicArrayQueue<R>(8);

--- a/src/main/java/rx/internal/operators/UnicastSubject.java
+++ b/src/main/java/rx/internal/operators/UnicastSubject.java
@@ -146,11 +146,11 @@ public final class UnicastSubject<T> extends Subject<T, T> {
             
             Queue<Object> q;
             if (capacityHint > 1) {
-                q = UnsafeAccess.isUnsafeAvailable()
+                q = UnsafeAccess.IS_UNSAFE_AVAILABLE
                         ? new SpscUnboundedArrayQueue<Object>(capacityHint)
                         : new SpscUnboundedAtomicArrayQueue<Object>(capacityHint);
             } else {
-                q = UnsafeAccess.isUnsafeAvailable()
+                q = UnsafeAccess.IS_UNSAFE_AVAILABLE
                         ? new SpscLinkedQueue<Object>()
                         : new SpscLinkedAtomicQueue<Object>();
             }

--- a/src/main/java/rx/internal/producers/QueuedProducer.java
+++ b/src/main/java/rx/internal/producers/QueuedProducer.java
@@ -50,7 +50,7 @@ public final class QueuedProducer<T> extends AtomicLong implements Producer, Obs
      * @param child the target child subscriber
      */
     public QueuedProducer(Subscriber<? super T> child) {
-        this(child, UnsafeAccess.isUnsafeAvailable() 
+        this(child, UnsafeAccess.IS_UNSAFE_AVAILABLE
                 ? new SpscLinkedQueue<Object>() : new SpscLinkedAtomicQueue<Object>());
     }
     /**

--- a/src/main/java/rx/internal/producers/QueuedValueProducer.java
+++ b/src/main/java/rx/internal/producers/QueuedValueProducer.java
@@ -47,7 +47,7 @@ public final class QueuedValueProducer<T> extends AtomicLong implements Producer
      * @param child the target child subscriber
      */
     public QueuedValueProducer(Subscriber<? super T> child) {
-        this(child, UnsafeAccess.isUnsafeAvailable() 
+        this(child, UnsafeAccess.IS_UNSAFE_AVAILABLE
                 ? new SpscLinkedQueue<Object>() : new SpscLinkedAtomicQueue<Object>());
     }
     /**

--- a/src/main/java/rx/internal/util/ObjectPool.java
+++ b/src/main/java/rx/internal/util/ObjectPool.java
@@ -139,7 +139,7 @@ public abstract class ObjectPool<T> implements SchedulerLifecycle {
     protected abstract T createObject();
 
     private void initialize(final int min) {
-        if (UnsafeAccess.isUnsafeAvailable()) {
+        if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             pool = new MpmcArrayQueue<T>(Math.max(maxSize, 1024));
         } else {
             pool = new ConcurrentLinkedQueue<T>();

--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -33,7 +33,7 @@ import rx.internal.util.unsafe.UnsafeAccess;
 public class RxRingBuffer implements Subscription {
 
     public static RxRingBuffer getSpscInstance() {
-        if (UnsafeAccess.isUnsafeAvailable()) {
+        if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return new RxRingBuffer(SPSC_POOL, SIZE);
         } else {
             return new RxRingBuffer();
@@ -41,7 +41,7 @@ public class RxRingBuffer implements Subscription {
     }
 
     public static RxRingBuffer getSpmcInstance() {
-        if (UnsafeAccess.isUnsafeAvailable()) {
+        if (UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return new RxRingBuffer(SPMC_POOL, SIZE);
         } else {
             return new RxRingBuffer();

--- a/src/main/java/rx/internal/util/unsafe/UnsafeAccess.java
+++ b/src/main/java/rx/internal/util/unsafe/UnsafeAccess.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Field;
 import sun.misc.Unsafe;
 
 /**
- * All use of this class MUST first check that UnsafeAccess.isUnsafeAvailable() == true
+ * All use of this class MUST first check that {@code UnsafeAccess.IS_UNSAFE_AVAILABLE == true}
  * otherwise NPEs will happen in environments without "suc.misc.Unsafe" such as Android.
  */
 public final class UnsafeAccess {
@@ -28,7 +28,9 @@ public final class UnsafeAccess {
         throw new IllegalStateException("No instances!");
     }
 
-    public static final Unsafe UNSAFE;
+    static final Unsafe UNSAFE;
+    public static final boolean IS_UNSAFE_AVAILABLE;
+
     static {
         Unsafe u = null;
         try {
@@ -45,10 +47,7 @@ public final class UnsafeAccess {
             // do nothing, hasUnsafe() will return false
         }
         UNSAFE = u;
-    }
-
-    public static boolean isUnsafeAvailable() {
-        return UNSAFE != null;
+        IS_UNSAFE_AVAILABLE = UNSAFE != null;
     }
 
     /*

--- a/src/test/java/rx/internal/util/JCToolsQueueTests.java
+++ b/src/test/java/rx/internal/util/JCToolsQueueTests.java
@@ -41,7 +41,7 @@ public class JCToolsQueueTests {
     }
     @Test
     public void casBasedUnsafe() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         long offset = UnsafeAccess.addressOf(IntField.class, "value");
@@ -74,7 +74,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = NullPointerException.class)
     public void testMpmcArrayQueueNull() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         MpmcArrayQueue<Integer> q = new MpmcArrayQueue<Integer>(16);
@@ -83,7 +83,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = UnsupportedOperationException.class)
     public void testMpmcArrayQueueIterator() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         MpmcArrayQueue<Integer> q = new MpmcArrayQueue<Integer>(16);
@@ -92,7 +92,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testMpmcArrayQueueOfferPoll() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         Queue<Integer> q = new MpmcArrayQueue<Integer>(128);
@@ -102,7 +102,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testMpmcOfferUpToCapacity() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         int n = 128;
@@ -176,7 +176,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = UnsupportedOperationException.class)
     public void testMpscLinkedQueueIterator() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         MpscLinkedQueue<Integer> q = new MpscLinkedQueue<Integer>();
@@ -185,7 +185,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = NullPointerException.class)
     public void testMpscLinkedQueueNull() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         MpscLinkedQueue<Integer> q = new MpscLinkedQueue<Integer>();
@@ -194,7 +194,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testMpscLinkedQueueOfferPoll() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         MpscLinkedQueue<Integer> q = new MpscLinkedQueue<Integer>();
@@ -203,7 +203,7 @@ public class JCToolsQueueTests {
     }
     @Test(timeout = 2000)
     public void testMpscLinkedQueuePipelined() throws InterruptedException {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         final MpscLinkedQueue<Integer> q = new MpscLinkedQueue<Integer>();
@@ -273,7 +273,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = NullPointerException.class)
     public void testSpmcArrayQueueNull() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpmcArrayQueue<Integer> q = new SpmcArrayQueue<Integer>(16);
@@ -282,7 +282,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testSpmcArrayQueueOfferPoll() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         Queue<Integer> q = new SpmcArrayQueue<Integer>(128);
@@ -291,7 +291,7 @@ public class JCToolsQueueTests {
     }
     @Test(expected = UnsupportedOperationException.class)
     public void testSpmcArrayQueueIterator() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpmcArrayQueue<Integer> q = new SpmcArrayQueue<Integer>(16);
@@ -300,7 +300,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testSpmcOfferUpToCapacity() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         int n = 128;
@@ -313,7 +313,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = NullPointerException.class)
     public void testSpscArrayQueueNull() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(16);
@@ -322,7 +322,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testSpscArrayQueueOfferPoll() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         Queue<Integer> q = new SpscArrayQueue<Integer>(128);
@@ -331,7 +331,7 @@ public class JCToolsQueueTests {
     }
     @Test(expected = UnsupportedOperationException.class)
     public void testSpscArrayQueueIterator() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(16);
@@ -384,7 +384,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = UnsupportedOperationException.class)
     public void testSpscLinkedQueueIterator() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpscLinkedQueue<Integer> q = new SpscLinkedQueue<Integer>();
@@ -393,7 +393,7 @@ public class JCToolsQueueTests {
     
     @Test(expected = NullPointerException.class)
     public void testSpscLinkedQueueNull() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpscLinkedQueue<Integer> q = new SpscLinkedQueue<Integer>();
@@ -402,7 +402,7 @@ public class JCToolsQueueTests {
     
     @Test
     public void testSpscLinkedQueueOfferPoll() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         SpscLinkedQueue<Integer> q = new SpscLinkedQueue<Integer>();
@@ -412,7 +412,7 @@ public class JCToolsQueueTests {
     
     @Test(timeout = 2000)
     public void testSpscLinkedQueuePipelined() throws InterruptedException {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         final SpscLinkedQueue<Integer> q = new SpscLinkedQueue<Integer>();
@@ -442,7 +442,7 @@ public class JCToolsQueueTests {
 
     @Test
     public void testSpscOfferUpToCapacity() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         int n = 128;
@@ -455,7 +455,7 @@ public class JCToolsQueueTests {
 
     @Test(expected = InternalError.class)
     public void testUnsafeAccessAddressOf() {
-        if (!UnsafeAccess.isUnsafeAvailable()) {
+        if (!UnsafeAccess.IS_UNSAFE_AVAILABLE) {
             return;
         }
         UnsafeAccess.addressOf(Object.class, "field");


### PR DESCRIPTION
Motivation: save some nanoseconds on JVM and a little bit more on Android, new construction will also be easier for JIT.