### PR TITLE
1.x: Add assertSubscribed() to TestSubscriber analog to assertUnsubscribed()

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -297,6 +297,18 @@ public class TestSubscriber<T> extends Subscriber<T> {
     }
 
     /**
+     * Asserts that this {@code Subscriber} is subscribed.
+     *
+     * @throws AssertionError
+     *          if this {@code Subscriber} is not subscribed
+     */
+    public void assertSubscribed() {
+        if (isUnsubscribed()) {
+            throw new AssertionError("Not subscribed.");
+        }
+    }
+
+    /**
      * Asserts that this {@code Subscriber} has received no {@code onError} notifications.
      * 
      * @throws AssertionError

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -212,6 +212,19 @@ public class TestSubscriberTest {
         }
         fail("Not unsubscribed but not reported!");
     }
+
+    @Test
+    public void testSubscribed() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.unsubscribe();
+        try {
+            ts.assertSubscribed();
+        } catch (AssertionError ex) {
+            // expected
+            return;
+        }
+        fail("Not subscribed but not reported!");
+    }
     
     @Test
     public void testNoErrors() {


### PR DESCRIPTION
`assertUnsubscribed()` exists, `assertSubscribed()` was missing