### PR TITLE
1.x: javac 9 compatibility fixes

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -609,7 +609,7 @@ public class Observable<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T1, T2, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Func2<? super T1, ? super T2, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -637,7 +637,7 @@ public class Observable<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Func3<? super T1, ? super T2, ? super T3, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -668,7 +668,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4,
             Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3, o4), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -701,7 +701,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5,
             Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3, o4, o5), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -736,7 +736,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6,
             Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -773,7 +773,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7,
             Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -812,7 +812,7 @@ public class Observable<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7, Observable<? extends T8> o8,
             Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7, o8), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7, o8), Functions.fromFunc(combineFunction));
     }
 
     /**
@@ -854,7 +854,7 @@ public class Observable<T> {
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7, Observable<? extends T8> o8,
             Observable<? extends T9> o9,
             Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combineFunction) {
-        return combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7, o8, o9), Functions.fromFunc(combineFunction));
+        return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7, o8, o9), Functions.fromFunc(combineFunction));
     }
     /**
      * Combines a list of source Observables by emitting an item that aggregates the latest values of each of
@@ -1330,7 +1330,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     public static <T> Observable<T> from(Future<? extends T> future) {
-        return create(OnSubscribeToObservableFuture.toObservableFuture(future));
+        return (Observable<T>)create(OnSubscribeToObservableFuture.toObservableFuture(future));
     }
 
     /**
@@ -1361,7 +1361,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     public static <T> Observable<T> from(Future<? extends T> future, long timeout, TimeUnit unit) {
-        return create(OnSubscribeToObservableFuture.toObservableFuture(future, timeout, unit));
+        return (Observable<T>)create(OnSubscribeToObservableFuture.toObservableFuture(future, timeout, unit));
     }
 
     /**
@@ -1390,7 +1390,8 @@ public class Observable<T> {
      */
     public static <T> Observable<T> from(Future<? extends T> future, Scheduler scheduler) {
         // TODO in a future revision the Scheduler will become important because we'll start polling instead of blocking on the Future
-        return create(OnSubscribeToObservableFuture.toObservableFuture(future)).subscribeOn(scheduler);
+        Observable<T> o = (Observable<T>)create(OnSubscribeToObservableFuture.toObservableFuture(future));
+        return o.subscribeOn(scheduler);
     }
 
     /**
@@ -5834,7 +5835,7 @@ public class Observable<T> {
      */
     public final <U, R> Observable<R> flatMapIterable(Func1<? super T, ? extends Iterable<? extends U>> collectionSelector,
             Func2<? super T, ? super U, ? extends R> resultSelector) {
-        return flatMap(OperatorMapPair.convertSelector(collectionSelector), resultSelector);
+        return (Observable<R>)flatMap(OperatorMapPair.convertSelector(collectionSelector), resultSelector);
     }
 
     /**
@@ -5870,7 +5871,7 @@ public class Observable<T> {
     @Beta
     public final <U, R> Observable<R> flatMapIterable(Func1<? super T, ? extends Iterable<? extends U>> collectionSelector,
             Func2<? super T, ? super U, ? extends R> resultSelector, int maxConcurrent) {
-        return flatMap(OperatorMapPair.convertSelector(collectionSelector), resultSelector, maxConcurrent);
+        return (Observable<R>)flatMap(OperatorMapPair.convertSelector(collectionSelector), resultSelector, maxConcurrent);
     }
 
     /**
@@ -6655,7 +6656,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     public final Observable<T> onErrorResumeNext(final Observable<? extends T> resumeSequence) {
-        return lift(OperatorOnErrorResumeNextViaFunction.withOther(resumeSequence));
+        return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withOther(resumeSequence));
     }
 
     /**
@@ -6685,7 +6686,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     public final Observable<T> onErrorReturn(Func1<Throwable, ? extends T> resumeFunction) {
-        return lift(OperatorOnErrorResumeNextViaFunction.withSingle(resumeFunction));
+        return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withSingle(resumeFunction));
     }
 
     /**
@@ -6721,7 +6722,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     public final Observable<T> onExceptionResumeNext(final Observable<? extends T> resumeSequence) {
-        return lift(OperatorOnErrorResumeNextViaFunction.withException(resumeSequence));
+        return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withException(resumeSequence));
     }
 
     /**
@@ -10564,7 +10565,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public final <T2, R> Observable<R> zipWith(Observable<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
-        return zip(this, other, zipFunction);
+        return (Observable<R>)zip(this, other, zipFunction);
     }
 
     /**

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -524,7 +524,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     public static <T> Single<T> from(Future<? extends T> future) {
-        return new Single<T>(OnSubscribeToObservableFuture.toObservableFuture(future));
+        return new Single<T>((Observable.OnSubscribe<T>)OnSubscribeToObservableFuture.toObservableFuture(future));
     }
 
     /**
@@ -555,7 +555,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     public static <T> Single<T> from(Future<? extends T> future, long timeout, TimeUnit unit) {
-        return new Single<T>(OnSubscribeToObservableFuture.toObservableFuture(future, timeout, unit));
+        return new Single<T>((Observable.OnSubscribe<T>)OnSubscribeToObservableFuture.toObservableFuture(future, timeout, unit));
     }
 
     /**
@@ -583,7 +583,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     public static <T> Single<T> from(Future<? extends T> future, Scheduler scheduler) {
-        return new Single<T>(OnSubscribeToObservableFuture.toObservableFuture(future)).subscribeOn(scheduler);
+        return new Single<T>((Observable.OnSubscribe<T>)OnSubscribeToObservableFuture.toObservableFuture(future)).subscribeOn(scheduler);
     }
 
     /**
@@ -949,7 +949,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public static <T1, T2, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, final Func2<? super T1, ? super T2, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1]);
@@ -980,7 +980,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public static <T1, T2, T3, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, final Func3<? super T1, ? super T2, ? super T3, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2]);
@@ -1013,7 +1013,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public static <T1, T2, T3, T4, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, final Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3]);
@@ -1048,7 +1048,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public static <T1, T2, T3, T4, T5, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, final Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4]);
@@ -1086,7 +1086,7 @@ public class Single<T> {
      */
     public static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6,
                                                             final Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5]);
@@ -1126,7 +1126,7 @@ public class Single<T> {
      */
     public static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7,
                                                                 final Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6, s7}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6]);
@@ -1168,7 +1168,7 @@ public class Single<T> {
      */
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
                                                                     final Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6, s7, s8}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], (T8) args[7]);
@@ -1212,7 +1212,7 @@ public class Single<T> {
      */
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
                                                                         Single<? extends T9> s9, final Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single<?>[] {s1, s2, s3, s4, s5, s6, s7, s8, s9}, new FuncN<R>() {
+        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8, s9}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], (T8) args[7], (T9) args[8]);
@@ -1242,7 +1242,8 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public static <R> Single<R> zip(Iterable<? extends Single<?>> singles, FuncN<? extends R> zipFunction) {
-        return SingleOperatorZip.zip(iterableToArray(singles), zipFunction);
+        Single[] iterableToArray = iterableToArray(singles);
+        return SingleOperatorZip.zip(iterableToArray, zipFunction);
     }
 
     /**
@@ -1401,7 +1402,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     public final Single<T> onErrorReturn(Func1<Throwable, ? extends T> resumeFunction) {
-        return lift(OperatorOnErrorResumeNextViaFunction.withSingle(resumeFunction));
+        return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withSingle(resumeFunction));
     }
 
     /**
@@ -2234,7 +2235,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     public final <T2, R> Single<R> zipWith(Single<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
-        return zip(this, other, zipFunction);
+        return (Single<R>)zip(this, other, zipFunction);
     }
 
     /**

--- a/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
@@ -49,7 +49,7 @@ public final class BlockingOperatorLatest {
             @Override
             public Iterator<T> iterator() {
                 LatestObserverIterator<T> lio = new LatestObserverIterator<T>();
-                source.materialize().subscribe(lio);
+                ((Observable<T>)source).materialize().subscribe(lio);
                 return lio;
             }
         };

--- a/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
@@ -53,7 +53,7 @@ public final class BlockingOperatorMostRecent {
                  * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
                  * since it is for BlockingObservable.
                  */
-                source.subscribe(mostRecentObserver);
+                ((Observable<T>)source).subscribe(mostRecentObserver);
 
                 return mostRecentObserver.getIterable();
             }

--- a/src/main/java/rx/internal/operators/BlockingOperatorNext.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorNext.java
@@ -96,7 +96,7 @@ public final class BlockingOperatorNext {
                     started = true;
                     // if not started, start now
                     observer.setWaiting(1);
-                    items.materialize().subscribe(observer);
+                    ((Observable<T>)items).materialize().subscribe(observer);
                 }
                 
                 Notification<? extends T> nextNotification = observer.takeNext();

--- a/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
@@ -54,7 +54,7 @@ public final class BlockingOperatorToFuture {
         final AtomicReference<T> value = new AtomicReference<T>();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
-        final Subscription s = that.single().subscribe(new Subscriber<T>() {
+        final Subscription s = ((Observable<T>)that).single().subscribe(new Subscriber<T>() {
 
             @Override
             public void onCompleted() {

--- a/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
@@ -50,7 +50,7 @@ public final class BlockingOperatorToIterator {
         SubscriberIterator<T> subscriber = new SubscriberIterator<T>();
 
         // using subscribe instead of unsafeSubscribe since this is a BlockingObservable "final subscribe"
-        source.materialize().subscribe(subscriber);
+        ((Observable<T>)source).materialize().subscribe(subscriber);
         return subscriber;
     }
 

--- a/src/main/java/rx/internal/operators/CachedObservable.java
+++ b/src/main/java/rx/internal/operators/CachedObservable.java
@@ -39,7 +39,7 @@ public final class CachedObservable<T> extends Observable<T> {
      * @return the CachedObservable instance
      */
     public static <T> CachedObservable<T> from(Observable<? extends T> source) {
-        return from(source, 16);
+        return (CachedObservable<T>)from(source, 16);
     }
     
     /**

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
@@ -26,11 +26,11 @@ import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.SerialSubscription;
 
 public final class CompletableOnSubscribeConcat implements CompletableOnSubscribe {
-    final Observable<? extends Completable> sources;
+    final Observable<Completable> sources;
     final int prefetch;
     
     public CompletableOnSubscribeConcat(Observable<? extends Completable> sources, int prefetch) {
-        this.sources = sources;
+        this.sources = (Observable<Completable>)sources;
         this.prefetch = prefetch;
     }
     

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
@@ -28,12 +28,12 @@ import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.CompositeSubscription;
 
 public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe {
-    final Observable<? extends Completable> source;
+    final Observable<Completable> source;
     final int maxConcurrency;
     final boolean delayErrors;
     
     public CompletableOnSubscribeMerge(Observable<? extends Completable> source, int maxConcurrency, boolean delayErrors) {
-        this.source = source;
+        this.source = (Observable<Completable>)source;
         this.maxConcurrency = maxConcurrency;
         this.delayErrors = delayErrors;
     }

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -140,7 +140,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
                 if (cancelled) {
                     return;
                 }
-                sources[i].subscribe(as[i]);
+                ((Observable<T>)sources[i]).subscribe(as[i]);
             }
         }
         

--- a/src/main/java/rx/internal/operators/OperatorMapPair.java
+++ b/src/main/java/rx/internal/operators/OperatorMapPair.java
@@ -47,7 +47,7 @@ public final class OperatorMapPair<T, U, R> implements Operator<Observable<? ext
         return new Func1<T, Observable<U>>() {
             @Override
             public Observable<U> call(T t1) {
-                return Observable.from(selector.call(t1));
+                return (Observable<U>)Observable.from(selector.call(t1));
             }
         };
     }

--- a/src/main/java/rx/internal/operators/OperatorMulticast.java
+++ b/src/main/java/rx/internal/operators/OperatorMulticast.java
@@ -149,6 +149,6 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
             sub = subscription;
         }
         if (sub != null)
-            source.subscribe(sub);
+            ((Observable<T>)source).subscribe(sub);
     }
 }

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -135,7 +135,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
     public static <T> ConnectableObservable<T> create(Observable<? extends T> source, 
             final int bufferSize) {
         if (bufferSize == Integer.MAX_VALUE) {
-            return create(source);
+            return (ConnectableObservable<T>)create(source);
         }
         return create(source, new Func0<ReplayBuffer<T>>() {
             @Override
@@ -155,7 +155,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
      */
     public static <T> ConnectableObservable<T> create(Observable<? extends T> source, 
             long maxAge, TimeUnit unit, Scheduler scheduler) {
-        return create(source, maxAge, unit, scheduler, Integer.MAX_VALUE);
+        return (ConnectableObservable<T>)create(source, maxAge, unit, scheduler, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/rx/internal/operators/SingleOnSubscribeDelaySubscriptionOther.java
+++ b/src/main/java/rx/internal/operators/SingleOnSubscribeDelaySubscriptionOther.java
@@ -86,6 +86,6 @@ public final class SingleOnSubscribeDelaySubscriptionOther<T> implements Single.
 
         serial.set(otherSubscriber);
 
-        other.subscribe(otherSubscriber);
+        ((Observable<Object>)other).subscribe(otherSubscriber);
     }
 }

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -608,12 +608,13 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
             };
             subscriptions.add(s);
 
-            t.doOnTerminate(new Action0() {
+            Observable<? extends T> doOnTerminate = t.doOnTerminate(new Action0() {
                     @Override
                     public void call() {
                         subscriptions.remove(s);
-                    }})
-                .subscribe(s);
+                    }});
+            
+            ((Observable<T>)doOnTerminate).subscribe(s);
 
             merger.onNext(buffer);
         }

--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -99,7 +99,7 @@ public final class BlockingObservable<T> {
          * Use 'subscribe' instead of 'unsafeSubscribe' for Rx contract behavior
          * (see http://reactivex.io/documentation/contract.html) as this is the final subscribe in the chain.
          */
-        Subscription subscription = o.subscribe(new Subscriber<T>() {
+        Subscription subscription = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onCompleted() {
                 latch.countDown();
@@ -144,7 +144,7 @@ public final class BlockingObservable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public Iterator<T> getIterator() {
-        return BlockingOperatorToIterator.toIterator(o);
+        return BlockingOperatorToIterator.toIterator((Observable<T>)o);
     }
 
     /**
@@ -299,7 +299,7 @@ public final class BlockingObservable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX documentation: TakeLast</a>
      */
     public Iterable<T> next() {
-        return BlockingOperatorNext.next(o);
+        return BlockingOperatorNext.next((Observable<T>)o);
     }
 
     /**
@@ -316,7 +316,7 @@ public final class BlockingObservable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public Iterable<T> latest() {
-        return BlockingOperatorLatest.latest(o);
+        return BlockingOperatorLatest.latest((Observable<T>)o);
     }
 
     /**
@@ -398,7 +398,7 @@ public final class BlockingObservable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public Future<T> toFuture() {
-        return BlockingOperatorToFuture.toFuture(o);
+        return BlockingOperatorToFuture.toFuture((Observable<T>)o);
     }
 
     /**
@@ -430,7 +430,7 @@ public final class BlockingObservable<T> {
         final AtomicReference<Throwable> returnException = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        Subscription subscription = observable.subscribe(new Subscriber<T>() {
+        Subscription subscription = ((Observable<T>)observable).subscribe(new Subscriber<T>() {
             @Override
             public void onCompleted() {
                 latch.countDown();
@@ -467,7 +467,7 @@ public final class BlockingObservable<T> {
     public void subscribe() {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] error = { null };
-        Subscription s = o.subscribe(new Subscriber<T>() {
+        Subscription s = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onNext(T t) {
                 
@@ -504,7 +504,7 @@ public final class BlockingObservable<T> {
         final NotificationLite<T> nl = NotificationLite.instance();
         final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
         
-        Subscription s = o.subscribe(new Subscriber<T>() {
+        Subscription s = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onNext(T t) {
                 queue.offer(nl.next(t));
@@ -592,7 +592,7 @@ public final class BlockingObservable<T> {
             }
         }));
         
-        o.subscribe(s);
+        ((Observable<T>)o).subscribe(s);
         
         try {
             for (;;) {

--- a/src/main/java/rx/singles/BlockingSingle.java
+++ b/src/main/java/rx/singles/BlockingSingle.java
@@ -100,7 +100,7 @@ public class BlockingSingle<T> {
      */
     @Experimental
     public Future<T> toFuture() {
-        return BlockingOperatorToFuture.toFuture(single.toObservable());
+        return BlockingOperatorToFuture.toFuture(((Single<T>)single).toObservable());
     }
 }
 


### PR DESCRIPTION
The type inference of javac in JDK 9 has been changed in an incompatible way, marking many generics-related code invalid.

The most common problems:

  - The inference calculates `Observable<? extends T>` but from its perspective, a call to `subscribe()` with a `Subscriber<T>` is ambiguous as it matches `subscribe(Observer<? super T>)` and `subscribe(Subscriber<? super T>)`. Somehow, the more specific class is not considered as a valid choice. Downcasting to `Observable<T>` fixes the error.
  - `A<?>[]` no longer accepts `A<Ti>` elements, requires the use of raw types to get around

The tests appear to compile fine.

Note that I couldn't find a working IDE for JDK 9 and had to revert to command line trickery:

```
@echo off

dir /s /B src\main\java\rx\*.java > sources.txt
dir /s /B src\test\java\rx\*.java >> sources.txt

"c:\program files\java\jdk-9\bin\javac.exe" -cp C:/temp/rx/junit.jar;C:/temp/rx/mockito.jar @sources.txt 

del sources.txt
```