### PR TITLE
simplify OperatorObserveOn now that error is a non-volatile field

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -248,10 +248,9 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
             if (done) {
                 if (delayError) {
                     if (isEmpty) {
-                        Throwable e = error;
                         try {
-                            if (e != null) {
-                                a.onError(e);
+                            if (error != null) {
+                                a.onError(error);
                             } else {
                                 a.onCompleted();
                             }
@@ -260,11 +259,10 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
                         }
                     }
                 } else {
-                    Throwable e = error;
-                    if (e != null) {
+                    if (error != null) {
                         q.clear();
                         try {
-                            a.onError(e);
+                            a.onError(error);
                         } finally {
                             recursiveScheduler.unsubscribe();
                         }


### PR DESCRIPTION
This is a minor simplification in `OperatorObserveOn` where a temporary variable was created to avoid unnecessary additional reads of what used to be the volatile field `error`.  The field was changed to be non-volatile a while back so the temporary variable is no longer required. 

I assume it would have very minor perf impact (I haven't run them).  