### PR TITLE
1.x: AsyncSubject now supports backpressure

### DIFF
--- a/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -203,7 +203,7 @@ import rx.subscriptions.Subscriptions;
      */
     protected static final class SubjectObserver<T> implements Observer<T> {
         /** The actual Observer. */
-        final Observer<? super T> actual;
+        final Subscriber<? super T> actual;
         /** Was the emitFirst run? Guarded by this. */
         boolean first = true;
         /** Guarded by this. */
@@ -215,7 +215,7 @@ import rx.subscriptions.Subscriptions;
         protected volatile boolean caughtUp;
         /** Indicate where the observer is at replaying. */
         private volatile Object index;
-        public SubjectObserver(Observer<? super T> actual) {
+        public SubjectObserver(Subscriber<? super T> actual) {
             this.actual = actual;
         }
         @Override

--- a/src/test/java/rx/subjects/AsyncSubjectTest.java
+++ b/src/test/java/rx/subjects/AsyncSubjectTest.java
@@ -430,4 +430,47 @@ public class AsyncSubjectTest {
         assertNull(async.getValue());
         assertFalse(async.hasValue());
     }
+    
+    @Test
+    public void backpressureOnline() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        AsyncSubject<Integer> subject = AsyncSubject.create();
+        
+        subject.subscribe(ts);
+        
+        subject.onNext(1);
+        subject.onCompleted();
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        
+        ts.assertValue(1);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+    
+    @Test
+    public void backpressureOffline() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        AsyncSubject<Integer> subject = AsyncSubject.create();
+        subject.onNext(1);
+        subject.onCompleted();
+        
+        subject.subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+        ts.requestMore(1);
+        
+        ts.assertValue(1);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
 }


### PR DESCRIPTION
`AsyncSubject` can trivially support backpressure when it emits a single item by setting the `SingleProducer` on the child `Subscriber` instead of calling `onNext` immediately.