### PR TITLE
1.x: fix concatMap scalar/empty source behavior

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
@@ -220,7 +220,7 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
 
             final int delayErrorMode = this.delayErrorMode;
             
-            do {
+            for (;;) {
                 if (actual.isUnsubscribed()) {
                     return;
                 }
@@ -288,11 +288,17 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
                                     return;
                                 }
                             }
+                            request(1);
+                        } else {
+                            request(1);
+                            continue;
                         }
-                        request(1);
                     }
                 }
-            } while (wip.decrementAndGet() != 0);
+                if (wip.decrementAndGet() == 0) {
+                    break;
+                }
+            }
         }
         
         void drainError(Throwable mapperError) {

--- a/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
@@ -273,6 +273,8 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
                             if (source instanceof ScalarSynchronousObservable) {
                                 ScalarSynchronousObservable<? extends R> scalarSource = (ScalarSynchronousObservable<? extends R>) source;
                                 
+                                active = true;
+                                
                                 arbiter.setProducer(new ConcatMapInnerScalarProducer<T, R>(scalarSource.get(), this));
                             } else {
                                 ConcatMapInnerSubscriber<T, R> innerSubscriber = new ConcatMapInnerSubscriber<T, R>(this);
@@ -352,7 +354,7 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
 
         @Override
         public void request(long n) {
-            if (!once) {
+            if (!once && n > 0L) {
                 once = true;
                 ConcatMapSubscriber<T, R> p = parent;
                 p.innerNext(value);

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -850,4 +850,18 @@ public class OperatorConcatTest {
         }
     }
     
+    @Test
+    public void scalarAndRangeBackpressured() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.just(1).concatWith(Observable.range(2, 3)).subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(5);
+        
+        ts.assertValues(1, 2, 3, 4);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -864,4 +864,50 @@ public class OperatorConcatTest {
         ts.assertCompleted();
         ts.assertNoErrors();
     }
+    
+    @Test
+    public void scalarAndEmptyBackpressured() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.just(1).concatWith(Observable.<Integer>empty()).subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(5);
+        
+        ts.assertValue(1);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void rangeAndEmptyBackpressured() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.range(1, 2).concatWith(Observable.<Integer>empty()).subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(5);
+        
+        ts.assertValues(1, 2);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
+    @Test
+    public void emptyAndScalarBackpressured() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.<Integer>empty().concatWith(Observable.just(1)).subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(5);
+        
+        ts.assertValue(1);
+        ts.assertCompleted();
+        ts.assertNoErrors();
+    }
+
 }


### PR DESCRIPTION
There were two tiny problems with the rewritten `concatMap` operator, mainly due to copy-paste error:

   - When a scalar was concatenated, the `active` field was not set and thus the next prefetched source overwrote it.
   - When the scalar was set on the arbiter, its custom producer didn't check for n > 0 zero causing instant emission always. Generally Producer.request(0) is allowed and should be no-op (unlike RS).
   - When an empty() was encountered as a last source, the it didn't trigger the check for completion afterwards.