### PR TITLE
1.x: improve ExecutorScheduler worker unsubscription

### DIFF
--- a/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -96,11 +96,20 @@ import rx.subscriptions.*;
         @Override
         public void run() {
             do {
+                if (tasks.isUnsubscribed()) {
+                    queue.clear();
+                    return;
+                }
+
                 ScheduledAction sa = queue.poll();
+                if (sa == null) {
+                    return;
+                }
+
                 if (!sa.isUnsubscribed()) {
                     sa.run();
                 }
-            } while (wip.decrementAndGet() > 0);
+            } while (wip.decrementAndGet() != 0);
         }
         
         @Override
@@ -170,6 +179,7 @@ import rx.subscriptions.*;
         @Override
         public void unsubscribe() {
             tasks.unsubscribe();
+            queue.clear();
         }
         
     }


### PR DESCRIPTION
I noticed that when a worker built from `Schedulers.from(Executors.newFixedThread(1))` is unsubscribed the use of a `CompositeSubscription` to track task subscriptions means that the tasks may be unsubscribed in any old order (`CompositeSubscription` holds its subscriptions in a `HashSet`).  This means that if the worker is given task A and task B then the race can prevent A from running but allow B to run! I've included a unit test in this PR that demos it. Fails every time on my machine on the first loop.

This  PR is really for discussion about the problem and possible fixes.

I have included a possible fix which is to track overall subscription using a volatile boolean and check that boolean before running any task. If this was considered the way to go some further simplification would take place in the operator (might not need to check individual task subscriptions).

I haven't checked other schedulers for this sort of problem yet.


