### PR TITLE
1.x: fix from(Iterable) error handling of Iterable/Iterator

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -55,11 +55,12 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
             return;
         }
             
-            
-        if (!b && !o.isUnsubscribed()) {
-            o.onCompleted();
-        } else { 
-            o.setProducer(new IterableProducer<T>(o, it));
+        if (!o.isUnsubscribed()) {
+            if (!b) {
+                o.onCompleted();
+            } else { 
+                o.setProducer(new IterableProducer<T>(o, it));
+            }
         }
     }
 

--- a/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromIterable.java
@@ -95,7 +95,7 @@ public final class OnSubscribeFromIterable<T> implements OnSubscribe<T> {
             final Subscriber<? super T> o = this.o;
             final Iterator<? extends T> it = this.it;
 
-            long r = get();
+            long r = n;
             long e = 0;
             
             for (;;) {

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -15,28 +15,21 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
+import rx.exceptions.TestException;
 import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -313,5 +306,196 @@ public class OnSubscribeFromIterableTest {
         });
         assertFalse(called.get());
     }
+
+    @Test
+    public void getIteratorThrows() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                throw new TestException("Forced failure");
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void hasNextThrowsImmediately() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        throw new TestException("Forced failure");
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return null;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        // ignored
+                    }
+                };
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void hasNextThrowsSecondTimeFastpath() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    int count;
+                    @Override
+                    public boolean hasNext() {
+                        if (++count >= 2) {
+                            throw new TestException("Forced failure");
+                        }
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        // ignored
+                    }
+                };
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertValues(1);
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void hasNextThrowsSecondTimeSlowpath() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    int count;
+                    @Override
+                    public boolean hasNext() {
+                        if (++count >= 2) {
+                            throw new TestException("Forced failure");
+                        }
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        // ignored
+                    }
+                };
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5);
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertValues(1);
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
     
+    @Test
+    public void nextThrowsFastpath() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        throw new TestException("Forced failure");
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        // ignored
+                    }
+                };
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void nextThrowsSlowpath() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        throw new TestException("Forced failure");
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        // ignored
+                    }
+                };
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5);
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -498,4 +498,38 @@ public class OnSubscribeFromIterableTest {
         ts.assertNotCompleted();
     }
 
+    @Test
+    public void deadOnArrival() {
+        Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return false;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        throw new NoSuchElementException();
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        // ignored
+                    }
+                };
+            }
+        };
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5);
+        ts.unsubscribe();
+        
+        Observable.from(it).unsafeSubscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+        
+    }
 }


### PR DESCRIPTION
The `from(Iterable)` ignored non-fatal exceptions thrown by the `Iterable` and `Iterator`.

Apart from wrapping the calls into `try-catch`, the overal emission algorithm has been changed:

  - It calls `hasNext` only once for each available value. Since the subscribe() checks for an outright empty `Iterable`, the drain loop runs only if it wasn't empty and does another `hasNext` check immediately to complete immediately if possible.
  - It uses what I call a fast-flow algorithm to avoid decrementing the requested amount (this) if there were more requests issued during the emission.