### PR TITLE
1.x: improve ExecutorScheduler worker unsubscription some more

### DIFF
--- a/src/main/java/rx/schedulers/ExecutorScheduler.java
+++ b/src/main/java/rx/schedulers/ExecutorScheduler.java
@@ -100,14 +100,17 @@ import rx.subscriptions.*;
                     queue.clear();
                     return;
                 }
-
                 ScheduledAction sa = queue.poll();
                 if (sa == null) {
                     return;
                 }
-
                 if (!sa.isUnsubscribed()) {
-                    sa.run();
+                    if (!tasks.isUnsubscribed()) {
+                        sa.run();
+                    } else {
+                        queue.clear();
+                        return;
+                    }
                 }
             } while (wip.decrementAndGet() != 0);
         }


### PR DESCRIPTION
As per discussion in #3842, there was an outstanding possibility that unsubscription of a `Worker` would not cancel all tasks waiting in the queue. This PR addresses that possibility. I attempted to provoke the condition in a unit test but didn't manage it. Nethertheless I think this change completes the protection desired in #3842.

I do have mixed feelings about the possible double calling of `queue.clear()` (once in the `run()` method and once in the `unsubscribe()` method. Any preferences?

