### PR TITLE
Fix an unsubscribe race in EventLoopWorker

### DIFF
--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -156,20 +156,37 @@ public class EventLoopsScheduler extends Scheduler implements SchedulerLifecycle
         }
 
         @Override
-        public Subscription schedule(Action0 action) {
+        public Subscription schedule(final Action0 action) {
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
 
-            return poolWorker.scheduleActual(action, 0, null, serial);
+            return poolWorker.scheduleActual(new Action0() {
+                @Override
+                public void call() {
+                    if (isUnsubscribed()) {
+                        return;
+                    }
+                    action.call();
+                }
+            }, 0, null, serial);
         }
+
         @Override
-        public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
+        public Subscription schedule(final Action0 action, long delayTime, TimeUnit unit) {
             if (isUnsubscribed()) {
                 return Subscriptions.unsubscribed();
             }
 
-            return poolWorker.scheduleActual(action, delayTime, unit, timed);
+            return poolWorker.scheduleActual(new Action0() {
+                @Override
+                public void call() {
+                    if (isUnsubscribed()) {
+                        return;
+                    }
+                    action.call();
+                }
+            }, delayTime, unit, timed);
         }
     }
 

--- a/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -423,4 +425,33 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         assertEquals(5, count.get());
     }
 
+    @Test
+    public void workerUnderConcurrentUnsubscribeShouldNotAllowLaterTasksToRunDueToUnsubscriptionRace() {
+        Scheduler scheduler = getScheduler();
+        for (int i = 0; i < 1000; i++) {
+            Worker worker = scheduler.createWorker();
+            final Queue<Integer> q = new ConcurrentLinkedQueue<Integer>();
+            Action0 action1 = new Action0() {
+
+                @Override
+                public void call() {
+                    q.add(1);
+                }
+            };
+            Action0 action2 = new Action0() {
+
+                @Override
+                public void call() {
+                    q.add(2);
+                }
+            };
+            worker.schedule(action1);
+            worker.schedule(action2);
+            worker.unsubscribe();
+            if (q.size() == 1 && q.poll() == 2) {
+                //expect a queue of 1,2 or 1. If queue is just 2 then we have a problem!
+                fail("wrong order on loop " + i);
+            }
+        }
+    }
 }

--- a/src/test/java/rx/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/rx/schedulers/ExecutorSchedulerTest.java
@@ -18,11 +18,9 @@ package rx.schedulers;
 import static org.junit.Assert.*;
 
 import java.lang.management.*;
-import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import rx.*;
@@ -276,33 +274,5 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         s.unsubscribe();
         
         assertFalse(w.tasks.hasSubscriptions());
-    }
-    
-    @Test
-    public void workerUnderConcurrentUnsubscribeShouldNotAllowLaterTasksToRunDueToUnsubscriptionRace() {
-        Scheduler scheduler = Schedulers.from(Executors.newFixedThreadPool(1));
-        for (int i = 0; i< 1000; i++) {
-            Worker worker = scheduler.createWorker();
-            final Queue<Integer> q = new ConcurrentLinkedQueue<Integer>();
-            Action0 action1 = new Action0() {
-    
-                @Override
-                public void call() {
-                    q.add(1);
-                }};
-            Action0 action2 = new Action0() {
-    
-                @Override
-                public void call() {
-                    q.add(2);
-                }};
-            worker.schedule(action1);
-            worker.schedule(action2);
-            worker.unsubscribe();
-            if (q.size()==1 && q.poll() == 2) {
-                //expect a queue of 1,2 or 1. If queue is just 2 then we have a problem!
-                Assert.fail("wrong order on loop " + i);
-            }
-        }
     }
 }


### PR DESCRIPTION
There is an unsubscribe race condition similar to #3842 in `CachedThreadScheduler.EventLoopWorker` and `EventLoopsScheduler.EventLoopWorker`. Image the following execution order:

| Execution Order  | thread 1 | thread 2 |
| ------------- | ------------- | ------------- |
| 1 |  | submit task A |
| 2 |  | submit task B |
| 3 | unsubscribe Worker  |  |
| 4 | unsubscribe task A |   |
| 5 | | task A won't run as it's unsubscribed |
| 6 | | run task B |
| 7 | unsubscribe task B |  |

So task B will run but its previous task A will be skipped.

This PR adds a check before running an action and moves `workerUnderConcurrentUnsubscribeShouldNotAllowLaterTasksToRunDueToUnsubscriptionRace` to `AbstractSchedulerConcurrencyTests` to test all concurrent schedulers.

