### PR TITLE
Expose scheduler factories which accept thread factories.

### DIFF
--- a/src/main/java/rx/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/rx/internal/schedulers/NewThreadScheduler.java
@@ -15,22 +15,21 @@
  */
 package rx.internal.schedulers;
 
+import java.util.concurrent.ThreadFactory;
 import rx.Scheduler;
-import rx.internal.util.RxThreadFactory;
 
 /**
  * Schedules work on a new thread.
  */
 public final class NewThreadScheduler extends Scheduler {
+    private final ThreadFactory threadFactory;
 
-    private static final String THREAD_NAME_PREFIX = "RxNewThreadScheduler-";
-    private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
-
-    public NewThreadScheduler() {
+    public NewThreadScheduler(ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
     }
 
     @Override
     public Worker createWorker() {
-        return new NewThreadWorker(THREAD_FACTORY);
+        return new NewThreadWorker(threadFactory);
     }
 }

--- a/src/main/java/rx/internal/util/RxThreadFactory.java
+++ b/src/main/java/rx/internal/util/RxThreadFactory.java
@@ -19,6 +19,12 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
+    public static final ThreadFactory NONE = new ThreadFactory() {
+        @Override public Thread newThread(Runnable r) {
+            throw new AssertionError("No threads allowed.");
+        }
+    };
+
     final String prefix;
 
     public RxThreadFactory(String prefix) {

--- a/src/main/java/rx/plugins/RxJavaSchedulersHook.java
+++ b/src/main/java/rx/plugins/RxJavaSchedulersHook.java
@@ -16,12 +16,14 @@
 
 package rx.plugins;
 
+import java.util.concurrent.ThreadFactory;
 import rx.Scheduler;
 import rx.annotations.Experimental;
 import rx.functions.Action0;
 import rx.internal.schedulers.CachedThreadScheduler;
 import rx.internal.schedulers.EventLoopsScheduler;
 import rx.internal.schedulers.NewThreadScheduler;
+import rx.internal.util.RxThreadFactory;
 import rx.schedulers.Schedulers;
 
 /**
@@ -45,7 +47,17 @@ public class RxJavaSchedulersHook {
      */
     @Experimental
     public static Scheduler createComputationScheduler() {
-        return new EventLoopsScheduler();
+        return createComputationScheduler(new RxThreadFactory("RxComputationScheduler-"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}
+     * except using {@code threadFactory} for thread creation.
+     */
+    @Experimental
+    public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
+        if (threadFactory == null) throw new NullPointerException("threadFactory == null");
+        return new EventLoopsScheduler(threadFactory);
     }
 
     /**
@@ -53,7 +65,17 @@ public class RxJavaSchedulersHook {
      */
     @Experimental
     public static Scheduler createIoScheduler() {
-        return new CachedThreadScheduler();
+        return createIoScheduler(new RxThreadFactory("RxIoScheduler-"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}
+     * except using {@code threadFactory} for thread creation.
+     */
+    @Experimental
+    public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
+        if (threadFactory == null) throw new NullPointerException("threadFactory == null");
+        return new CachedThreadScheduler(threadFactory);
     }
 
     /**
@@ -61,7 +83,17 @@ public class RxJavaSchedulersHook {
      */
     @Experimental
     public static Scheduler createNewThreadScheduler() {
-        return new NewThreadScheduler();
+        return createNewThreadScheduler(new RxThreadFactory("RxNewThreadScheduler-"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}
+     * except using {@code threadFactory} for thread creation.
+     */
+    @Experimental
+    public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
+        if (threadFactory == null) throw new NullPointerException("threadFactory == null");
+        return new NewThreadScheduler(threadFactory);
     }
 
     protected RxJavaSchedulersHook() {

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -238,7 +238,7 @@ public class OperatorObserveOnTest {
      * Confirm that running on a ThreadPoolScheduler allows multiple threads but is still ordered.
      */
     @Test
-    public void testObserveOnWithThreadPoolScheduler() {
+    public void testObserveOnWithComputationScheduler() {
         final AtomicInteger count = new AtomicInteger();
         final int _multiple = 99;
 
@@ -255,7 +255,7 @@ public class OperatorObserveOnTest {
                     @Override
                     public void call(Integer t1) {
                         assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
-                        assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
+                        assertTrue(Thread.currentThread().getName().startsWith("RxComputationScheduler"));
                     }
 
                 });
@@ -295,7 +295,7 @@ public class OperatorObserveOnTest {
                     @Override
                     public void call(Integer t1) {
                         assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
-                        assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
+                        assertTrue(Thread.currentThread().getName().startsWith("RxComputationScheduler"));
                     }
 
                 });

--- a/src/test/java/rx/plugins/RxJavaSchedulersHookTest.java
+++ b/src/test/java/rx/plugins/RxJavaSchedulersHookTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.plugins;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import rx.Scheduler;
+import rx.Scheduler.Worker;
+import rx.functions.Action0;
+import rx.internal.schedulers.SchedulerLifecycle;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class RxJavaSchedulersHookTest {
+    @Test
+    public void schedulerFactoriesDisallowNull() {
+        try {
+            RxJavaSchedulersHook.createComputationScheduler(null);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("threadFactory == null", e.getMessage());
+        }
+        try {
+            RxJavaSchedulersHook.createIoScheduler(null);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("threadFactory == null", e.getMessage());
+        }
+        try {
+            RxJavaSchedulersHook.createNewThreadScheduler(null);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("threadFactory == null", e.getMessage());
+        }
+    }
+
+    @Test public void computationSchedulerUsesSuppliedThreadFactory() throws InterruptedException {
+        final AtomicReference<Thread> threadRef = new AtomicReference<Thread>();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                threadRef.set(thread);
+                return thread;
+            }
+        };
+
+        Scheduler scheduler = RxJavaSchedulersHook.createComputationScheduler(threadFactory);
+        Worker worker = scheduler.createWorker();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        worker.schedule(new Action0() {
+            @Override
+            public void call() {
+                assertSame(threadRef.get(), Thread.currentThread());
+                latch.countDown();
+            }
+        });
+        assertTrue(latch.await(10, SECONDS));
+
+        if (scheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) scheduler).shutdown();
+        }
+    }
+
+    @Test public void ioSchedulerUsesSuppliedThreadFactory() throws InterruptedException {
+        final AtomicReference<Thread> threadRef = new AtomicReference<Thread>();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                threadRef.set(thread);
+                return thread;
+            }
+        };
+
+        Scheduler scheduler = RxJavaSchedulersHook.createIoScheduler(threadFactory);
+        Worker worker = scheduler.createWorker();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        worker.schedule(new Action0() {
+            @Override public void call() {
+                assertSame(threadRef.get(), Thread.currentThread());
+                latch.countDown();
+            }
+        });
+        assertTrue(latch.await(10, SECONDS));
+
+        if (scheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) scheduler).shutdown();
+        }
+    }
+
+    @Test public void newThreadSchedulerUsesSuppliedThreadFactory() throws InterruptedException {
+        final AtomicReference<Thread> threadRef = new AtomicReference<Thread>();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            @Override public Thread newThread(Runnable r) {
+              Thread thread = new Thread(r);
+              threadRef.set(thread);
+              return thread;
+            }
+        };
+
+        Scheduler scheduler = RxJavaSchedulersHook.createNewThreadScheduler(threadFactory);
+        Worker worker = scheduler.createWorker();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        worker.schedule(new Action0() {
+            @Override public void call() {
+              assertSame(threadRef.get(), Thread.currentThread());
+              latch.countDown();
+          }
+          });
+        assertTrue(latch.await(10, SECONDS));
+
+        if (scheduler instanceof SchedulerLifecycle) {
+            ((SchedulerLifecycle) scheduler).shutdown();
+        }
+    }
+}

--- a/src/test/java/rx/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/rx/schedulers/ComputationSchedulerTests.java
@@ -102,7 +102,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
             @Override
             public String call(Integer t) {
-                assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
+                assertTrue(Thread.currentThread().getName().startsWith("RxComputationScheduler"));
                 return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
             }
         });
@@ -129,7 +129,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             @Override
             public String call(Integer t) {
                 assertFalse(Thread.currentThread().getName().equals(currentThreadName));
-                assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
+                assertTrue(Thread.currentThread().getName().startsWith("RxComputationScheduler"));
                 return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
             }
         });

--- a/src/test/java/rx/schedulers/IoSchedulerTest.java
+++ b/src/test/java/rx/schedulers/IoSchedulerTest.java
@@ -43,7 +43,7 @@ public class IoSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
             @Override
             public String call(Integer t) {
-                assertTrue(Thread.currentThread().getName().startsWith("RxCachedThreadScheduler"));
+                assertTrue(Thread.currentThread().getName().startsWith("RxIoScheduler"));
                 return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
             }
         });


### PR DESCRIPTION
This allows hooks to create schedulers whose threads have different priorities.

Closes #3724.