### PR TITLE
throwIfFatal() now throws OnCompletedFailedException

### DIFF
--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -61,6 +61,7 @@ public final class Exceptions {
      * <ul>
      * <li>{@link OnErrorNotImplementedException}</li>
      * <li>{@link OnErrorFailedException}</li>
+     * <li>{@link OnCompletedFailedException}</li>
      * <li>{@code StackOverflowError}</li>
      * <li>{@code VirtualMachineError}</li>
      * <li>{@code ThreadDeath}</li>
@@ -80,6 +81,8 @@ public final class Exceptions {
             throw (OnErrorNotImplementedException) t;
         } else if (t instanceof OnErrorFailedException) {
             throw (OnErrorFailedException) t;
+        } else if (t instanceof OnCompletedFailedException) {
+            throw (OnCompletedFailedException) t;
         }
         // values here derived from https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495
         else if (t instanceof StackOverflowError) {

--- a/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -46,6 +46,28 @@ public class ExceptionsTest {
         });
     }
 
+    /**
+     * https://github.com/ReactiveX/RxJava/issues/3885
+     */
+    @Test(expected = OnCompletedFailedException.class)
+    public void testOnCompletedExceptionIsThrown() {
+        Observable.empty()
+            .subscribe(new Subscriber<Object>() {
+                @Override
+                public void onCompleted() {
+                    throw new RuntimeException();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Object o) {
+                }
+            });
+    }
+
     @Test
     public void testStackOverflowWouldOccur() {
         final PublishSubject<Integer> a = PublishSubject.create();


### PR DESCRIPTION
Otherwise, if there's an error in onCompleted, the exception is
swallowed and unreported.

Fixes #3885