### PR TITLE
Have undeliverable errors on subscribe() sent to plugin error handler.

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -8530,18 +8530,23 @@ public class Observable<T> {
         } catch (Throwable e) {
             // special handling for certain Throwable/Error/Exception types
             Exceptions.throwIfFatal(e);
-            // if an unhandled error occurs executing the onSubscribe we will propagate it
-            try {
-                subscriber.onError(hook.onSubscribeError(e));
-            } catch (Throwable e2) {
-                Exceptions.throwIfFatal(e2);
-                // if this happens it means the onError itself failed (perhaps an invalid function implementation)
-                // so we are unable to propagate the error correctly and will just throw
-                RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
-                // TODO could the hook be the cause of the error in the on error handling.
-                hook.onSubscribeError(r);
-                // TODO why aren't we throwing the hook's return value.
-                throw r;
+            // in case the subscriber can't listen to exceptions anymore
+            if (subscriber.isUnsubscribed()) {
+                RxJavaPluginUtils.handleException(hook.onSubscribeError(e));
+            } else {
+                // if an unhandled error occurs executing the onSubscribe we will propagate it
+                try {
+                    subscriber.onError(hook.onSubscribeError(e));
+                } catch (Throwable e2) {
+                    Exceptions.throwIfFatal(e2);
+                    // if this happens it means the onError itself failed (perhaps an invalid function implementation)
+                    // so we are unable to propagate the error correctly and will just throw
+                    RuntimeException r = new OnErrorFailedException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
+                    // TODO could the hook be the cause of the error in the on error handling.
+                    hook.onSubscribeError(r);
+                    // TODO why aren't we throwing the hook's return value.
+                    throw r;
+                }
             }
             return Subscriptions.unsubscribed();
         }


### PR DESCRIPTION
This change will make sure if the `Subscriber` has unsubscribed, the non-fatal error is sent to the plugin error handler at least. I.e.,

```java
Observable.create(s -> {
    s.onError(new RuntimeException());
    throw new IllegalArgumentException();
}).subscribe();
```

In addition, if the original code threw `RuntimeException` in case the `subscriber.onError()` threw. I've changed this to `OnErrorFailedException` but not sure the original type was intentional or just left out.