### PR TITLE
AssertionError should be treated as fatal

### DIFF
--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -90,6 +90,8 @@ public final class Exceptions {
             throw (ThreadDeath) t;
         } else if (t instanceof LinkageError) {
             throw (LinkageError) t;
+        } else if (t instanceof AssertionError) {
+            throw (AssertionError) t;
         }
     }
 

--- a/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -27,10 +27,16 @@ import rx.SingleSubscriber;
 import rx.Subscriber;
 import rx.Observable;
 import rx.Observer;
+import rx.functions.Action0;
 import rx.functions.Action1;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.observables.GroupedObservable;
 import rx.subjects.PublishSubject;
+import rx.Subscription;
+import rx.observers.TestSubscriber;
+
+import static org.mockito.Mockito.*;
 
 public class ExceptionsTest {
 
@@ -137,6 +143,21 @@ public class ExceptionsTest {
 
         });
     }
+
+	@Test(expected = AssertionError.class)
+	public void testAssertionErrorIsNotSwallowedByOnErrorResumeNext() {
+		Observable<Integer> subject = Observable.just(42);
+		TestSubscriber<Integer> subscriber = new TestSubscriber();
+		subject.doOnNext(new Action1<Integer>() {
+				@Override
+				public void call(Integer i) {
+					throw new AssertionError("Unexpected method call");
+				}
+			})
+			.onErrorResumeNext(Observable.<Integer>empty())
+			.subscribe(subscriber);
+		subscriber.assertNoErrors();
+	}
 
     /**
      * https://github.com/ReactiveX/RxJava/issues/969
@@ -336,4 +357,5 @@ public class ExceptionsTest {
         public void onNext(Integer value) {
         }
     }
+
 }

--- a/src/test/java/rx/util/AssertObservableTest.java
+++ b/src/test/java/rx/util/AssertObservableTest.java
@@ -31,12 +31,12 @@ public class AssertObservableTest {
         AssertObservable.assertObservableEqualsBlocking("foo", null, null);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = AssertionError.class)
     public void testFailNotNull() {
         AssertObservable.assertObservableEqualsBlocking("foo", Observable.just(1, 2), Observable.just(1));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = AssertionError.class)
     public void testFailNull() {
         AssertObservable.assertObservableEqualsBlocking("foo", Observable.just(1, 2), null);
     }


### PR DESCRIPTION
Many test frameworks throw an `AssertionError` to indicate a failure.  For example, mock objects created using EasyMock will throw an `AssertionError` immediately if the mock receives an unexpected method call.  When using `onErrorResumeNext()`, this error may be silently swallowed.  And since this type of exception is not a part of normal program flow (it is only used in tests), it should not be up to the application to handle these errors specifically.

According to the Java documentation on throwables, I would actually expect RxJava to treat all `Error` subclasses as fatal, but perhaps there are other reasons not to do so.  My first thought was to register a global error handling plugin which would rethrow `AssertionError`s, but `onErrorResumeNext()` prevents the error from reaching the plugin.  