### PR TITLE
Spare a few redundant calls in SleepingAction around determining the …

### DIFF
--- a/src/main/java/rx/internal/schedulers/SleepingAction.java
+++ b/src/main/java/rx/internal/schedulers/SleepingAction.java
@@ -34,15 +34,14 @@ import rx.functions.Action0;
         if (innerScheduler.isUnsubscribed()) {
             return;
         }
-        if (execTime > innerScheduler.now()) {
-            long delay = execTime - innerScheduler.now();
-            if (delay > 0) {
-                try {
-                    Thread.sleep(delay);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
+
+        long delay = execTime - innerScheduler.now();
+        if (delay > 0) {
+            try {
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
             }
         }
 


### PR DESCRIPTION
…delay value

- Remove redundant outer conditional.
- Skip calling into System.currentTimeMillis(), which could potentially result in different values.