### PR TITLE
1.x: Subscriber.NOT_SET Long -> long, saves an unboxing per instance

### DIFF
--- a/src/main/java/rx/Subscriber.java
+++ b/src/main/java/rx/Subscriber.java
@@ -33,7 +33,7 @@ import rx.internal.util.SubscriptionList;
 public abstract class Subscriber<T> implements Observer<T>, Subscription {
     
     // represents requested not set yet
-    private static final Long NOT_SET = Long.MIN_VALUE;
+    private static final long NOT_SET = Long.MIN_VALUE;
 
     private final SubscriptionList subscriptions;
     private final Subscriber<?> subscriber;


### PR DESCRIPTION
Somehow, Subscriber.NOT_SET was object `Long` instead of primitive `long`.