### PR TITLE
1.x: fix using() resource cleanup when factory throws or being non-eager

### DIFF
--- a/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
@@ -15,31 +15,22 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
+import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
-import rx.Subscriber;
-import rx.Subscription;
 import rx.exceptions.TestException;
-import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.functions.Func0;
-import rx.functions.Func1;
+import rx.functions.*;
+import rx.observers.TestSubscriber;
 import rx.subscriptions.Subscriptions;
 
 public class OnSubscribeUsingTest {
@@ -432,4 +423,73 @@ public class OnSubscribeUsingTest {
         };
     }
     
+    @Test
+    public void factoryThrows() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        final AtomicInteger count = new AtomicInteger();
+        
+        Observable.<Integer, Integer>using(
+                new Func0<Integer>() {
+                    @Override
+                    public Integer call() {
+                        return 1;
+                    }
+                }, 
+                new Func1<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> call(Integer v) { 
+                        throw new TestException("forced failure"); 
+                    }
+                }, 
+                new Action1<Integer>() {
+                    @Override
+                    public void call(Integer c) {
+                        count.incrementAndGet();
+                    }
+                }
+        )
+        .unsafeSubscribe(ts);
+        
+        ts.assertError(TestException.class);
+        
+        Assert.assertEquals(1, count.get());
+    }
+    
+    @Test
+    public void nonEagerTermination() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        final AtomicInteger count = new AtomicInteger();
+        
+        Observable.<Integer, Integer>using(
+                new Func0<Integer>() {
+                    @Override
+                    public Integer call() {
+                        return 1;
+                    }
+                }, 
+                new Func1<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> call(Integer v) { 
+                        return Observable.just(v);
+                    }
+                }, 
+                new Action1<Integer>() {
+                    @Override
+                    public void call(Integer c) {
+                        count.incrementAndGet();
+                    }
+                }, false
+        )
+        .unsafeSubscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertEquals(1, count.get());
+    }
 }


### PR DESCRIPTION
The operator `using` didn't call the resource cleanup code if the `observableFactory.call()` code crashed. In addition, a non-eager using didn't call the resource cleanup if one subscribed with `unsafeSubscribe` or the subscription to the generated `Observable` crashed.

Related: #3921 