### PR TITLE
1.x: add groupBy overload with evictingMapFactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ apply plugin: 'nebula.rxjava-project'
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'com.google.guava:guava:19.0'
 
     perfCompile 'org.openjdk.jmh:jmh-core:1.11.3'
     perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.11.3'


### PR DESCRIPTION
I have a long running stream using `groupBy` that over time will accumulate 10s of millions of keys. If I can specify an evicting map to `groupBy` then I'll be able to keep it down to ~10,000 keys. 

This PR supports this use case and could be used with Guava's `CacheBuilder` like this:

```java
Func1<Action1<K>, Map<K, Object>> mapFactory = 
    action -> CacheBuilder.newBuilder()
              .maximumSize(1000)
              .expireAfterAccess(12, TimeUnit.HOUR)
              .removalListener(key -> action.call(key))
              .<K, Object> build().asMap();
observable
    .groupBy(keySelector, elementSelector, mapFactory)
    ...
```
I'll enhance this PR with more unit tests if this looks a good direction.

