### PR TITLE
1.x: TestSubscriber extra info on assertion failures

### DIFF
--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -167,16 +167,17 @@ public class TestObserver<T> implements Observer<T> {
      * @param message the message to use for the error
      */
     final void assertionError(String message) {
-        StringBuilder b = new StringBuilder();
-        
-        if (onCompletedEvents.isEmpty()) {
-            b.append("(active) ");
-        }
+        StringBuilder b = new StringBuilder(message.length() + 32);
         
         b.append(message);
         
+        
+        b.append(" (");
+        b.append(onCompletedEvents.size());
+        b.append(" completions)");
+        
         if (!onErrorEvents.isEmpty()) {
-            b.append(" (+ ")
+            b.append(" (+")
             .append(onErrorEvents.size())
             .append(" errors)");
         }

--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -174,13 +174,23 @@ public class TestObserver<T> implements Observer<T> {
         
         
         b.append(" (");
-        b.append(onCompletedEvents.size());
-        b.append(" completions)");
+        int c = onCompletedEvents.size();
+        b.append(c);
+        b.append(" completion");
+        if (c != 1) {
+            b.append("s");
+        }
+        b.append(")");
         
         if (!onErrorEvents.isEmpty()) {
+            int size = onErrorEvents.size();
             b.append(" (+")
-            .append(onErrorEvents.size())
-            .append(" errors)");
+            .append(size)
+            .append(" error");
+            if (size != 1) {
+                b.append("s");
+            }
+            b.append(")");
         }
         
         AssertionError ae = new AssertionError(b.toString());

--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -15,12 +15,11 @@
  */
 package rx.observers;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import rx.Notification;
 import rx.Observer;
+import rx.exceptions.CompositeException;
 
 /**
  * Observer usable for unit testing to perform assertions, inspect received events or wrap a mocked Observer.
@@ -113,7 +112,7 @@ public class TestObserver<T> implements Observer<T> {
      */
     public void assertReceivedOnNext(List<T> items) {
         if (onNextEvents.size() != items.size()) {
-            throw new AssertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + onNextEvents.size()
+            assertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + onNextEvents.size()
             + ".\n"
             + "Provided values: " + items
             + "\n"
@@ -126,10 +125,10 @@ public class TestObserver<T> implements Observer<T> {
             if (expected == null) {
                 // check for null equality
                 if (actual != null) {
-                    throw new AssertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]");
+                    assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]");
                 }
             } else if (!expected.equals(actual)) {
-                throw new AssertionError("Value at index: " + i 
+                assertionError("Value at index: " + i 
                         + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName() 
                         + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")");
 
@@ -146,22 +145,53 @@ public class TestObserver<T> implements Observer<T> {
      */
     public void assertTerminalEvent() {
         if (onErrorEvents.size() > 1) {
-            throw new AssertionError("Too many onError events: " + onErrorEvents.size());
+            assertionError("Too many onError events: " + onErrorEvents.size());
         }
 
         if (onCompletedEvents.size() > 1) {
-            throw new AssertionError("Too many onCompleted events: " + onCompletedEvents.size());
+            assertionError("Too many onCompleted events: " + onCompletedEvents.size());
         }
 
         if (onCompletedEvents.size() == 1 && onErrorEvents.size() == 1) {
-            throw new AssertionError("Received both an onError and onCompleted. Should be one or the other.");
+            assertionError("Received both an onError and onCompleted. Should be one or the other.");
         }
 
         if (onCompletedEvents.size() == 0 && onErrorEvents.size() == 0) {
-            throw new AssertionError("No terminal events received.");
+            assertionError("No terminal events received.");
         }
     }
 
+    /**
+     * Combines an assertion error message with the current completion and error state of this
+     * TestSubscriber, giving more information when some assertXXX check fails.
+     * @param message the message to use for the error
+     */
+    final void assertionError(String message) {
+        StringBuilder b = new StringBuilder();
+        
+        if (onCompletedEvents.isEmpty()) {
+            b.append("(active) ");
+        }
+        
+        b.append(message);
+        
+        if (!onErrorEvents.isEmpty()) {
+            b.append(" (+ ")
+            .append(onErrorEvents.size())
+            .append(" errors)");
+        }
+        
+        AssertionError ae = new AssertionError(b.toString());
+        if (!onErrorEvents.isEmpty()) {
+            if (onErrorEvents.size() == 1) {
+                ae.initCause(onErrorEvents.get(0));
+            } else {
+                ae.initCause(new CompositeException(onErrorEvents));
+            }
+        }
+        throw ae;
+    }
+    
     // do nothing ... including swallowing errors
     private static Observer<Object> INERT = new Observer<Object>() {
 

--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -116,7 +116,8 @@ public class TestObserver<T> implements Observer<T> {
             + ".\n"
             + "Provided values: " + items
             + "\n"
-            + "Actual values: " + onNextEvents);
+            + "Actual values: " + onNextEvents
+            + "\n");
         }
 
         for (int i = 0; i < items.size(); i++) {
@@ -125,12 +126,12 @@ public class TestObserver<T> implements Observer<T> {
             if (expected == null) {
                 // check for null equality
                 if (actual != null) {
-                    assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]");
+                    assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]\n");
                 }
             } else if (!expected.equals(actual)) {
                 assertionError("Value at index: " + i 
                         + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName() 
-                        + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")");
+                        + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")\n");
 
             }
         }

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -292,7 +292,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
      */
     public void assertUnsubscribed() {
         if (!isUnsubscribed()) {
-            throw new AssertionError("Not unsubscribed.");
+            testObserver.assertionError("Not unsubscribed.");
         }
     }
 
@@ -393,10 +393,10 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void assertCompleted() {
         int s = testObserver.getOnCompletedEvents().size();
         if (s == 0) {
-            throw new AssertionError("Not completed!");
+            testObserver.assertionError("Not completed!");
         } else
         if (s > 1) {
-            throw new AssertionError("Completed multiple times: " + s);
+            testObserver.assertionError("Completed multiple times: " + s);
         }
     }
 
@@ -409,10 +409,10 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void assertNotCompleted() {
         int s = testObserver.getOnCompletedEvents().size();
         if (s == 1) {
-            throw new AssertionError("Completed!");
+            testObserver.assertionError("Completed!");
         } else
         if (s > 1) {
-            throw new AssertionError("Completed multiple times: " + s);
+            testObserver.assertionError("Completed multiple times: " + s);
         }
     }
 
@@ -427,7 +427,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void assertError(Class<? extends Throwable> clazz) {
         List<Throwable> err = testObserver.getOnErrorEvents();
         if (err.size() == 0) {
-            throw new AssertionError("No errors");
+            testObserver.assertionError("No errors");
         } else
         if (err.size() > 1) {
             AssertionError ae = new AssertionError("Multiple errors: " + err.size());
@@ -452,7 +452,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void assertError(Throwable throwable) {
         List<Throwable> err = testObserver.getOnErrorEvents();
         if (err.size() == 0) {
-            throw new AssertionError("No errors");
+            testObserver.assertionError("No errors");
         } else
         if (err.size() > 1) {
             AssertionError ae = new AssertionError("Multiple errors: " + err.size());
@@ -477,7 +477,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
         int s = testObserver.getOnCompletedEvents().size();
         if (err.size() > 0 || s > 0) {
             if (err.isEmpty()) {
-                throw new AssertionError("Found " + err.size() + " errors and " + s + " completion events instead of none");
+                testObserver.assertionError("Found " + err.size() + " errors and " + s + " completion events instead of none");
             } else
             if (err.size() == 1) {
                 AssertionError ae = new AssertionError("Found " + err.size() + " errors and " + s + " completion events instead of none");
@@ -500,7 +500,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void assertNoValues() {
         int s = testObserver.getOnNextEvents().size();
         if (s > 0) {
-            throw new AssertionError("No onNext events expected yet some received: " + s);
+            testObserver.assertionError("No onNext events expected yet some received: " + s);
         }
     }
 
@@ -514,7 +514,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
     public void assertValueCount(int count) {
         int s = testObserver.getOnNextEvents().size();
         if (s != count) {
-            throw new AssertionError("Number of onNext events differ; expected: " + count + ", actual: " + s);
+            testObserver.assertionError("Number of onNext events differ; expected: " + count + ", actual: " + s);
         }
     }
     

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -610,9 +610,9 @@ public class TestSubscriberTest {
             ts.assertValues("1", "2");
             fail();
         } catch (AssertionError expected) {
-            assertEquals("(active) Number of items does not match. Provided: 2  Actual: 3.\n" +
+            assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c]",
+                    "Actual values: [a, b, c] (0 completions)",
                     expected.getMessage()
             );
         }
@@ -631,9 +631,9 @@ public class TestSubscriberTest {
             ts.assertValues("1", "2");
             fail();
         } catch (AssertionError expected) {
-            assertEquals("(active) Number of items does not match. Provided: 2  Actual: 3.\n" +
+            assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (+ 1 errors)",
+                    "Actual values: [a, b, c] (0 completions) (+1 errors)",
                     expected.getMessage()
             );
             Throwable ex = expected.getCause();
@@ -656,9 +656,9 @@ public class TestSubscriberTest {
             ts.assertValues("1", "2");
             fail();
         } catch (AssertionError expected) {
-            assertEquals("(active) Number of items does not match. Provided: 2  Actual: 3.\n" +
+            assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (+ 2 errors)",
+                    "Actual values: [a, b, c] (0 completions) (+2 errors)",
                     expected.getMessage()
             );
             Throwable ex = expected.getCause();
@@ -669,4 +669,48 @@ public class TestSubscriberTest {
             assertEquals("forced failure 2", list.get(1).getMessage());
         }
     }
+
+    @Test
+    public void assertionFailureShowsCompletion() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+
+        ts.onNext("a");
+        ts.onNext("b");
+        ts.onNext("c");
+        ts.onCompleted();
+
+        try {
+            ts.assertValues("1", "2");
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
+                    "Provided values: [1, 2]\n" +
+                    "Actual values: [a, b, c] (1 completions)",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void assertionFailureShowsMultipleCompletions() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+
+        ts.onNext("a");
+        ts.onNext("b");
+        ts.onNext("c");
+        ts.onCompleted();
+        ts.onCompleted();
+
+        try {
+            ts.assertValues("1", "2");
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
+                    "Provided values: [1, 2]\n" +
+                    "Actual values: [a, b, c] (2 completions)",
+                    expected.getMessage()
+            );
+        }
+    }
+
 }

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -612,7 +612,7 @@ public class TestSubscriberTest {
         } catch (AssertionError expected) {
             assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (0 completions)",
+                    "Actual values: [a, b, c]\n (0 completions)",
                     expected.getMessage()
             );
         }
@@ -633,7 +633,7 @@ public class TestSubscriberTest {
         } catch (AssertionError expected) {
             assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (0 completions) (+1 errors)",
+                    "Actual values: [a, b, c]\n (0 completions) (+1 error)",
                     expected.getMessage()
             );
             Throwable ex = expected.getCause();
@@ -658,7 +658,7 @@ public class TestSubscriberTest {
         } catch (AssertionError expected) {
             assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (0 completions) (+2 errors)",
+                    "Actual values: [a, b, c]\n (0 completions) (+2 errors)",
                     expected.getMessage()
             );
             Throwable ex = expected.getCause();
@@ -685,7 +685,7 @@ public class TestSubscriberTest {
         } catch (AssertionError expected) {
             assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (1 completions)",
+                    "Actual values: [a, b, c]\n (1 completion)",
                     expected.getMessage()
             );
         }
@@ -707,7 +707,7 @@ public class TestSubscriberTest {
         } catch (AssertionError expected) {
             assertEquals("Number of items does not match. Provided: 2  Actual: 3.\n" +
                     "Provided values: [1, 2]\n" +
-                    "Actual values: [a, b, c] (2 completions)",
+                    "Actual values: [a, b, c]\n (2 completions)",
                     expected.getMessage()
             );
         }


### PR DESCRIPTION
This PR adds extra information to assertion failure messages on `TestSubscriber` and `TestObserver`, indicating:

  - the listener didn't receive any `onCompleted` calls, which is an indication of hung or skipping operation,
  - there were errors received, indicating a failure in the event generation process.

Previously, if there was something wrong with the sequence, the order and type of assertions were mostly unhelpful: if `assertValues` was first, the lack of values failure could hide a revealing onError call. If the `assertNoErrors()` was first, the error is visible but no way of knowing how far the sequence got.

Now, it is generally okay to use `assertValues` first, which along the difference, will print the lack of completion and the number of exceptions received, plus, the `AssertionError` will have its cause initialized to the actual or composited exception. The message format thus changes:

```
original assertion message with details (0 completions) (+1 error)
...
caused by
...
```

This extra information saved me a lot of time in 2.x and Rsc development.

Note that this change doesn't make the `assertXXX`s also assert for completion or error at all. If the values match, but there is an additional error instead of completion, one has to assert that separately, just like now.