### PR TITLE
1.x: promote UnicastSubject to be a standard+experimental Subject

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorWindowWithObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithObservable.java
@@ -22,6 +22,7 @@ import rx.Observable.Operator;
 import rx.Observable;
 import rx.Observer;
 import rx.observers.SerializedSubscriber;
+import rx.subjects.UnicastSubject;
 
 /**
  * Creates non-overlapping windows of items where each window is terminated by

--- a/src/main/java/rx/internal/operators/OperatorWindowWithObservableFactory.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithObservableFactory.java
@@ -23,6 +23,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.functions.Func0;
 import rx.observers.SerializedSubscriber;
+import rx.subjects.UnicastSubject;
 import rx.subscriptions.SerialSubscription;
 
 /**

--- a/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithSize.java
@@ -23,7 +23,7 @@ import rx.Observable;
 import rx.Observable.Operator;
 import rx.functions.Action0;
 import rx.internal.util.atomic.SpscLinkedArrayQueue;
-import rx.subjects.Subject;
+import rx.subjects.*;
 import rx.subscriptions.Subscriptions;
 
 /**

--- a/src/main/java/rx/internal/operators/OperatorWindowWithStartEndObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithStartEndObservable.java
@@ -23,6 +23,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.functions.Func1;
 import rx.observers.*;
+import rx.subjects.UnicastSubject;
 import rx.subscriptions.CompositeSubscription;
 
 /**

--- a/src/main/java/rx/internal/operators/OperatorWindowWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithTime.java
@@ -25,6 +25,7 @@ import rx.Observable;
 import rx.Observer;
 import rx.functions.Action0;
 import rx.observers.*;
+import rx.subjects.UnicastSubject;
 import rx.subscriptions.Subscriptions;
 
 /**

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -42,7 +42,7 @@ import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
-import rx.subjects.Subject;
+import rx.subjects.*;
 import rx.subscriptions.BooleanSubscription;
 
 public class OperatorConcatTest {

--- a/src/test/java/rx/subjects/BufferUntilSubscriberTest.java
+++ b/src/test/java/rx/subjects/BufferUntilSubscriberTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.internal.operators;
+package rx.subjects;
 
 import java.util.List;
 import java.util.concurrent.*;
@@ -26,7 +26,6 @@ import rx.exceptions.TestException;
 import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
-import rx.subjects.PublishSubject;
 
 public class BufferUntilSubscriberTest {
 


### PR DESCRIPTION
Plus, the unsubscribe indirection has been inlined, making `State` implement `Subscription` directly (instead of `Action0` + `Subscriptions.create`).