### PR TITLE
1.x: Change the workers to capture the stack trace

### DIFF
--- a/src/main/java/rx/internal/schedulers/CachedThreadScheduler.java
+++ b/src/main/java/rx/internal/schedulers/CachedThreadScheduler.java
@@ -78,6 +78,7 @@ public final class CachedThreadScheduler extends Scheduler implements SchedulerL
             while (!expiringWorkerQueue.isEmpty()) {
                 ThreadWorker threadWorker = expiringWorkerQueue.poll();
                 if (threadWorker != null) {
+                    threadWorker.resetContext();
                     return threadWorker;
                 }
             }

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -142,7 +142,7 @@ public final class EventLoopsScheduler extends Scheduler implements SchedulerLif
 
         EventLoopWorker(PoolWorker poolWorker) {
             this.poolWorker = poolWorker;
-            
+            poolWorker.resetContext();
         }
 
         @Override

--- a/src/main/java/rx/internal/schedulers/SchedulerContextException.java
+++ b/src/main/java/rx/internal/schedulers/SchedulerContextException.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.schedulers;
+
+/**
+ * Used only for providing context around where work was scheduled should an error occur in a different thread.
+ */
+public class SchedulerContextException extends Exception {
+    /**
+     * Constant to use when disabled
+     */
+    private static final Throwable CONTEXT_MISSING = new SchedulerContextException("Missing context. Enable by setting the system property \"rxjava.captureSchedulerContext=true\"");
+
+    static {
+        CONTEXT_MISSING.setStackTrace(new StackTraceElement[0]);
+    }
+
+    /**
+     * @return a {@link Throwable} that captures the stack trace or a {@link Throwable} that documents how to enable the feature if needed.
+     */
+    public static Throwable create() {
+        String def = "false";
+        String setTo = System.getProperty("rxjava.captureSchedulerContext", def);
+        return setTo != def && "true".equals(setTo) ? new SchedulerContextException("Asynchronous work scheduled at") : CONTEXT_MISSING;
+    }
+
+    private SchedulerContextException(String message) {
+        super(message);
+    }
+
+    private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Watched @dlew presentation of the pit falls of debugging RxJava https://www.youtube.com/watch?v=QdmkXL7XikQ&feature=youtu.be&t=38m12s

This change is to create an exception when a thread based `Scheduler.Worker` is constructed and reused it for all subsequent scheduled actions to increase the readability of uncaught and fatal exceptions that bubble up to the schedulers but spread the cost out across many scheduled actions.

A future improvement to spread the cost out even more, that I didn't want to do in the first attempt, would to create the exception when `Scheduler.io()` is called and reuse the exception across multiple `Worker`s.

The example from the presentation
```
import rx.Observable;
import rx.schedulers.Schedulers;

public class Main {
    public static void main(String[] args) throws InterruptedException {
        Observable.empty()
                .first()
                .subscribeOn(Schedulers.io())
                .subscribe();

        Thread.sleep(100);
    }
}
```

Used to print this just this exception with no mention the Main class.
```
Exception in thread "RxIoScheduler-2" java.lang.IllegalStateException: Exception thrown on Scheduler.Worker thread. Add `onError` handling.
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:65)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: rx.exceptions.OnErrorNotImplementedException: Sequence contains no elements
	at rx.internal.util.InternalObservableUtils$ErrorNotImplementedAction.call(InternalObservableUtils.java:374)
	at rx.internal.util.InternalObservableUtils$ErrorNotImplementedAction.call(InternalObservableUtils.java:1)
	at rx.internal.util.ActionSubscriber.onError(ActionSubscriber.java:44)
	at rx.observers.SafeSubscriber._onError(SafeSubscriber.java:157)
	at rx.observers.SafeSubscriber.onError(SafeSubscriber.java:120)
	at rx.internal.operators.OperatorSubscribeOn$1$1.onError(OperatorSubscribeOn.java:59)
	at rx.internal.operators.OperatorSingle$ParentSubscriber.onCompleted(OperatorSingle.java:116)
	at rx.internal.operators.OperatorTake$1.onCompleted(OperatorTake.java:56)
	at rx.internal.operators.EmptyObservableHolder.call(EmptyObservableHolder.java:44)
	at rx.internal.operators.EmptyObservableHolder.call(EmptyObservableHolder.java:1)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:50)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:1)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:50)
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:1)
	at rx.Observable.unsafeSubscribe(Observable.java:8460)
	at rx.internal.operators.OperatorSubscribeOn$1.call(OperatorSubscribeOn.java:94)
	at rx.internal.schedulers.CachedThreadScheduler$EventLoopWorker$1.call(CachedThreadScheduler.java:222)
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:60)
	... 7 more
Caused by: java.util.NoSuchElementException: Sequence contains no elements
	... 19 more
```

But will now print the exception above but with an additional caused by
```
Caused by: rx.internal.schedulers.SchedulerContextException: Asynchronous work scheduled at
	at rx.internal.schedulers.NewThreadWorker.<init>(NewThreadWorker.java:36)
	at rx.internal.schedulers.CachedThreadScheduler$ThreadWorker.<init>(CachedThreadScheduler.java:235)
	at rx.internal.schedulers.CachedThreadScheduler$CachedWorkerPool.get(CachedThreadScheduler.java:86)
	at rx.internal.schedulers.CachedThreadScheduler$EventLoopWorker.<init>(CachedThreadScheduler.java:187)
	at rx.internal.schedulers.CachedThreadScheduler.createWorker(CachedThreadScheduler.java:173)
	at rx.internal.operators.OperatorSubscribeOn.call(OperatorSubscribeOn.java:42)
	at rx.internal.operators.OperatorSubscribeOn.call(OperatorSubscribeOn.java:1)
	at rx.Observable.subscribe(Observable.java:8553)
	at rx.Observable.subscribe(Observable.java:8520)
	at rx.Observable.subscribe(Observable.java:8316)
	at rx.schedulers.Main.main(Main.java:10)
```