### PR TITLE
1.x: add Completable.safeSubscribe option + RxJavaPlugins hook support

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -1932,7 +1932,7 @@ public class Completable {
                     try {
                         onComplete.call();
                     } catch (Throwable e) {
-                        onError(e);
+                        callOnError(e);
                         return;
                     }
                     mad.unsubscribe();
@@ -1943,18 +1943,22 @@ public class Completable {
             public void onError(Throwable e) {
                 if (!done) {
                     done = true;
-                    try {
-                        onError.call(e);
-                    } catch (Throwable ex) {
-                        e = new CompositeException(Arrays.asList(e, ex));
-                        ERROR_HANDLER.handleError(e);
-                        deliverUncaughtException(e);
-                    } finally {
-                        mad.unsubscribe();
-                    }
+                    callOnError(e);
                 } else {
                     ERROR_HANDLER.handleError(e);
                     deliverUncaughtException(e);
+                }
+            }
+            
+            void callOnError(Throwable e) {
+                try {
+                    onError.call(e);
+                } catch (Throwable ex) {
+                    e = new CompositeException(Arrays.asList(e, ex));
+                    ERROR_HANDLER.handleError(e);
+                    deliverUncaughtException(e);
+                } finally {
+                    mad.unsubscribe();
                 }
             }
             

--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -173,7 +173,7 @@ public class Completable {
                     }
                     
                     // no need to have separate subscribers because inner is stateless
-                    c.subscribe(inner);
+                    c.unsafeSubscribe(inner);
                 }
             }
         });
@@ -301,7 +301,7 @@ public class Completable {
                     }
                     
                     // no need to have separate subscribers because inner is stateless
-                    c.subscribe(inner);
+                    c.unsafeSubscribe(inner);
                 }
             }
         });
@@ -416,7 +416,7 @@ public class Completable {
                     return;
                 }
                 
-                c.subscribe(s);
+                c.unsafeSubscribe(s);
             }
         });
     }
@@ -899,7 +899,7 @@ public class Completable {
                 
                 final AtomicBoolean once = new AtomicBoolean();
                 
-                cs.subscribe(new CompletableSubscriber() {
+                cs.unsafeSubscribe(new CompletableSubscriber() {
                     Subscription d;
                     void dispose() {
                         d.unsubscribe();
@@ -999,7 +999,7 @@ public class Completable {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] err = new Throwable[1];
         
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
 
             @Override
             public void onCompleted() {
@@ -1050,7 +1050,7 @@ public class Completable {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] err = new Throwable[1];
         
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
 
             @Override
             public void onCompleted() {
@@ -1190,7 +1190,7 @@ public class Completable {
                 final Scheduler.Worker w = scheduler.createWorker();
                 set.add(w);
                 
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     
                     @Override
@@ -1302,7 +1302,7 @@ public class Completable {
         return create(new CompletableOnSubscribe() {
             @Override
             public void call(final CompletableSubscriber s) {
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     @Override
                     public void onCompleted() {
@@ -1434,7 +1434,7 @@ public class Completable {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] err = new Throwable[1];
         
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
 
             @Override
             public void onCompleted() {
@@ -1478,7 +1478,7 @@ public class Completable {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] err = new Throwable[1];
         
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
 
             @Override
             public void onCompleted() {
@@ -1530,7 +1530,7 @@ public class Completable {
 
                     CompletableSubscriber sw = onLift.call(s);
                     
-                    subscribe(sw);
+                    unsafeSubscribe(sw);
                 } catch (NullPointerException ex) {
                     throw ex;
                 } catch (Throwable ex) {
@@ -1571,7 +1571,7 @@ public class Completable {
                 
                 s.onSubscribe(ad);
                 
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     @Override
                     public void onCompleted() {
@@ -1633,7 +1633,7 @@ public class Completable {
         return create(new CompletableOnSubscribe() {
             @Override
             public void call(final CompletableSubscriber s) {
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     @Override
                     public void onCompleted() {
@@ -1682,7 +1682,7 @@ public class Completable {
             @Override
             public void call(final CompletableSubscriber s) {
                 final SerialSubscription sd = new SerialSubscription();
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     @Override
                     public void onCompleted() {
@@ -1708,7 +1708,7 @@ public class Completable {
                             return;
                         }
                         
-                        c.subscribe(new CompletableSubscriber() {
+                        c.unsafeSubscribe(new CompletableSubscriber() {
 
                             @Override
                             public void onCompleted() {
@@ -1844,7 +1844,7 @@ public class Completable {
      */
     public final Subscription subscribe() {
         final MultipleAssignmentSubscription mad = new MultipleAssignmentSubscription();
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onCompleted() {
                 mad.unsubscribe();
@@ -1877,7 +1877,7 @@ public class Completable {
         requireNonNull(onComplete);
         
         final MultipleAssignmentSubscription mad = new MultipleAssignmentSubscription();
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onCompleted() {
                 try {
@@ -1919,7 +1919,7 @@ public class Completable {
         requireNonNull(onComplete);
         
         final MultipleAssignmentSubscription mad = new MultipleAssignmentSubscription();
-        subscribe(new CompletableSubscriber() {
+        unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onCompleted() {
                 try {
@@ -1963,7 +1963,7 @@ public class Completable {
      * @param s the CompletableSubscriber, not null
      * @throws NullPointerException if s is null
      */
-    public final void subscribe(CompletableSubscriber s) {
+    public final void unsafeSubscribe(CompletableSubscriber s) {
         requireNonNull(s);
         try {
             // TODO plugin wrapping the subscriber
@@ -1980,11 +1980,11 @@ public class Completable {
 
     /**
      * Subscribes the given CompletableSubscriber to this Completable instance
-     * and handles exceptions throw by its onXXX methods.
+     * and handles exceptions thrown by its onXXX methods.
      * @param s the CompletableSubscriber, not null
      * @throws NullPointerException if s is null
      */
-    public final void safeSubscribe(CompletableSubscriber s) {
+    public final void subscribe(CompletableSubscriber s) {
         requireNonNull(s);
         try {
             // TODO plugin wrapping the subscriber
@@ -2000,12 +2000,12 @@ public class Completable {
     }
 
     /**
-     * Subscribes a reactive-streams Subscriber to this Completable instance which
+     * Subscribes a regular Subscriber to this Completable instance which
      * will receive only an onError or onComplete event.
      * @param s the reactive-streams Subscriber, not null
      * @throws NullPointerException if s is null
      */
-    public final <T> void subscribe(Subscriber<T> s) {
+    public final <T> void unsafeSubscribe(Subscriber<T> s) {
         requireNonNull(s);
         try {
             final Subscriber<?> sw = s; // FIXME hooking in 1.x is kind of strange to me
@@ -2014,7 +2014,7 @@ public class Completable {
                 throw new NullPointerException("The RxJavaPlugins.onSubscribe returned a null Subscriber");
             }
             
-            subscribe(new CompletableSubscriber() {
+            unsafeSubscribe(new CompletableSubscriber() {
                 @Override
                 public void onCompleted() {
                     sw.onCompleted();
@@ -2041,12 +2041,13 @@ public class Completable {
     }
 
     /**
-     * Subscribes a reactive-streams Subscriber to this Completable instance which
-     * will receive only an onError or onComplete event.
+     * Subscribes a regular Subscriber to this Completable instance which
+     * will receive only an onError or onComplete event
+     * and handles exceptions thrown by its onXXX methods.
      * @param s the reactive-streams Subscriber, not null
      * @throws NullPointerException if s is null
      */
-    public final <T> void safeSubscribe(Subscriber<T> s) {
+    public final <T> void subscribe(Subscriber<T> s) {
         requireNonNull(s);
         try {
             final Subscriber<?> sw = s; // FIXME hooking in 1.x is kind of strange to me
@@ -2055,7 +2056,7 @@ public class Completable {
                 throw new NullPointerException("The RxJavaPlugins.onSubscribe returned a null Subscriber");
             }
             
-            subscribe(new SafeCompletableSubscriber(new CompletableSubscriber() {
+            unsafeSubscribe(new SafeCompletableSubscriber(new CompletableSubscriber() {
                 @Override
                 public void onCompleted() {
                     sw.onCompleted();
@@ -2102,7 +2103,7 @@ public class Completable {
                     @Override
                     public void call() {
                         try {
-                            subscribe(s);
+                            unsafeSubscribe(s);
                         } finally {
                             w.unsubscribe();
                         }
@@ -2205,7 +2206,7 @@ public class Completable {
         return Observable.create(new OnSubscribe<T>() {
             @Override
             public void call(Subscriber<? super T> s) {
-                subscribe(s);
+                unsafeSubscribe(s);
             }
         });
     }
@@ -2222,7 +2223,7 @@ public class Completable {
         return Single.create(new rx.Single.OnSubscribe<T>() {
             @Override
             public void call(final SingleSubscriber<? super T> s) {
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     @Override
                     public void onCompleted() {
@@ -2286,7 +2287,7 @@ public class Completable {
         return create(new CompletableOnSubscribe() {
             @Override
             public void call(final CompletableSubscriber s) {
-                subscribe(new CompletableSubscriber() {
+                unsafeSubscribe(new CompletableSubscriber() {
 
                     @Override
                     public void onCompleted() {

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1927,7 +1927,7 @@ public class Single<T> {
                 serial.add(main);
                 child.add(serial);
 
-                other.subscribe(so);
+                other.unsafeSubscribe(so);
 
                 return main;
             }

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
@@ -129,7 +129,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
                 return;
             }
             
-            c.subscribe(inner);
+            c.unsafeSubscribe(inner);
         }
         
         final class ConcatInnerSubscriber implements CompletableSubscriber {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
@@ -89,7 +89,7 @@ public final class CompletableOnSubscribeConcatArray implements CompletableOnSub
                     return;
                 }
                 
-                a[idx].subscribe(this);
+                a[idx].unsafeSubscribe(this);
             } while (decrementAndGet() != 0);
         }
     }

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatIterable.java
@@ -128,7 +128,7 @@ public final class CompletableOnSubscribeConcatIterable implements CompletableOn
                     return;
                 }
                 
-                c.subscribe(this);
+                c.unsafeSubscribe(this);
             } while (decrementAndGet() != 0);
         }
     }

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
@@ -100,7 +100,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
 
             wip.getAndIncrement();
             
-            t.subscribe(new CompletableSubscriber() {
+            t.unsafeSubscribe(new CompletableSubscriber() {
                 Subscription d;
                 boolean innerDone;
                 @Override

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
@@ -54,7 +54,7 @@ public final class CompletableOnSubscribeMergeArray implements CompletableOnSubs
                 }
             }
             
-            c.subscribe(new CompletableSubscriber() {
+            c.unsafeSubscribe(new CompletableSubscriber() {
                 @Override
                 public void onSubscribe(Subscription d) {
                     set.add(d);

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorArray.java
@@ -51,7 +51,7 @@ public final class CompletableOnSubscribeMergeDelayErrorArray implements Complet
                 continue;
             }
             
-            c.subscribe(new CompletableSubscriber() {
+            c.unsafeSubscribe(new CompletableSubscriber() {
                 @Override
                 public void onSubscribe(Subscription d) {
                     set.add(d);

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorIterable.java
@@ -117,7 +117,7 @@ public final class CompletableOnSubscribeMergeDelayErrorIterable implements Comp
             
             wip.getAndIncrement();
             
-            c.subscribe(new CompletableSubscriber() {
+            c.unsafeSubscribe(new CompletableSubscriber() {
                 @Override
                 public void onSubscribe(Subscription d) {
                     set.add(d);

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeIterable.java
@@ -110,7 +110,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
             
             wip.getAndIncrement();
             
-            c.subscribe(new CompletableSubscriber() {
+            c.unsafeSubscribe(new CompletableSubscriber() {
                 @Override
                 public void onSubscribe(Subscription d) {
                     set.add(d);

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeTimeout.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeTimeout.java
@@ -60,7 +60,7 @@ public final class CompletableOnSubscribeTimeout implements CompletableOnSubscri
                     if (other == null) {
                         s.onError(new TimeoutException());
                     } else {
-                        other.subscribe(new CompletableSubscriber() {
+                        other.unsafeSubscribe(new CompletableSubscriber() {
    
                             @Override
                             public void onSubscribe(Subscription d) {
@@ -85,7 +85,7 @@ public final class CompletableOnSubscribeTimeout implements CompletableOnSubscri
             }
         }, timeout, unit);
         
-        source.subscribe(new CompletableSubscriber() {
+        source.unsafeSubscribe(new CompletableSubscriber() {
 
             @Override
             public void onSubscribe(Subscription d) {

--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -52,8 +52,8 @@ public final class SafeCompletableSubscriber implements CompletableSubscriber, S
 
     @Override
     public void onError(Throwable e) {
+        RxJavaPluginUtils.handleException(e);
         if (done) {
-            RxJavaPluginUtils.handleException(e);
             return;
         }
         done = true;

--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import rx.Completable.CompletableSubscriber;
+import rx.exceptions.*;
+import rx.Subscription;
+import rx.internal.util.RxJavaPluginUtils;
+
+/**
+ * Wraps another CompletableSubscriber and handles exceptions thrown
+ * from onError and onCompleted.
+ */
+public final class SafeCompletableSubscriber implements CompletableSubscriber, Subscription {
+    final CompletableSubscriber actual;
+
+    Subscription s;
+    
+    boolean done;
+    
+    public SafeCompletableSubscriber(CompletableSubscriber actual) {
+        this.actual = actual;
+    }
+
+    @Override
+    public void onCompleted() {
+        if (done) {
+            return;
+        }
+        done = true;
+        try {
+            actual.onCompleted();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            
+            throw new OnCompletedFailedException(ex);
+        }
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        if (done) {
+            RxJavaPluginUtils.handleException(e);
+            return;
+        }
+        done = true;
+        try {
+            actual.onError(e);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            
+            throw new OnErrorFailedException(new CompositeException(e, ex));
+        }
+    }
+
+    @Override
+    public void onSubscribe(Subscription d) {
+        this.s = d;
+        try {
+            actual.onSubscribe(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            d.unsubscribe();
+            onError(ex);
+        }
+    }
+    
+    @Override
+    public void unsubscribe() {
+        s.unsubscribe();
+    }
+    
+    @Override
+    public boolean isUnsubscribed() {
+        return done || s.isUnsubscribed();
+    }
+}

--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -16,14 +16,18 @@
 package rx.observers;
 
 import rx.Completable.CompletableSubscriber;
-import rx.exceptions.*;
 import rx.Subscription;
+import rx.annotations.Experimental;
+import rx.exceptions.*;
 import rx.internal.util.RxJavaPluginUtils;
 
 /**
  * Wraps another CompletableSubscriber and handles exceptions thrown
  * from onError and onCompleted.
+ * 
+ * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
  */
+@Experimental
 public final class SafeCompletableSubscriber implements CompletableSubscriber, Subscription {
     final CompletableSubscriber actual;
 

--- a/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
@@ -16,6 +16,7 @@
 package rx.plugins;
 
 import rx.*;
+import rx.annotations.Experimental;
 import rx.functions.Func1;
 
 /**
@@ -34,7 +35,9 @@ import rx.functions.Func1;
  * should be fast. If anything time-consuming is to be done it should be spawned asynchronously onto separate
  * worker threads.
  *
+ * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
  */
+@Experimental
 public abstract class RxJavaCompletableExecutionHook {
     /**
      * Invoked during the construction by {@link Completable#create(Completable.CompletableOnSubscribe)}
@@ -43,11 +46,11 @@ public abstract class RxJavaCompletableExecutionHook {
      * logging, metrics and other such things and pass through the function.
      *
      * @param f
-     *            original {@link Completable.CompletableOnSubscribe}<{@code T}> to be executed
-     * @return {@link Completable.CompletableOnSubscribe} function that can be modified, decorated, replaced or just
+     *            original {@link rx.Completable.CompletableOnSubscribe}<{@code T}> to be executed
+     * @return {@link rx.Completable.CompletableOnSubscribe} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
-    public <T> Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe f) {
+    public Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe f) {
         return f;
     }
 
@@ -57,12 +60,13 @@ public abstract class RxJavaCompletableExecutionHook {
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.
      *
+     * @param completableInstance the target completable instance
      * @param onSubscribe
-     *            original {@link Completable.CompletableOnSubscribe}<{@code T}> to be executed
-     * @return {@link Completable.CompletableOnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
+     *            original {@link rx.Completable.CompletableOnSubscribe}<{@code T}> to be executed
+     * @return {@link rx.Completable.CompletableOnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
-    public <T> Completable.CompletableOnSubscribe onSubscribeStart(Completable completableInstance, final Completable.CompletableOnSubscribe onSubscribe) {
+    public Completable.CompletableOnSubscribe onSubscribeStart(Completable completableInstance, final Completable.CompletableOnSubscribe onSubscribe) {
         // pass through by default
         return onSubscribe;
     }
@@ -77,7 +81,7 @@ public abstract class RxJavaCompletableExecutionHook {
      *            Throwable thrown by {@link Completable#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass through
      */
-    public <T> Throwable onSubscribeError(Throwable e) {
+    public Throwable onSubscribeError(Throwable e) {
         // pass through by default
         return e;
     }
@@ -86,15 +90,15 @@ public abstract class RxJavaCompletableExecutionHook {
      * Invoked just as the operator functions is called to bind two operations together into a new
      * {@link Completable} and the return value is used as the lifted function
      * <p>
-     * This can be used to decorate or replace the {@link Completable.CompletableOperator} instance or just perform extra
+     * This can be used to decorate or replace the {@link rx.Completable.CompletableOperator} instance or just perform extra
      * logging, metrics and other such things and pass through the onSubscribe.
      *
      * @param lift
-     *            original {@link Completable.CompletableOperator}{@code <R, T>}
-     * @return {@link Completable.CompletableOperator}{@code <R, T>} function that can be modified, decorated, replaced or just
+     *            original {@link rx.Completable.CompletableOperator}{@code <R, T>}
+     * @return {@link rx.Completable.CompletableOperator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
-    public <T, R> Completable.CompletableOperator onLift(final Completable.CompletableOperator lift) {
+    public Completable.CompletableOperator onLift(final Completable.CompletableOperator lift) {
         return lift;
     }
 }

--- a/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.plugins;
+
+import rx.*;
+import rx.functions.Func1;
+
+/**
+ * Abstract ExecutionHook with invocations at different lifecycle points of {@link Completable} execution with a
+ * default no-op implementation.
+ * <p>
+ * See {@link RxJavaPlugins} or the RxJava GitHub Wiki for information on configuring plugins:
+ * <a href="https://github.com/ReactiveX/RxJava/wiki/Plugins">https://github.com/ReactiveX/RxJava/wiki/Plugins</a>.
+ * <p>
+ * <b>Note on thread-safety and performance:</b>
+ * <p>
+ * A single implementation of this class will be used globally so methods on this class will be invoked
+ * concurrently from multiple threads so all functionality must be thread-safe.
+ * <p>
+ * Methods are also invoked synchronously and will add to execution time of the completable so all behavior
+ * should be fast. If anything time-consuming is to be done it should be spawned asynchronously onto separate
+ * worker threads.
+ *
+ */
+public abstract class RxJavaCompletableExecutionHook {
+    /**
+     * Invoked during the construction by {@link Completable#create(Completable.CompletableOnSubscribe)}
+     * <p>
+     * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
+     * logging, metrics and other such things and pass through the function.
+     *
+     * @param f
+     *            original {@link Completable.CompletableOnSubscribe}<{@code T}> to be executed
+     * @return {@link Completable.CompletableOnSubscribe} function that can be modified, decorated, replaced or just
+     *         returned as a pass through
+     */
+    public <T> Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe f) {
+        return f;
+    }
+
+    /**
+     * Invoked before {@link Completable#subscribe(Subscriber)} is about to be executed.
+     * <p>
+     * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
+     * logging, metrics and other such things and pass through the function.
+     *
+     * @param onSubscribe
+     *            original {@link Completable.CompletableOnSubscribe}<{@code T}> to be executed
+     * @return {@link Completable.CompletableOnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
+     *         returned as a pass through
+     */
+    public <T> Completable.CompletableOnSubscribe onSubscribeStart(Completable completableInstance, final Completable.CompletableOnSubscribe onSubscribe) {
+        // pass through by default
+        return onSubscribe;
+    }
+
+    /**
+     * Invoked after failed execution of {@link Completable#subscribe(Subscriber)} with thrown Throwable.
+     * <p>
+     * This is <em>not</em> errors emitted via {@link Subscriber#onError(Throwable)} but exceptions thrown when
+     * attempting to subscribe to a {@link Func1}<{@link Subscriber}{@code <T>}, {@link Subscription}>.
+     *
+     * @param e
+     *            Throwable thrown by {@link Completable#subscribe(Subscriber)}
+     * @return Throwable that can be decorated, replaced or just returned as a pass through
+     */
+    public <T> Throwable onSubscribeError(Throwable e) {
+        // pass through by default
+        return e;
+    }
+
+    /**
+     * Invoked just as the operator functions is called to bind two operations together into a new
+     * {@link Completable} and the return value is used as the lifted function
+     * <p>
+     * This can be used to decorate or replace the {@link Completable.CompletableOperator} instance or just perform extra
+     * logging, metrics and other such things and pass through the onSubscribe.
+     *
+     * @param lift
+     *            original {@link Completable.CompletableOperator}{@code <R, T>}
+     * @return {@link Completable.CompletableOperator}{@code <R, T>} function that can be modified, decorated, replaced or just
+     *         returned as a pass through
+     */
+    public <T, R> Completable.CompletableOperator onLift(final Completable.CompletableOperator lift) {
+        return lift;
+    }
+}

--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -52,6 +52,7 @@ public class RxJavaPlugins {
     private final AtomicReference<RxJavaErrorHandler> errorHandler = new AtomicReference<RxJavaErrorHandler>();
     private final AtomicReference<RxJavaObservableExecutionHook> observableExecutionHook = new AtomicReference<RxJavaObservableExecutionHook>();
     private final AtomicReference<RxJavaSingleExecutionHook> singleExecutionHook = new AtomicReference<RxJavaSingleExecutionHook>();
+    private final AtomicReference<RxJavaCompletableExecutionHook> completableExecutionHook = new AtomicReference<RxJavaCompletableExecutionHook>();
     private final AtomicReference<RxJavaSchedulersHook> schedulersHook = new AtomicReference<RxJavaSchedulersHook>();
 
     /**
@@ -207,6 +208,48 @@ public class RxJavaPlugins {
      */
     public void registerSingleExecutionHook(RxJavaSingleExecutionHook impl) {
         if (!singleExecutionHook.compareAndSet(null, impl)) {
+            throw new IllegalStateException("Another strategy was already registered: " + singleExecutionHook.get());
+        }
+    }
+
+    /**
+     * Retrieves the instance of {@link RxJavaCompletableExecutionHook} to use based on order of precedence as
+     * defined in {@link RxJavaPlugins} class header.
+     * <p>
+     * Override the default by calling {@link #registerCompletableExecutionHook(RxJavaCompletableExecutionHook)}
+     * or by setting the property {@code rxjava.plugin.RxJavaCompletableExecutionHook.implementation} with the
+     * full classname to load.
+     *
+     * @return {@link RxJavaCompletableExecutionHook} implementation to use
+     */
+    public RxJavaCompletableExecutionHook getCompletableExecutionHook() {
+        if (completableExecutionHook.get() == null) {
+            // check for an implementation from System.getProperty first
+            Object impl = getPluginImplementationViaProperty(RxJavaCompletableExecutionHook.class, System.getProperties());
+            if (impl == null) {
+                // nothing set via properties so initialize with default
+                completableExecutionHook.compareAndSet(null, new RxJavaCompletableExecutionHook() { });
+                // we don't return from here but call get() again in case of thread-race so the winner will always get returned
+            } else {
+                // we received an implementation from the system property so use it
+                completableExecutionHook.compareAndSet(null, (RxJavaCompletableExecutionHook) impl);
+            }
+        }
+        return completableExecutionHook.get();
+    }
+
+    /**
+     * Register an {@link RxJavaCompletableExecutionHook} implementation as a global override of any injected or
+     * default implementations.
+     *
+     * @param impl
+     *            {@link RxJavaCompletableExecutionHook} implementation
+     * @throws IllegalStateException
+     *             if called more than once or after the default was initialized (if usage occurs before trying
+     *             to register)
+     */
+    public void registerCompletableExecutionHook(RxJavaCompletableExecutionHook impl) {
+        if (!completableExecutionHook.compareAndSet(null, impl)) {
             throw new IllegalStateException("Another strategy was already registered: " + singleExecutionHook.get());
         }
     }

--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -221,7 +221,9 @@ public class RxJavaPlugins {
      * full classname to load.
      *
      * @return {@link RxJavaCompletableExecutionHook} implementation to use
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
+    @Experimental
     public RxJavaCompletableExecutionHook getCompletableExecutionHook() {
         if (completableExecutionHook.get() == null) {
             // check for an implementation from System.getProperty first
@@ -247,7 +249,9 @@ public class RxJavaPlugins {
      * @throws IllegalStateException
      *             if called more than once or after the default was initialized (if usage occurs before trying
      *             to register)
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
+    @Experimental
     public void registerCompletableExecutionHook(RxJavaCompletableExecutionHook impl) {
         if (!completableExecutionHook.compareAndSet(null, impl)) {
             throw new IllegalStateException("Another strategy was already registered: " + singleExecutionHook.get());

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -1159,7 +1159,7 @@ public class CompletableTest {
     public void never() {
         final AtomicBoolean onSubscribeCalled = new AtomicBoolean();
         final AtomicInteger calls = new AtomicInteger();
-        Completable.never().subscribe(new CompletableSubscriber() {
+        Completable.never().unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 onSubscribeCalled.set(true);
@@ -1202,7 +1202,7 @@ public class CompletableTest {
         
         final AtomicInteger calls = new AtomicInteger();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1235,7 +1235,7 @@ public class CompletableTest {
         final MultipleAssignmentSubscription mad = new MultipleAssignmentSubscription();
         final AtomicInteger calls = new AtomicInteger();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 mad.set(d);
@@ -1295,7 +1295,7 @@ public class CompletableTest {
         final AtomicBoolean unsubscribedFirst = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1341,7 +1341,7 @@ public class CompletableTest {
         final AtomicBoolean unsubscribedFirst = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1387,7 +1387,7 @@ public class CompletableTest {
         final AtomicBoolean unsubscribedFirst = new AtomicBoolean();
         final AtomicBoolean complete = new AtomicBoolean();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1433,7 +1433,7 @@ public class CompletableTest {
         final AtomicBoolean unsubscribedFirst = new AtomicBoolean();
         final AtomicBoolean complete = new AtomicBoolean();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1630,7 +1630,7 @@ public class CompletableTest {
         final AtomicBoolean done = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1665,7 +1665,7 @@ public class CompletableTest {
         final AtomicBoolean done = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1699,7 +1699,7 @@ public class CompletableTest {
         final AtomicBoolean done = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -1826,7 +1826,7 @@ public class CompletableTest {
             }
         });
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 d.unsubscribe();
@@ -1858,7 +1858,7 @@ public class CompletableTest {
             public void call() { throw new TestException(); }
         });
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 d.unsubscribe();
@@ -2017,7 +2017,7 @@ public class CompletableTest {
             }
         });
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -2173,7 +2173,7 @@ public class CompletableTest {
         
         Completable c = normal.completable.observeOn(Schedulers.computation());
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -2206,7 +2206,7 @@ public class CompletableTest {
         
         Completable c = error.completable.observeOn(Schedulers.computation());
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(Subscription d) {
                 
@@ -2337,7 +2337,7 @@ public class CompletableTest {
             }
         }).repeat();
         
-        c.subscribe(new CompletableSubscriber() {
+        c.unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(final Subscription d) {
                 final Scheduler.Worker w = Schedulers.io().createWorker();
@@ -2680,19 +2680,19 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void subscribeSubscriberNull() {
-        normal.completable.subscribe((Subscriber<Object>)null);
+        normal.completable.unsafeSubscribe((Subscriber<Object>)null);
     }
     
     @Test(expected = NullPointerException.class)
     public void subscribeCompletableSubscriberNull() {
-        normal.completable.subscribe((CompletableSubscriber)null);
+        normal.completable.unsafeSubscribe((CompletableSubscriber)null);
     }
 
     @Test(timeout = 1000)
     public void subscribeSubscriberNormal() {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
         
-        normal.completable.subscribe(ts);
+        normal.completable.unsafeSubscribe(ts);
         
         ts.assertCompleted();
         ts.assertNoValues();
@@ -2703,7 +2703,7 @@ public class CompletableTest {
     public void subscribeSubscriberError() {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
         
-        error.completable.subscribe(ts);
+        error.completable.unsafeSubscribe(ts);
         
         ts.assertNotCompleted();
         ts.assertNoValues();
@@ -3028,7 +3028,7 @@ public class CompletableTest {
             }
         })
         .unsubscribeOn(Schedulers.computation())
-        .subscribe(new CompletableSubscriber() {
+        .unsafeSubscribe(new CompletableSubscriber() {
             @Override
             public void onSubscribe(final Subscription d) {
                 final Scheduler.Worker w = Schedulers.io().createWorker();
@@ -3628,7 +3628,7 @@ public class CompletableTest {
             public Completable call(Integer t) {
                 throw new TestException();
             }
-        }, onDispose).subscribe(ts);
+        }, onDispose).unsafeSubscribe(ts);
         
         verify(onDispose).call(1);
         
@@ -3659,7 +3659,7 @@ public class CompletableTest {
             public Completable call(Integer t) {
                 throw new TestException();
             }
-        }, onDispose).subscribe(ts);
+        }, onDispose).unsafeSubscribe(ts);
         
         ts.assertNoValues();
         ts.assertNotCompleted();
@@ -3693,7 +3693,7 @@ public class CompletableTest {
             public Completable call(Integer t) {
                 return null;
             }
-        }, onDispose).subscribe(ts);
+        }, onDispose).unsafeSubscribe(ts);
         
         verify(onDispose).call(1);
         
@@ -3724,7 +3724,7 @@ public class CompletableTest {
             public Completable call(Integer t) {
                 return null;
             }
-        }, onDispose).subscribe(ts);
+        }, onDispose).unsafeSubscribe(ts);
         
         ts.assertNoValues();
         ts.assertNotCompleted();
@@ -3901,7 +3901,7 @@ public class CompletableTest {
     @Test
     public void safeOnCompleteThrows() {
         try {
-            normal.completable.safeSubscribe(new CompletableSubscriber() {
+            normal.completable.subscribe(new CompletableSubscriber() {
     
                 @Override
                 public void onCompleted() {
@@ -3931,7 +3931,7 @@ public class CompletableTest {
     @Test
     public void safeOnCompleteThrowsRegularSubscriber() {
         try {
-            normal.completable.safeSubscribe(new Subscriber<Object>() {
+            normal.completable.subscribe(new Subscriber<Object>() {
     
                 @Override
                 public void onCompleted() {
@@ -3960,7 +3960,7 @@ public class CompletableTest {
     @Test
     public void safeOnErrorThrows() {
         try {
-            error.completable.safeSubscribe(new CompletableSubscriber() {
+            error.completable.subscribe(new CompletableSubscriber() {
     
                 @Override
                 public void onCompleted() {
@@ -3999,7 +3999,7 @@ public class CompletableTest {
     @Test
     public void safeOnErrorThrowsRegularSubscriber() {
         try {
-            error.completable.safeSubscribe(new Subscriber<Object>() {
+            error.completable.subscribe(new Subscriber<Object>() {
     
                 @Override
                 public void onCompleted() {

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -3898,4 +3898,141 @@ public class CompletableTest {
         }
     }
 
+    @Test
+    public void safeOnCompleteThrows() {
+        try {
+            normal.completable.safeSubscribe(new CompletableSubscriber() {
+    
+                @Override
+                public void onCompleted() {
+                    throw new TestException("Forced failure");
+                }
+    
+                @Override
+                public void onError(Throwable e) {
+                    
+                }
+    
+                @Override
+                public void onSubscribe(Subscription d) {
+                    
+                }
+                
+            });
+            Assert.fail("Did not propagate exception!");
+        } catch (OnCompletedFailedException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertNotNull(c);
+            
+            Assert.assertEquals("Forced failure", c.getMessage());
+        }
+    }
+
+    @Test
+    public void safeOnCompleteThrowsRegularSubscriber() {
+        try {
+            normal.completable.safeSubscribe(new Subscriber<Object>() {
+    
+                @Override
+                public void onCompleted() {
+                    throw new TestException("Forced failure");
+                }
+    
+                @Override
+                public void onError(Throwable e) {
+                    
+                }
+    
+                @Override
+                public void onNext(Object t) {
+                    
+                }
+            });
+            Assert.fail("Did not propagate exception!");
+        } catch (OnCompletedFailedException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertNotNull(c);
+            
+            Assert.assertEquals("Forced failure", c.getMessage());
+        }
+    }
+
+    @Test
+    public void safeOnErrorThrows() {
+        try {
+            error.completable.safeSubscribe(new CompletableSubscriber() {
+    
+                @Override
+                public void onCompleted() {
+                }
+    
+                @Override
+                public void onError(Throwable e) {
+                    throw new TestException("Forced failure");
+                }
+    
+                @Override
+                public void onSubscribe(Subscription d) {
+                    
+                }
+                
+            });
+            Assert.fail("Did not propagate exception!");
+        } catch (OnErrorFailedException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertTrue("" + c, c instanceof CompositeException);
+            
+            CompositeException ce = (CompositeException)c;
+            
+            List<Throwable> list = ce.getExceptions();
+            
+            Assert.assertEquals(2, list.size());
+
+            Assert.assertTrue("" + list.get(0), list.get(0) instanceof TestException);
+            Assert.assertNull(list.get(0).getMessage());
+
+            Assert.assertTrue("" + list.get(1), list.get(1) instanceof TestException);
+            Assert.assertEquals("Forced failure", list.get(1).getMessage());
+        }
+    }
+
+    @Test
+    public void safeOnErrorThrowsRegularSubscriber() {
+        try {
+            error.completable.safeSubscribe(new Subscriber<Object>() {
+    
+                @Override
+                public void onCompleted() {
+
+                }
+    
+                @Override
+                public void onError(Throwable e) {
+                    throw new TestException("Forced failure");
+                }
+    
+                @Override
+                public void onNext(Object t) {
+                    
+                }
+            });
+            Assert.fail("Did not propagate exception!");
+        } catch (OnErrorFailedException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertTrue("" + c, c instanceof CompositeException);
+            
+            CompositeException ce = (CompositeException)c;
+            
+            List<Throwable> list = ce.getExceptions();
+            
+            Assert.assertEquals(2, list.size());
+
+            Assert.assertTrue("" + list.get(0), list.get(0) instanceof TestException);
+            Assert.assertNull(list.get(0).getMessage());
+
+            Assert.assertTrue("" + list.get(1), list.get(1) instanceof TestException);
+            Assert.assertEquals("Forced failure", list.get(1).getMessage());
+        }
+    }
+
 }

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -30,7 +30,7 @@ import rx.Completable.*;
 import rx.Observable.OnSubscribe;
 import rx.exceptions.*;
 import rx.functions.*;
-import rx.observers.*;
+import rx.observers.TestSubscriber;
 import rx.plugins.*;
 import rx.schedulers.*;
 import rx.subjects.PublishSubject;
@@ -4078,6 +4078,38 @@ public class CompletableTest {
         completable.unsafeSubscribe(ts);
 
         verify(hookSpy, times(1)).onSubscribeStart(eq(completable), any(Completable.CompletableOnSubscribe.class));
+    }
+
+    @Test
+    public void onStartCalledSafe() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>() {
+            @Override
+            public void onStart() {
+                onNext(1);
+            }
+        };
+        
+        normal.completable.subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void onStartCalledUnsafeSafe() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>() {
+            @Override
+            public void onStart() {
+                onNext(1);
+            }
+        };
+        
+        normal.completable.unsafeSubscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 
 }

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -816,7 +816,7 @@ public class SingleTest {
     public void toCompletableSuccess() {
         Completable completable = Single.just("value").toCompletable();
         TestSubscriber<Object> testSubscriber = new TestSubscriber<Object>();
-        completable.subscribe(testSubscriber);
+        completable.unsafeSubscribe(testSubscriber);
 
         testSubscriber.assertCompleted();
         testSubscriber.assertNoValues();
@@ -828,7 +828,7 @@ public class SingleTest {
         TestException exception = new TestException();
         Completable completable = Single.error(exception).toCompletable();
         TestSubscriber<Object> testSubscriber = new TestSubscriber<Object>();
-        completable.subscribe(testSubscriber);
+        completable.unsafeSubscribe(testSubscriber);
 
         testSubscriber.assertError(exception);
         testSubscriber.assertNoValues();

--- a/src/test/java/rx/internal/operators/OnSubscribeCompletableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCompletableTest.java
@@ -32,7 +32,7 @@ public class OnSubscribeCompletableTest {
     public void testJustSingleItemObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         Completable cmp = Observable.just("Hello World!").toCompletable();
-        cmp.subscribe(subscriber);
+        cmp.unsafeSubscribe(subscriber);
 
         subscriber.assertNoValues();
         subscriber.assertCompleted();
@@ -44,7 +44,7 @@ public class OnSubscribeCompletableTest {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         IllegalArgumentException error = new IllegalArgumentException("Error");
         Completable cmp = Observable.<String>error(error).toCompletable();
-        cmp.subscribe(subscriber);
+        cmp.unsafeSubscribe(subscriber);
 
         subscriber.assertError(error);
         subscriber.assertNoValues();
@@ -54,7 +54,7 @@ public class OnSubscribeCompletableTest {
     public void testJustTwoEmissionsObservableThrowsError() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         Completable cmp = Observable.just("First", "Second").toCompletable();
-        cmp.subscribe(subscriber);
+        cmp.unsafeSubscribe(subscriber);
 
         subscriber.assertNoErrors();
         subscriber.assertNoValues();
@@ -64,7 +64,7 @@ public class OnSubscribeCompletableTest {
     public void testEmptyObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         Completable cmp = Observable.<String>empty().toCompletable();
-        cmp.subscribe(subscriber);
+        cmp.unsafeSubscribe(subscriber);
 
         subscriber.assertNoErrors();
         subscriber.assertNoValues();
@@ -75,7 +75,7 @@ public class OnSubscribeCompletableTest {
     public void testNeverObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         Completable cmp = Observable.<String>never().toCompletable();
-        cmp.subscribe(subscriber);
+        cmp.unsafeSubscribe(subscriber);
 
         subscriber.assertNoTerminalEvent();
         subscriber.assertNoValues();
@@ -91,7 +91,7 @@ public class OnSubscribeCompletableTest {
             public void call() {
                 unsubscribed.set(true);
             }}).toCompletable();
-        cmp.subscribe(subscriber);
+        cmp.unsafeSubscribe(subscriber);
         subscriber.assertCompleted();
         assertFalse(unsubscribed.get());
     }

--- a/src/test/java/rx/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/rx/plugins/RxJavaPluginsTest.java
@@ -253,6 +253,11 @@ public class RxJavaPluginsTest {
         // just use defaults
     }
 
+    // inside test so it is stripped from Javadocs
+    public static class RxJavaCompletableExecutionHookTestImpl extends RxJavaCompletableExecutionHook {
+        // just use defaults
+    }
+
     private static String getFullClassNameForTestClass(Class<?> cls) {
         return RxJavaPlugins.class.getPackage()
                                   .getName() + "." + RxJavaPluginsTest.class.getSimpleName() + "$" + cls.getSimpleName();

--- a/src/test/java/rx/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/rx/plugins/RxJavaPluginsTest.java
@@ -23,8 +23,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.*;
 
+import rx.*;
 import rx.Observable;
-import rx.Subscriber;
 import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
@@ -290,5 +290,57 @@ public class RxJavaPluginsTest {
         props.setProperty("rxjava.plugin.1.class", "Map");
 
         RxJavaPlugins.getPluginImplementationViaProperty(Map.class, props);
+    }
+
+    @Test
+    public void testOnErrorWhenUsingCompletable() {
+        RxJavaErrorHandlerTestImpl errorHandler = new RxJavaErrorHandlerTestImpl();
+           RxJavaPlugins.getInstance().registerErrorHandler(errorHandler);
+
+        RuntimeException re = new RuntimeException("test onError");
+        Completable.error(re).subscribe(new Subscriber<Object>() {
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Object o) {
+
+            }
+        });
+        assertEquals(re, errorHandler.e);
+        assertEquals(1, errorHandler.count);
+    }
+
+    @Test
+    public void testOnErrorWhenUsingSingle() {
+        RxJavaErrorHandlerTestImpl errorHandler = new RxJavaErrorHandlerTestImpl();
+        RxJavaPlugins.getInstance().registerErrorHandler(errorHandler);
+
+        RuntimeException re = new RuntimeException("test onError");
+        Single.error(re).subscribe(new Subscriber<Object>() {
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Object o) {
+
+            }
+        });
+        assertEquals(re, errorHandler.e);
+        assertEquals(1, errorHandler.count);
     }
 }


### PR DESCRIPTION
Add option to safely subscribe a `CompletableSubscriber` / regular `Subscriber` and handle `onXXX` failures.

See also: #3938

Naming and whether or not the safe wrapping should be the default is open to discussion.