### PR TITLE
1.x: javac- and javadoc-related cleanup in components, part 1

### DIFF
--- a/src/main/java/rx/BackpressureOverflow.java
+++ b/src/main/java/rx/BackpressureOverflow.java
@@ -37,11 +37,11 @@ public final class BackpressureOverflow {
     }
 
     public static final BackpressureOverflow.Strategy ON_OVERFLOW_DEFAULT = Error.INSTANCE;
-    @SuppressWarnings("unused")
+
     public static final BackpressureOverflow.Strategy ON_OVERFLOW_ERROR = Error.INSTANCE;
-    @SuppressWarnings("unused")
+
     public static final BackpressureOverflow.Strategy ON_OVERFLOW_DROP_OLDEST = DropOldest.INSTANCE;
-    @SuppressWarnings("unused")
+
     public static final BackpressureOverflow.Strategy ON_OVERFLOW_DROP_LATEST = DropLatest.INSTANCE;
 
     /**

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -116,6 +116,7 @@ public class Observable<T> {
      * 
      * @param <T>
      *            the type of the items that this Observable emits
+     * @param <S> the state type
      * @param syncOnSubscribe
      *            an implementation of {@link SyncOnSubscribe}. There are many static creation methods 
      *            on the class for convenience.  
@@ -151,6 +152,7 @@ public class Observable<T> {
      * 
      * @param <T>
      *            the type of the items that this Observable emits
+     * @param <S> the state type
      * @param asyncOnSubscribe
      *            an implementation of {@link AsyncOnSubscribe}. There are many static creation methods 
      *            on the class for convenience. 
@@ -167,6 +169,7 @@ public class Observable<T> {
 
     /**
      * Invoked when Observable.subscribe is called.
+     * @param <T> the output value type
      */
     public interface OnSubscribe<T> extends Action1<Subscriber<? super T>> {
         // cover for generics insanity
@@ -174,6 +177,8 @@ public class Observable<T> {
 
     /**
      * Operator function for lifting into an Observable.
+     * @param <T> the upstream's value type (input)
+     * @param <R> the downstream's value type (output)
      */
     public interface Operator<R, T> extends Func1<Subscriber<? super R>, Subscriber<? super T>> {
         // cover for generics insanity

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -135,6 +135,7 @@ public class Single<T> {
 
     /**
      * Invoked when Single.execute is called.
+     * @param <T> the output value type
      */
     public interface OnSubscribe<T> extends Action1<SingleSubscriber<? super T>> {
         // cover for generics insanity
@@ -157,6 +158,7 @@ public class Single<T> {
      * <dd>{@code lift} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
+     * @param <R> the downstream's value type (output)
      * @param lift
      *            the Operator that implements the Single-operating function to be applied to the source Single
      * @return a Single that is the result of applying the lifted Operator to the source Single
@@ -657,12 +659,14 @@ public class Single<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
+     * @param <T> the value type of the sources and the output
      * @param source
      *            a {@code Single} that emits a {@code Single}
      * @return a {@code Single} that emits the item that is the result of flattening the {@code Single} emitted
      *         by {@code source}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Single<T> merge(final Single<? extends Single<? extends T>> source) {
         if (source instanceof ScalarSynchronousSingle) {
             return ((ScalarSynchronousSingle<T>) source).scalarFlatMap((Func1) UtilityFunctions.identity());

--- a/src/main/java/rx/exceptions/CompositeException.java
+++ b/src/main/java/rx/exceptions/CompositeException.java
@@ -41,7 +41,11 @@ public final class CompositeException extends RuntimeException {
     private final List<Throwable> exceptions;
     private final String message;
 
-    /** @deprecated please use {@link #CompositeException(Collection)} */
+    /** 
+     * Constructs a CompositeException with the given prefix and error collection.
+     * @param messagePrefix the prefix to use (actually unused)
+     * @param errors the collection of errors
+     * @deprecated please use {@link #CompositeException(Collection)} */
     @Deprecated
     public CompositeException(String messagePrefix, Collection<? extends Throwable> errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();

--- a/src/main/java/rx/exceptions/OnCompletedFailedException.java
+++ b/src/main/java/rx/exceptions/OnCompletedFailedException.java
@@ -27,7 +27,7 @@ public final class OnCompletedFailedException extends RuntimeException {
     /**
      * Wraps the {@code Throwable} before it is to be re-thrown as an {@code OnCompletedFailedException}.
      *
-     * @param e
+     * @param throwable
      *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
      */
     public OnCompletedFailedException(Throwable throwable) {
@@ -40,7 +40,7 @@ public final class OnCompletedFailedException extends RuntimeException {
      *
      * @param message
      *          the message to assign to the {@code Throwable} to re-throw
-     * @param e
+     * @param throwable
      *          the {@code Throwable} to re-throw; if null, a NullPointerException is constructed
      */
     public OnCompletedFailedException(String message, Throwable throwable) {

--- a/src/main/java/rx/functions/Action1.java
+++ b/src/main/java/rx/functions/Action1.java
@@ -17,6 +17,7 @@ package rx.functions;
 
 /**
  * A one-argument action.
+ * @param <T> the first argument type
  */
 public interface Action1<T> extends Action {
     void call(T t);

--- a/src/main/java/rx/functions/Action2.java
+++ b/src/main/java/rx/functions/Action2.java
@@ -17,6 +17,8 @@ package rx.functions;
 
 /**
  * A two-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
  */
 public interface Action2<T1, T2> extends Action {
     void call(T1 t1, T2 t2);

--- a/src/main/java/rx/functions/Action3.java
+++ b/src/main/java/rx/functions/Action3.java
@@ -17,6 +17,9 @@ package rx.functions;
 
 /**
  * A three-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
  */
 public interface Action3<T1, T2, T3> extends Action {
     void call(T1 t1, T2 t2, T3 t3);

--- a/src/main/java/rx/functions/Action4.java
+++ b/src/main/java/rx/functions/Action4.java
@@ -18,6 +18,10 @@ package rx.functions;
 
 /**
  * A four-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
  */
 public interface Action4<T1, T2, T3, T4> extends Action {
     void call(T1 t1, T2 t2, T3 t3, T4 t4);

--- a/src/main/java/rx/functions/Action5.java
+++ b/src/main/java/rx/functions/Action5.java
@@ -18,6 +18,11 @@ package rx.functions;
 
 /**
  * A five-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
  */
 public interface Action5<T1, T2, T3, T4, T5> extends Action {
     void call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);

--- a/src/main/java/rx/functions/Action6.java
+++ b/src/main/java/rx/functions/Action6.java
@@ -18,6 +18,12 @@ package rx.functions;
 
 /**
  * A six-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
  */
 public interface Action6<T1, T2, T3, T4, T5, T6> extends Action {
     void call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);

--- a/src/main/java/rx/functions/Action7.java
+++ b/src/main/java/rx/functions/Action7.java
@@ -17,6 +17,13 @@ package rx.functions;
 
 /**
  * A seven-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <T7> the seventh argument type
  */
 public interface Action7<T1, T2, T3, T4, T5, T6, T7> extends Action {
     void call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);

--- a/src/main/java/rx/functions/Action8.java
+++ b/src/main/java/rx/functions/Action8.java
@@ -17,6 +17,14 @@ package rx.functions;
 
 /**
  * An eight-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <T7> the seventh argument type
+ * @param <T8> the eigth argument type
  */
 public interface Action8<T1, T2, T3, T4, T5, T6, T7, T8> extends Action {
     void call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);

--- a/src/main/java/rx/functions/Action9.java
+++ b/src/main/java/rx/functions/Action9.java
@@ -17,6 +17,15 @@ package rx.functions;
 
 /**
  * A nine-argument action.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <T7> the seventh argument type
+ * @param <T8> the eigth argument type
+ * @param <T9> the ninth argument type
  */
 public interface Action9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Action {
     void call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9);

--- a/src/main/java/rx/functions/Actions.java
+++ b/src/main/java/rx/functions/Actions.java
@@ -105,6 +105,7 @@ public final class Actions {
     /**
      * Converts an {@link Action1} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
      * @param action
      *            the {@link Action1} to convert
      * @return a {@link Func1} that calls {@code action} and returns {@code null}
@@ -116,6 +117,8 @@ public final class Actions {
     /**
      * Converts an {@link Action2} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
      * @param action
      *            the {@link Action2} to convert
      * @return a {@link Func2} that calls {@code action} and returns {@code null}
@@ -127,6 +130,9 @@ public final class Actions {
     /**
      * Converts an {@link Action3} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
      * @param action
      *            the {@link Action3} to convert
      * @return a {@link Func3} that calls {@code action} and returns {@code null}
@@ -138,6 +144,10 @@ public final class Actions {
     /**
      * Converts an {@link Action4} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
      * @param action
      *            the {@link Action4} to convert
      * @return a {@link Func4} that calls {@code action} and returns {@code null}
@@ -149,6 +159,11 @@ public final class Actions {
     /**
      * Converts an {@link Action5} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
      * @param action
      *            the {@link Action5} to convert
      * @return a {@link Func5} that calls {@code action} and returns {@code null}
@@ -161,6 +176,12 @@ public final class Actions {
     /**
      * Converts an {@link Action6} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
      * @param action
      *            the {@link Action6} to convert
      * @return a {@link Func6} that calls {@code action} and returns {@code null}
@@ -173,6 +194,13 @@ public final class Actions {
     /**
      * Converts an {@link Action7} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <T7> the seventh argument type
      * @param action
      *            the {@link Action7} to convert
      * @return a {@link Func7} that calls {@code action} and returns {@code null}
@@ -185,6 +213,14 @@ public final class Actions {
     /**
      * Converts an {@link Action8} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <T7> the seventh argument type
+     * @param <T8> the eigth argument type
      * @param action
      *            the {@link Action8} to convert
      * @return a {@link Func8} that calls {@code action} and returns {@code null}
@@ -197,6 +233,15 @@ public final class Actions {
     /**
      * Converts an {@link Action9} to a function that calls the action and returns {@code null}.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <T7> the seventh argument type
+     * @param <T8> the eigth argument type
+     * @param <T9> the ninth argument type
      * @param action
      *            the {@link Action9} to convert
      * @return a {@link Func9} that calls {@code action} and returns {@code null}
@@ -221,6 +266,7 @@ public final class Actions {
     /**
      * Converts an {@link Action0} to a function that calls the action and returns a specified value.
      * 
+     * @param <R> the result type
      * @param action
      *            the {@link Action0} to convert
      * @param result
@@ -240,6 +286,8 @@ public final class Actions {
     /**
      * Converts an {@link Action1} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action1} to convert
      * @param result
@@ -259,6 +307,9 @@ public final class Actions {
     /**
      * Converts an {@link Action2} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action2} to convert
      * @param result
@@ -278,6 +329,10 @@ public final class Actions {
     /**
      * Converts an {@link Action3} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action3} to convert
      * @param result
@@ -297,6 +352,11 @@ public final class Actions {
     /**
      * Converts an {@link Action4} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action4} to convert
      * @param result
@@ -316,6 +376,12 @@ public final class Actions {
     /**
      * Converts an {@link Action5} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action5} to convert
      * @param result
@@ -336,6 +402,13 @@ public final class Actions {
     /**
      * Converts an {@link Action6} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action6} to convert
      * @param result
@@ -356,6 +429,14 @@ public final class Actions {
     /**
      * Converts an {@link Action7} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <T7> the seventh argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action7} to convert
      * @param result
@@ -376,6 +457,15 @@ public final class Actions {
     /**
      * Converts an {@link Action8} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <T7> the seventh argument type
+     * @param <T8> the eigth argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action8} to convert
      * @param result
@@ -396,6 +486,16 @@ public final class Actions {
     /**
      * Converts an {@link Action9} to a function that calls the action and returns a specified value.
      * 
+     * @param <T1> the first argument type
+     * @param <T2> the second argument type
+     * @param <T3> the third argument type
+     * @param <T4> the fourth argument type
+     * @param <T5> the fifth argument type
+     * @param <T6> the sixth argument type
+     * @param <T7> the seventh argument type
+     * @param <T8> the eigth argument type
+     * @param <T9> the ninth argument type
+     * @param <R> the result type
      * @param action
      *            the {@link Action9} to convert
      * @param result
@@ -416,6 +516,7 @@ public final class Actions {
     /**
      * Converts an {@link ActionN} to a function that calls the action and returns a specified value.
      * 
+     * @param <R> the result type
      * @param action
      *            the {@link ActionN} to convert
      * @param result
@@ -436,6 +537,7 @@ public final class Actions {
     /**
      * Wraps an Action0 instance into an Action1 instance where the latter calls
      * the former.
+     * @param <T> the first argument type
      * @param action the action to call
      * @return the new Action1 instance
      */

--- a/src/main/java/rx/functions/Func0.java
+++ b/src/main/java/rx/functions/Func0.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 
 /**
  * Represents a function with zero arguments.
+ * @param <R> the result type
  */
 public interface Func0<R> extends Function, Callable<R> {
     @Override

--- a/src/main/java/rx/functions/Func1.java
+++ b/src/main/java/rx/functions/Func1.java
@@ -17,6 +17,8 @@ package rx.functions;
 
 /**
  * Represents a function with one argument.
+ * @param <T> the first argument type
+ * @param <R> the result type
  */
 public interface Func1<T, R> extends Function {
     R call(T t);

--- a/src/main/java/rx/functions/Func2.java
+++ b/src/main/java/rx/functions/Func2.java
@@ -17,6 +17,9 @@ package rx.functions;
 
 /**
  * Represents a function with two arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <R> the result type
  */
 public interface Func2<T1, T2, R> extends Function {
     R call(T1 t1, T2 t2);

--- a/src/main/java/rx/functions/Func3.java
+++ b/src/main/java/rx/functions/Func3.java
@@ -17,6 +17,10 @@ package rx.functions;
 
 /**
  * Represents a function with three arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <R> the result type
  */
 public interface Func3<T1, T2, T3, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3);

--- a/src/main/java/rx/functions/Func4.java
+++ b/src/main/java/rx/functions/Func4.java
@@ -17,6 +17,11 @@ package rx.functions;
 
 /**
  * Represents a function with four arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <R> the result type
  */
 public interface Func4<T1, T2, T3, T4, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3, T4 t4);

--- a/src/main/java/rx/functions/Func5.java
+++ b/src/main/java/rx/functions/Func5.java
@@ -17,6 +17,12 @@ package rx.functions;
 
 /**
  * Represents a function with five arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <R> the result type
  */
 public interface Func5<T1, T2, T3, T4, T5, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);

--- a/src/main/java/rx/functions/Func6.java
+++ b/src/main/java/rx/functions/Func6.java
@@ -17,6 +17,13 @@ package rx.functions;
 
 /**
  * Represents a function with six arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <R> the result type
  */
 public interface Func6<T1, T2, T3, T4, T5, T6, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);

--- a/src/main/java/rx/functions/Func7.java
+++ b/src/main/java/rx/functions/Func7.java
@@ -17,6 +17,14 @@ package rx.functions;
 
 /**
  * Represents a function with seven arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <T7> the seventh argument type
+ * @param <R> the result type
  */
 public interface Func7<T1, T2, T3, T4, T5, T6, T7, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);

--- a/src/main/java/rx/functions/Func8.java
+++ b/src/main/java/rx/functions/Func8.java
@@ -17,6 +17,15 @@ package rx.functions;
 
 /**
  * Represents a function with eight arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <T7> the seventh argument type
+ * @param <T8> the eigth argument type
+ * @param <R> the result type
  */
 public interface Func8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);

--- a/src/main/java/rx/functions/Func9.java
+++ b/src/main/java/rx/functions/Func9.java
@@ -17,6 +17,16 @@ package rx.functions;
 
 /**
  * Represents a function with nine arguments.
+ * @param <T1> the first argument type
+ * @param <T2> the second argument type
+ * @param <T3> the third argument type
+ * @param <T4> the fourth argument type
+ * @param <T5> the fifth argument type
+ * @param <T6> the sixth argument type
+ * @param <T7> the seventh argument type
+ * @param <T8> the eigth argument type
+ * @param <T9> the ninth argument type
+ * @param <R> the result type
  */
 public interface Func9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends Function {
     R call(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9);

--- a/src/main/java/rx/functions/FuncN.java
+++ b/src/main/java/rx/functions/FuncN.java
@@ -17,6 +17,7 @@ package rx.functions;
 
 /**
  * Represents a vector-argument function.
+ * @param <R> the result type
  */
 public interface FuncN<R> extends Function {
     R call(Object... args);

--- a/src/main/java/rx/functions/Functions.java
+++ b/src/main/java/rx/functions/Functions.java
@@ -23,6 +23,7 @@ public final class Functions {
     /**
      * Converts a {@link Func0} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <R> the result type
      * @param f
      *          the {@code Func0} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -44,6 +45,8 @@ public final class Functions {
     /**
      * Converts a {@link Func1} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func1} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -66,6 +69,9 @@ public final class Functions {
     /**
      * Converts a {@link Func2} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func2} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -88,6 +94,10 @@ public final class Functions {
     /**
      * Converts a {@link Func3} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func3} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -110,6 +120,11 @@ public final class Functions {
     /**
      * Converts a {@link Func4} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func4} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -132,6 +147,12 @@ public final class Functions {
     /**
      * Converts a {@link Func5} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <T4> the fifth argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func5} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -154,6 +175,13 @@ public final class Functions {
     /**
      * Converts a {@link Func6} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <T4> the fifth argument type
+     * @param <T5> the sixth argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func6} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -176,6 +204,14 @@ public final class Functions {
     /**
      * Converts a {@link Func7} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <T4> the fifth argument type
+     * @param <T5> the sixth argument type
+     * @param <T6> the seventh argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func7} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -198,6 +234,15 @@ public final class Functions {
     /**
      * Converts a {@link Func8} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <T4> the fifth argument type
+     * @param <T5> the sixth argument type
+     * @param <T6> the seventh argument type
+     * @param <T7> the eigth argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func8} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -220,6 +265,16 @@ public final class Functions {
     /**
      * Converts a {@link Func9} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <T4> the fifth argument type
+     * @param <T5> the sixth argument type
+     * @param <T6> the seventh argument type
+     * @param <T7> the eigth argument type
+     * @param <T8> the ninth argument type
+     * @param <R> the result type
      * @param f
      *          the {@code Func9} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -264,6 +319,7 @@ public final class Functions {
     /**
      * Converts an {@link Action1} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
      * @param f
      *          the {@code Action1} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -287,6 +343,8 @@ public final class Functions {
     /**
      * Converts an {@link Action2} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
      * @param f
      *          the {@code Action2} to convert
      * @return a {@link FuncN} representation of {@code f}
@@ -310,6 +368,9 @@ public final class Functions {
     /**
      * Converts an {@link Action3} to a {@link FuncN} to allow heterogeneous handling of functions with different arities.
      * 
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
      * @param f
      *          the {@code Action3} to convert
      * @return a {@link FuncN} representation of {@code f}

--- a/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
@@ -98,7 +98,6 @@ public final class BlockingOperatorLatest {
                         throw Exceptions.propagate(ex);
                     }
 
-                    @SuppressWarnings("unchecked")
                     Notification<? extends T> n = value.getAndSet(null);
                     iNotif = n;
                     if (iNotif.isOnError()) {

--- a/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
+++ b/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
@@ -60,6 +60,8 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
 
     /** The common state. */
     static final class State<T> extends AtomicReference<Observer<? super T>> {
+        /** */
+        private static final long serialVersionUID = 8026705089538090368L;
         boolean casObserverRef(Observer<? super T>  expected, Observer<? super T>  next) {
             return compareAndSet(expected, next);
         }

--- a/src/main/java/rx/internal/operators/SingleOperatorOnErrorResumeNext.java
+++ b/src/main/java/rx/internal/operators/SingleOperatorOnErrorResumeNext.java
@@ -20,7 +20,6 @@ import rx.Single;
 import rx.SingleSubscriber;
 import rx.exceptions.Exceptions;
 import rx.functions.Func1;
-import rx.plugins.RxJavaPlugins;
 
 public class SingleOperatorOnErrorResumeNext<T> implements Single.OnSubscribe<T> {
 

--- a/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
+++ b/src/main/java/rx/internal/schedulers/EventLoopsScheduler.java
@@ -88,6 +88,7 @@ public final class EventLoopsScheduler extends Scheduler implements SchedulerLif
     /**
      * Create a scheduler with pool size equal to the available processor
      * count and using least-recent worker selection policy.
+     * @param threadFactory the factory to use with the executors
      */
     public EventLoopsScheduler(ThreadFactory threadFactory) {
         this.threadFactory = threadFactory;

--- a/src/main/java/rx/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/rx/internal/schedulers/ExecutorScheduler.java
@@ -35,10 +35,6 @@ public final class ExecutorScheduler extends Scheduler {
         this.executor = executor;
     }
 
-    /**
-     * @warn javadoc missing
-     * @return
-     */
     @Override
     public Worker createWorker() {
         return new ExecutorSchedulerWorker(executor);

--- a/src/main/java/rx/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/rx/internal/schedulers/NewThreadWorker.java
@@ -225,11 +225,12 @@ public class NewThreadWorker extends Scheduler.Worker implements Subscription {
     }
 
     /**
-     * @warn javadoc missing
-     * @param action
-     * @param delayTime
-     * @param unit
-     * @return
+     * Schedules the given action by wrapping it into a ScheduledAction on the
+     * underlying ExecutorService, returning the ScheduledAction. 
+     * @param action the action to wrap and schedule
+     * @param delayTime the delay in execution
+     * @param unit the time unit of the delay
+     * @return the wrapper ScheduledAction
      */
     public ScheduledAction scheduleActual(final Action0 action, long delayTime, TimeUnit unit) {
         Action0 decoratedAction = schedulersHook.onSchedule(action);

--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -29,6 +29,8 @@ import rx.annotations.Experimental;
  */
 @Experimental
 public final class BackpressureDrainManager extends AtomicLong implements Producer {
+    /** */
+    private static final long serialVersionUID = 2826241102729529449L;
     /**
      * Interface representing the minimal callbacks required
      * to operate the drain part of a backpressure system.

--- a/src/main/java/rx/internal/util/IndexedRingBuffer.java
+++ b/src/main/java/rx/internal/util/IndexedRingBuffer.java
@@ -296,8 +296,8 @@ public final class IndexedRingBuffer<E> implements Subscription {
     /**
      * Add an element and return the index where it was added to allow removal.
      * 
-     * @param e
-     * @return
+     * @param e the element to add
+     * @return the index where the element was added
      */
     public int add(E e) {
         int i = getIndexForAdd();
@@ -429,9 +429,10 @@ public final class IndexedRingBuffer<E> implements Subscription {
     }
 
     /**
-     * 
+     * Loop through each element in the buffer and call a specific function.
      * @param action
      *            that processes each item and returns true if it wants to continue to the next
+     * @param startIndex at which index the loop should start
      * @return int of next index to process, or last index seen if it exited early
      */
     public int forEach(Func1<? super E, Boolean> action, int startIndex) {

--- a/src/main/java/rx/internal/util/InternalObservableUtils.java
+++ b/src/main/java/rx/internal/util/InternalObservableUtils.java
@@ -163,6 +163,8 @@ public enum InternalObservableUtils {
     /**
      * Creates a Func1 which calls the selector function with the received argument, applies an
      * observeOn on the result and returns the resulting Observable.
+     * @param <T> the input value type
+     * @param <R> the output value type
      * @param selector the selector function
      * @param scheduler the scheduler to apply on the output of the selector
      * @return the new Func1 instance
@@ -226,6 +228,7 @@ public enum InternalObservableUtils {
     
     /**
      * Returns a Func0 that supplies the ConnectableObservable returned by calling replay() on the source.
+     * @param <T> the input value type
      * @param source the source to call replay on by the supplier function
      * @return the new Func0 instance
      */
@@ -247,6 +250,7 @@ public enum InternalObservableUtils {
     }
     /**
      * Returns a Func0 that supplies the ConnectableObservable returned by calling a parameterized replay() on the source.
+     * @param <T> the input value type
      * @param source the source to call replay on by the supplier function
      * @param bufferSize
      *            the buffer size that limits the number of items the connectable observable can replay
@@ -273,14 +277,17 @@ public enum InternalObservableUtils {
 
     /**
      * Returns a Func0 that supplies the ConnectableObservable returned by calling a parameterized replay() on the source.
+     * @param <T> the input value type
      * @param source the source to call replay on by the supplier function
      * @param time
      *            the duration of the window in which the replayed items must have been emitted
      * @param unit
      *            the time unit of {@code time}
+     * @param scheduler the scheduler to use for timing information
      * @return the new Func0 instance
      */
-    public static <T> Func0<ConnectableObservable<T>> createReplaySupplier(final Observable<T> source, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public static <T> Func0<ConnectableObservable<T>> createReplaySupplier(final Observable<T> source, 
+            final long time, final TimeUnit unit, final Scheduler scheduler) {
         return new ReplaySupplierBufferTime<T>(source, time, unit, scheduler);
     }
 
@@ -305,6 +312,7 @@ public enum InternalObservableUtils {
 
     /**
      * Returns a Func0 that supplies the ConnectableObservable returned by calling a parameterized replay() on the source.
+     * @param <T> the input value type
      * @param source the source to call replay on by the supplier function
      * @param bufferSize
      *            the buffer size that limits the number of items the connectable observable can replay
@@ -312,9 +320,11 @@ public enum InternalObservableUtils {
      *            the duration of the window in which the replayed items must have been emitted
      * @param unit
      *            the time unit of {@code time}
+     * @param scheduler the scheduler to use for timing information
      * @return the new Func0 instance
      */
-    public static <T> Func0<ConnectableObservable<T>> createReplaySupplier(final Observable<T> source, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public static <T> Func0<ConnectableObservable<T>> createReplaySupplier(final Observable<T> source, 
+            final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
         return new ReplaySupplierTime<T>(source, bufferSize, time, unit, scheduler);
     }
 
@@ -342,6 +352,8 @@ public enum InternalObservableUtils {
 
     /**
      * Returns a Func2 which calls a collector with its parameters and returns the first (R) parameter.
+     * @param <T> the input value type
+     * @param <R> the result value type
      * @param collector the collector action to call
      * @return the new Func2 instance
      */

--- a/src/main/java/rx/internal/util/LinkedArrayList.java
+++ b/src/main/java/rx/internal/util/LinkedArrayList.java
@@ -77,35 +77,35 @@ public class LinkedArrayList {
     }
     /**
      * Returns the head buffer segment or null if the list is empty.
-     * @return
+     * @return the head object array
      */
     public Object[] head() {
         return head;
     }
     /**
      * Returns the tail buffer segment or null if the list is empty.
-     * @return
+     * @return the tail object array
      */
     public Object[] tail() {
         return tail;
     }
     /**
      * Returns the total size of the list.
-     * @return
+     * @return the total size of the list
      */
     public int size() {
         return size;
     }
     /**
      * Returns the index of the next slot in the tail buffer segment.
-     * @return
+     * @return the index of the next slot in the tail buffer segment
      */
     public int indexInTail() {
         return indexInTail;
     }
     /**
      * Returns the capacity hint that indicates the capacity of each buffer segment.
-     * @return
+     * @return the capacity hint that indicates the capacity of each buffer segment
      */
     public int capacityHint() {
         return capacityHint;

--- a/src/main/java/rx/internal/util/PlatformDependent.java
+++ b/src/main/java/rx/internal/util/PlatformDependent.java
@@ -36,6 +36,7 @@ public final class PlatformDependent {
 
     /**
      * Returns {@code true} if and only if the current platform is Android.
+     * @return {@code true} if and only if the current platform is Android
      */
     public static boolean isAndroid() {
         return IS_ANDROID;

--- a/src/main/java/rx/internal/util/RxThreadFactory.java
+++ b/src/main/java/rx/internal/util/RxThreadFactory.java
@@ -19,6 +19,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
+    /** */
+    private static final long serialVersionUID = -8841098858898482335L;
+
     public static final ThreadFactory NONE = new ThreadFactory() {
         @Override public Thread newThread(Runnable r) {
             throw new AssertionError("No threads allowed.");

--- a/src/main/java/rx/internal/util/UtilityFunctions.java
+++ b/src/main/java/rx/internal/util/UtilityFunctions.java
@@ -32,6 +32,7 @@ public final class UtilityFunctions {
     /**
      * Returns a function that always returns {@code true}.
      *
+     * @param <T> the value type
      * @return a {@link Func1} that accepts an Object and returns the Boolean {@code true}
      */
     public static <T> Func1<? super T, Boolean> alwaysTrue() {
@@ -41,6 +42,7 @@ public final class UtilityFunctions {
     /**
      * Returns a function that always returns {@code false}.
      *
+     * @param <T> the value type
      * @return a {@link Func1} that accepts an Object and returns the Boolean {@code false}
      */
     public static <T> Func1<? super T, Boolean> alwaysFalse() {
@@ -50,6 +52,7 @@ public final class UtilityFunctions {
     /**
      * Returns a function that always returns the Object it is passed.
      *
+     * @param <T> the input and output value type
      * @return a {@link Func1} that accepts an Object and returns the same Object
      */
     public static <T> Func1<T, T> identity() {
@@ -82,6 +85,17 @@ public final class UtilityFunctions {
     /**
      * Returns a function that merely returns {@code null}, without side effects.
      *
+     * @param <T0> the first argument type
+     * @param <T1> the second argument type
+     * @param <T2> the third argument type
+     * @param <T3> the fourth argument type
+     * @param <T4> the fifth argument type
+     * @param <T5> the sixth argument type
+     * @param <T6> the seventh argument type
+     * @param <T7> the eigth argument type
+     * @param <T8> the ninth argument type
+     * @param <T9> the thenth first argument type
+     * @param <R> the result type
      * @return a function that returns {@code null}
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/rx/internal/util/atomic/BaseLinkedAtomicQueue.java
+++ b/src/main/java/rx/internal/util/atomic/BaseLinkedAtomicQueue.java
@@ -83,8 +83,6 @@ abstract class BaseLinkedAtomicQueue<E> extends AbstractQueue<E> {
      * Queue is empty when producerNode is the same as consumerNode. An alternative implementation would be to observe
      * the producerNode.value is null, which also means an empty queue because only the consumerNode.value is allowed to
      * be null.
-     * 
-     * @see MessagePassingQueue#isEmpty()
      */
     @Override
     public final boolean isEmpty() {

--- a/src/main/java/rx/internal/util/atomic/MpscLinkedAtomicQueue.java
+++ b/src/main/java/rx/internal/util/atomic/MpscLinkedAtomicQueue.java
@@ -52,7 +52,6 @@ public final class MpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
      * This works because each producer is guaranteed to 'plant' a new node and link the old node. No 2 producers can
      * get the same producer node as part of XCHG guarantee.
      * 
-     * @see MessagePassingQueue#offer(Object)
      * @see java.util.Queue#offer(java.lang.Object)
      */
     @Override
@@ -81,7 +80,6 @@ public final class MpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
      * This means the consumerNode.value is always null, which is also the starting point for the queue. Because null
      * values are not allowed to be offered this is the only node with it's value set to null at any one time.
      * 
-     * @see MessagePassingQueue#poll()
      * @see java.util.Queue#poll()
      */
     @Override

--- a/src/main/java/rx/internal/util/atomic/SpscExactAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscExactAtomicArrayQueue.java
@@ -26,6 +26,7 @@ import rx.internal.util.unsafe.Pow2;
  * A single-producer single-consumer bounded queue with exact capacity tracking.
  * <p>This means that a queue of 10 will allow exactly 10 offers, however, the underlying storage is still power-of-2.
  * <p>The implementation uses field updaters and thus should be platform-safe.
+ * @param <T> the value type held by this queue
  */
 public final class SpscExactAtomicArrayQueue<T> extends AtomicReferenceArray<T> implements Queue<T> {
     /** */

--- a/src/main/java/rx/internal/util/atomic/SpscLinkedAtomicQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscLinkedAtomicQueue.java
@@ -53,7 +53,6 @@ public final class SpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
      * </ol>
      * From this follows that producerNode.next is always null and for all other nodes node.next is not null.
      * 
-     * @see MessagePassingQueue#offer(Object)
      * @see java.util.Queue#offer(java.lang.Object)
      */
     @Override

--- a/src/main/java/rx/internal/util/atomic/SpscUnboundedAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscUnboundedAtomicArrayQueue.java
@@ -28,6 +28,7 @@ import rx.internal.util.unsafe.Pow2;
  * structure if the production overshoots the consumption.
  * <p>Note that the minimum capacity of the 'islands' are 8 due to how the look-ahead optimization works.
  * <p>The implementation uses field updaters and thus should be platform-safe.
+ * @param <T> the value type held by this queue
  */
 public final class SpscUnboundedAtomicArrayQueue<T> implements Queue<T> {
     static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -39,7 +39,7 @@ import rx.subscriptions.CompositeSubscription;
  *
  * @param <S>
  *            the type of the user-define state used in {@link #generateState() generateState(S)} ,
- *            {@link #next(Object, Long, Subscriber) next(S, Long, Subscriber)}, and
+ *            {@link #next(Object, long, Observer) next(S, Long, Observer)}, and
  *            {@link #onUnsubscribe(Object) onUnsubscribe(S)}.
  * @param <T>
  *            the type of {@code Subscribers} that will be compatible with {@code this}.
@@ -48,7 +48,7 @@ import rx.subscriptions.CompositeSubscription;
 public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
 
     /**
-     * Executed once when subscribed to by a subscriber (via {@link OnSubscribe#call(Subscriber)})
+     * Executed once when subscribed to by a subscriber (via {@link #call(Subscriber)})
      * to produce a state value. This value is passed into {@link #next(Object, long, Observer)
      * next(S state, Observer <T> observer)} on the first iteration. Subsequent iterations of
      * {@code next} will receive the state returned by the previous invocation of {@code next}.
@@ -101,6 +101,8 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * Generates a synchronous {@link AsyncOnSubscribe} that calls the provided {@code next}
      * function to generate data to downstream subscribers.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
@@ -127,6 +129,8 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * 
      * This overload creates a AsyncOnSubscribe without an explicit clean up step.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
@@ -155,6 +159,8 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * Generates a synchronous {@link AsyncOnSubscribe} that calls the provided {@code next}
      * function to generate data to downstream subscribers.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
@@ -176,6 +182,8 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * Generates a synchronous {@link AsyncOnSubscribe} that calls the provided {@code next}
      * function to generate data to downstream subscribers.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
@@ -197,6 +205,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * This overload creates a "state-less" AsyncOnSubscribe which does not have an explicit state
      * value. This should be used when the {@code next} function closes over it's state.
      * 
+     * @param <T> the type of the generated values
      * @param next
      *            produces data to the downstream subscriber (see
      *            {@link #next(Object, long, Observer) next(S, long, Observer)})
@@ -222,6 +231,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * This overload creates a "state-less" AsyncOnSubscribe which does not have an explicit state
      * value. This should be used when the {@code next} function closes over it's state.
      * 
+     * @param <T> the type of the generated values
      * @param next
      *            produces data to the downstream subscriber (see
      *            {@link #next(Object, long, Observer) next(S, long, Observer)})
@@ -582,6 +592,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
             subscribeBufferToObservable(t);
         }
 
+        @SuppressWarnings("unchecked")
         private void subscribeBufferToObservable(final Observable<? extends T> t) {
             final BufferUntilSubscriber<T> buffer = BufferUntilSubscriber.<T> create();
 

--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -60,6 +60,7 @@ public final class BlockingObservable<T> {
     /**
      * Converts an {@link Observable} into a {@code BlockingObservable}.
      *
+     * @param <T> the observed value type
      * @param o
      *          the {@link Observable} you want to convert
      * @return a {@code BlockingObservable} version of {@code o}
@@ -99,6 +100,7 @@ public final class BlockingObservable<T> {
          * Use 'subscribe' instead of 'unsafeSubscribe' for Rx contract behavior
          * (see http://reactivex.io/documentation/contract.html) as this is the final subscribe in the chain.
          */
+        @SuppressWarnings("unchecked")
         Subscription subscription = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onCompleted() {
@@ -143,6 +145,7 @@ public final class BlockingObservable<T> {
      * @return an {@link Iterator} that can iterate over the items emitted by this {@code BlockingObservable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @SuppressWarnings({ "unchecked", "cast" })
     public Iterator<T> getIterator() {
         return BlockingOperatorToIterator.toIterator((Observable<T>)o);
     }
@@ -298,6 +301,7 @@ public final class BlockingObservable<T> {
      *         a new item, whereupon the Iterable returns that item
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX documentation: TakeLast</a>
      */
+    @SuppressWarnings({ "cast", "unchecked" })
     public Iterable<T> next() {
         return BlockingOperatorNext.next((Observable<T>)o);
     }
@@ -315,6 +319,7 @@ public final class BlockingObservable<T> {
      * @return an Iterable that always returns the latest item emitted by this {@code BlockingObservable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SuppressWarnings({ "cast", "unchecked" })
     public Iterable<T> latest() {
         return BlockingOperatorLatest.latest((Observable<T>)o);
     }
@@ -397,6 +402,7 @@ public final class BlockingObservable<T> {
      * @return a {@link Future} that expects a single item to be emitted by this {@code BlockingObservable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @SuppressWarnings({ "cast", "unchecked" })
     public Future<T> toFuture() {
         return BlockingOperatorToFuture.toFuture((Observable<T>)o);
     }
@@ -430,6 +436,7 @@ public final class BlockingObservable<T> {
         final AtomicReference<Throwable> returnException = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(1);
 
+        @SuppressWarnings("unchecked")
         Subscription subscription = ((Observable<T>)observable).subscribe(new Subscriber<T>() {
             @Override
             public void onCompleted() {
@@ -467,6 +474,7 @@ public final class BlockingObservable<T> {
     public void subscribe() {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] error = { null };
+        @SuppressWarnings("unchecked")
         Subscription s = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onNext(T t) {
@@ -504,6 +512,7 @@ public final class BlockingObservable<T> {
         final NotificationLite<T> nl = NotificationLite.instance();
         final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
         
+        @SuppressWarnings("unchecked")
         Subscription s = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onNext(T t) {
@@ -552,6 +561,7 @@ public final class BlockingObservable<T> {
      * The unsubscription and backpressure is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
      */
+    @SuppressWarnings("unchecked")
     @Experimental
     public void subscribe(Subscriber<? super T> subscriber) {
         final NotificationLite<T> nl = NotificationLite.instance();

--- a/src/main/java/rx/observables/GroupedObservable.java
+++ b/src/main/java/rx/observables/GroupedObservable.java
@@ -40,7 +40,9 @@ public class GroupedObservable<K, T> extends Observable<T> {
 
     /**
      * Converts an {@link Observable} into a {@code GroupedObservable} with a particular key.
-     *
+     * 
+     * @param <K> the key type
+     * @param <T> the value type
      * @param key
      *            the key to identify the group of items emitted by this {@code GroupedObservable}
      * @param o
@@ -80,6 +82,7 @@ public class GroupedObservable<K, T> extends Observable<T> {
      *            the type of the key
      * @param <T>
      *            the type of the items that this Observable emits
+     * @param key the key value
      * @param f
      *            a function that accepts an {@code Subscriber<T>}, and invokes its {@code onNext}, {@code onError}, and {@code onCompleted} methods as appropriate
      * @return a GroupedObservable that, when a {@link Subscriber} subscribes to it, will execute the specified

--- a/src/main/java/rx/observables/SyncOnSubscribe.java
+++ b/src/main/java/rx/observables/SyncOnSubscribe.java
@@ -24,7 +24,6 @@ import rx.Producer;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.annotations.Beta;
-import rx.annotations.Experimental;
 import rx.exceptions.Exceptions;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -42,7 +41,7 @@ import rx.plugins.RxJavaPlugins;
  *
  * @param <S>
  *            the type of the user-define state used in {@link #generateState() generateState(S)} ,
- *            {@link #next(Object, Subscriber) next(S, Subscriber)}, and
+ *            {@link #next(Object, Observer) next(S, Subscriber)}, and
  *            {@link #onUnsubscribe(Object) onUnsubscribe(S)}.
  * @param <T>
  *            the type of {@code Subscribers} that will be compatible with {@code this}.
@@ -71,7 +70,7 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
     }
 
     /**
-     * Executed once when subscribed to by a subscriber (via {@link OnSubscribe#call(Subscriber)})
+     * Executed once when subscribed to by a subscriber (via {@link #call(Subscriber)})
      * to produce a state value. This value is passed into {@link #next(Object, Observer) next(S
      * state, Observer <T> observer)} on the first iteration. Subsequent iterations of {@code next}
      * will receive the state returned by the previous invocation of {@code next}.
@@ -120,10 +119,12 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * Generates a synchronous {@link SyncOnSubscribe} that calls the provided {@code next} function
      * to generate data to downstream subscribers.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
-     *            produces data to the downstream subscriber (see {@link #next(Object, Subscriber)
+     *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @return a SyncOnSubscribe that emits data in a protocol compatible with back-pressure.
      */
@@ -146,10 +147,12 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * 
      * This overload creates a SyncOnSubscribe without an explicit clean up step.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
-     *            produces data to the downstream subscriber (see {@link #next(Object, Subscriber)
+     *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @param onUnsubscribe
      *            clean up behavior (see {@link #onUnsubscribe(Object) onUnsubscribe(S)})
@@ -174,10 +177,12 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * Generates a synchronous {@link SyncOnSubscribe} that calls the provided {@code next} function
      * to generate data to downstream subscribers.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
-     *            produces data to the downstream subscriber (see {@link #next(Object, Subscriber)
+     *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @param onUnsubscribe
      *            clean up behavior (see {@link #onUnsubscribe(Object) onUnsubscribe(S)})
@@ -195,10 +200,12 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * Generates a synchronous {@link SyncOnSubscribe} that calls the provided {@code next} function
      * to generate data to downstream subscribers.
      * 
+     * @param <T> the type of the generated values
+     * @param <S> the type of the associated state with each Subscriber
      * @param generator
      *            generates the initial state value (see {@link #generateState()})
      * @param next
-     *            produces data to the downstream subscriber (see {@link #next(Object, Subscriber)
+     *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
@@ -216,8 +223,9 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * This overload creates a "state-less" SyncOnSubscribe which does not have an explicit state
      * value. This should be used when the {@code next} function closes over it's state.
      * 
+     * @param <T> the type of the generated values
      * @param next
-     *            produces data to the downstream subscriber (see {@link #next(Object, Subscriber)
+     *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
@@ -241,8 +249,9 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * This overload creates a "state-less" SyncOnSubscribe which does not have an explicit state
      * value. This should be used when the {@code next} function closes over it's state.
      * 
+     * @param <T> the type of the generated values
      * @param next
-     *            produces data to the downstream subscriber (see {@link #next(Object, Subscriber)
+     *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @param onUnsubscribe
      *            clean up behavior (see {@link #onUnsubscribe(Object) onUnsubscribe(S)})

--- a/src/main/java/rx/observers/Observers.java
+++ b/src/main/java/rx/observers/Observers.java
@@ -51,7 +51,7 @@ public final class Observers {
      * Returns an inert {@link Observer} that does nothing in response to the emissions or notifications from
      * any {@code Observable} it subscribes to but will throw an exception if its
      * {@link Observer#onError onError} method is called.
-     *
+     * @param <T> the observed value type
      * @return an inert {@code Observer}
      */
     @SuppressWarnings("unchecked")
@@ -64,6 +64,7 @@ public final class Observers {
      * {@link Observer#onNext onNext} but ignores {@link Observer#onCompleted onCompleted} notifications; 
      * it will throw an {@link OnErrorNotImplementedException} if {@link Observer#onError onError} is invoked.
      *
+     * @param <T> the observed value type
      * @param onNext
      *          a function that handles each item emitted by an {@code Observable}
      * @throws IllegalArgumentException
@@ -101,6 +102,7 @@ public final class Observers {
      * {@link Observer#onNext onNext} and handles any {@link Observer#onError onError} notification but ignores
      * an {@link Observer#onCompleted onCompleted} notification.
      * 
+     * @param <T> the observed value type
      * @param onNext
      *          a function that handles each item emitted by an {@code Observable}
      * @param onError
@@ -144,6 +146,7 @@ public final class Observers {
      * {@link Observer#onNext onNext} and handles any {@link Observer#onError onError} or
      * {@link Observer#onCompleted onCompleted} notifications.
      * 
+     * @param <T> the observed value type
      * @param onNext
      *          a function that handles each item emitted by an {@code Observable}
      * @param onError

--- a/src/main/java/rx/observers/Subscribers.java
+++ b/src/main/java/rx/observers/Subscribers.java
@@ -32,6 +32,7 @@ public final class Subscribers {
      * from any {@code Observable} it subscribes to.  Will throw an {@link OnErrorNotImplementedException} if {@link Subscriber#onError onError} 
      * method is called
      *
+     * @param <T> the observed value type
      * @return an inert {@code Observer}
      */
     public static <T> Subscriber<T> empty() {
@@ -41,6 +42,7 @@ public final class Subscribers {
     /**
      * Converts an {@link Observer} into a {@link Subscriber}.
      *
+     * @param <T> the observed value type
      * @param o
      *          the {@link Observer} to convert
      * @return a {@link Subscriber} version of {@code o}
@@ -71,9 +73,10 @@ public final class Subscribers {
      * {@link Subscriber#onNext onNext} but ignores {@link Subscriber#onCompleted onCompleted} notifications;
      * it will throw an {@link OnErrorNotImplementedException} if {@link Subscriber#onError onError} is invoked.
      *
+     * @param <T> the observed value type
      * @param onNext
      *          a function that handles each item emitted by an {@code Observable}
-     * @throws IllegalArgument Exception
+     * @throws IllegalArgumentException
      *          if {@code onNext} is {@code null}
      * @return a {@code Subscriber} that calls {@code onNext} for each emitted item from the {@code Observable}
      *         the {@code Subscriber} subscribes to
@@ -108,11 +111,12 @@ public final class Subscribers {
      * {@link Subscriber#onNext onNext} and handles any {@link Subscriber#onError onError} notification but
      * ignores an {@link Subscriber#onCompleted onCompleted} notification.
      * 
+     * @param <T> the observed value type
      * @param onNext
      *          a function that handles each item emitted by an {@code Observable}
      * @param onError
      *          a function that handles an error notification if one is sent by an {@code Observable}
-     * @throws IllegalArgument Exception
+     * @throws IllegalArgumentException
      *          if either {@code onNext} or {@code onError} are {@code null}
      * @return an {@code Subscriber} that calls {@code onNext} for each emitted item from the {@code Observable}
      *         the {@code Subscriber} subscribes to, and calls {@code onError} if the {@code Observable}
@@ -151,13 +155,14 @@ public final class Subscribers {
      * {@link Subscriber#onNext onNext} and handles any {@link Subscriber#onError onError} or
      * {@link Subscriber#onCompleted onCompleted} notifications.
      * 
+     * @param <T> the observed value type
      * @param onNext
      *          a function that handles each item emitted by an {@code Observable}
      * @param onError
      *          a function that handles an error notification if one is sent by an {@code Observable}
      * @param onComplete
      *          a function that handles a sequence complete notification if one is sent by an {@code Observable}
-     * @throws IllegalArgument Exception
+     * @throws IllegalArgumentException
      *          if either {@code onNext}, {@code onError}, or {@code onComplete} are {@code null}
      * @return an {@code Subscriber} that calls {@code onNext} for each emitted item from the {@code Observable}
      *         the {@code Subscriber} subscribes to, calls {@code onError} if the {@code Observable} notifies
@@ -202,6 +207,7 @@ public final class Subscribers {
      * <code>subscriber</code> when {@link Subscriber#add(rx.Subscription)} is
      * called.
      * 
+     * @param <T> the observed value type
      * @param subscriber
      *            the Subscriber to wrap.
      * 

--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -24,6 +24,7 @@ import rx.Observer;
 
 /**
  * Observer usable for unit testing to perform assertions, inspect received events or wrap a mocked Observer.
+ * @param <T> the observed value type
  */
 public class TestObserver<T> implements Observer<T> {
 

--- a/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
@@ -46,6 +46,7 @@ public abstract class RxJavaObservableExecutionHook {
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.
      * 
+     * @param <T> the value type
      * @param f
      *            original {@link OnSubscribe}<{@code T}> to be executed
      * @return {@link OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
@@ -61,6 +62,8 @@ public abstract class RxJavaObservableExecutionHook {
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.
      * 
+     * @param <T> the value type
+     * @param observableInstance the parent observable instance
      * @param onSubscribe
      *            original {@link OnSubscribe}<{@code T}> to be executed
      * @return {@link OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
@@ -78,6 +81,7 @@ public abstract class RxJavaObservableExecutionHook {
      * This can be used to decorate or replace the {@link Subscription} instance or just perform extra logging,
      * metrics and other such things and pass through the subscription.
      * 
+     * @param <T> the value type
      * @param subscription
      *            original {@link Subscription}
      * @return {@link Subscription} subscription that can be modified, decorated, replaced or just returned as a
@@ -94,6 +98,7 @@ public abstract class RxJavaObservableExecutionHook {
      * This is <em>not</em> errors emitted via {@link Subscriber#onError(Throwable)} but exceptions thrown when
      * attempting to subscribe to a {@link Func1}<{@link Subscriber}{@code <T>}, {@link Subscription}>.
      * 
+     * @param <T> the value type
      * @param e
      *            Throwable thrown by {@link Observable#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass through
@@ -110,6 +115,8 @@ public abstract class RxJavaObservableExecutionHook {
      * This can be used to decorate or replace the {@link Operator} instance or just perform extra
      * logging, metrics and other such things and pass through the onSubscribe.
      * 
+     * @param <T> the upstream's value type (input)
+     * @param <R> the downstream's value type (output)
      * @param lift
      *            original {@link Operator}{@code <R, T>}
      * @return {@link Operator}{@code <R, T>} function that can be modified, decorated, replaced or just

--- a/src/main/java/rx/plugins/RxJavaSchedulersHook.java
+++ b/src/main/java/rx/plugins/RxJavaSchedulersHook.java
@@ -44,6 +44,7 @@ public class RxJavaSchedulersHook {
 
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
+     * @return the created Scheduler instance
      */
     @Experimental
     public static Scheduler createComputationScheduler() {
@@ -53,6 +54,8 @@ public class RxJavaSchedulersHook {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}
      * except using {@code threadFactory} for thread creation.
+     * @param threadFactory the factory to use for each worker thread
+     * @return the created Scheduler instance
      */
     @Experimental
     public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
@@ -62,6 +65,7 @@ public class RxJavaSchedulersHook {
 
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
+     * @return the created Scheduler instance
      */
     @Experimental
     public static Scheduler createIoScheduler() {
@@ -71,6 +75,8 @@ public class RxJavaSchedulersHook {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}
      * except using {@code threadFactory} for thread creation.
+     * @param threadFactory the factory to use for each worker thread
+     * @return the created Scheduler instance
      */
     @Experimental
     public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
@@ -80,6 +86,7 @@ public class RxJavaSchedulersHook {
 
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
+     * @return the created Scheduler instance
      */
     @Experimental
     public static Scheduler createNewThreadScheduler() {
@@ -89,6 +96,8 @@ public class RxJavaSchedulersHook {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}
      * except using {@code threadFactory} for thread creation.
+     * @param threadFactory the factory to use for each worker thread
+     * @return the created Scheduler instance
      */
     @Experimental
     public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
@@ -107,6 +116,7 @@ public class RxJavaSchedulersHook {
      * used.
      *
      * This instance should be or behave like a stateless singleton;
+     * @return the current computation scheduler instance
      */
     public Scheduler getComputationScheduler() {
         return null;
@@ -116,6 +126,7 @@ public class RxJavaSchedulersHook {
      * Scheduler to return from {@link rx.schedulers.Schedulers#io()} or null if default should be used.
      *
      * This instance should be or behave like a stateless singleton;
+     * @return the created Scheduler instance
      */
     public Scheduler getIOScheduler() {
         return null;
@@ -125,6 +136,7 @@ public class RxJavaSchedulersHook {
      * Scheduler to return from {@link rx.schedulers.Schedulers#newThread()} or null if default should be used.
      *
      * This instance should be or behave like a stateless singleton;
+     * @return the current new thread scheduler instance
      */
     public Scheduler getNewThreadScheduler() {
         return null;

--- a/src/main/java/rx/plugins/RxJavaSingleExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaSingleExecutionHook.java
@@ -45,9 +45,10 @@ public abstract class RxJavaSingleExecutionHook {
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.
      *
+     * @param <T> the value type emitted by Single
      * @param f
-     *            original {@link Single.OnSubscribe}<{@code T}> to be executed
-     * @return {@link Single.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
+     *            original {@link rx.Single.OnSubscribe}<{@code T}> to be executed
+     * @return {@link rx.Single.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     public <T> Single.OnSubscribe<T> onCreate(Single.OnSubscribe<T> f) {
@@ -60,9 +61,11 @@ public abstract class RxJavaSingleExecutionHook {
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.
      *
+     * @param <T> the value type emitted
+     * @param singleInstance the parent single instance
      * @param onSubscribe
-     *            original {@link Observable.OnSubscribe}<{@code T}> to be executed
-     * @return {@link Observable.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
+     *            original {@link rx.Observable.OnSubscribe}<{@code T}> to be executed
+     * @return {@link rx.Observable.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     public <T> Observable.OnSubscribe<T> onSubscribeStart(Single<? extends T> singleInstance, final Observable.OnSubscribe<T> onSubscribe) {
@@ -77,6 +80,7 @@ public abstract class RxJavaSingleExecutionHook {
      * This can be used to decorate or replace the {@link Subscription} instance or just perform extra logging,
      * metrics and other such things and pass through the subscription.
      *
+     * @param <T> the value type emitted by Single
      * @param subscription
      *            original {@link Subscription}
      * @return {@link Subscription} subscription that can be modified, decorated, replaced or just returned as a
@@ -93,6 +97,7 @@ public abstract class RxJavaSingleExecutionHook {
      * This is <em>not</em> errors emitted via {@link Subscriber#onError(Throwable)} but exceptions thrown when
      * attempting to subscribe to a {@link Func1}<{@link Subscriber}{@code <T>}, {@link Subscription}>.
      *
+     * @param <T> the value type emitted by Single
      * @param e
      *            Throwable thrown by {@link Single#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass through
@@ -106,12 +111,14 @@ public abstract class RxJavaSingleExecutionHook {
      * Invoked just as the operator functions is called to bind two operations together into a new
      * {@link Single} and the return value is used as the lifted function
      * <p>
-     * This can be used to decorate or replace the {@link Observable.Operator} instance or just perform extra
+     * This can be used to decorate or replace the {@link rx.Observable.Operator} instance or just perform extra
      * logging, metrics and other such things and pass through the onSubscribe.
      *
+     * @param <T> the upstream value type (input)
+     * @param <R> the downstream value type (output)
      * @param lift
-     *            original {@link Observable.Operator}{@code <R, T>}
-     * @return {@link Observable.Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
+     *            original {@link rx.Observable.Operator}{@code <R, T>}
+     * @return {@link rx.Observable.Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     public <T, R> Observable.Operator<? extends R, ? super T> onLift(final Observable.Operator<? extends R, ? super T> lift) {

--- a/src/main/java/rx/schedulers/ImmediateScheduler.java
+++ b/src/main/java/rx/schedulers/ImmediateScheduler.java
@@ -21,7 +21,7 @@ import rx.Scheduler;
  * @deprecated This type was never publicly instantiable. Use {@link Schedulers#immediate()}.
  */
 @Deprecated
-@SuppressWarnings("unused") // Class was part of public API.
+// Class was part of public API.
 public final class ImmediateScheduler extends Scheduler {
     private ImmediateScheduler() {
         throw new AssertionError();

--- a/src/main/java/rx/schedulers/NewThreadScheduler.java
+++ b/src/main/java/rx/schedulers/NewThreadScheduler.java
@@ -21,7 +21,7 @@ import rx.Scheduler;
  * @deprecated This type was never publicly instantiable. Use {@link Schedulers#newThread()}.
  */
 @Deprecated
-@SuppressWarnings("unused") // Class was part of public API.
+// Class was part of public API.
 public final class NewThreadScheduler extends Scheduler {
     private NewThreadScheduler() {
         throw new AssertionError();

--- a/src/main/java/rx/schedulers/TimeInterval.java
+++ b/src/main/java/rx/schedulers/TimeInterval.java
@@ -19,6 +19,7 @@ package rx.schedulers;
  * A {@code TimeInterval} represents an item emitted by an {@code Observable} along with the amount of time that
  * elapsed either since the emission of the previous item or (if there was no previous item) since the
  * {@code Observable} was first subscribed to.
+ * @param <T> the value type held along with the interval length
  */
 public class TimeInterval<T> {
     private final long intervalInMilliseconds;

--- a/src/main/java/rx/schedulers/Timestamped.java
+++ b/src/main/java/rx/schedulers/Timestamped.java
@@ -17,6 +17,7 @@ package rx.schedulers;
 
 /**
  * Composite class that takes a value and a timestamp and wraps them.
+ * @param <T> the value type held along with the timestamp
  */
 public final class Timestamped<T> {
     private final long timestampMillis;

--- a/src/main/java/rx/schedulers/TrampolineScheduler.java
+++ b/src/main/java/rx/schedulers/TrampolineScheduler.java
@@ -21,7 +21,7 @@ import rx.Scheduler;
  * @deprecated This type was never publicly instantiable. Use {@link Schedulers#trampoline()}.
  */
 @Deprecated
-@SuppressWarnings("unused") // Class was part of public API.
+// Class was part of public API.
 public final class TrampolineScheduler extends Scheduler {
     private TrampolineScheduler() {
         throw new AssertionError();

--- a/src/main/java/rx/singles/BlockingSingle.java
+++ b/src/main/java/rx/singles/BlockingSingle.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p/>
  * You construct a {@code BlockingSingle} from a {@code Single} with {@link #from(Single)}
  * or {@link Single#toBlocking()}.
+ * 
+ * @param <T> the value type of the sequence
  */
 @Experimental
 public class BlockingSingle<T> {
@@ -45,6 +47,7 @@ public class BlockingSingle<T> {
     /**
      * Converts a {@link Single} into a {@code BlockingSingle}.
      *
+     * @param <T> the value type of the sequence
      * @param single the {@link Single} you want to convert
      * @return a {@code BlockingSingle} version of {@code single}
      */
@@ -98,6 +101,7 @@ public class BlockingSingle<T> {
      *
      * @return a {@link Future} that returns the value
      */
+    @SuppressWarnings("unchecked")
     @Experimental
     public Future<T> toFuture() {
         return BlockingOperatorToFuture.toFuture(((Single<T>)single).toObservable());

--- a/src/main/java/rx/subjects/SerializedSubject.java
+++ b/src/main/java/rx/subjects/SerializedSubject.java
@@ -31,6 +31,9 @@ import rx.observers.SerializedObserver;
  * <p><pre>{@code
  * mySafeSubject = new SerializedSubject( myUnsafeSubject );
  * }</pre>
+ * 
+ * @param <T> the input value type
+ * @param <R> the output value type
  */
 public class SerializedSubject<T, R> extends Subject<T, R> {
     private final SerializedObserver<T> observer;

--- a/src/main/java/rx/subjects/Subject.java
+++ b/src/main/java/rx/subjects/Subject.java
@@ -19,6 +19,8 @@ import rx.*;
 
 /**
  * Represents an object that is both an Observable and an Observer.
+ * @param <T> the input value type
+ * @param <R> the output value type
  */
 public abstract class Subject<T, R> extends Observable<R> implements Observer<T> {
     protected Subject(OnSubscribe<R> onSubscribe) {

--- a/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -34,6 +34,8 @@ import rx.subscriptions.Subscriptions;
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 /* package */final class SubjectSubscriptionManager<T> extends AtomicReference<SubjectSubscriptionManager.State<T>> implements OnSubscribe<T> {
+    /** */
+    private static final long serialVersionUID = 6035251036011671568L;
     /** Stores the latest value or the terminal value for some Subjects. */
     volatile Object latest;
     /** Indicates that the subject is active (cheaper than checking the state).*/

--- a/src/main/java/rx/subscriptions/RefCountSubscription.java
+++ b/src/main/java/rx/subscriptions/RefCountSubscription.java
@@ -126,6 +126,9 @@ public final class RefCountSubscription implements Subscription {
 
     /** The individual sub-subscriptions. */
     private static final class InnerSubscription extends AtomicInteger implements Subscription {
+        /** */
+        private static final long serialVersionUID = 7005765588239987643L;
+        
         final RefCountSubscription parent;
         public InnerSubscription(RefCountSubscription parent) {
             this.parent = parent;

--- a/src/test/java/rx/CovarianceTest.java
+++ b/src/test/java/rx/CovarianceTest.java
@@ -188,6 +188,7 @@ public class CovarianceTest {
     };
 
     static Func1<List<List<Movie>>, Observable<Movie>> calculateDelta = new Func1<List<List<Movie>>, Observable<Movie>>() {
+        @Override
         public Observable<Movie> call(List<List<Movie>> listOfLists) {
             if (listOfLists.size() == 1) {
                 return Observable.from(listOfLists.get(0));

--- a/src/test/java/rx/ErrorHandlingTests.java
+++ b/src/test/java/rx/ErrorHandlingTests.java
@@ -29,6 +29,7 @@ public class ErrorHandlingTests {
 
     /**
      * Test that an error from a user provided Observer.onNext is handled and emitted to the onError
+     * @throws InterruptedException on interrupt
      */
     @Test
     public void testOnNextError() throws InterruptedException {
@@ -64,6 +65,7 @@ public class ErrorHandlingTests {
     /**
      * Test that an error from a user provided Observer.onNext is handled and emitted to the onError
      * even when done across thread boundaries with observeOn
+     * @throws InterruptedException on interrupt
      */
     @Test
     public void testOnNextErrorAcrossThread() throws InterruptedException {

--- a/src/test/java/rx/MergeTests.java
+++ b/src/test/java/rx/MergeTests.java
@@ -17,6 +17,7 @@ package rx;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
@@ -72,7 +73,7 @@ public class MergeTests {
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
-        assertTrue(values.get(2) instanceof Media);
+        assertNotNull(values.get(2));
         assertTrue(values.get(3) instanceof HorrorMovie);
     }
 
@@ -96,7 +97,7 @@ public class MergeTests {
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
-        assertTrue(values.get(2) instanceof Media);
+        assertNotNull(values.get(2));
         assertTrue(values.get(3) instanceof HorrorMovie);
     }
 

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -321,6 +321,7 @@ public class ObservableTests {
      * It is handled by the AtomicObserver that wraps the provided Observer.
      * 
      * Result: Passes (if AtomicObserver functionality exists)
+     * @throws InterruptedException on interrupt
      */
     @Test
     public void testCustomObservableWithErrorInObserverAsynchronous() throws InterruptedException {

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -31,7 +31,6 @@ import rx.exceptions.*;
 import rx.functions.*;
 import rx.observers.SafeSubscriber;
 import rx.observers.TestSubscriber;
-import rx.schedulers.*;
 import rx.plugins.RxJavaPluginsTest;
 import rx.plugins.RxJavaSingleExecutionHook;
 import rx.schedulers.Schedulers;
@@ -292,6 +291,7 @@ public class SingleTest {
     @Test
     public void zipIterableShouldZipListOfSingles() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
+        @SuppressWarnings("unchecked")
         Iterable<Single<Integer>> singles = Arrays.asList(Single.just(1), Single.just(2), Single.just(3));
 
         Single
@@ -396,12 +396,14 @@ public class SingleTest {
 
     @Test
     public void testHookCreate() {
-        OnSubscribe subscriber = mock(OnSubscribe.class);
+        @SuppressWarnings("unchecked")
+        OnSubscribe<Object> subscriber = mock(OnSubscribe.class);
         Single.create(subscriber);
 
         verify(hookSpy, times(1)).onCreate(subscriber);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testHookSubscribeStart() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
@@ -416,6 +418,7 @@ public class SingleTest {
         verify(hookSpy, times(1)).onSubscribeStart(eq(single), any(Observable.OnSubscribe.class));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testHookUnsafeSubscribeStart() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
@@ -654,6 +657,7 @@ public class SingleTest {
 
     /**
      * Assert that unsubscribe propagates when passing in a SingleSubscriber and not a Subscriber
+     * @throws InterruptedException on interrupt
      */
     @Test
     public void testUnsubscribe2() throws InterruptedException {
@@ -723,6 +727,7 @@ public class SingleTest {
 
     /**
      * Assert that unsubscribe propagates when passing in a SingleSubscriber and not a Subscriber
+     * @throws InterruptedException on interrupt
      */
     @Test
     public void testUnsubscribeViaReturnedSubscription() throws InterruptedException {
@@ -837,6 +842,7 @@ public class SingleTest {
 
     @Test
     public void doOnErrorShouldNotCallActionIfNoErrorHasOccurred() {
+        @SuppressWarnings("unchecked")
         Action1<Throwable> action = mock(Action1.class);
 
         TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
@@ -854,6 +860,7 @@ public class SingleTest {
 
     @Test
     public void doOnErrorShouldCallActionIfErrorHasOccurred() {
+        @SuppressWarnings("unchecked")
         Action1<Throwable> action = mock(Action1.class);
 
         TestSubscriber<Object> testSubscriber = new TestSubscriber<Object>();
@@ -873,6 +880,7 @@ public class SingleTest {
 
     @Test
     public void doOnErrorShouldThrowCompositeExceptionIfOnErrorActionThrows() {
+        @SuppressWarnings("unchecked")
         Action1<Throwable> action = mock(Action1.class);
 
 
@@ -899,6 +907,7 @@ public class SingleTest {
 
     @Test
     public void shouldEmitValueFromCallable() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<String> callable = mock(Callable.class);
 
         when(callable.call()).thenReturn("value");
@@ -917,6 +926,7 @@ public class SingleTest {
 
     @Test
     public void shouldPassErrorFromCallable() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<String> callable = mock(Callable.class);
 
         Throwable error = new IllegalStateException();
@@ -937,6 +947,7 @@ public class SingleTest {
 
     @Test
     public void doOnSuccessShouldInvokeAction() {
+        @SuppressWarnings("unchecked")
         Action1<String> action = mock(Action1.class);
 
         TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
@@ -954,6 +965,7 @@ public class SingleTest {
 
     @Test
     public void doOnSuccessShouldPassErrorFromActionToSubscriber() {
+        @SuppressWarnings("unchecked")
         Action1<String> action = mock(Action1.class);
 
         Throwable error = new IllegalStateException();
@@ -974,6 +986,7 @@ public class SingleTest {
 
     @Test
     public void doOnSuccessShouldNotCallActionIfSingleThrowsError() {
+        @SuppressWarnings("unchecked")
         Action1<Object> action = mock(Action1.class);
 
         Throwable error = new IllegalStateException();
@@ -993,6 +1006,7 @@ public class SingleTest {
 
     @Test
     public void doOnSuccessShouldNotSwallowExceptionThrownByAction() {
+        @SuppressWarnings("unchecked")
         Action1<String> action = mock(Action1.class);
 
         Throwable exceptionFromAction = new IllegalStateException();
@@ -1090,6 +1104,7 @@ public class SingleTest {
 
     @Test
     public void deferShouldNotCallFactoryFuncUntilSubscriberSubscribes() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<Single<Object>> singleFactory = mock(Callable.class);
         Single.defer(singleFactory);
         verifyZeroInteractions(singleFactory);
@@ -1097,6 +1112,7 @@ public class SingleTest {
 
     @Test
     public void deferShouldSubscribeSubscriberToSingleFromFactoryFuncAndEmitValue() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<Single<Object>> singleFactory = mock(Callable.class);
         Object value = new Object();
         Single<Object> single = Single.just(value);
@@ -1117,6 +1133,7 @@ public class SingleTest {
 
     @Test
     public void deferShouldSubscribeSubscriberToSingleFromFactoryFuncAndEmitError() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<Single<Object>> singleFactory = mock(Callable.class);
         Throwable error = new IllegalStateException();
         Single<Object> single = Single.error(error);
@@ -1137,6 +1154,7 @@ public class SingleTest {
 
     @Test
     public void deferShouldPassErrorFromSingleFactoryToTheSubscriber() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<Single<Object>> singleFactory = mock(Callable.class);
         Throwable errorFromSingleFactory = new IllegalStateException();
         when(singleFactory.call()).thenThrow(errorFromSingleFactory);
@@ -1155,10 +1173,12 @@ public class SingleTest {
 
     @Test
     public void deferShouldCallSingleFactoryForEachSubscriber() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<Single<String>> singleFactory = mock(Callable.class);
 
         String[] values = {"1", "2", "3"};
-        final Single[] singles = new Single[] {Single.just(values[0]), Single.just(values[1]), Single.just(values[2])};
+        @SuppressWarnings("unchecked")
+        final Single<String>[] singles = new Single[] {Single.just(values[0]), Single.just(values[1]), Single.just(values[2])};
 
         final AtomicInteger singleFactoryCallsCounter = new AtomicInteger();
 
@@ -1198,6 +1218,7 @@ public class SingleTest {
 
     @Test
     public void deferShouldPassNullPointerExceptionToTheSubscriberIfSingleFactoryReturnsNull() throws Exception {
+        @SuppressWarnings("unchecked")
         Callable<Single<Object>> singleFactory = mock(Callable.class);
         when(singleFactory.call()).thenReturn(null);
 
@@ -1434,6 +1455,7 @@ public class SingleTest {
 
     @Test
     public void iterableToArrayShouldConvertList() {
+        @SuppressWarnings("unchecked")
         List<Single<String>> singlesList = Arrays.asList(Single.just("1"), Single.just("2"));
 
         Single<? extends String>[] singlesArray = Single.iterableToArray(singlesList);

--- a/src/test/java/rx/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/rx/exceptions/CompositeExceptionTest.java
@@ -183,6 +183,9 @@ public class CompositeExceptionTest {
     @Test(timeout = 1000)
     public void testCompositeExceptionWithUnsupportedInitCause() {
         Throwable t = new Throwable() {
+            /** */
+            private static final long serialVersionUID = -3282577447436848385L;
+
             @Override
             public synchronized Throwable initCause(Throwable cause) {
                 throw new UnsupportedOperationException();
@@ -204,6 +207,9 @@ public class CompositeExceptionTest {
     @Test(timeout = 1000)
     public void testCompositeExceptionWithNullInitCause() {
         Throwable t = new Throwable("ThrowableWithNullInitCause") {
+            /** */
+            private static final long serialVersionUID = -7984762607894527888L;
+
             @Override
             public synchronized Throwable initCause(Throwable cause) {
                 return null;

--- a/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -192,6 +192,7 @@ public class ExceptionsTest {
 
     /**
      * https://github.com/ReactiveX/RxJava/issues/2998
+     * @throws Exception on arbitrary errors
      */
     @Test(expected = OnErrorFailedException.class)
     public void testOnErrorExceptionIsThrownFromGroupBy() throws Exception {
@@ -223,6 +224,7 @@ public class ExceptionsTest {
 
     /**
      * https://github.com/ReactiveX/RxJava/issues/2998
+     * @throws Exception on arbitrary errors
      */
     @Test(expected = OnErrorFailedException.class)
     public void testOnErrorExceptionIsThrownFromOnNext() throws Exception {

--- a/src/test/java/rx/exceptions/OnNextValueTest.java
+++ b/src/test/java/rx/exceptions/OnNextValueTest.java
@@ -15,7 +15,6 @@
  */
 package rx.exceptions;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import rx.Observable;

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -172,6 +172,7 @@ public class OperatorConcatTest {
 
     /**
      * Test an async Observable that emits more async Observables
+     * @throws Throwable on any error
      */
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -1581,6 +1581,7 @@ public class OperatorGroupByTest {
         ts2.assertNotCompleted();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testGroupedObservableCollection() {
 
@@ -1637,6 +1638,7 @@ public class OperatorGroupByTest {
 
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testCollectedGroups() {
 

--- a/src/test/java/rx/internal/operators/OperatorMaterializeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMaterializeTest.java
@@ -191,7 +191,7 @@ public class OperatorMaterializeTest {
     @Test
     public void testUnsubscribeJustBeforeCompletionNotificationShouldPreventThatNotificationArriving() {
         TestSubscriber<Notification<Integer>> ts = TestSubscriber.create(0);
-        IllegalArgumentException ex = new IllegalArgumentException();
+
         Observable.<Integer>empty().materialize()
                 .subscribe(ts);
         ts.assertNoValues();

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -652,6 +652,7 @@ public class OperatorMergeTest {
      * This is the same as the upstreams ones, but now adds the downstream as well by using observeOn.
      * 
      * This requires merge to also obey the Product.request values coming from it's child subscriber.
+     * @throws InterruptedException if the wait is interrupted
      */
     @Test(timeout = 10000)
     public void testBackpressureDownstreamWithConcurrentStreams() throws InterruptedException {
@@ -1334,6 +1335,7 @@ public class OperatorMergeTest {
         ts.assertCompleted();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void negativeMaxConcurrent() {
         try {
@@ -1344,6 +1346,7 @@ public class OperatorMergeTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void zeroMaxConcurrent() {
         try {

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
@@ -28,7 +28,6 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Subscriber;
-import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;

--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -605,7 +605,10 @@ public class OperatorRetryTest {
 
         protected Observer<T> target;
 
-        /** Wrap existing Observer */
+        /**
+         * Wrap existing Observer.
+         * @param target the target observer instance
+         */
         public AsyncObserver(Observer<T> target) {
             this.target = target;
         }
@@ -749,7 +752,7 @@ public class OperatorRetryTest {
                                     for (Throwable t : ts.getOnErrorEvents()) {
                                         onNextEvents.add(t.toString());
                                     }
-                                    for (Object o : ts.getOnCompletedEvents()) {
+                                    for (int k = 0; k < ts.getOnCompletedEvents().size(); k++) {
                                         onNextEvents.add("onCompleted");
                                     }
                                     data.put(j, onNextEvents);

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -147,7 +147,7 @@ public class OperatorTakeUntilPredicateTest {
         }).subscribe(ts);
         ts.assertTerminalEvent();
         ts.assertNotCompleted();
-        assertEquals(1, (int) ts.getOnErrorEvents().size());
+        assertEquals(1, ts.getOnErrorEvents().size());
         assertTrue(ts.getOnErrorEvents().get(0).getCause().getMessage().contains("abc"));
     }
 }

--- a/src/test/java/rx/internal/schedulers/NewThreadWorkerTest.java
+++ b/src/test/java/rx/internal/schedulers/NewThreadWorkerTest.java
@@ -16,17 +16,13 @@
 
 package rx.internal.schedulers;
 
-import org.junit.Test;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static java.lang.reflect.Modifier.FINAL;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.*;
+
+import org.junit.Test;
 
 public class NewThreadWorkerTest {
 
@@ -53,7 +49,7 @@ public class NewThreadWorkerTest {
 
     private static abstract class ScheduledExecutorServiceWithSetRemoveOnCancelPolicy implements ScheduledExecutorService {
         // Just declaration of required method to allow run tests on JDK 6
-        public void setRemoveOnCancelPolicy(@SuppressWarnings("UnusedParameters") boolean value) {}
+        public void setRemoveOnCancelPolicy(boolean value) {}
     }
 
     @Test

--- a/src/test/java/rx/internal/util/RxRingBufferSpmcTest.java
+++ b/src/test/java/rx/internal/util/RxRingBufferSpmcTest.java
@@ -38,6 +38,7 @@ public class RxRingBufferSpmcTest extends RxRingBufferBase {
 
     /**
      * Single producer, 2 consumers. The request() ensures it gets scheduled back on the same Producer thread.
+     * @throws InterruptedException if the wait is interrupted
      */
     @Test
     public void testConcurrency() throws InterruptedException {

--- a/src/test/java/rx/internal/util/RxRingBufferSpscTest.java
+++ b/src/test/java/rx/internal/util/RxRingBufferSpscTest.java
@@ -38,6 +38,7 @@ public class RxRingBufferSpscTest extends RxRingBufferBase {
 
     /**
      * Single producer, single consumer. The request() ensures it gets scheduled back on the same Producer thread.
+     * @throws InterruptedException if the wait is interrupted
      */
     @Test
     public void testConcurrency() throws InterruptedException {

--- a/src/test/java/rx/internal/util/RxRingBufferWithoutUnsafeTest.java
+++ b/src/test/java/rx/internal/util/RxRingBufferWithoutUnsafeTest.java
@@ -45,6 +45,7 @@ public class RxRingBufferWithoutUnsafeTest extends RxRingBufferBase {
     
     /**
      * Single producer, 2 consumers. The request() ensures it gets scheduled back on the same Producer thread.
+     * @throws InterruptedException if the wait is interrupted
      */
     @Test(timeout = 10000)
     public void testConcurrency() throws InterruptedException {

--- a/src/test/java/rx/internal/util/ScalarSynchronousSingleTest.java
+++ b/src/test/java/rx/internal/util/ScalarSynchronousSingleTest.java
@@ -280,6 +280,6 @@ public class ScalarSynchronousSingleTest {
     @Test
     public void getValue() {
         Single<Integer> s = Single.just(1);
-        assertEquals(1, ((ScalarSynchronousSingle) s).get());
+        assertEquals(1, ((ScalarSynchronousSingle<?>) s).get());
     }
 }

--- a/src/test/java/rx/observers/SafeSubscriberTest.java
+++ b/src/test/java/rx/observers/SafeSubscriberTest.java
@@ -270,8 +270,8 @@ public class SafeSubscriberTest {
             safe.onCompleted();
             Assert.fail();
         } catch(UnsubscribeFailedException e) {
-            assertEquals(1, (int) calls.get());
-            assertEquals(0, (int) errors.get());
+            assertEquals(1, calls.get());
+            assertEquals(0, errors.get());
         }
     }
 
@@ -310,8 +310,8 @@ public class SafeSubscriberTest {
             safe.onCompleted();
             Assert.fail();
         } catch(UnsubscribeFailedException e) {
-            assertEquals(2, (int) calls.get());
-            assertEquals(0, (int) errors.get());
+            assertEquals(2, calls.get());
+            assertEquals(0, errors.get());
         }
     }
 

--- a/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -51,6 +51,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
 
     /**
      * Bug report: https://github.com/ReactiveX/RxJava/issues/431
+     * @throws InterruptedException if a wait is interrupted
      */
     @Test
     public final void testUnSubscribeForScheduler() throws InterruptedException {

--- a/src/test/java/rx/schedulers/SchedulerTests.java
+++ b/src/test/java/rx/schedulers/SchedulerTests.java
@@ -44,6 +44,9 @@ public final class SchedulerTests {
      * <p>
      * Schedulers which execute on a separate thread from their calling thread should exhibit this behavior. Schedulers
      * which execute on their calling thread may not.
+     * 
+     * @param scheduler the scheduler to test
+     * @throws InterruptedException if some wait is interrupted
      */
     public static void testUnhandledErrorIsDeliveredToThreadHandler(Scheduler scheduler) throws InterruptedException {
         Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();
@@ -78,6 +81,8 @@ public final class SchedulerTests {
      * <p>
      * This is a companion test to {@link #testUnhandledErrorIsDeliveredToThreadHandler}, and is needed only for the
      * same Schedulers.
+     * @param scheduler the scheduler to test
+     * @throws InterruptedException if some wait is interrupted
      */
     public static void testHandledErrorIsNotDeliveredToThreadHandler(Scheduler scheduler) throws InterruptedException {
         Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();

--- a/src/test/java/rx/singles/BlockingSingleTest.java
+++ b/src/test/java/rx/singles/BlockingSingleTest.java
@@ -76,5 +76,8 @@ public class BlockingSingleTest {
     }
 
     private static final class TestCheckedException extends Exception {
+
+        /** */
+        private static final long serialVersionUID = -5601856891331290034L;
     }
 }

--- a/src/test/java/rx/test/OperatorTester.java
+++ b/src/test/java/rx/test/OperatorTester.java
@@ -37,8 +37,8 @@ public final class OperatorTester {
     /**
      * Used for mocking of Schedulers since many Scheduler implementations are static/final.
      * 
-     * @param underlying
-     * @return
+     * @param underlying the actual scheduler
+     * @return the wrapping Scheduler instance
      */
     public static Scheduler forwardingScheduler(Scheduler underlying) {
         return new ForwardingScheduler(underlying);

--- a/src/test/java/rx/util/AssertObservable.java
+++ b/src/test/java/rx/util/AssertObservable.java
@@ -28,7 +28,7 @@ public final class AssertObservable {
      * Asserts that two Observables are equal. If they are not, an {@link AssertionError} is thrown
      * with the given message. If <code>expecteds</code> and <code>actuals</code> are
      * <code>null</code>, they are considered equal.
-     * 
+     * @param <T> the value tpye
      * @param expected
      *            Observable with expected values.
      * @param actual
@@ -43,6 +43,7 @@ public final class AssertObservable {
      * with the given message. If <code>expected</code> and <code>actual</code> are
      * <code>null</code>, they are considered equal.
      * 
+     * @param <T> the value tpye
      * @param message
      *            the identifying message for the {@link AssertionError} (<code>null</code> okay)
      * @param expected
@@ -59,12 +60,12 @@ public final class AssertObservable {
      * they are not, an {@link Observable} is returned that calls onError with an {@link AssertionError} when subscribed to. If <code>expected</code> and <code>actual</code>
      * are <code>null</code>, they are considered equal.
      * 
-     * @param message
-     *            the identifying message for the {@link AssertionError} (<code>null</code> okay)
+     * @param <T> the value tpye
      * @param expected
      *            Observable with expected values.
      * @param actual
      *            Observable with actual values
+     * @return the observable resulting in a complete or error signal.
      */
     public static <T> Observable<Void> assertObservableEquals(Observable<T> expected, Observable<T> actual) {
         return assertObservableEquals(null, expected, actual);
@@ -74,13 +75,15 @@ public final class AssertObservable {
      * Asserts that two {@link Observable}s are equal and returns an empty {@link Observable}. If
      * they are not, an {@link Observable} is returned that calls onError with an {@link AssertionError} when subscribed to with the given message. If <code>expected</code>
      * and <code>actual</code> are <code>null</code>, they are considered equal.
-     * 
+     *
+     * @param <T> the value type
      * @param message
      *            the identifying message for the {@link AssertionError} (<code>null</code> okay)
      * @param expected
      *            Observable with expected values.
      * @param actual
      *            Observable with actual values
+     * @return the observable resulting in a complete or error signal.
      */
     public static <T> Observable<Void> assertObservableEquals(final String message, Observable<T> expected, Observable<T> actual) {
         if (actual == null && expected != null) {


### PR DESCRIPTION
My Eclipse warned me about several hundred javac and javadoc errors which could hide other significant warnings. This PR is the first part to fix those warnings. Note that `Observable` and `Single` itself is full of those as well (several hundred in each).
