### PR TITLE
1.x: javac- and javadoc-related cleanup in components, part 2 final

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -600,7 +600,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Func2<? super T1, ? super T2, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2), Functions.fromFunc(combineFunction));
     }
@@ -628,7 +628,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Func3<? super T1, ? super T2, ? super T3, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3), Functions.fromFunc(combineFunction));
     }
@@ -658,7 +658,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, T4, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4,
             Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4), Functions.fromFunc(combineFunction));
@@ -691,7 +691,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, T4, T5, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5,
             Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5), Functions.fromFunc(combineFunction));
@@ -726,7 +726,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6,
             Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6), Functions.fromFunc(combineFunction));
@@ -763,7 +763,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7,
             Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7), Functions.fromFunc(combineFunction));
@@ -802,7 +802,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7, Observable<? extends T8> o8,
             Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combineFunction) {
         return (Observable<R>)combineLatest(Arrays.asList(o1, o2, o3, o4, o5, o6, o7, o8), Functions.fromFunc(combineFunction));
@@ -843,7 +843,7 @@ public class Observable<T> {
      *         Observables by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "cast" })
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> combineLatest(Observable<? extends T1> o1, Observable<? extends T2> o2, Observable<? extends T3> o3, Observable<? extends T4> o4, Observable<? extends T5> o5, Observable<? extends T6> o6, Observable<? extends T7> o7, Observable<? extends T8> o8,
             Observable<? extends T9> o9,
             Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combineFunction) {
@@ -1311,6 +1311,7 @@ public class Observable<T> {
      * @return an Observable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings("cast")
     public static <T> Observable<T> from(Future<? extends T> future) {
         return (Observable<T>)create(OnSubscribeToObservableFuture.toObservableFuture(future));
     }
@@ -1342,6 +1343,7 @@ public class Observable<T> {
      * @return an Observable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings("cast")
     public static <T> Observable<T> from(Future<? extends T> future, long timeout, TimeUnit unit) {
         return (Observable<T>)create(OnSubscribeToObservableFuture.toObservableFuture(future, timeout, unit));
     }
@@ -1372,6 +1374,7 @@ public class Observable<T> {
      */
     public static <T> Observable<T> from(Future<? extends T> future, Scheduler scheduler) {
         // TODO in a future revision the Scheduler will become important because we'll start polling instead of blocking on the Future
+        @SuppressWarnings("cast")
         Observable<T> o = (Observable<T>)create(OnSubscribeToObservableFuture.toObservableFuture(future));
         return o.subscribeOn(scheduler);
     }
@@ -5742,6 +5745,7 @@ public class Observable<T> {
      *         Observable
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SuppressWarnings("cast")
     public final <U, R> Observable<R> flatMapIterable(Func1<? super T, ? extends Iterable<? extends U>> collectionSelector,
             Func2<? super T, ? super U, ? extends R> resultSelector) {
         return (Observable<R>)flatMap(OperatorMapPair.convertSelector(collectionSelector), resultSelector);
@@ -5777,6 +5781,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
+    @SuppressWarnings("cast")
     @Beta
     public final <U, R> Observable<R> flatMapIterable(Func1<? super T, ? extends Iterable<? extends U>> collectionSelector,
             Func2<? super T, ? super U, ? extends R> resultSelector, int maxConcurrent) {
@@ -6554,6 +6559,7 @@ public class Observable<T> {
      * @return the original Observable, with appropriately modified behavior
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
+    @SuppressWarnings("cast")
     public final Observable<T> onErrorResumeNext(final Observable<? extends T> resumeSequence) {
         return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withOther(resumeSequence));
     }
@@ -6584,6 +6590,7 @@ public class Observable<T> {
      * @return the original Observable with appropriately modified behavior
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
+    @SuppressWarnings("cast")
     public final Observable<T> onErrorReturn(Func1<Throwable, ? extends T> resumeFunction) {
         return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withSingle(resumeFunction));
     }
@@ -6620,6 +6627,7 @@ public class Observable<T> {
      * @return the original Observable, with appropriately modified behavior
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
+    @SuppressWarnings("cast")
     public final Observable<T> onExceptionResumeNext(final Observable<? extends T> resumeSequence) {
         return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withException(resumeSequence));
     }
@@ -10327,6 +10335,7 @@ public class Observable<T> {
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("cast")
     public final <T2, R> Observable<R> zipWith(Observable<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
         return (Observable<R>)zip(this, other, zipFunction);
     }

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -248,6 +248,7 @@ public class Single<T> {
      * @return a Single that emits an Observable that emits the same item as the source Single
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
+    @SuppressWarnings("unused")
     private Single<Observable<T>> nest() {
         return Single.just(asObservable(this));
     }
@@ -525,6 +526,7 @@ public class Single<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings("cast")
     public static <T> Single<T> from(Future<? extends T> future) {
         return new Single<T>((Observable.OnSubscribe<T>)OnSubscribeToObservableFuture.toObservableFuture(future));
     }
@@ -556,6 +558,7 @@ public class Single<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings("cast")
     public static <T> Single<T> from(Future<? extends T> future, long timeout, TimeUnit unit) {
         return new Single<T>((Observable.OnSubscribe<T>)OnSubscribeToObservableFuture.toObservableFuture(future, timeout, unit));
     }
@@ -584,6 +587,7 @@ public class Single<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings("cast")
     public static <T> Single<T> from(Future<? extends T> future, Scheduler scheduler) {
         return new Single<T>((Observable.OnSubscribe<T>)OnSubscribeToObservableFuture.toObservableFuture(future)).subscribeOn(scheduler);
     }
@@ -954,6 +958,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, final Func2<? super T1, ? super T2, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2}, new FuncN<R>() {
             @Override
@@ -985,6 +990,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, final Func3<? super T1, ? super T2, ? super T3, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3}, new FuncN<R>() {
             @Override
@@ -1018,6 +1024,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, final Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4}, new FuncN<R>() {
             @Override
@@ -1053,6 +1060,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, final Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5}, new FuncN<R>() {
             @Override
@@ -1090,6 +1098,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6,
                                                             final Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6}, new FuncN<R>() {
@@ -1130,6 +1139,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7,
                                                                 final Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7}, new FuncN<R>() {
@@ -1172,6 +1182,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
                                                                     final Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8}, new FuncN<R>() {
@@ -1216,6 +1227,7 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
                                                                         Single<? extends T9> s9, final Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipFunction) {
         return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8, s9}, new FuncN<R>() {
@@ -1247,7 +1259,9 @@ public class Single<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("unchecked")
     public static <R> Single<R> zip(Iterable<? extends Single<?>> singles, FuncN<? extends R> zipFunction) {
+        @SuppressWarnings("rawtypes")
         Single[] iterableToArray = iterableToArray(singles);
         return SingleOperatorZip.zip(iterableToArray, zipFunction);
     }
@@ -1407,6 +1421,7 @@ public class Single<T> {
      * @return the original Single with appropriately modified behavior
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
+    @SuppressWarnings("cast")
     public final Single<T> onErrorReturn(Func1<Throwable, ? extends T> resumeFunction) {
         return lift((Operator<T, T>)OperatorOnErrorResumeNextViaFunction.withSingle(resumeFunction));
     }
@@ -2265,6 +2280,7 @@ public class Single<T> {
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings("cast")
     public final <T2, R> Single<R> zipWith(Single<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
         return (Single<R>)zip(this, other, zipFunction);
     }

--- a/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorLatest.java
@@ -46,6 +46,7 @@ public final class BlockingOperatorLatest {
      */
     public static <T> Iterable<T> latest(final Observable<? extends T> source) {
         return new Iterable<T>() {
+            @SuppressWarnings("unchecked")
             @Override
             public Iterator<T> iterator() {
                 LatestObserverIterator<T> lio = new LatestObserverIterator<T>();

--- a/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
@@ -45,6 +45,7 @@ public final class BlockingOperatorMostRecent {
      */
     public static <T> Iterable<T> mostRecent(final Observable<? extends T> source, final T initialValue) {
         return new Iterable<T>() {
+            @SuppressWarnings("unchecked")
             @Override
             public Iterator<T> iterator() {
                 MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<T>(initialValue);

--- a/src/main/java/rx/internal/operators/BlockingOperatorNext.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorNext.java
@@ -90,6 +90,7 @@ public final class BlockingOperatorNext {
             return moveToNext();
         }
 
+        @SuppressWarnings("unchecked")
         private boolean moveToNext() {
             try {
                 if (!started) {

--- a/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToFuture.java
@@ -54,6 +54,7 @@ public final class BlockingOperatorToFuture {
         final AtomicReference<T> value = new AtomicReference<T>();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
+        @SuppressWarnings("unchecked")
         final Subscription s = ((Observable<T>)that).single().subscribe(new Subscriber<T>() {
 
             @Override

--- a/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorToIterator.java
@@ -46,6 +46,7 @@ public final class BlockingOperatorToIterator {
      *            the type of source.
      * @return the iterator that could be used to iterate over the elements of the observable.
      */
+    @SuppressWarnings("unchecked")
     public static <T> Iterator<T> toIterator(Observable<? extends T> source) {
         SubscriberIterator<T> subscriber = new SubscriberIterator<T>();
 

--- a/src/main/java/rx/internal/operators/CachedObservable.java
+++ b/src/main/java/rx/internal/operators/CachedObservable.java
@@ -38,6 +38,7 @@ public final class CachedObservable<T> extends Observable<T> {
      * @param source the source Observable to cache
      * @return the CachedObservable instance
      */
+    @SuppressWarnings("cast")
     public static <T> CachedObservable<T> from(Observable<? extends T> source) {
         return (CachedObservable<T>)from(source, 16);
     }

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
@@ -29,6 +29,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
     final Observable<Completable> sources;
     final int prefetch;
     
+    @SuppressWarnings("unchecked")
     public CompletableOnSubscribeConcat(Observable<? extends Completable> sources, int prefetch) {
         this.sources = (Observable<Completable>)sources;
         this.prefetch = prefetch;

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
@@ -32,6 +32,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
     final int maxConcurrency;
     final boolean delayErrors;
     
+    @SuppressWarnings("unchecked")
     public CompletableOnSubscribeMerge(Observable<? extends Completable> source, int maxConcurrency, boolean delayErrors) {
         this.source = (Observable<Completable>)source;
         this.maxConcurrency = maxConcurrency;

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -127,6 +127,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
             this.error = new AtomicReference<Throwable>();
         }
         
+        @SuppressWarnings("unchecked")
         public void subscribe(Observable<? extends T>[] sources) {
             Subscriber<T>[] as = subscribers;
             int len = as.length;

--- a/src/main/java/rx/internal/operators/OperatorMulticast.java
+++ b/src/main/java/rx/internal/operators/OperatorMulticast.java
@@ -76,6 +76,7 @@ public final class OperatorMulticast<T, R> extends ConnectableObservable<R> {
         this.subjectFactory = subjectFactory;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void connect(Action1<? super Subscription> connection) {
         // each time we connect we create a new Subject and Subscription

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -132,6 +132,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
      * @param bufferSize
      * @return
      */
+    @SuppressWarnings("cast")
     public static <T> ConnectableObservable<T> create(Observable<? extends T> source, 
             final int bufferSize) {
         if (bufferSize == Integer.MAX_VALUE) {
@@ -153,6 +154,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
      * @param scheduler
      * @return
      */
+    @SuppressWarnings("cast")
     public static <T> ConnectableObservable<T> create(Observable<? extends T> source, 
             long maxAge, TimeUnit unit, Scheduler scheduler) {
         return (ConnectableObservable<T>)create(source, maxAge, unit, scheduler, Integer.MAX_VALUE);

--- a/src/main/java/rx/internal/operators/SingleOnSubscribeDelaySubscriptionOther.java
+++ b/src/main/java/rx/internal/operators/SingleOnSubscribeDelaySubscriptionOther.java
@@ -38,6 +38,7 @@ public final class SingleOnSubscribeDelaySubscriptionOther<T> implements Single.
         this.other = other;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void call(final SingleSubscriber<? super T> subscriber) {
         final SingleSubscriber<T> child = new SingleSubscriber<T>() {


### PR DESCRIPTION
This PR clears the cast warnings introduced by the need to be JDK 9 compilable.
