### PR TITLE
Composite exception should update cause to match the correct throwable that's first in the chain

### DIFF
--- a/src/main/java/rx/exceptions/CompositeException.java
+++ b/src/main/java/rx/exceptions/CompositeException.java
@@ -155,7 +155,7 @@ public final class CompositeException extends RuntimeException {
                     chain = e;
                 }
             }
-            cause = _cause;
+            cause = chain;
         }
         return cause;
     }

--- a/src/main/java/rx/exceptions/CompositeException.java
+++ b/src/main/java/rx/exceptions/CompositeException.java
@@ -155,7 +155,7 @@ public final class CompositeException extends RuntimeException {
                     chain = e;
                 }
             }
-            cause = chain;
+            cause = !exceptions.isEmpty() ? exceptions.get(0) : _cause;
         }
         return cause;
     }

--- a/src/test/java/rx/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/rx/exceptions/CompositeExceptionTest.java
@@ -61,6 +61,24 @@ public class CompositeExceptionTest {
         assertNotNull(getRootCause(ce));
         System.err.println("----------------------------- print cause stacktrace");
         ce.getCause().printStackTrace();
+
+        assertEquals(e1, ce.getCause());
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionCause() {
+        Throwable error = new Throwable("TheCause");
+        CompositeException ce = new CompositeException(error);
+
+        System.err.println("----------------------------- print composite stacktrace");
+        ce.printStackTrace();
+
+        assertNoCircularReferences(ce);
+        assertNotNull(getRootCause(ce));
+        System.err.println("----------------------------- print cause stacktrace");
+        ce.getCause().printStackTrace();
+
+        assertEquals(error, ce.getCause());
     }
 
     @Test(timeout = 1000)


### PR DESCRIPTION
Fixes https://github.com/ReactiveX/RxJava/issues/3679 
