### PR TITLE
1.x: observeOn + immediate scheduler to be a request rebatcher

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -63,10 +63,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
 
     @Override
     public Subscriber<? super T> call(Subscriber<? super T> child) {
-        if (scheduler instanceof ImmediateScheduler) {
-            // avoid overhead, execute directly
-            return child;
-        } else if (scheduler instanceof TrampolineScheduler) {
+        if (scheduler instanceof TrampolineScheduler) {
             // avoid overhead, execute directly
             return child;
         } else {

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -23,7 +23,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import rx.*;
@@ -932,5 +932,28 @@ public class OperatorObserveOnTest {
             ts.assertCompleted();
             ts.assertNoErrors();
         }
+    }
+    
+    @Test
+    public void synchronousRebatching() {
+        final List<Long> requests = new ArrayList<Long>();
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable.range(1, 50)
+        .doOnRequest(new Action1<Long>() {
+            @Override
+            public void call(Long r) {
+                requests.add(r);
+            }
+        })
+        .observeOn(Schedulers.immediate(), 20)
+        .subscribe(ts);
+        
+        ts.assertValueCount(50);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertEquals(Arrays.asList(20L, 15L, 15L, 15L), requests);
     }
 }


### PR DESCRIPTION
This PR removes the `immediate()` scheduler "optimization" from `observeOn` and treats it as a common scheduler. Since `observeOn` has a stable request pattern, this turns it into a rebatching operator. No matter what the downstream requests, the upstream will requests of the specified size (with 25% as low water mark; i.e., replenishment after 75%). Since `immediate` is synchronous, this will run the drain loop, non-reentrant, on the caller thread.

I found this mode of operation very handy in my Reactive-RPC prototype and a simple streaming echo RPC call; it prevents going unbounded and bloating the message sender threads:

``` java
// remote
public Observable<Integer> echo(RpcStreamContext<?> ctx, Observable<Integer> in) {
   return in.observeOn(Schedulers.immediate(), 16);
}

// client
api.echo(Observable.range(1, 100_000)).observeOn(Schedulers.immediate(), 32)
.subscribe(System.out::println, Throwable::printStackTrace);
```
