### PR TITLE
1.x: add optional tracking of worker creation sites + report it on error

### DIFF
--- a/src/main/java/rx/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/rx/internal/schedulers/NewThreadScheduler.java
@@ -30,6 +30,10 @@ public final class NewThreadScheduler extends Scheduler {
 
     @Override
     public Worker createWorker() {
-        return new NewThreadWorker(threadFactory);
+        Throwable site = null;
+        if (WorkerDebugSupport.isEnabled()) {
+            site = new RuntimeException("createWorker() called");
+        }
+        return new NewThreadWorker(threadFactory, site);
     }
 }

--- a/src/main/java/rx/internal/schedulers/WorkerCallback.java
+++ b/src/main/java/rx/internal/schedulers/WorkerCallback.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.schedulers;
+
+/**
+ * Called by the ScheduledAction to remove itself from the parent tracking structure
+ * and ask for the instantiation location of the parent Worker.
+ */
+public interface WorkerCallback {
+    /**
+     * Adds the specified action to the tracking structure.
+     * @param action the action to add, not null
+     */
+    void add(ScheduledAction action);
+    /**
+     * Remove the specified action from the tracking structure.
+     * @param action the action to remove, not null
+     */
+    void remove(ScheduledAction action);
+    /**
+     * Returns the Throwable exception representing the stacktrace
+     * where the parent worker has been created or null
+     * if worker tracking is disabled.
+     * @return the Throwable or null
+     */
+    Throwable workerCreationSite();
+}

--- a/src/main/java/rx/internal/schedulers/WorkerDebugSupport.java
+++ b/src/main/java/rx/internal/schedulers/WorkerDebugSupport.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package rx.internal.schedulers;
+
+import java.security.*;
+
+/**
+ * Holds onto a flag that enables the capture of the current stacktrace when
+ * a Scheduler.Worker is created.
+ * 
+ * Use the system property {@code rx.scheduler-worker.debug} ({@code true|false})
+ * to initialize its value, or use the setEnabled() method during runtime.
+ */
+public enum WorkerDebugSupport {
+    ;
+    
+    private static volatile boolean enabled;
+    
+    static {
+        String s = System.getProperty("rx.scheduler-worker.debug", "false");
+        enabled = "true".equals(s);
+    }
+    /**
+     * Returns the current state of the worker debug mode.
+     * @return the current state of the worker debug mode
+     */
+    public static boolean isEnabled() {
+        return enabled;
+    }
+    
+    /**
+     * Enables or disables the worker debug mode.
+     * @param value the new state
+     */
+    public static void setEnabled(final boolean value) {
+        SecurityManager smgr = System.getSecurityManager();
+        if (smgr == null) {
+            enabled = value;
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    enabled = value;
+                    return null;
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/rx/schedulers/Schedulers.java
+++ b/src/main/java/rx/schedulers/Schedulers.java
@@ -15,13 +15,13 @@
  */
 package rx.schedulers;
 
+import java.util.concurrent.Executor;
+
 import rx.Scheduler;
+import rx.annotations.Experimental;
 import rx.internal.schedulers.*;
 import rx.internal.util.RxRingBuffer;
-import rx.plugins.RxJavaPlugins;
-import rx.plugins.RxJavaSchedulersHook;
-
-import java.util.concurrent.Executor;
+import rx.plugins.*;
 
 /**
  * Static factory methods for creating Schedulers.
@@ -188,5 +188,18 @@ public final class Schedulers {
             
             RxRingBuffer.SPMC_POOL.shutdown();
         }
+    }
+    
+    /**
+     * Enable or disable worker tracking; if a scheduled task crashes,
+     * the error reported to the RxJavaPlugins will contain an IllegalStateException
+     * with a CompositeException cause of the original crash exception 
+     * along with a RuntimeException holding the
+     * stacktrace where the parent worker has been instantiated.
+     * @param value the state
+     */
+    @Experimental
+    public static void setWorkerTracking(boolean value) {
+        WorkerDebugSupport.setEnabled(value);
     }
 }


### PR DESCRIPTION
This is an alternative to #3937 to capture worker creation sites for `computation`, `io` and `newThread` schedulers.
