### PR TITLE
1.x: add multi-other withLatestFrom operators

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9929,7 +9929,332 @@ public class Observable<T> {
     public final <U, R> Observable<R> withLatestFrom(Observable<? extends U> other, Func2<? super T, ? super U, ? extends R> resultSelector) {
         return lift(new OperatorWithLatestFrom<T, U, R>(other, resultSelector));
     }
-    
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, R> Observable<R> withLatestFrom(Observable<T1> o1, Observable<T2> o2, Func3<? super T, ? super T1, ? super T2, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, new Observable<?>[] { o1, o2 }, null, Functions.fromFunc(combiner)));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <T3> the third other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, T3, R> Observable<R> withLatestFrom(
+            Observable<T1> o1, Observable<T2> o2, 
+            Observable<T3> o3, 
+            Func4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, 
+                new Observable<?>[] { o1, o2, o3 }, null, Functions.fromFunc(combiner)));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <T3> the third other source's value type
+     * @param <T4> the fourth other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, T3, T4, R> Observable<R> withLatestFrom(
+            Observable<T1> o1, Observable<T2> o2, 
+            Observable<T3> o3, Observable<T4> o4, 
+            Func5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, 
+                new Observable<?>[] { o1, o2, o3, o4 }, null, Functions.fromFunc(combiner)));
+    }
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <T3> the third other source's value type
+     * @param <T4> the fourth other source's value type
+     * @param <T5> the fifth other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, T3, T4, T5, R> Observable<R> withLatestFrom(
+            Observable<T1> o1, Observable<T2> o2, 
+            Observable<T1> o3, Observable<T2> o4, 
+            Observable<T1> o5, 
+            Func6<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, 
+                new Observable<?>[] { o1, o2, o3, o4, o5 }, null, Functions.fromFunc(combiner)));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <T3> the third other source's value type
+     * @param <T4> the fourth other source's value type
+     * @param <T5> the fifth other source's value type
+     * @param <T6> the sixth other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, T3, T4, T5, T6, R> Observable<R> withLatestFrom(
+            Observable<T1> o1, Observable<T2> o2, 
+            Observable<T1> o3, Observable<T2> o4, 
+            Observable<T1> o5, Observable<T2> o6, 
+            Func7<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, 
+                new Observable<?>[] { o1, o2, o3, o4, o5, o6 }, null, Functions.fromFunc(combiner)));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <T3> the third other source's value type
+     * @param <T4> the fourth other source's value type
+     * @param <T5> the fifth other source's value type
+     * @param <T6> the sixth other source's value type
+     * @param <T7> the seventh other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> withLatestFrom(
+            Observable<T1> o1, Observable<T2> o2, 
+            Observable<T1> o3, Observable<T2> o4, 
+            Observable<T1> o5, Observable<T2> o6, 
+            Observable<T1> o7,
+            Func8<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, 
+                new Observable<?>[] { o1, o2, o3, o4, o5, o6, o7 }, null, Functions.fromFunc(combiner)));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T1> the first other source's value type
+     * @param <T2> the second other source's value type
+     * @param <T3> the third other source's value type
+     * @param <T4> the fourth other source's value type
+     * @param <T5> the fifth other source's value type
+     * @param <T6> the sixth other source's value type
+     * @param <T7> the seventh other source's value type
+     * @param <T8> the eigth other source's value type
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> withLatestFrom(
+            Observable<T1> o1, Observable<T2> o2, 
+            Observable<T1> o3, Observable<T2> o4, 
+            Observable<T1> o5, Observable<T2> o6, 
+            Observable<T1> o7, Observable<T2> o8, 
+            Func9<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, 
+                new Observable<?>[] { o1, o2, o3, o4, o5, o6, o7, o8 }, null, Functions.fromFunc(combiner)));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <R> the result value type
+     * @param others the array of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <R> Observable<R> withLatestFrom(Observable<?>[] others, FuncN<R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, others, null, combiner));
+    }
+
+    /**
+     * Combines the value emission from this Observable with the latest emissions from the
+     * other Observables via a function to produce the output item.
+     * 
+     * <p>Note that this operator doesn't emit anything until all other sources have produced at
+     * least one value. The resulting emission only happens when this Observable emits (and
+     * not when any of the other sources emit, unlike combineLatest). 
+     * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * 
+     * <dl>
+     *  <dt><b>Backpressure Support:</b></dt>
+     *  <dd>This operator is a pass-through for backpressure behavior between this {@code Observable}
+     *  and the downstream Subscriber. The other {@code Observable}s are consumed in an unbounded manner.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <R> the result value type
+     * @param others the iterable of other sources
+     * @param combiner the function called with an array of values from each participating observable
+     * @return the new Observable instance
+     * @Experimental The behavior of this can change at any time.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <R> Observable<R> withLatestFrom(Iterable<Observable<?>> others, FuncN<R> combiner) {
+        return create(new OperatorWithLatestFromMany<T, R>(this, null, others, combiner));
+    }
+
     /**
      * Returns an Observable that emits windows of items it collects from the source Observable. The resulting
      * Observable emits connected, non-overlapping windows. It emits the current window and opens a new one

--- a/src/main/java/rx/internal/operators/OperatorWithLatestFromMany.java
+++ b/src/main/java/rx/internal/operators/OperatorWithLatestFromMany.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.*;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+import rx.exceptions.Exceptions;
+import rx.functions.FuncN;
+import rx.internal.util.RxJavaPluginUtils;
+import rx.observers.SerializedSubscriber;
+
+public final class OperatorWithLatestFromMany<T, R> implements OnSubscribe<R> {
+    final Observable<T> main;
+    
+    final Observable<?>[] others;
+    
+    final Iterable<Observable<?>> othersIterable;
+    
+    final FuncN<R> combiner;
+    
+    public OperatorWithLatestFromMany(Observable<T> main, Observable<?>[] others, Iterable<Observable<?>> othersIterable, FuncN<R> combiner) {
+        this.main = main;
+        this.others = others;
+        this.othersIterable = othersIterable;
+        this.combiner = combiner;
+    }
+
+    @Override
+    public void call(Subscriber<? super R> t) {
+        SerializedSubscriber<R> serial = new SerializedSubscriber<R>(t);
+        
+        
+        Observable<?>[] sources;
+        int n = 0;
+        
+        if (others != null) {
+            sources = others;
+            n = sources.length;
+        } else {
+            sources = new Observable[8];
+            for (Observable<?> o : othersIterable) {
+                if (n == sources.length) {
+                    sources = Arrays.copyOf(sources, n + (n >> 2));
+                }
+                sources[n++] = o;
+            }
+        }
+            
+        WithLatestMainSubscriber<T, R> parent = new WithLatestMainSubscriber<T, R>(t, combiner, n);
+    
+        serial.add(parent);
+
+            
+        for (int i = 0; i < n; i++) {
+            Observable<?> o = sources[i];
+            if (serial.isUnsubscribed()) {
+                return;
+            }
+            
+            WithLatestOtherSubscriber inner = new WithLatestOtherSubscriber(parent, i + 1);
+            parent.add(inner);
+            
+            o.unsafeSubscribe(inner);
+        }
+        
+        main.unsafeSubscribe(parent);
+    }
+    
+    static final class WithLatestMainSubscriber<T, R> extends Subscriber<T> {
+        final Subscriber<? super R> actual;
+        
+        final FuncN<R> combiner;
+        
+        final AtomicReferenceArray<Object> current;
+        
+        static final Object EMPTY = new Object();
+        
+        final AtomicInteger ready;
+        
+        boolean done;
+        
+        public WithLatestMainSubscriber(Subscriber<? super R> actual, FuncN<R> combiner, int n) {
+            this.actual = actual;
+            this.combiner = combiner;
+            
+            AtomicReferenceArray<Object> array = new AtomicReferenceArray<Object>(n + 1);
+            for (int i = 0; i <= n; i++) {
+                array.lazySet(i, EMPTY);
+            }
+            this.current = array;
+            
+            this.ready = new AtomicInteger(n);
+            this.request(0);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            if (ready.get() == 0) {
+                
+                AtomicReferenceArray<Object> array = current;
+                int n = array.length();
+                array.lazySet(0, t);
+                
+                Object[] copy = new Object[array.length()];
+                for (int i = 0; i < n; i++) {
+                    copy[i] = array.get(i);
+                }
+                
+                R result;
+                
+                try {
+                    result = combiner.call(copy);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    onError(ex);
+                    return;
+                }
+                
+                actual.onNext(result);
+            } else {
+                request(1);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPluginUtils.handleException(e);
+                return;
+            }
+            done = true;
+            unsubscribe();
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            if (done) {
+                return;
+            }
+            done = true;
+            unsubscribe();
+            actual.onCompleted();
+        }
+        
+        @Override
+        public void setProducer(Producer p) {
+            super.setProducer(p);
+            actual.setProducer(p);
+        }
+        
+        void innerNext(int index, Object o) {
+            Object last = current.getAndSet(index, o);
+            if (last == EMPTY) {
+                ready.decrementAndGet();
+            }
+        }
+        
+        void innerError(int index, Throwable e) {
+            onError(e);
+        }
+        
+        void innerComplete(int index) {
+            if (current.get(index) == EMPTY) {
+                onCompleted();
+            }
+        }
+    }
+    
+    static final class WithLatestOtherSubscriber extends Subscriber<Object> {
+        final WithLatestMainSubscriber<?, ?> parent;
+        
+        final int index;
+
+        public WithLatestOtherSubscriber(WithLatestMainSubscriber<?, ?> parent, int index) {
+            this.parent = parent;
+            this.index = index;
+        }
+        
+        @Override
+        public void onNext(Object t) {
+            parent.innerNext(index, t);
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            parent.innerError(index, e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            parent.innerComplete(index);
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
@@ -21,13 +21,13 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import rx.Observable;
 import rx.Observer;
 import rx.exceptions.TestException;
-import rx.functions.Func2;
+import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.subjects.PublishSubject;
 
@@ -295,4 +295,365 @@ public class OperatorWithLatestFromTest {
 
         ts.assertNoErrors();
     }
+
+    static final FuncN<String> toArray = new FuncN<String>() {
+        @Override
+        public String call(Object... args) {
+            return Arrays.toString(args);
+        }
+    };
+
+    @Test
+    public void manySources() {
+        PublishSubject<String> ps1 = PublishSubject.create();
+        PublishSubject<String> ps2 = PublishSubject.create();
+        PublishSubject<String> ps3 = PublishSubject.create();
+        PublishSubject<String> main = PublishSubject.create();
+        
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        
+        main.withLatestFrom(new Observable[] { ps1, ps2, ps3 }, toArray)
+        .subscribe(ts);
+        
+        main.onNext("1");
+        ts.assertNoValues();
+        ps1.onNext("a");
+        ts.assertNoValues();
+        ps2.onNext("A");
+        ts.assertNoValues();
+        ps3.onNext("=");
+        ts.assertNoValues();
+        
+        main.onNext("2");
+        ts.assertValues("[2, a, A, =]");
+        
+        ps2.onNext("B");
+        
+        ts.assertValues("[2, a, A, =]");
+        
+        ps3.onCompleted();
+        ts.assertValues("[2, a, A, =]");
+        
+        ps1.onNext("b");
+        
+        main.onNext("3");
+        
+        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        
+        main.onCompleted();
+        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertFalse("ps1 has subscribers?", ps1.hasObservers());
+        Assert.assertFalse("ps2 has subscribers?", ps2.hasObservers());
+        Assert.assertFalse("ps3 has subscribers?", ps3.hasObservers());
+    }
+    
+    @Test
+    public void manySourcesIterable() {
+        PublishSubject<String> ps1 = PublishSubject.create();
+        PublishSubject<String> ps2 = PublishSubject.create();
+        PublishSubject<String> ps3 = PublishSubject.create();
+        PublishSubject<String> main = PublishSubject.create();
+        
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        
+        main.withLatestFrom(Arrays.<Observable<?>>asList(ps1, ps2, ps3), toArray)
+        .subscribe(ts);
+        
+        main.onNext("1");
+        ts.assertNoValues();
+        ps1.onNext("a");
+        ts.assertNoValues();
+        ps2.onNext("A");
+        ts.assertNoValues();
+        ps3.onNext("=");
+        ts.assertNoValues();
+        
+        main.onNext("2");
+        ts.assertValues("[2, a, A, =]");
+        
+        ps2.onNext("B");
+        
+        ts.assertValues("[2, a, A, =]");
+        
+        ps3.onCompleted();
+        ts.assertValues("[2, a, A, =]");
+        
+        ps1.onNext("b");
+        
+        main.onNext("3");
+        
+        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        
+        main.onCompleted();
+        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertFalse("ps1 has subscribers?", ps1.hasObservers());
+        Assert.assertFalse("ps2 has subscribers?", ps2.hasObservers());
+        Assert.assertFalse("ps3 has subscribers?", ps3.hasObservers());
+    }
+    
+    @Test
+    public void manySourcesIterableSweep() {
+        for (String val : new String[] { "1", null }) {
+            int n = 35;
+            for (int i = 0; i < n; i++) {
+                List<Observable<?>> sources = new ArrayList<Observable<?>>();
+                List<String> expected = new ArrayList<String>();
+                expected.add(val);
+                
+                for (int j = 0; j < i; j++) {
+                    sources.add(Observable.just(val));
+                    expected.add(String.valueOf(val));
+                }
+                
+                TestSubscriber<String> ts = new TestSubscriber<String>();
+                
+                PublishSubject<String> main = PublishSubject.create();
+                
+                main.withLatestFrom(sources, toArray).subscribe(ts);
+                
+                ts.assertNoValues();
+                
+                main.onNext(val);
+                main.onCompleted();
+                
+                ts.assertValue(expected.toString());
+                ts.assertNoErrors();
+                ts.assertCompleted();
+            }
+        }
+    }
+    
+    @Test
+    public void backpressureNoSignal() {
+        PublishSubject<String> ps1 = PublishSubject.create();
+        PublishSubject<String> ps2 = PublishSubject.create();
+        
+        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        
+        Observable.range(1, 10).withLatestFrom(new Observable<?>[] { ps1, ps2 }, toArray)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertFalse("ps1 has subscribers?", ps1.hasObservers());
+        Assert.assertFalse("ps2 has subscribers?", ps2.hasObservers());
+    }
+    
+    @Test
+    public void backpressureWithSignal() {
+        PublishSubject<String> ps1 = PublishSubject.create();
+        PublishSubject<String> ps2 = PublishSubject.create();
+        
+        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        
+        Observable.range(1, 3).withLatestFrom(new Observable<?>[] { ps1, ps2 }, toArray)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ps1.onNext("1");
+        ps2.onNext("1");
+        
+        ts.requestMore(1);
+        
+        ts.assertValue("[1, 1, 1]");
+        
+        ts.requestMore(1);
+
+        ts.assertValues("[1, 1, 1]", "[2, 1, 1]");
+
+        ts.requestMore(1);
+        
+        ts.assertValues("[1, 1, 1]", "[2, 1, 1]", "[3, 1, 1]");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        Assert.assertFalse("ps1 has subscribers?", ps1.hasObservers());
+        Assert.assertFalse("ps2 has subscribers?", ps2.hasObservers());
+    }
+    
+    @Test
+    public void withEmpty() {
+        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        
+        Observable.range(1, 3).withLatestFrom(
+                new Observable<?>[] { Observable.just(1), Observable.empty() }, toArray)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void withError() {
+        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        
+        Observable.range(1, 3).withLatestFrom(
+                new Observable<?>[] { Observable.just(1), Observable.error(new TestException()) }, toArray)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void withMainError() {
+        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        
+        Observable.error(new TestException()).withLatestFrom(
+                new Observable<?>[] { Observable.just(1), Observable.just(1) }, toArray)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void with2Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, new Func3<Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c) {
+                return Arrays.asList(a, b, c);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void with3Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, just, new Func4<Integer, Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c, Integer d) {
+                return Arrays.asList(a, b, c, d);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void with4Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, just, just, new Func5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c, Integer d, Integer e) {
+                return Arrays.asList(a, b, c, d, e);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void with5Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, just, just, just, new Func6<Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f) {
+                return Arrays.asList(a, b, c, d, e, f);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1, 1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void with6Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, just, just, just, just, new Func7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g) {
+                return Arrays.asList(a, b, c, d, e, f, g);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1, 1, 1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void with7Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, just, just, just, just, just, new Func8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g, Integer i) {
+                return Arrays.asList(a, b, c, d, e, f, g, i);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1, 1, 1, 1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void with8Others() {
+        Observable<Integer> just = Observable.just(1);
+        
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        
+        just.withLatestFrom(just, just, just, just, just, just, just, just, new Func9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> call(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g, Integer i, Integer j) {
+                return Arrays.asList(a, b, c, d, e, f, g, i, j);
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(1, 1, 1, 1, 1, 1, 1, 1, 1));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
 }


### PR DESCRIPTION
Add `withLatestFrom` operator version that can take 2 to N other sources and combine them with the main source.

Related: #3779.
