### PR TITLE
1.x fix long-chained xWith() operator stack overflow

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -965,8 +965,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2) {
-        return concat(just(t1, t2));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2 }));
     }
 
     /**
@@ -989,8 +990,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3) {
-        return concat(just(t1, t2, t3));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3 }));
     }
 
     /**
@@ -1015,8 +1017,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4) {
-        return concat(just(t1, t2, t3, t4));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3, t4 }));
     }
 
     /**
@@ -1043,8 +1046,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5) {
-        return concat(just(t1, t2, t3, t4, t5));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3, t4, t5 }));
     }
 
     /**
@@ -1073,8 +1077,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6) {
-        return concat(just(t1, t2, t3, t4, t5, t6));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3, t4, t5, t6 }));
     }
 
     /**
@@ -1105,8 +1110,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7) {
-        return concat(just(t1, t2, t3, t4, t5, t6, t7));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3, t4, t5, t6, t7 }));
     }
 
     /**
@@ -1140,7 +1146,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8) {
-        return concat(just(t1, t2, t3, t4, t5, t6, t7, t8));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3, t4, t5, t6, t7, t8 }));
     }
 
     /**
@@ -1175,8 +1181,9 @@ public class Observable<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @SuppressWarnings("unchecked")
     public static <T> Observable<T> concat(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8, Observable<? extends T> t9) {
-        return concat(just(t1, t2, t3, t4, t5, t6, t7, t8, t9));
+        return create(new OnSubscribeConcatArray<T>(new Observable[] { t1, t2, t3, t4, t5, t6, t7, t8, t9 }));
     }
 
     /**
@@ -2246,7 +2253,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     public static <T> Observable<T> merge(Observable<? extends T>[] sequences) {
-        return merge(from(sequences));
+        return create(new OnSubscribeMergeArray<T>(sequences));
     }
     
     /**
@@ -3490,6 +3497,13 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
     public final Observable<T> ambWith(Observable<? extends T> t1) {
+        if (onSubscribe instanceof OnSubscribeAmb) {
+            OnSubscribeAmb o = (OnSubscribeAmb) onSubscribe;
+            OnSubscribeAmb ambWith = o.ambWith(t1);
+            if (ambWith != null) {
+                return create(ambWith);
+            }
+        }
         return amb(this, t1);
     }
 
@@ -4089,6 +4103,10 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
     public final Observable<T> concatWith(Observable<? extends T> t1) {
+        if (onSubscribe instanceof OnSubscribeConcatArray) {
+            OnSubscribeConcatArray<T> o = (OnSubscribeConcatArray<T>) onSubscribe;
+            return create(o.endWith(t1));
+        }
         return concat(this, t1);
     }
 
@@ -6196,6 +6214,10 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     public final Observable<T> mergeWith(Observable<? extends T> t1) {
+        if (onSubscribe instanceof OnSubscribeMergeArray) {
+            OnSubscribeMergeArray o = (OnSubscribeMergeArray) onSubscribe;
+            return create(o.mergeWith(t1));
+        }
         return merge(this, t1);
     }
     
@@ -8033,6 +8055,10 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/startwith.html">ReactiveX operators documentation: StartWith</a>
      */
     public final Observable<T> startWith(Observable<T> values) {
+        if (onSubscribe instanceof OnSubscribeConcatArray) {
+            OnSubscribeConcatArray<T> o = (OnSubscribeConcatArray<T>) onSubscribe;
+            return create(o.startWith(values));
+        }
         return concat(values, this);
     }
 
@@ -10337,6 +10363,10 @@ public class Observable<T> {
      */
     @SuppressWarnings("cast")
     public final <T2, R> Observable<R> zipWith(Observable<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
-        return (Observable<R>)zip(this, other, zipFunction);
+        if (onSubscribe instanceof OnSubscribeZipArray) {
+            OnSubscribeZipArray o = (OnSubscribeZipArray) onSubscribe;
+            return create(o.zipWith(other, zipFunction));
+        }
+        return create(new OnSubscribeZipArray<Object, R>(new Observable[] { this, other }, zipFunction));
     }
 }

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -71,30 +71,39 @@ public class Single<T> {
      */
     protected Single(final OnSubscribe<T> f) {
         // bridge between OnSubscribe (which all Operators and Observables use) and OnExecute (for Single)
-        this.onSubscribe = new Observable.OnSubscribe<T>() {
+        this.onSubscribe = new ObservableOnSubscribe<T>(f);
+    }
+    
+    /**
+     * Wraps a Single.OnSubscribe into an Observable.OnSubscribe.
+     * @param <T> the single emitted value type
+     */
+    static final class ObservableOnSubscribe<T> implements Observable.OnSubscribe<T> {
+        final Single.OnSubscribe<T> f;
+        
+        public ObservableOnSubscribe(Single.OnSubscribe<T> f) {
+            this.f = f;
+        }
+        @Override
+        public void call(final Subscriber<? super T> child) {
+            final SingleDelayedProducer<T> producer = new SingleDelayedProducer<T>(child);
+            child.setProducer(producer);
+            SingleSubscriber<T> ss = new SingleSubscriber<T>() {
 
-            @Override
-            public void call(final Subscriber<? super T> child) {
-                final SingleDelayedProducer<T> producer = new SingleDelayedProducer<T>(child);
-                child.setProducer(producer);
-                SingleSubscriber<T> ss = new SingleSubscriber<T>() {
+                @Override
+                public void onSuccess(T value) {
+                    producer.setValue(value);
+                }
 
-                    @Override
-                    public void onSuccess(T value) {
-                        producer.setValue(value);
-                    }
+                @Override
+                public void onError(Throwable error) {
+                    child.onError(error);
+                }
 
-                    @Override
-                    public void onError(Throwable error) {
-                        child.onError(error);
-                    }
-
-                };
-                child.add(ss);
-                f.call(ss);
-            }
-
-        };
+            };
+            child.add(ss);
+            f.call(ss);
+        }
     }
 
     private Single(final Observable.OnSubscribe<T> f) {
@@ -982,12 +991,12 @@ public class Single<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T1, T2, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, final Func2<? super T1, ? super T2, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1]);
             }
-        });
+        }));
     }
 
     /**
@@ -1018,12 +1027,12 @@ public class Single<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, final Func3<? super T1, ? super T2, ? super T3, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2]);
             }
-        });
+        }));
     }
 
     /**
@@ -1057,12 +1066,12 @@ public class Single<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, final Func4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3]);
             }
-        });
+        }));
     }
 
     /**
@@ -1099,12 +1108,12 @@ public class Single<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, final Func5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4]);
             }
-        });
+        }));
     }
 
     /**
@@ -1145,12 +1154,12 @@ public class Single<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6,
                                                             final Func6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5]);
             }
-        });
+        }));
     }
 
     /**
@@ -1194,12 +1203,12 @@ public class Single<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7,
                                                                 final Func7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6]);
             }
-        });
+        }));
     }
 
     /**
@@ -1246,12 +1255,12 @@ public class Single<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
                                                                     final Func8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], (T8) args[7]);
             }
-        });
+        }));
     }
 
     /**
@@ -1301,12 +1310,12 @@ public class Single<T> {
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(Single<? extends T1> s1, Single<? extends T2> s2, Single<? extends T3> s3, Single<? extends T4> s4, Single<? extends T5> s5, Single<? extends T6> s6, Single<? extends T7> s7, Single<? extends T8> s8,
                                                                         Single<? extends T9> s9, final Func9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipFunction) {
-        return SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8, s9}, new FuncN<R>() {
+        return create(SingleOperatorZip.zip(new Single[] {s1, s2, s3, s4, s5, s6, s7, s8, s9}, new FuncN<R>() {
             @Override
             public R call(Object... args) {
                 return zipFunction.call((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], (T8) args[7], (T9) args[8]);
             }
-        });
+        }));
     }
 
     /**
@@ -1335,7 +1344,7 @@ public class Single<T> {
     public static <R> Single<R> zip(Iterable<? extends Single<?>> singles, FuncN<? extends R> zipFunction) {
         @SuppressWarnings("rawtypes")
         Single[] iterableToArray = iterableToArray(singles);
-        return SingleOperatorZip.zip(iterableToArray, zipFunction);
+        return create(SingleOperatorZip.zip(iterableToArray, zipFunction));
     }
 
     /**
@@ -2355,9 +2364,17 @@ public class Single<T> {
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("cast")
+    @SuppressWarnings({ "unchecked" })
     public final <T2, R> Single<R> zipWith(Single<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
-        return (Single<R>)zip(this, other, zipFunction);
+        if (onSubscribe instanceof ObservableOnSubscribe) {
+            ObservableOnSubscribe<T> o = (ObservableOnSubscribe<T>) onSubscribe;
+            if (o.f instanceof SingleOnSubscribeZipArray) {
+                @SuppressWarnings("rawtypes")
+                SingleOnSubscribeZipArray p = (SingleOnSubscribeZipArray)o.f;
+                return create(p.zipWith(other, zipFunction));
+            }
+        }
+        return create(new SingleOnSubscribeZipArray<Object, R>(new Single[] { this, other }, zipFunction));
     }
 
     /**

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeAmbArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeAmbArray.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.*;
+import rx.Completable.*;
+import rx.internal.util.RxJavaPluginUtils;
+import rx.subscriptions.CompositeSubscription;
+
+public final class CompletableOnSubscribeAmbArray implements CompletableOnSubscribe {
+    final Completable[] sources;
+    
+    public CompletableOnSubscribeAmbArray(Completable[] sources) {
+        this.sources = sources;
+    }
+    
+    public CompletableOnSubscribeAmbArray ambWith(Completable source) {
+        Completable[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Completable[] newSources = new Completable[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = source;
+        
+        return new CompletableOnSubscribeAmbArray(newSources);
+    }
+    
+    @Override
+    public void call(final CompletableSubscriber s) {
+        final CompositeSubscription set = new CompositeSubscription();
+        s.onSubscribe(set);
+
+        final AtomicBoolean once = new AtomicBoolean();
+        
+        CompletableSubscriber inner = new CompletableSubscriber() {
+            @Override
+            public void onCompleted() {
+                if (once.compareAndSet(false, true)) {
+                    set.unsubscribe();
+                    s.onCompleted();
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                if (once.compareAndSet(false, true)) {
+                    set.unsubscribe();
+                    s.onError(e);
+                } else {
+                    RxJavaPluginUtils.handleException(e);
+                }
+            }
+
+            @Override
+            public void onSubscribe(Subscription d) {
+                set.add(d);
+            }
+            
+        };
+        
+        for (Completable c : sources) {
+            if (set.isUnsubscribed()) {
+                return;
+            }
+            if (c == null) {
+                NullPointerException npe = new NullPointerException("One of the sources is null");
+                if (once.compareAndSet(false, true)) {
+                    set.unsubscribe();
+                    s.onError(npe);
+                } else {
+                    RxJavaPluginUtils.handleException(npe);
+                }
+                return;
+            }
+            if (once.get() || set.isUnsubscribed()) {
+                return;
+            }
+            
+            // no need to have separate subscribers because inner is stateless
+            c.subscribe(inner);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
@@ -36,6 +36,28 @@ public final class CompletableOnSubscribeConcatArray implements CompletableOnSub
         inner.next();
     }
     
+    public CompletableOnSubscribe startWith(Completable source) {
+        Completable[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Completable[] newSources = new Completable[oldLen + 1];
+        newSources[0] = source;
+        System.arraycopy(oldSources, 0, newSources, 1, oldLen);
+        
+        return new CompletableOnSubscribeConcatArray(newSources);
+    }
+
+    public CompletableOnSubscribe endWith(Completable source) {
+        Completable[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Completable[] newSources = new Completable[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = source;
+        
+        return new CompletableOnSubscribeConcatArray(newSources);
+    }
+
     static final class ConcatInnerSubscriber extends AtomicInteger implements CompletableSubscriber {
         /** */
         private static final long serialVersionUID = -7965400327305809232L;

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
@@ -30,6 +30,17 @@ public final class CompletableOnSubscribeMergeArray implements CompletableOnSubs
         this.sources = sources;
     }
     
+    public CompletableOnSubscribeMergeArray mergeWith(Completable source) {
+        Completable[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Completable[] newSources = new Completable[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = source;
+        
+        return new CompletableOnSubscribeMergeArray(newSources);
+    }
+    
     @Override
     public void call(final CompletableSubscriber s) {
         final CompositeSubscription set = new CompositeSubscription();

--- a/src/main/java/rx/internal/operators/OnSubscribeAmb.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeAmb.java
@@ -360,6 +360,19 @@ public final class OnSubscribeAmb<T> implements OnSubscribe<T>{
 
     }
     
+    public OnSubscribeAmb<T> ambWith(Observable<? extends T> source) {
+        if (sources instanceof List) {
+            List<? extends Observable<? extends T>> list = (List<? extends Observable<? extends T>>) sources;
+            
+            List<Observable<? extends T>> newList = new ArrayList<Observable<? extends T>>(list.size() + 1);
+            newList.addAll(list);
+            newList.add(source);
+            
+            return new OnSubscribeAmb<T>(newList);
+        }
+        return null; // won't work with generic iterable because those need deferred evaluation
+    }
+    
     //give default access instead of private as a micro-optimization 
     //for access from anonymous classes below
     final Iterable<? extends Observable<? extends T>> sources;

--- a/src/main/java/rx/internal/operators/OnSubscribeConcatArray.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatArray.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+import rx.functions.Func1;
+import rx.internal.operators.OnSubscribeConcatMap.ConcatMapSubscriber;
+
+public final class OnSubscribeConcatArray<T> implements OnSubscribe<T>, Func1<Observable<T>, Observable<T>> {
+    final Observable<T>[] sources;
+    
+    public OnSubscribeConcatArray(Observable<T>[] sources) {
+        this.sources = sources;
+    }
+
+    @SuppressWarnings("unchecked")
+    public OnSubscribeConcatArray<T> startWith(Observable<? extends T> source) {
+        Observable<T>[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Observable<T>[] newSources = new Observable[oldLen + 1];
+        newSources[0] = (Observable<T>)source;
+        System.arraycopy(oldSources, 0, newSources, 1, oldLen);
+        
+        return new OnSubscribeConcatArray<T>(newSources);
+    }
+
+    @SuppressWarnings("unchecked")
+    public OnSubscribeConcatArray<T> endWith(Observable<? extends T> source) {
+        Observable<T>[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Observable<T>[] newSources = new Observable[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = (Observable<T>)source;
+        
+        return new OnSubscribeConcatArray<T>(newSources);
+    }
+    
+    @Override
+    public void call(final Subscriber<? super T> s) {
+        ConcatMapSubscriber<Observable<T>, T> parent = OnSubscribeConcatMap.prepare(s, this, 2, OnSubscribeConcatMap.IMMEDIATE);
+        if (!s.isUnsubscribed()) {
+            parent.setProducer(new OnSubscribeFromArray.FromArrayProducer<Observable<T>>(parent, sources));
+        }
+    }
+
+    @Override
+    public Observable<T> call(Observable<T> t) {
+        return t;
+    }
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeConcatArray.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatArray.java
@@ -18,10 +18,10 @@ package rx.internal.operators;
 
 import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.functions.Func1;
 import rx.internal.operators.OnSubscribeConcatMap.ConcatMapSubscriber;
+import rx.internal.util.UtilityFunctions;
 
-public final class OnSubscribeConcatArray<T> implements OnSubscribe<T>, Func1<Observable<T>, Observable<T>> {
+public final class OnSubscribeConcatArray<T> implements OnSubscribe<T> {
     final Observable<T>[] sources;
     
     public OnSubscribeConcatArray(Observable<T>[] sources) {
@@ -54,14 +54,9 @@ public final class OnSubscribeConcatArray<T> implements OnSubscribe<T>, Func1<Ob
     
     @Override
     public void call(final Subscriber<? super T> s) {
-        ConcatMapSubscriber<Observable<T>, T> parent = OnSubscribeConcatMap.prepare(s, this, 2, OnSubscribeConcatMap.IMMEDIATE);
+        ConcatMapSubscriber<Observable<T>, T> parent = OnSubscribeConcatMap.prepare(s, UtilityFunctions.<Observable<T>>identity(), 2, OnSubscribeConcatMap.IMMEDIATE);
         if (!s.isUnsubscribed()) {
             parent.setProducer(new OnSubscribeFromArray.FromArrayProducer<Observable<T>>(parent, sources));
         }
-    }
-
-    @Override
-    public Observable<T> call(Observable<T> t) {
-        return t;
     }
 }

--- a/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
@@ -69,8 +69,9 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
         this.delayErrorMode = delayErrorMode;
     }
     
-    @Override
-    public void call(Subscriber<? super R> child) {
+    public static <T, R> ConcatMapSubscriber<T, R> prepare(Subscriber<? super R> child, 
+            Func1<? super T, ? extends Observable<? extends R>> mapper, 
+                    int prefetch, int delayErrorMode) {
         Subscriber<? super R> s;
         
         if (delayErrorMode == IMMEDIATE) {
@@ -89,7 +90,12 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
                 parent.requestMore(n);
             }
         });
-        
+        return parent;
+    }
+    
+    @Override
+    public void call(Subscriber<? super R> child) {
+        Subscriber<T> parent = prepare(child, mapper, prefetch, delayErrorMode);
         if (!child.isUnsubscribed()) {
             source.unsafeSubscribe(parent);
         }

--- a/src/main/java/rx/internal/operators/OnSubscribeMergeArray.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeMergeArray.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+
+public final class OnSubscribeMergeArray<T> implements OnSubscribe<T> {
+    final Observable<? extends T>[] sources;
+    
+    public OnSubscribeMergeArray(Observable<? extends T>[] sources) {
+        this.sources = sources;
+    }
+
+    @SuppressWarnings("unchecked")
+    public OnSubscribeMergeArray<T> mergeWith(Observable<? extends T> source) {
+        Observable<? extends T>[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Observable<? extends T>[] newSources = new Observable[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = source;
+        
+        return new OnSubscribeMergeArray<T>(newSources);
+    }
+    
+    @Override
+    public void call(final Subscriber<? super T> s) {
+        
+        OperatorMerge<T> op = OperatorMerge.instance(false);
+        
+        Subscriber<Observable<? extends T>> parent = op.call(s);
+        
+        if (!s.isUnsubscribed()) {
+            parent.setProducer(new OnSubscribeFromArray.FromArrayProducer<Observable<? extends T>>(parent, sources));
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeZipArray.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeZipArray.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+import rx.functions.*;
+import rx.internal.producers.SingleProducer;
+
+public final class OnSubscribeZipArray<T, R> implements OnSubscribe<R> {
+    final Observable<? extends T>[] sources;
+    
+    final PairwiseZipper zipper;
+
+    @SuppressWarnings("rawtypes") 
+    public OnSubscribeZipArray(Observable<? extends T>[] sources, Func2 zipper) {
+        this.sources = sources;
+        this.zipper = new PairwiseZipper(new Func2[] { zipper });
+    }
+
+    OnSubscribeZipArray(Observable<? extends T>[] sources, PairwiseZipper zipper) {
+        this.sources = sources;
+        this.zipper = zipper;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <U> OnSubscribeZipArray<T, U> zipWith(Observable<? extends T> source, Func2<R, T, U> zipper) {
+        Observable<? extends T>[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Observable<? extends T>[] newSources = new Observable[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = source;
+        
+        return new OnSubscribeZipArray<T, U>(newSources, this.zipper.then(zipper));
+    }
+    
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void call(final Subscriber<? super R> s) {
+        OperatorZip<R> op = new OperatorZip<R>(zipper);
+        Subscriber<? super Observable[]> call = op.call(s);
+        
+        if (!s.isUnsubscribed()) {
+            call.setProducer(new SingleProducer<Observable[]>(call, sources));
+        }
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    static final class PairwiseZipper implements FuncN {
+        final Func2[] zippers;
+        
+        public PairwiseZipper(Func2[] zippers) {
+            this.zippers = zippers;
+        }
+        
+        @Override
+        public Object call(Object... args) {
+            Object o = zippers[0].call(args[0], args[1]);
+            for (int i = 1; i < zippers.length; i++) {
+                o = zippers[i].call(o, args[i + 1]);
+            }
+            return o;
+        }
+        
+        public PairwiseZipper then(Func2 zipper) {
+            Func2[] zippers = this.zippers;
+            int n = zippers.length;
+            Func2[] newZippers = new Func2[n + 1];
+            System.arraycopy(zippers, 0, newZippers, 0, n);
+            newZippers[n] = zipper;
+            
+            return new PairwiseZipper(newZippers);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleOnSubscribeZipArray.java
+++ b/src/main/java/rx/internal/operators/SingleOnSubscribeZipArray.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.functions.Func2;
+import rx.internal.operators.OnSubscribeZipArray.PairwiseZipper;
+
+public final class SingleOnSubscribeZipArray<T, R> implements Single.OnSubscribe<R> {
+    final Single<? extends T>[] sources;
+    
+    final PairwiseZipper zipper;
+
+    @SuppressWarnings("rawtypes") 
+    public SingleOnSubscribeZipArray(Single<? extends T>[] sources, Func2 zipper) {
+        this.sources = sources;
+        this.zipper = new PairwiseZipper(new Func2[] { zipper });
+    }
+
+    SingleOnSubscribeZipArray(Single<? extends T>[] sources, PairwiseZipper zipper) {
+        this.sources = sources;
+        this.zipper = zipper;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <U> SingleOnSubscribeZipArray<T, U> zipWith(Single<? extends T> source, Func2<R, T, U> zipper) {
+        Single<? extends T>[] oldSources = sources;
+        
+        int oldLen = oldSources.length;
+        Single<? extends T>[] newSources = new Single[oldLen + 1];
+        System.arraycopy(oldSources, 0, newSources, 0, oldLen);
+        newSources[oldLen] = source;
+        
+        return new SingleOnSubscribeZipArray<T, U>(newSources, this.zipper.then(zipper));
+    }
+    
+    @Override
+    @SuppressWarnings({ "unchecked" })
+    public void call(final SingleSubscriber<? super R> s) {
+        SingleOperatorZip.zip(sources, zipper).call(s);
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleOperatorZip.java
+++ b/src/main/java/rx/internal/operators/SingleOperatorZip.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class SingleOperatorZip {
 
-    public static <T, R> Single<R> zip(final Single<? extends T>[] singles, final FuncN<? extends R> zipper) {
-        return Single.create(new Single.OnSubscribe<R>() {
+    public static <T, R> Single.OnSubscribe<R> zip(final Single<? extends T>[] singles, final FuncN<? extends R> zipper) {
+        return new Single.OnSubscribe<R>() {
             @Override
             public void call(final SingleSubscriber<? super R> subscriber) {
                 if (singles.length == 0) {
@@ -89,6 +89,6 @@ public class SingleOperatorZip {
                     singles[i].subscribe(singleSubscriber);
                 }
             }
-        });
+        };
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorXWithTest.java
+++ b/src/test/java/rx/internal/operators/OperatorXWithTest.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package rx.internal.operators;
+
+import org.junit.Test;
+
+import rx.*;
+import rx.functions.Func2;
+import rx.observers.TestSubscriber;
+import rx.subjects.PublishSubject;
+
+/**
+ * Test if an xWith operator chained repeatedly does not cause StackOverflowError.
+ */
+public class OperatorXWithTest {
+    
+    final int n = 5000;
+    
+    @Test
+    public void mergeWithObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable<Integer> source = Observable.just(1);
+        Observable<Integer> result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.mergeWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount(n + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void concatWithObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable<Integer> source = Observable.just(1);
+        Observable<Integer> result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.concatWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount(n + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void ambWithObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        PublishSubject<Integer> source = PublishSubject.create();
+        Observable<Integer> result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.ambWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        source.onNext(1);
+        source.onCompleted();
+        
+        ts.assertValueCount(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void startWithObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Observable<Integer> source = Observable.just(1);
+        Observable<Integer> result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.startWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount(n + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void zipWithObservable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Func2<Integer, Integer, Integer> f = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer a, Integer b) {
+                return a + b;
+            }
+        };
+        
+        Observable<Integer> source = Observable.just(1);
+        Observable<Integer> result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.zipWith(source, f);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValue(n + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+// TODO There is no Single.ambWith yet
+//    @Test
+//    public void ambWithSingle() {
+//        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+//        
+//        PublishSubject<Integer> source = PublishSubject.create();
+//        Single<Integer> result = source.toSingle();
+//        
+//        for (int i = 0; i < n; i++) {
+//            result = result.ambWith(source);
+//        }
+//        
+//        result.subscribe(ts);
+//        
+//        source.onNext(1);
+//        source.onCompleted();
+//        
+//        ts.assertValueCount(1);
+//        ts.assertNoErrors();
+//        ts.assertCompleted();
+//    }
+    
+    @Test
+    public void zipWithSingle() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Func2<Integer, Integer, Integer> f = new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer a, Integer b) {
+                return a + b;
+            }
+        };
+        
+        Single<Integer> source = Single.just(1);
+        Single<Integer> result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.zipWith(source, f);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValue(n + 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void mergeWithCompletable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Completable source = Completable.complete();
+        Completable result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.mergeWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount(0);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void concatWithCompletable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Completable source = Completable.complete();
+        Completable result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.concatWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount(0);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void ambWithCompletable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        PublishSubject<Integer> source = PublishSubject.create();
+        Completable result = source.toCompletable();
+        
+        for (int i = 0; i < n; i++) {
+            result = result.ambWith(source.toCompletable());
+        }
+        
+        result.subscribe(ts);
+        
+        source.onNext(1);
+        source.onCompleted();
+        
+        ts.assertValueCount(0);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void startWithCompletable() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Completable source = Completable.complete();
+        Completable result = source;
+        
+        for (int i = 0; i < n; i++) {
+            result = result.startWith(source);
+        }
+        
+        result.subscribe(ts);
+        
+        ts.assertValueCount(0);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+}


### PR DESCRIPTION
This PR fixes the case when operators of pattern `xWith` chained into a long sequence causes `StackOverflowError` because the subscription call-stack gets deep.

Operators affected and fixes:
- `Observable.ambWith()`
- `Observable.mergeWith()`
- `Observable.concatWith()`
- `Observable.startWith()`
- `Observable.zipWith()`
- `Completable.ambWith()`
- `Completable.mergeWith()`
- `Completable.concatWith()`
- `Completable.startWith()`
- `Single.zipWith()`

The PR contains some tidy-up of existing functionality and introducing short operators that delegate to the "big" operators for the purpose of identification.
