### PR TITLE
1.x: lift into Subject

### DIFF
--- a/src/main/java/rx/subjects/LiftedSubject.java
+++ b/src/main/java/rx/subjects/LiftedSubject.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subjects;
+
+import rx.*;
+
+/**
+ * Wraps another Subject and applies Operators to the front and back side of it. 
+ * <p>
+ * This class allows composing Subjects with front and back-behavior and remain in the
+ * Subject world.
+ * 
+ * @param <T> the new front value type
+ * @param <U> the input value type of the wrapped subject
+ * @param <V> the output value type of the wrapped subject
+ * @param <R> the new output type
+ */
+final class LiftedSubject<T, U, V, R> extends Subject<T, R> {
+    
+    /**
+     * Constructs a new subject wrapper around the given Subject and
+     * applies the specified front and back operators to it while still acting
+     * as a self-contained Subject.
+     * <p>
+     * Note that the same sequential requirement applies to the returned Subject instance
+     * as any other Subject. In addition, one should avoid calling onXXX methods on the
+     * wrapped Subject and the returned Subject instance concurrently as this may lead
+     * to undefined behavior.
+     * 
+     * @param <T> the new front value type
+     * @param <U> the input value type of the wrapped subject
+     * @param <V> the output value type of the wrapped subject
+     * @param <R> the new output type
+     * @param actual the actual subject
+     * @param front the operator to apply to the input side
+     * @param back the operator to apply to the output side
+     * @return the new Subject wrapper
+     */
+    public static <T, U, V, R> Subject<T, R> create(
+            final Subject<U, V> actual, 
+            Operator<U, T> front, 
+            Operator<R, V> back) {
+        if (actual == null) {
+            throw new NullPointerException("actual is null");
+        }
+        if (front == null) {
+            throw new NullPointerException("front is null");
+        }
+        if (back == null) {
+            throw new NullPointerException("back is null");
+        }
+        Subscriber<? super T> frontSubscriber = front.call(new Subscriber<U>() {
+            @Override
+            public void onNext(U t) {
+                actual.onNext(t);
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                actual.onError(e);
+            }
+            
+            @Override
+            public void onCompleted() {
+                actual.onCompleted();
+            }
+        });
+        
+        if (frontSubscriber == null) {
+            throw new NullPointerException("The operator " + front + " returned a null Subscriber");
+        }
+        
+        State<T, U, V, R> state = new State<T, U, V, R>(actual, frontSubscriber, back);
+        return new LiftedSubject<T, U, V, R>(state);
+    }
+    
+    final State<T, U, V, R> state;
+    
+    private LiftedSubject(State<T, U, V, R> state) {
+        super(state);
+        this.state = state;
+    }
+    
+    @Override
+    public boolean hasObservers() {
+        return state.subject.hasObservers();
+    }
+    
+    @Override
+    public void onNext(T t) {
+        state.onNext(t);
+    }
+    
+    @Override
+    public void onError(Throwable e) {
+        state.onError(e);
+    }
+    
+    @Override
+    public void onCompleted() {
+        state.onCompleted();
+    }
+    
+    /**
+     * Holds onto the wrapped subject, the input operator's Subscriber and the output
+     * operator (which has to be lifted for every incoming Subscriber).
+     *
+     * @param <T> the new front value type
+     * @param <U> the input value type of the wrapped subject
+     * @param <V> the output value type of the wrapped subject
+     * @param <R> the new output type
+     */
+    static final class State<T, U, V, R> extends Subscriber<T> implements OnSubscribe<R> {
+        
+        final Subject<U, V> subject;
+        
+        final Subscriber<? super T> frontSubscriber;
+        
+        final Operator<R, V> backOperator;
+        
+        public State(Subject<U, V> subject, Subscriber<? super T> frontSubscriber, 
+                Operator<R, V> backOperator) {
+            this.subject = subject;
+            this.frontSubscriber = frontSubscriber;
+            this.backOperator = backOperator;
+        }
+
+        @Override
+        public void call(Subscriber<? super R> t) {
+            this.subject.lift(backOperator).unsafeSubscribe(t);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            this.frontSubscriber.onNext(t);
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            this.frontSubscriber.onError(e);
+        }
+        
+        @Override
+        public void onCompleted() {
+            this.frontSubscriber.onCompleted();
+        }
+    }
+    
+    /** The single instance of the identity Operator. */
+    enum IdentityOperator implements Operator<Object, Object> {
+        INSTANCE
+        ;
+        
+        @Override
+        public Subscriber<? super Object> call(Subscriber<? super Object> t) {
+            return t;
+        }
+    }
+    /**
+     * Returns the identity operator that returns the passed Subscriber (i.e., the downstream
+     * Subscriber passes through directly).
+     * @param <T> the value type
+     * @return the identity operator
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Operator<T, T> identity() {
+        return (Operator<T, T>)IdentityOperator.INSTANCE;
+    }
+}

--- a/src/main/java/rx/subjects/Subject.java
+++ b/src/main/java/rx/subjects/Subject.java
@@ -16,6 +16,7 @@
 package rx.subjects;
 
 import rx.*;
+import rx.annotations.Experimental;
 
 /**
  * Represents an object that is both an Observable and an Observer.
@@ -56,5 +57,62 @@ public abstract class Subject<T, R> extends Observable<R> implements Observer<T>
             return (SerializedSubject<T, R>)this;
         }
         return new SerializedSubject<T, R>(this);
+    }
+    
+    /**
+     * Lifts an Operator into the front of this Subject allowing custom
+     * behavior to be performed on the signals the returned Subject receives
+     * while still presenting the Subject API to the outside world.
+     * 
+     * <p>
+     * This allows staying in the Subject world while adding front behavior
+     * to incoming onXXX calls.
+     * 
+     * @param <A> the new input value type
+     * @param operator the operator that transforms the onXXX calls
+     * @return the new Subject wrapping this Subject and having a front-side operator.
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <A> Subject<A, R> frontLift(Operator<T, A> operator) {
+        return lift(operator, LiftedSubject.<R>identity());
+    }
+    
+    /**
+     * Lifts an Operator into the back of this Subject allowing custom
+     * behavior to be performed on the output signals of this Subject 
+     * while still presenting the Subject API to the outside world.
+     * 
+     * <p>
+     * This is similar to a regular application of subject.lift() but the
+     * wrapping allows staying in the Subject world.
+     * 
+     * @param <Z> the new output value type
+     * @param operator the operator to lift as the back transformation
+     * @return the new Subject wrapping this Subject and having a back-side operator
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <Z> Subject<T, Z> backLift(Operator<Z, R> operator) {
+        return lift(LiftedSubject.<T>identity(), operator);
+    }
+    
+    /**
+     * Lifts a front and a back Operator into this Subject and allowing
+     * custom behavior on both sides while still presenting the Subject
+     * API to the outside world.
+     * 
+     * @param <A> the new input value type
+     * @param <Z> the new output value type
+     * @param frontOperator the operator that transforms the onXXX calls
+     * @param backOperator the operator to lift as the back transformation
+     * @return the new Subject wrapping this Subject and having
+     * a front-side operator and back-side operator
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public final <A, Z> Subject<A, Z> lift(Operator<T, A> frontOperator, 
+            Operator<Z, R> backOperator) {
+        return LiftedSubject.create(this, frontOperator, backOperator);
     }
 }

--- a/src/test/java/rx/subjects/LiftedSubjectTest.java
+++ b/src/test/java/rx/subjects/LiftedSubjectTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.subjects;
+
+import org.junit.Test;
+
+import rx.Observable.Operator;
+import rx.functions.Func1;
+import rx.internal.operators.OperatorMap;
+import rx.observers.TestSubscriber;
+
+public class LiftedSubjectTest {
+    
+    final Operator<Integer, String> parseInt = new OperatorMap<String, Integer>(new Func1<String, Integer>() {
+        @Override
+        public Integer call(String s) {
+            return Integer.parseInt(s);
+        }
+    });
+    
+    final Operator<String, Integer> toString = new OperatorMap<Integer, String>(new Func1<Integer, String>() {
+        @Override
+        public String call(Integer s) {
+            return String.valueOf(s + 1);
+        }
+    });
+    
+    void liftFront(Subject<Integer, Integer> actual) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Subject<String, Integer> subject = actual.frontLift(parseInt);
+        
+        subject.subscribe(ts);
+        
+        subject.onNext("1");
+        subject.onCompleted();
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    void liftBack(Subject<Integer, Integer> actual) {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        
+        Subject<Integer, String> subject = actual.backLift(toString);
+        
+        subject.subscribe(ts);
+        
+        subject.onNext(1);
+        subject.onCompleted();
+        
+        ts.assertValue("2");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    void liftBoth(Subject<Integer, Integer> actual) {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        
+        Subject<String, String> subject = actual.lift(parseInt, toString);
+        
+        subject.subscribe(ts);
+        
+        subject.onNext("1");
+        subject.onCompleted();
+        
+        ts.assertValue("2");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void asyncFront() {
+        AsyncSubject<Integer> actual = AsyncSubject.create();
+        liftFront(actual);
+    }
+    
+    @Test
+    public void asyncBack() {
+        AsyncSubject<Integer> actual = AsyncSubject.create();
+        liftBack(actual);
+    }
+    
+    @Test
+    public void asyncBoth() {
+        AsyncSubject<Integer> actual = AsyncSubject.create();
+        liftBoth(actual);
+    }
+    
+    @Test
+    public void publishFront() {
+        PublishSubject<Integer> actual = PublishSubject.create();
+        liftFront(actual);
+    }
+    
+    @Test
+    public void publishBack() {
+        PublishSubject<Integer> actual = PublishSubject.create();
+        liftBack(actual);
+    }
+    
+    @Test
+    public void publishBoth() {
+        PublishSubject<Integer> actual = PublishSubject.create();
+        liftBoth(actual);
+    }
+    
+    @Test
+    public void replayFront() {
+        ReplaySubject<Integer> actual = ReplaySubject.create();
+        liftFront(actual);
+    }
+    
+    @Test
+    public void replayBack() {
+        ReplaySubject<Integer> actual = ReplaySubject.create();
+        liftBack(actual);
+    }
+    
+    @Test
+    public void replayBoth() {
+        ReplaySubject<Integer> actual = ReplaySubject.create();
+        liftBoth(actual);
+    }
+    
+    @Test
+    public void behaviorFront() {
+        BehaviorSubject<Integer> actual = BehaviorSubject.create();
+        liftFront(actual);
+    }
+    
+    @Test
+    public void behaviorBack() {
+        BehaviorSubject<Integer> actual = BehaviorSubject.create();
+        liftBack(actual);
+    }
+    
+    @Test
+    public void behaviorBoth() {
+        BehaviorSubject<Integer> actual = BehaviorSubject.create();
+        liftBoth(actual);
+    }
+
+}


### PR DESCRIPTION
See #2458.

This PR shows a way to implement lifting into a Subject. It is possible to lift on the front and the back side. The main idea is to add behavior to a Subject while presenting it to the outside world still as a Subject.

I'm not 100% certain the value of this because one has to write operators for this to work (relying on the `rx.internal.operators` is not recommended). The front-side operator can be simpler since it doesn't have to deal with unsubscription and backpressure as the wrapped Subjects don't have that capability on their front anyway.
