### PR TITLE
1.x: remove remaining field updaters

### DIFF
--- a/src/main/java/rx/internal/operators/BackpressureUtils.java
+++ b/src/main/java/rx/internal/operators/BackpressureUtils.java
@@ -45,7 +45,9 @@ public final class BackpressureUtils {
      * @param n
      *            the number of requests to add to the requested count
      * @return requested value just prior to successful addition
+     * @deprecated Android has issues with reflection-based atomics
      */
+    @Deprecated
     public static <T> long getAndAddRequest(AtomicLongFieldUpdater<T> requested, T object, long n) {
         // add n to field but check for overflow
         while (true) {

--- a/src/main/java/rx/internal/schedulers/CachedThreadScheduler.java
+++ b/src/main/java/rx/internal/schedulers/CachedThreadScheduler.java
@@ -177,19 +177,17 @@ public final class CachedThreadScheduler extends Scheduler implements SchedulerL
         private final CompositeSubscription innerSubscription = new CompositeSubscription();
         private final CachedWorkerPool pool;
         private final ThreadWorker threadWorker;
-        @SuppressWarnings("unused")
-        volatile int once;
-        static final AtomicIntegerFieldUpdater<EventLoopWorker> ONCE_UPDATER
-                = AtomicIntegerFieldUpdater.newUpdater(EventLoopWorker.class, "once");
+        final AtomicBoolean once;
 
         EventLoopWorker(CachedWorkerPool pool) {
             this.pool = pool;
+            this.once = new AtomicBoolean();
             this.threadWorker = pool.get();
         }
 
         @Override
         public void unsubscribe() {
-            if (ONCE_UPDATER.compareAndSet(this, 0, 1)) {
+            if (once.compareAndSet(false, true)) {
                 // unsubscribe should be idempotent, so only do this once
                 pool.release(threadWorker);
             }


### PR DESCRIPTION
This PR removes the remaining `AtomicXFieldUpdater`s from the library because reflection is somewhat problematic on Android.

This also deprecates the internal `BackpressureUtils.getAndAddRequest` to indicate `requested` field updater should not be used anymore.
