### PR TITLE
Add Schedulers.reset() for better testing

### DIFF
--- a/src/main/java/rx/schedulers/Schedulers.java
+++ b/src/main/java/rx/schedulers/Schedulers.java
@@ -163,11 +163,8 @@ public final class Schedulers {
 
     /**
      * Resets the current {@link Schedulers} instance.
-     * <p>
-     * This API is experimental. Resetting the schedulers is dangerous
-     * during application runtime and also bad code could invoke it in
-     * the middle of an application life-cycle and really break applications
-     * if not used cautiously.
+     * This will re-init the cached schedulers on the next usage,
+     * which can be useful in testing.
      */
     @Experimental
     public static void reset() {

--- a/src/test/java/rx/schedulers/ResetSchedulersTest.java
+++ b/src/test/java/rx/schedulers/ResetSchedulersTest.java
@@ -1,0 +1,50 @@
+package rx.schedulers;
+
+
+import org.junit.Test;
+import rx.Scheduler;
+import rx.internal.schedulers.*;
+import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaSchedulersHook;
+
+import static org.junit.Assert.assertTrue;
+
+public class ResetSchedulersTest {
+
+    @Test
+    public void reset() {
+        RxJavaPlugins.getInstance().reset();
+
+        final TestScheduler testScheduler = new TestScheduler();
+        RxJavaPlugins.getInstance().registerSchedulersHook(new RxJavaSchedulersHook() {
+            @Override
+            public Scheduler getComputationScheduler() {
+                return testScheduler;
+            }
+
+            @Override
+            public Scheduler getIOScheduler() {
+                return testScheduler;
+            }
+
+            @Override
+            public Scheduler getNewThreadScheduler() {
+                return testScheduler;
+            }
+        });
+        Schedulers.reset();
+
+        assertTrue(Schedulers.io().equals(testScheduler));
+        assertTrue(Schedulers.computation().equals(testScheduler));
+        assertTrue(Schedulers.newThread().equals(testScheduler));
+
+        RxJavaPlugins.getInstance().reset();
+        RxJavaPlugins.getInstance().registerSchedulersHook(RxJavaSchedulersHook.getDefaultInstance());
+        Schedulers.reset();
+
+        assertTrue(Schedulers.io() instanceof CachedThreadScheduler);
+        assertTrue(Schedulers.computation() instanceof EventLoopsScheduler);
+        assertTrue(Schedulers.newThread() instanceof rx.internal.schedulers.NewThreadScheduler);
+    }
+
+}


### PR DESCRIPTION
Resolves #3985

This adds a `reset()` method to `Schedulers`, with the main benefit being improved testing support. This does slightly tweak the internal API of `Schedulers` to use a `getInstance()` approach to allow lazy init. This way we don't have to replace the singleton instance during `reset()` and allow it to lazily re-evaluate upon next usage. Otherwise, if you change your scheduler hook, you'd always have to make sure you set it before you call `Schedulers.reset()`.

Will run perf tests overnight in case, I'm not sure how much of a tradeoff moving to an internal `getInstance()` approach costs, if anything.

CC @zsxwing
