### PR TITLE
Add more time to certain tests that failed under heavy CI load

### DIFF
--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -867,7 +867,7 @@ public class OperatorSwitchTest {
                             });
                 }
             })
-            .timeout(10, TimeUnit.SECONDS)
+            .timeout(20, TimeUnit.SECONDS)
             .subscribe(ts);
             
             ts.awaitTerminalEvent(45, TimeUnit.SECONDS);

--- a/src/test/java/rx/internal/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/rx/internal/schedulers/ExecutorSchedulerTest.java
@@ -48,7 +48,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testCancelledTaskRetention() throws InterruptedException {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         Scheduler s = Schedulers.from(exec);

--- a/src/test/java/rx/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/rx/schedulers/ComputationSchedulerTests.java
@@ -153,7 +153,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testCancelledTaskRetention() throws InterruptedException {
         Worker w = Schedulers.computation().createWorker();
         try {

--- a/src/test/java/rx/schedulers/IoSchedulerTest.java
+++ b/src/test/java/rx/schedulers/IoSchedulerTest.java
@@ -67,7 +67,7 @@ public class IoSchedulerTest extends AbstractSchedulerConcurrencyTests {
         SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testCancelledTaskRetention() throws InterruptedException {
         Worker w = Schedulers.io().createWorker();
         try {


### PR DESCRIPTION
Sometimes, the heavy Travis CI load (or throttling) makes a few tests fail with timeout. This increases the timeout for some of them to reduce the likelihood.
