### PR TITLE
1.x: added distinctUntilChanged(comparator)

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -4761,6 +4761,44 @@ public class Observable<T> {
     public final <U> Observable<T> distinctUntilChanged(Func1<? super T, ? extends U> keySelector) {
         return lift(new OperatorDistinctUntilChanged<T, U>(keySelector));
     }
+    
+    /**
+     * Returns an Observable that emits all items emitted by the source Observable that are distinct from their
+     * immediate predecessors, according to a comparator function.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/distinctUntilChanged.key.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code distinctUntilChanged} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param comparator
+     *            a function that compares two successive items and decide whether an item
+     *            is distinct from another one or not
+     * @return an Observable that emits those items from the source Observable whose keys are distinct from
+     *         those of their immediate predecessors
+     * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
+     */
+    public final Observable<T> distinctUntilChanged(Func2<? super T, ? super T, Boolean> comparator) {
+        return lift(new OperatorDistinctUntilChanged<>(new Func1<T, Object>() {
+			T previousValue;
+
+			@Override
+			public Object call(T t) {
+				if (previousValue != null) {
+					if (comparator.call(previousValue, t)) {
+						return previousValue;
+					} else {
+						previousValue = t;
+						return t;
+					}
+				} else {
+					previousValue = t;
+					return previousValue;
+				}
+			}
+		}));
+    }
 
     /**
      * Modifies the source Observable so that it invokes an action when it calls {@code onCompleted}.

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -4780,24 +4780,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
      */
     public final Observable<T> distinctUntilChanged(Func2<? super T, ? super T, Boolean> comparator) {
-        return lift(new OperatorDistinctUntilChanged<>(new Func1<T, Object>() {
-			T previousValue;
-
-			@Override
-			public Object call(T t) {
-				if (previousValue != null) {
-					if (comparator.call(previousValue, t)) {
-						return previousValue;
-					} else {
-						previousValue = t;
-						return t;
-					}
-				} else {
-					previousValue = t;
-					return previousValue;
-				}
-			}
-		}));
+        return lift(new OperatorDistinctUntilChanged<T, Void>(comparator));
     }
 
     /**


### PR DESCRIPTION
For some cases, `Observable.distinctUntilChanged(keySelector)` isn't enough. For example, when data consists of 2+ objects with ID, you cannot simply summarize them and use it as a key. Also often there are stream of arrays of data which can't be distincted easily and generically.
So I think `Observable.distinctUntilChanged(comparator)` would be helpful. I use kinda tricky implementation, but think, it is okey. Firstly I tried to add ctor to OperatorDistinctUntilChanged(), but it was... too bad.

**p.s.** I was really confused by 

> If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request (on a branch other than master, 1.x, 2.x, or gh-pages).

and spent some time trying to create some sort of temporal branch here (newbie me). But finally looked up into PRs and so that it is okey to PR into 1.x. Is it an error in .md-file?
