### PR TITLE
1.x: fix Spsc queues reporting not empty but then poll() returns null

### DIFF
--- a/src/main/java/rx/internal/util/atomic/SpscAtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscAtomicArrayQueue.java
@@ -64,8 +64,8 @@ public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> 
                 return false;
             }
         }
-        soProducerIndex(index + 1); // ordered store -> atomic and ordered for size()
         soElement(buffer, offset, e); // StoreStore
+        soProducerIndex(index + 1); // ordered store -> atomic and ordered for size()
         return true;
     }
 
@@ -79,8 +79,8 @@ public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> 
         if (null == e) {
             return null;
         }
-        soConsumerIndex(index + 1); // ordered store -> atomic and ordered for size()
         soElement(lElementBuffer, offset, null);// StoreStore
+        soConsumerIndex(index + 1); // ordered store -> atomic and ordered for size()
         return e;
     }
 

--- a/src/main/java/rx/internal/util/atomic/SpscLinkedArrayQueue.java
+++ b/src/main/java/rx/internal/util/atomic/SpscLinkedArrayQueue.java
@@ -90,8 +90,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
     }
 
     private boolean writeToQueue(final AtomicReferenceArray<Object> buffer, final T e, final long index, final int offset) {
-        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
         soElement(buffer, offset, e);// StoreStore
+        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
         return true;
     }
 
@@ -101,11 +101,11 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
         producerBuffer = newBuffer;
         producerLookAhead = currIndex + mask - 1;
-        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
         soElement(newBuffer, offset, e);// StoreStore
         soNext(oldBuffer, newBuffer);
         soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is
                                                                  // inserted
+        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
     }
 
     private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
@@ -131,8 +131,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         final Object e = lvElement(buffer, offset);// LoadLoad
         boolean isNextBuffer = e == HAS_NEXT;
         if (null != e && !isNextBuffer) {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             soElement(buffer, offset, null);// StoreStore
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             return (T) e;
         } else if (isNextBuffer) {
             return newBufferPoll(lvNext(buffer), index, mask);
@@ -149,8 +149,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         if (null == n) {
             return null;
         } else {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             soElement(nextBuffer, offsetInNew, null);// StoreStore
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             return n;
         }
     }
@@ -330,8 +330,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         if (null == lvElement(buffer, pi)) {
             pi = calcWrappedOffset(p, m);
             soElement(buffer, pi + 1, second);
-            soProducerIndex(p + 2);
             soElement(buffer, pi, first);
+            soProducerIndex(p + 2);
         } else {
             final int capacity = buffer.length();
             final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
@@ -342,9 +342,9 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
             soElement(newBuffer, pi, first);
             soNext(buffer, newBuffer);
             
-            soProducerIndex(p + 2);// this ensures correctness on 32bit platforms
-            
             soElement(buffer, pi, HAS_NEXT); // new buffer is visible after element is
+            
+            soProducerIndex(p + 2);// this ensures correctness on 32bit platforms
         }
 
         return true;

--- a/src/main/java/rx/internal/util/unsafe/SpscArrayQueue.java
+++ b/src/main/java/rx/internal/util/unsafe/SpscArrayQueue.java
@@ -110,8 +110,8 @@ public final class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E> {
         if (null != lvElement(lElementBuffer, offset)){
             return false;
         }
-        soProducerIndex(index + 1); // ordered store -> atomic and ordered for size()
         soElement(lElementBuffer, offset, e); // StoreStore
+        soProducerIndex(index + 1); // ordered store -> atomic and ordered for size()
         return true;
     }
     
@@ -130,8 +130,8 @@ public final class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E> {
         if (null == e) {
             return null;
         }
-        soConsumerIndex(index + 1); // ordered store -> atomic and ordered for size()
         soElement(lElementBuffer, offset, null);// StoreStore
+        soConsumerIndex(index + 1); // ordered store -> atomic and ordered for size()
         return e;
     }
 

--- a/src/main/java/rx/internal/util/unsafe/SpscUnboundedArrayQueue.java
+++ b/src/main/java/rx/internal/util/unsafe/SpscUnboundedArrayQueue.java
@@ -132,8 +132,8 @@ public class SpscUnboundedArrayQueue<E> extends SpscUnboundedArrayQueueConsumerF
     }
 
     private boolean writeToQueue(final E[] buffer, final E e, final long index, final long offset) {
-        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
         soElement(buffer, offset, e);// StoreStore
+        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
         return true;
     }
 
@@ -144,11 +144,11 @@ public class SpscUnboundedArrayQueue<E> extends SpscUnboundedArrayQueueConsumerF
         final E[] newBuffer = (E[]) new Object[capacity];
         producerBuffer = newBuffer;
         producerLookAhead = currIndex + mask - 1;
-        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
         soElement(newBuffer, offset, e);// StoreStore
         soNext(oldBuffer, newBuffer);
         soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is
                                                                  // inserted
+        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
     }
 
     private void soNext(E[] curr, E[] next) {
@@ -174,8 +174,8 @@ public class SpscUnboundedArrayQueue<E> extends SpscUnboundedArrayQueueConsumerF
         final Object e = lvElement(buffer, offset);// LoadLoad
         boolean isNextBuffer = e == HAS_NEXT;
         if (null != e && !isNextBuffer) {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             soElement(buffer, offset, null);// StoreStore
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             return (E) e;
         } else if (isNextBuffer) {
             return newBufferPoll(lvNext(buffer), index, mask);
@@ -192,8 +192,8 @@ public class SpscUnboundedArrayQueue<E> extends SpscUnboundedArrayQueueConsumerF
         if (null == n) {
             return null;
         } else {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             soElement(nextBuffer, offsetInNew, null);// StoreStore
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             return n;
         }
     }


### PR DESCRIPTION
In the spsc queues, the indexes were written before the actual elements and thus a concurrent `isEmpty` check would report a non-empty queue but a `poll` would still return `null`. The fix swaps the two writes.

Note that this an inconsistency in the original JCTools code and not the lack of keeping up with it.
