### PR TITLE
1.x: new hook management proposal

### DIFF
--- a/src/main/java/rx/exceptions/AssemblyStackTraceException.java
+++ b/src/main/java/rx/exceptions/AssemblyStackTraceException.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.exceptions;
+
+import rx.annotations.Experimental;
+
+/**
+ * A RuntimeException that is stackless but holds onto a textual
+ * stacktrace from tracking the assembly location of operators.
+ */
+@Experimental
+public final class AssemblyStackTraceException extends RuntimeException {
+
+    /** */
+    private static final long serialVersionUID = 2038859767182585852L;
+
+    /**
+     * Constructs an AssemblyStackTraceException with the given message and
+     * a cause.
+     * @param message the message
+     * @param cause the cause
+     */
+    public AssemblyStackTraceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs an AssemblyStackTraceException with the given message.
+     * @param message the message
+     */
+    public AssemblyStackTraceException(String message) {
+        super(message);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -191,6 +191,7 @@ public final class OnErrorThrowable extends RuntimeException {
                 return ((Enum<?>) value).name();
             }
 
+            @SuppressWarnings("deprecation")
             String pluggedRendering = RxJavaPlugins.getInstance().getErrorHandler().handleOnNextValueRendering(value);
             if (pluggedRendering != null) {
                 return pluggedRendering;

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
@@ -22,7 +22,7 @@ import rx.*;
 import rx.Completable.*;
 import rx.exceptions.MissingBackpressureException;
 import rx.internal.util.unsafe.SpscArrayQueue;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
 public final class CompletableOnSubscribeConcat implements CompletableOnSubscribe {
@@ -87,7 +87,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
                 actual.onError(t);
                 return;
             }
-            RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+            RxJavaHooks.onError(t);
         }
         
         @Override
@@ -125,7 +125,7 @@ public final class CompletableOnSubscribeConcat implements CompletableOnSubscrib
                     }
                     return;
                 }
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(new IllegalStateException("Queue is empty?!"));
+                RxJavaHooks.onError(new IllegalStateException("Queue is empty?!"));
                 return;
             }
             

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
@@ -22,9 +22,9 @@ import java.util.concurrent.atomic.*;
 
 import rx.*;
 import rx.Completable.*;
-import rx.exceptions.CompositeException;
 import rx.Observable;
-import rx.plugins.RxJavaPlugins;
+import rx.exceptions.CompositeException;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
 public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe {
@@ -110,7 +110,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
                 @Override
                 public void onError(Throwable e) {
                     if (innerDone) {
-                        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                        RxJavaHooks.onError(e);
                         return;
                     }
                     innerDone = true;
@@ -145,7 +145,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
         @Override
         public void onError(Throwable t) {
             if (done) {
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                RxJavaHooks.onError(t);
                 return;
             }
             getOrCreateErrors().offer(t);
@@ -172,7 +172,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
                     if (once.compareAndSet(false, true)) {
                         actual.onError(e);
                     } else {
-                        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                        RxJavaHooks.onError(e);
                     }
                 }
             } else
@@ -183,7 +183,7 @@ public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe
                     if (once.compareAndSet(false, true)) {
                         actual.onError(e);
                     } else {
-                        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                        RxJavaHooks.onError(e);
                     }
                 }
             }

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 
 import rx.*;
 import rx.Completable.*;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
 public final class CompletableOnSubscribeMergeArray implements CompletableOnSubscribe {
@@ -50,7 +50,7 @@ public final class CompletableOnSubscribeMergeArray implements CompletableOnSubs
                     s.onError(npe);
                     return;
                 } else {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(npe);
+                    RxJavaHooks.onError(npe);
                 }
             }
             
@@ -66,7 +66,7 @@ public final class CompletableOnSubscribeMergeArray implements CompletableOnSubs
                     if (once.compareAndSet(false, true)) {
                         s.onError(e);
                     } else {
-                        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                        RxJavaHooks.onError(e);
                     }
                 }
 

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeIterable.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.*;
 
 import rx.*;
 import rx.Completable.*;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
 public final class CompletableOnSubscribeMergeIterable implements CompletableOnSubscribe {
@@ -66,7 +66,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
                 if (once.compareAndSet(false, true)) {
                     s.onError(e);
                 } else {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                    RxJavaHooks.onError(e);
                 }
                 return;
             }
@@ -88,7 +88,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
                 if (once.compareAndSet(false, true)) {
                     s.onError(e);
                 } else {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                    RxJavaHooks.onError(e);
                 }
                 return;
             }
@@ -103,7 +103,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
                 if (once.compareAndSet(false, true)) {
                     s.onError(npe);
                 } else {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(npe);
+                    RxJavaHooks.onError(npe);
                 }
                 return;
             }
@@ -122,7 +122,7 @@ public final class CompletableOnSubscribeMergeIterable implements CompletableOnS
                     if (once.compareAndSet(false, true)) {
                         s.onError(e);
                     } else {
-                        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                        RxJavaHooks.onError(e);
                     }
                 }
 

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeTimeout.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeTimeout.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import rx.*;
 import rx.Completable.*;
 import rx.functions.Action0;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
 public final class CompletableOnSubscribeTimeout implements CompletableOnSubscribe {
@@ -98,7 +98,7 @@ public final class CompletableOnSubscribeTimeout implements CompletableOnSubscri
                     set.unsubscribe();
                     s.onError(e);
                 } else {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                    RxJavaHooks.onError(e);
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -23,7 +23,7 @@ import rx.exceptions.CompositeException;
 import rx.functions.FuncN;
 import rx.internal.util.RxRingBuffer;
 import rx.internal.util.atomic.SpscLinkedArrayQueue;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 
 public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
     final Observable<? extends T>[] sources;
@@ -386,7 +386,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
         @Override
         public void onError(Throwable t) {
             if (done) {
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                RxJavaHooks.onError(t);
                 return;
             }
             parent.onError(t);

--- a/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
@@ -28,7 +28,7 @@ import rx.internal.util.*;
 import rx.internal.util.atomic.SpscAtomicArrayQueue;
 import rx.internal.util.unsafe.*;
 import rx.observers.SerializedSubscriber;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
 /**
@@ -210,7 +210,7 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
         }
         
         void pluginError(Throwable e) {
-            RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+            RxJavaHooks.onError(e);
         }
         
         void drain() {

--- a/src/main/java/rx/internal/operators/OnSubscribeDelaySubscriptionOther.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeDelaySubscriptionOther.java
@@ -56,7 +56,7 @@ public final class OnSubscribeDelaySubscriptionOther<T, U> implements OnSubscrib
             @Override
             public void onError(Throwable e) {
                 if (done) {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                    RxJavaHooks.onError(e);
                     return;
                 }
                 done = true;

--- a/src/main/java/rx/internal/operators/OnSubscribeLift.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeLift.java
@@ -29,8 +29,6 @@ import rx.plugins.*;
  */
 public final class OnSubscribeLift<T, R> implements OnSubscribe<R> {
     
-    static final RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
-
     final OnSubscribe<T> parent;
 
     final Operator<? extends R, ? super T> operator;
@@ -43,7 +41,7 @@ public final class OnSubscribeLift<T, R> implements OnSubscribe<R> {
     @Override
     public void call(Subscriber<? super R> o) {
         try {
-            Subscriber<? super T> st = hook.onLift(operator).call(o);
+            Subscriber<? super T> st = RxJavaHooks.onObservableLift(operator).call(o);
             try {
                 // new Subscriber created and being subscribed with so 'onStart' it
                 st.onStart();

--- a/src/main/java/rx/internal/operators/OnSubscribeOnAssembly.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeOnAssembly.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+import rx.exceptions.AssemblyStackTraceException;
+
+/**
+ * Captures the current stack when it is instantiated, makes
+ * it available through a field and attaches it to all
+ * passing exception.
+ *
+ * @param <T> the value type
+ */
+public final class OnSubscribeOnAssembly<T> implements OnSubscribe<T> {
+
+    final OnSubscribe<T> source;
+    
+    final String stacktrace;
+
+    /**
+     * If set to true, the creation of PublisherOnAssembly will capture the raw
+     * stacktrace instead of the sanitized version.
+     */
+    public static volatile boolean fullStackTrace;
+    
+    public OnSubscribeOnAssembly(OnSubscribe<T> source) {
+        this.source = source;
+        this.stacktrace = createStacktrace();
+    }
+    
+    static String createStacktrace() {
+        StackTraceElement[] stes = Thread.currentThread().getStackTrace();
+
+        StringBuilder sb = new StringBuilder("Assembly trace:");
+        
+        for (StackTraceElement e : stes) {
+            String row = e.toString();
+            if (!fullStackTrace) {
+                if (e.getLineNumber() <= 1) {
+                    continue;
+                }
+                if (row.contains("RxJavaHooks.")) {
+                    continue;
+                }
+                if (row.contains("OnSubscribeOnAssembly")) {
+                    continue;
+                }
+                if (row.contains(".junit.runner")) {
+                    continue;
+                }
+                if (row.contains(".junit4.runner")) {
+                    continue;
+                }
+                if (row.contains(".junit.internal")) {
+                    continue;
+                }
+                if (row.contains("sun.reflect")) {
+                    continue;
+                }
+                if (row.contains("java.lang.Thread.")) {
+                    continue;
+                }
+                if (row.contains("ThreadPoolExecutor")) {
+                    continue;
+                }
+                if (row.contains("org.apache.catalina.")) {
+                    continue;
+                }
+                if (row.contains("org.apache.tomcat.")) {
+                    continue;
+                }
+            }
+            sb.append("\n at ").append(row);
+        }
+        
+        return sb.append("\nOriginal exception:").toString();
+    }
+
+    @Override
+    public void call(Subscriber<? super T> t) {
+        source.call(new OnAssemblySubscriber<T>(t, stacktrace));
+    }
+    
+    static final class OnAssemblySubscriber<T> extends Subscriber<T> {
+
+        final Subscriber<? super T> actual;
+        
+        final String stacktrace;
+        
+        public OnAssemblySubscriber(Subscriber<? super T> actual, String stacktrace) {
+            super(actual);
+            this.actual = actual;
+            this.stacktrace = stacktrace;
+        }
+
+        @Override
+        public void onCompleted() {
+            actual.onCompleted();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            e = new AssemblyStackTraceException(stacktrace, e);
+            actual.onError(e);
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+        
+    }
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeOnAssemblyCompletable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeOnAssemblyCompletable.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.*;
+import rx.Completable.CompletableSubscriber;
+import rx.exceptions.AssemblyStackTraceException;
+
+/**
+ * Captures the current stack when it is instantiated, makes
+ * it available through a field and attaches it to all
+ * passing exception.
+ *
+ * @param <T> the value type
+ */
+public final class OnSubscribeOnAssemblyCompletable<T> implements Completable.CompletableOnSubscribe {
+
+    final Completable.CompletableOnSubscribe source;
+    
+    final String stacktrace;
+
+    /**
+     * If set to true, the creation of PublisherOnAssembly will capture the raw
+     * stacktrace instead of the sanitized version.
+     */
+    public static volatile boolean fullStackTrace;
+    
+    public OnSubscribeOnAssemblyCompletable(Completable.CompletableOnSubscribe source) {
+        this.source = source;
+        this.stacktrace = OnSubscribeOnAssembly.createStacktrace();
+    }
+    
+    @Override
+    public void call(Completable.CompletableSubscriber t) {
+        source.call(new OnAssemblyCompletableSubscriber(t, stacktrace));
+    }
+    
+    static final class OnAssemblyCompletableSubscriber implements CompletableSubscriber {
+
+        final CompletableSubscriber actual;
+        
+        final String stacktrace;
+        
+        public OnAssemblyCompletableSubscriber(CompletableSubscriber actual, String stacktrace) {
+            this.actual = actual;
+            this.stacktrace = stacktrace;
+        }
+
+        @Override
+        public void onSubscribe(Subscription d) {
+            actual.onSubscribe(d);
+        }
+        
+        @Override
+        public void onCompleted() {
+            actual.onCompleted();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            e = new AssemblyStackTraceException(stacktrace, e);
+            actual.onError(e);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeOnAssemblySingle.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeOnAssemblySingle.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.*;
+import rx.exceptions.AssemblyStackTraceException;
+
+/**
+ * Captures the current stack when it is instantiated, makes
+ * it available through a field and attaches it to all
+ * passing exception.
+ *
+ * @param <T> the value type
+ */
+public final class OnSubscribeOnAssemblySingle<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+    
+    final String stacktrace;
+
+    /**
+     * If set to true, the creation of PublisherOnAssembly will capture the raw
+     * stacktrace instead of the sanitized version.
+     */
+    public static volatile boolean fullStackTrace;
+    
+    public OnSubscribeOnAssemblySingle(Single.OnSubscribe<T> source) {
+        this.source = source;
+        this.stacktrace = OnSubscribeOnAssembly.createStacktrace();
+    }
+    
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        source.call(new OnAssemblySingleSubscriber<T>(t, stacktrace));
+    }
+    
+    static final class OnAssemblySingleSubscriber<T> extends SingleSubscriber<T> {
+
+        final SingleSubscriber<? super T> actual;
+        
+        final String stacktrace;
+        
+        public OnAssemblySingleSubscriber(SingleSubscriber<? super T> actual, String stacktrace) {
+            this.actual = actual;
+            this.stacktrace = stacktrace;
+            actual.add(this);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            e = new AssemblyStackTraceException(stacktrace, e);
+            actual.onError(e);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onSuccess(t);
+        }
+        
+    }
+}

--- a/src/main/java/rx/internal/operators/OperatorDoAfterTerminate.java
+++ b/src/main/java/rx/internal/operators/OperatorDoAfterTerminate.java
@@ -19,7 +19,7 @@ import rx.Observable.Operator;
 import rx.Subscriber;
 import rx.exceptions.Exceptions;
 import rx.functions.Action0;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 
 /**
  * Registers an action to be called after an Observable invokes {@code onComplete} or {@code onError}.
@@ -73,7 +73,7 @@ public final class OperatorDoAfterTerminate<T> implements Operator<T, T> {
                     action.call();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(ex);
+                    RxJavaHooks.onError(ex);
                 }
             }
         };

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -25,7 +25,7 @@ import rx.functions.*;
 import rx.internal.producers.ProducerArbiter;
 import rx.internal.util.*;
 import rx.observables.GroupedObservable;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -196,7 +196,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
         @Override
         public void onError(Throwable t) {
             if (done) {
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                RxJavaHooks.onError(t);
                 return;
             }
             error = t;

--- a/src/main/java/rx/internal/operators/OperatorMaterialize.java
+++ b/src/main/java/rx/internal/operators/OperatorMaterialize.java
@@ -17,11 +17,9 @@ package rx.internal.operators;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import rx.Notification;
+import rx.*;
 import rx.Observable.Operator;
-import rx.Producer;
-import rx.Subscriber;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 
 /**
  * Turns all of the notifications from an Observable into {@code onNext} emissions, and marks
@@ -104,7 +102,7 @@ public final class OperatorMaterialize<T> implements Operator<Notification<T>, T
         @Override
         public void onError(Throwable e) {
             terminalNotification = Notification.createOnError(e);
-            RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+            RxJavaHooks.onError(e);
             drain();
         }
 

--- a/src/main/java/rx/internal/operators/OperatorObserveOn.java
+++ b/src/main/java/rx/internal/operators/OperatorObserveOn.java
@@ -23,10 +23,10 @@ import rx.Observable.Operator;
 import rx.exceptions.MissingBackpressureException;
 import rx.functions.Action0;
 import rx.internal.schedulers.*;
-import rx.internal.util.*;
+import rx.internal.util.RxRingBuffer;
 import rx.internal.util.atomic.SpscAtomicArrayQueue;
 import rx.internal.util.unsafe.*;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.schedulers.Schedulers;
 
 /**
@@ -177,7 +177,7 @@ public final class OperatorObserveOn<T> implements Operator<T, T> {
         @Override
         public void onError(final Throwable e) {
             if (isUnsubscribed() || finished) {
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                RxJavaHooks.onError(e);
                 return;
             }
             error = e;

--- a/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
+++ b/src/main/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunction.java
@@ -20,7 +20,7 @@ import rx.Observable.Operator;
 import rx.exceptions.Exceptions;
 import rx.functions.Func1;
 import rx.internal.producers.ProducerArbiter;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
 /**
@@ -105,7 +105,7 @@ public final class OperatorOnErrorResumeNextViaFunction<T> implements Operator<T
             public void onError(Throwable e) {
                 if (done) {
                     Exceptions.throwIfFatal(e);
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                    RxJavaHooks.onError(e);
                     return;
                 }
                 done = true;

--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -25,7 +25,7 @@ import rx.exceptions.CompositeException;
 import rx.functions.Action0;
 import rx.internal.util.RxRingBuffer;
 import rx.internal.util.atomic.SpscLinkedArrayQueue;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.*;
 
 /**
@@ -238,7 +238,7 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
         }
 
         void pluginError(Throwable e) {
-            RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+            RxJavaHooks.onError(e);
         }
         
         void innerProducer(Producer p, long id) {

--- a/src/main/java/rx/internal/operators/SingleOnSubscribeDelaySubscriptionOther.java
+++ b/src/main/java/rx/internal/operators/SingleOnSubscribeDelaySubscriptionOther.java
@@ -16,11 +16,8 @@
 
 package rx.internal.operators;
 
-import rx.Observable;
-import rx.Single;
-import rx.SingleSubscriber;
-import rx.Subscriber;
-import rx.plugins.RxJavaPlugins;
+import rx.*;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
 /**
@@ -66,7 +63,7 @@ public final class SingleOnSubscribeDelaySubscriptionOther<T> implements Single.
             @Override
             public void onError(Throwable e) {
                 if (done) {
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                    RxJavaHooks.onError(e);
                     return;
                 }
                 done = true;

--- a/src/main/java/rx/internal/operators/SingleOnSubscribeUsing.java
+++ b/src/main/java/rx/internal/operators/SingleOnSubscribeUsing.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import rx.*;
 import rx.exceptions.*;
 import rx.functions.*;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 
 /**
  * Generates a resource, derives a Single from it and disposes that resource once the
@@ -91,7 +91,7 @@ public final class SingleOnSubscribeUsing<T, Resource> implements Single.OnSubsc
                         disposeAction.call(resource);
                     } catch (Throwable ex2) {
                         Exceptions.throwIfFatal(ex2);
-                        RxJavaPlugins.getInstance().getErrorHandler().handleError(ex2);
+                        RxJavaHooks.onError(ex2);
                     }
                 }
             }
@@ -125,7 +125,7 @@ public final class SingleOnSubscribeUsing<T, Resource> implements Single.OnSubsc
                 disposeAction.call(resource);
             } catch (Throwable ex2) {
                 Exceptions.throwIfFatal(ex2);
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(ex2);
+                RxJavaHooks.onError(ex2);
             }
         }
     }

--- a/src/main/java/rx/internal/operators/SingleOperatorZip.java
+++ b/src/main/java/rx/internal/operators/SingleOperatorZip.java
@@ -16,16 +16,14 @@
 
 package rx.internal.operators;
 
-import rx.Single;
-import rx.SingleSubscriber;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.*;
+
+import rx.*;
 import rx.exceptions.Exceptions;
 import rx.functions.FuncN;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
-
-import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class SingleOperatorZip {
 
@@ -75,7 +73,7 @@ public class SingleOperatorZip {
                             if (once.compareAndSet(false, true)) {
                                 subscriber.onError(error);
                             } else {
-                                RxJavaPlugins.getInstance().getErrorHandler().handleError(error);
+                                RxJavaHooks.onError(error);
                             }
                         }
                     };

--- a/src/main/java/rx/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/rx/internal/schedulers/ExecutorScheduler.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
 import rx.functions.Action0;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.*;
 
 /**
@@ -79,7 +79,7 @@ public final class ExecutorScheduler extends Scheduler {
                     tasks.remove(ea);
                     wip.decrementAndGet();
                     // report the error to the plugin
-                    RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                    RxJavaHooks.onError(t);
                     // throw it to the caller
                     throw t;
                 }
@@ -158,7 +158,7 @@ public final class ExecutorScheduler extends Scheduler {
                 ea.add(f);
             } catch (RejectedExecutionException t) {
                 // report the rejection to plugins
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
+                RxJavaHooks.onError(t);
                 throw t;
             }
             

--- a/src/main/java/rx/internal/schedulers/ScheduledAction.java
+++ b/src/main/java/rx/internal/schedulers/ScheduledAction.java
@@ -22,7 +22,7 @@ import rx.Subscription;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.functions.Action0;
 import rx.internal.util.SubscriptionList;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
 /**
@@ -61,7 +61,7 @@ public final class ScheduledAction extends AtomicReference<Thread> implements Ru
             } else {
                 ie = new IllegalStateException("Fatal Exception thrown on Scheduler.Worker thread.", e);
             }
-            RxJavaPlugins.getInstance().getErrorHandler().handleError(ie);
+            RxJavaHooks.onError(ie);
             Thread thread = Thread.currentThread();
             thread.getUncaughtExceptionHandler().uncaughtException(thread, ie);
         } finally {

--- a/src/main/java/rx/internal/util/RxJavaPluginUtils.java
+++ b/src/main/java/rx/internal/util/RxJavaPluginUtils.java
@@ -15,13 +15,13 @@
  */
 package rx.internal.util;
 
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 
 public final class RxJavaPluginUtils {
 
     public static void handleException(Throwable e) {
         try {
-            RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+            RxJavaHooks.onError(e);
         } catch (Throwable pluginException) {
             handlePluginException(pluginException);
         }

--- a/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
+++ b/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
@@ -34,14 +34,6 @@ import rx.plugins.*;
  * @param <T> the value type
  */
 public final class ScalarSynchronousObservable<T> extends Observable<T> {
-    /** 
-     * The execution hook instance. 
-     * <p>
-     * Can't be final to allow tests overriding it in place; if the class
-     * has been initialized, the plugin reset has no effect because
-     * how RxJavaPlugins was designed.
-     */
-    static RxJavaObservableExecutionHook hook = RxJavaPlugins.getInstance().getObservableExecutionHook();
     /**
      * Indicates that the Producer used by this Observable should be fully
      * threadsafe. It is possible, but unlikely that multiple concurrent
@@ -81,7 +73,7 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
     final T t;
 
     protected ScalarSynchronousObservable(final T t) {
-        super(hook.onCreate(new JustOnSubscribe<T>(t)));
+        super(RxJavaHooks.onCreate(new JustOnSubscribe<T>(t)));
         this.t = t;
     }
 

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -27,7 +27,7 @@ import rx.annotations.Experimental;
 import rx.functions.*;
 import rx.internal.operators.BufferUntilSubscriber;
 import rx.observers.SerializedObserver;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
 /**
@@ -554,7 +554,7 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
 
         private void handleThrownError(Throwable ex) {
             if (hasTerminated) {
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(ex);
+                RxJavaHooks.onError(ex);
             } else {
                 hasTerminated = true;
                 merger.onError(ex);

--- a/src/main/java/rx/observables/SyncOnSubscribe.java
+++ b/src/main/java/rx/observables/SyncOnSubscribe.java
@@ -18,20 +18,13 @@ package rx.observables;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Observer;
-import rx.Producer;
-import rx.Subscriber;
-import rx.Subscription;
 import rx.annotations.Beta;
 import rx.exceptions.Exceptions;
-import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.functions.Action2;
-import rx.functions.Func0;
-import rx.functions.Func2;
+import rx.functions.*;
 import rx.internal.operators.BackpressureUtils;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaHooks;
 
 /**
  * A utility class to create {@code OnSubscribe<T>} functions that respond correctly to back
@@ -387,7 +380,7 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
                 parent.onUnsubscribe(state);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+                RxJavaHooks.onError(e);
             }
         }
 
@@ -422,7 +415,7 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
 
         private void handleThrownError(Subscriber<? super T> a, Throwable ex) {
             if (hasTerminated) {
-                RxJavaPlugins.getInstance().getErrorHandler().handleError(ex);
+                RxJavaHooks.onError(ex);
             } else {
                 hasTerminated = true;
                 a.onError(ex);

--- a/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
@@ -50,6 +50,7 @@ public abstract class RxJavaCompletableExecutionHook {
      * @return {@link rx.Completable.CompletableOnSubscribe} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe f) {
         return f;
     }
@@ -66,6 +67,7 @@ public abstract class RxJavaCompletableExecutionHook {
      * @return {@link rx.Completable.CompletableOnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public Completable.CompletableOnSubscribe onSubscribeStart(Completable completableInstance, final Completable.CompletableOnSubscribe onSubscribe) {
         // pass through by default
         return onSubscribe;
@@ -81,6 +83,7 @@ public abstract class RxJavaCompletableExecutionHook {
      *            Throwable thrown by {@link Completable#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass through
      */
+    @Deprecated
     public Throwable onSubscribeError(Throwable e) {
         // pass through by default
         return e;
@@ -98,6 +101,7 @@ public abstract class RxJavaCompletableExecutionHook {
      * @return {@link rx.Completable.CompletableOperator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public Completable.CompletableOperator onLift(final Completable.CompletableOperator lift) {
         return lift;
     }

--- a/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -43,6 +43,7 @@ public abstract class RxJavaErrorHandler {
      * @param e
      *            the {@code Exception}
      */
+    @Deprecated
     public void handleError(Throwable e) {
         // do nothing by default
     }
@@ -57,7 +58,7 @@ public abstract class RxJavaErrorHandler {
      * Note that primitive types are always rendered as their {@code toString()} value.
      * <p>
      * If a {@code Throwable} is caught when rendering, this will fallback to the item's classname suffixed by
-     * {@value #ERROR_IN_RENDERING_SUFFIX}.
+     * {@code ERROR_IN_RENDERING_SUFFIX}.
      *
      * @param item the last emitted item, that caused the exception wrapped in
      *             {@code OnErrorThrowable.OnNextValue}

--- a/src/main/java/rx/plugins/RxJavaHooks.java
+++ b/src/main/java/rx/plugins/RxJavaHooks.java
@@ -1,0 +1,599 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.plugins;
+
+import rx.*;
+import rx.Completable.CompletableOnSubscribe;
+import rx.Observable.*;
+import rx.annotations.Experimental;
+import rx.functions.*;
+import rx.internal.operators.*;
+
+/**
+ * Utility class that holds hooks for various Observable, Single and Completable lifecycle-related
+ * points as well as Scheduler hooks.
+ */
+@Experimental
+public final class RxJavaHooks {
+    /** Utility class. */
+    private RxJavaHooks() {
+        throw new IllegalStateException("No instances!");
+    }
+    
+    /**
+     * Prevents changing the hook callbacks when set to true.
+     */
+    /* test */ static volatile boolean lockdown;
+    
+    static volatile Action1<Throwable> onError;
+    
+    @SuppressWarnings("rawtypes")
+    static volatile Func1<Observable.OnSubscribe, Observable.OnSubscribe> onObservableCreate;
+
+    @SuppressWarnings("rawtypes")
+    static volatile Func1<Single.OnSubscribe, Single.OnSubscribe> onSingleCreate;
+
+    static volatile Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableCreate;
+
+    @SuppressWarnings("rawtypes")
+    static volatile Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe> onObservableStart;
+
+    @SuppressWarnings("rawtypes")
+    static volatile Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> onSingleStart;
+
+    static volatile Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableStart;
+
+    
+    static volatile Func1<Scheduler, Scheduler> onComputationScheduler;
+
+    static volatile Func1<Scheduler, Scheduler> onIOScheduler;
+
+    static volatile Func1<Scheduler, Scheduler> onNewThreadScheduler;
+    
+    static volatile Func1<Action0, Action0> onScheduleAction;
+
+    static volatile Func1<Subscription, Subscription> onObservableReturn;
+
+    static volatile Func1<Subscription, Subscription> onSingleReturn;
+
+    /** Initialize with the default delegation to the original RxJavaPlugins. */
+    static {
+        init();
+    }
+    
+    /**
+     * Initialize the hooks via delegating to RxJavaPlugins.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked", "deprecation"})
+    static void init() {
+        onError = new Action1<Throwable>() {
+            @Override
+            public void call(Throwable e) {
+                RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+            }
+        };
+        
+        RxJavaPlugins.getInstance().getObservableExecutionHook();
+        
+        onObservableCreate = new Func1<OnSubscribe, OnSubscribe>() {
+            @Override
+            public OnSubscribe call(OnSubscribe f) {
+                return RxJavaPlugins.getInstance().getObservableExecutionHook().onCreate(f);
+            }
+        };
+        
+        onObservableStart = new Func2<Observable, OnSubscribe, OnSubscribe>() {
+            @Override
+            public OnSubscribe call(Observable t1, OnSubscribe t2) {
+                return RxJavaPlugins.getInstance().getObservableExecutionHook().onSubscribeStart(t1, t2);
+            }
+        };
+        
+        onObservableReturn = new Func1<Subscription, Subscription>() {
+            @Override
+            public Subscription call(Subscription f) {
+                return RxJavaPlugins.getInstance().getObservableExecutionHook().onSubscribeReturn(f);
+            }
+        };
+        
+        RxJavaPlugins.getInstance().getSingleExecutionHook();
+
+        onSingleCreate = new Func1<rx.Single.OnSubscribe, rx.Single.OnSubscribe>() {
+            @Override
+            public rx.Single.OnSubscribe call(rx.Single.OnSubscribe f) {
+                return RxJavaPlugins.getInstance().getSingleExecutionHook().onCreate(f);
+            }
+        };
+        
+        onSingleStart = new Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe>() {
+            @Override
+            public Observable.OnSubscribe call(Single t1, Observable.OnSubscribe t2) {
+                return RxJavaPlugins.getInstance().getSingleExecutionHook().onSubscribeStart(t1, t2);
+            }
+        };
+        
+        onSingleReturn = new Func1<Subscription, Subscription>() {
+            @Override
+            public Subscription call(Subscription f) {
+                return RxJavaPlugins.getInstance().getSingleExecutionHook().onSubscribeReturn(f);
+            }
+        };
+        
+        RxJavaPlugins.getInstance().getCompletableExecutionHook();
+
+        onCompletableCreate = new Func1<CompletableOnSubscribe, CompletableOnSubscribe>() {
+            @Override
+            public CompletableOnSubscribe call(CompletableOnSubscribe f) {
+                return RxJavaPlugins.getInstance().getCompletableExecutionHook().onCreate(f);
+            }
+        };
+        
+        onCompletableStart = new Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe>() {
+            @Override
+            public Completable.CompletableOnSubscribe call(Completable t1, Completable.CompletableOnSubscribe t2) {
+                return RxJavaPlugins.getInstance().getCompletableExecutionHook().onSubscribeStart(t1, t2);
+            }
+        };
+
+        onScheduleAction = new Func1<Action0, Action0>() {
+            @Override
+            public Action0 call(Action0 a) {
+                return RxJavaPlugins.getInstance().getSchedulersHook().onSchedule(a);
+            }
+        };
+    }
+    
+    /**
+     * Reset all hook callbacks to those of the current RxJavaPlugins handlers.
+     * 
+     * @see #clear()
+     */
+    public static void reset() {
+        if (lockdown) {
+            return;
+        }
+        init();
+    }
+
+    /**
+     * Clears all hooks to be no-operations (and passthroughs)
+     * and onError hook to signal errors to the caller thread's
+     * UncaughtExceptionHandler.
+     * 
+     * @see #reset()
+     */
+    public static void clear() {
+        if (lockdown) {
+            return;
+        }
+        onError = null;
+        
+        onObservableCreate = null;
+        onObservableStart = null;
+        onObservableReturn = null;
+        
+        onSingleCreate = null;
+        onSingleStart = null;
+        onSingleReturn = null;
+        
+        onCompletableCreate = null;
+        onCompletableStart = null;
+        
+        onComputationScheduler = null;
+        onIOScheduler = null;
+        onNewThreadScheduler = null;
+    }
+
+    /**
+     * Prevents changing a hooks.
+     */
+    public static void lockdown() {
+        lockdown = true;
+    }
+    
+    /**
+     * Returns true if the hooks can no longer be changed.
+     * @return true if the hooks can no longer be changed
+     */
+    public static boolean isLockdown() {
+        return lockdown;
+    }
+    /**
+     * Consume undeliverable Throwables (acts as a global catch).
+     * @param ex the exception to handle
+     */
+    public static void onError(Throwable ex) {
+        Action1<Throwable> f = onError;
+        if (f != null) {
+            f.call(ex);
+            return;
+        }
+        Thread current = Thread.currentThread();
+        current.getUncaughtExceptionHandler().uncaughtException(current, ex);
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Observable.OnSubscribe<T> onCreate(Observable.OnSubscribe<T> onSubscribe) {
+        Func1<OnSubscribe, OnSubscribe> f = onObservableCreate;
+        if (f != null) {
+            return f.call(onSubscribe);
+        }
+        return onSubscribe;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Single.OnSubscribe<T> onCreate(Single.OnSubscribe<T> onSubscribe) {
+        Func1<Single.OnSubscribe, Single.OnSubscribe> f = onSingleCreate;
+        if (f != null) {
+            return f.call(onSubscribe);
+        }
+        return onSubscribe;
+    }
+
+    public static <T> Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe onSubscribe) {
+        Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> f = onCompletableCreate;
+        if (f != null) {
+            return f.call(onSubscribe);
+        }
+        return onSubscribe;
+    }
+    
+    public static Scheduler onComputationScheduler(Scheduler scheduler) {
+        Func1<Scheduler, Scheduler> f = onComputationScheduler;
+        if (f != null) {
+            return f.call(scheduler);
+        }
+        return scheduler;
+    }
+
+    public static Scheduler onIOScheduler(Scheduler scheduler) {
+        Func1<Scheduler, Scheduler> f = onIOScheduler;
+        if (f != null) {
+            return f.call(scheduler);
+        }
+        return scheduler;
+    }
+
+    public static Scheduler onNewThreadScheduler(Scheduler scheduler) {
+        Func1<Scheduler, Scheduler> f = onNewThreadScheduler;
+        if (f != null) {
+            return f.call(scheduler);
+        }
+        return scheduler;
+    }
+
+    public static Action0 onScheduledAction(Action0 action) {
+        Func1<Action0, Action0> f = onScheduleAction;
+        if (f != null) {
+            return f.call(action);
+        }
+        return action;
+    }
+    
+    public static void setOnCompletableCreate(
+            Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableCreate) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onCompletableCreate = onCompletableCreate;
+    }
+    
+    public static void setOnComputationScheduler(Func1<Scheduler, Scheduler> onComputationScheduler) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onComputationScheduler = onComputationScheduler;
+    }
+    
+    public static void setOnError(Action1<Throwable> onError) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onError = onError;
+    }
+    
+    public static void setOnIOScheduler(Func1<Scheduler, Scheduler> onIOScheduler) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onIOScheduler = onIOScheduler;
+    }
+    
+    public static void setOnNewThreadScheduler(Func1<Scheduler, Scheduler> onNewThreadScheduler) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onNewThreadScheduler = onNewThreadScheduler;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static void setOnObservableCreate(
+            Func1<Observable.OnSubscribe, Observable.OnSubscribe> onObservableCreate) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onObservableCreate = onObservableCreate;
+    }
+    
+    public static void setOnScheduleAction(Func1<Action0, Action0> onScheduleAction) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onScheduleAction = onScheduleAction;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static void setOnSingleCreate(Func1<Single.OnSubscribe, Single.OnSubscribe> onSingleCreate) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onSingleCreate = onSingleCreate;
+    }
+    
+    public static void setOnCompletableStart(
+            Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableStart) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onCompletableStart = onCompletableStart;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static void setOnObservableStart(
+            Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe> onObservableStart) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onObservableStart = onObservableStart;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static void setOnSingleStart(Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> onSingleStart) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onSingleStart = onSingleStart;
+    }
+    
+    public static void setOnObservableReturn(Func1<Subscription, Subscription> onObservableReturn) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onObservableReturn = onObservableReturn;
+    }
+    
+    public static void setOnSingleReturn(Func1<Subscription, Subscription> onSingleReturn) {
+        if (lockdown) {
+            return;
+        }
+        RxJavaHooks.onSingleReturn = onSingleReturn;
+    }
+    
+    public static Func1<Scheduler, Scheduler> getOnComputationScheduler() {
+        return onComputationScheduler;
+    }
+    
+    public static Action1<Throwable> getOnError() {
+        return onError;
+    }
+    
+    public static Func1<Scheduler, Scheduler> getOnIOScheduler() {
+        return onIOScheduler;
+    }
+    
+    public static Func1<Scheduler, Scheduler> getOnNewThreadScheduler() {
+        return onNewThreadScheduler;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static Func1<Observable.OnSubscribe, Observable.OnSubscribe> getOnObservableCreate() {
+        return onObservableCreate;
+    }
+    
+    public static Func1<Action0, Action0> getOnScheduleAction() {
+        return onScheduleAction;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static Func1<Single.OnSubscribe, Single.OnSubscribe> getOnSingleCreate() {
+        return onSingleCreate;
+    }
+    
+    public static Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> getOnCompletableCreate() {
+        return onCompletableCreate;
+    }
+    
+    public static Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> getOnCompletableStart() {
+        return onCompletableStart;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe> getOnObservableStart() {
+        return onObservableStart;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> getOnSingleStart() {
+        return onSingleStart;
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> OnSubscribe<T> onObservableStart(Observable<T> instance, OnSubscribe<T> onSubscribe) {
+        Func2<Observable, OnSubscribe, OnSubscribe> f = onObservableStart;
+        if (f != null) {
+            return f.call(instance, onSubscribe);
+        }
+        return onSubscribe;
+    }
+    
+    public static Func1<Subscription, Subscription> getOnObservableReturn() {
+        return onObservableReturn;
+    }
+    
+    public static Func1<Subscription, Subscription> getOnSingleReturn() {
+        return onSingleReturn;
+    }
+    
+    public static Subscription onObservableReturn(Subscription subscription) {
+        Func1<Subscription, Subscription> f = onObservableReturn;
+        if (f != null) {
+            return f.call(subscription);
+        }
+        return subscription;
+    }
+
+    public static Throwable onObservableError(Throwable error) {
+        // TODO add hook
+        return error;
+    }
+
+    public static <T, R> Operator<R, T> onObservableLift(Operator<R, T> operator) {
+        // TODO add hook
+        return operator;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Observable.OnSubscribe<T> onSingleStart(Single<T> instance, Observable.OnSubscribe<T> onSubscribe) {
+        Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> f = onSingleStart;
+        if (f != null) {
+            return f.call(instance, onSubscribe);
+        }
+        return onSubscribe;
+    }
+
+    public static Subscription onSingleReturn(Subscription subscription) {
+        Func1<Subscription, Subscription> f = onSingleReturn;
+        if (f != null) {
+            return f.call(subscription);
+        }
+        return subscription;
+    }
+
+    public static Throwable onSingleError(Throwable error) {
+        // TODO add hook
+        return error;
+    }
+
+    public static <T, R> Operator<R, T> onSingleLift(Operator<R, T> operator) {
+        // TODO add hook
+        return operator;
+    }
+
+    public static <T> Completable.CompletableOnSubscribe onCompletableStart(Completable instance, Completable.CompletableOnSubscribe onSubscribe) {
+        Func2<Completable, CompletableOnSubscribe, CompletableOnSubscribe> f = onCompletableStart;
+        if (f != null) {
+            return f.call(instance, onSubscribe);
+        }
+        return onSubscribe;
+    }
+
+    public static Throwable onCompletableError(Throwable error) {
+        // TODO add hook
+        return error;
+    }
+
+    public static <T, R> Completable.CompletableOperator onCompletableLift(Completable.CompletableOperator operator) {
+        // TODO add hook
+        return operator;
+    }
+    
+    /**
+     * Resets the assembly tracking hooks to their default delegates to
+     * RxJavaPlugins.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
+    public static void resetAssemblyTracking() {
+        if (lockdown) {
+            return;
+        }
+
+        RxJavaPlugins plugin = RxJavaPlugins.getInstance();
+        
+        final RxJavaObservableExecutionHook observableExecutionHook = plugin.getObservableExecutionHook();
+        
+        onObservableCreate = new Func1<OnSubscribe, OnSubscribe>() {
+            @Override
+            public OnSubscribe call(OnSubscribe f) {
+                return observableExecutionHook.onCreate(f);
+            }
+        };
+        
+        final RxJavaSingleExecutionHook singleExecutionHook = plugin.getSingleExecutionHook();
+
+        onSingleCreate = new Func1<rx.Single.OnSubscribe, rx.Single.OnSubscribe>() {
+            @Override
+            public rx.Single.OnSubscribe call(rx.Single.OnSubscribe f) {
+                return singleExecutionHook.onCreate(f);
+            }
+        };
+        
+        final RxJavaCompletableExecutionHook completableExecutionHook = plugin.getCompletableExecutionHook();
+
+        onCompletableCreate = new Func1<CompletableOnSubscribe, CompletableOnSubscribe>() {
+            @Override
+            public CompletableOnSubscribe call(CompletableOnSubscribe f) {
+                return completableExecutionHook.onCreate(f);
+            }
+        };
+
+    }
+
+    /**
+     * Clears the assembly tracking hooks to their default pass-through behavior.
+     */
+    public static void crearAssemblyTracking() {
+        if (lockdown) {
+            return;
+        }
+        onObservableCreate = null;
+        onSingleCreate = null;
+        onCompletableCreate = null;
+    }
+
+    /**
+     * Sets up hooks that capture the current stacktrace when a source or an
+     * operator is instantiated, keeping it in a field for debugging purposes
+     * and alters exceptions passign along to hold onto this stacktrace.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static void enableAssemblyTracking() {
+        if (lockdown) {
+            return;
+        }
+        
+        onObservableCreate = new Func1<OnSubscribe, OnSubscribe>() {
+            @Override
+            public OnSubscribe call(OnSubscribe f) {
+                return new OnSubscribeOnAssembly(f);
+            }
+        };
+
+        onSingleCreate = new Func1<rx.Single.OnSubscribe, rx.Single.OnSubscribe>() {
+            @Override
+            public rx.Single.OnSubscribe call(rx.Single.OnSubscribe f) {
+                return new OnSubscribeOnAssemblySingle(f);
+            }
+        };
+
+        onCompletableCreate = new Func1<CompletableOnSubscribe, CompletableOnSubscribe>() {
+            @Override
+            public CompletableOnSubscribe call(CompletableOnSubscribe f) {
+                return new OnSubscribeOnAssemblyCompletable(f);
+            }
+        };
+
+    }
+}

--- a/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
@@ -52,6 +52,7 @@ public abstract class RxJavaObservableExecutionHook {
      * @return {@link OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public <T> OnSubscribe<T> onCreate(OnSubscribe<T> f) {
         return f;
     }
@@ -69,6 +70,7 @@ public abstract class RxJavaObservableExecutionHook {
      * @return {@link OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public <T> OnSubscribe<T> onSubscribeStart(Observable<? extends T> observableInstance, final OnSubscribe<T> onSubscribe) {
         // pass through by default
         return onSubscribe;
@@ -87,6 +89,7 @@ public abstract class RxJavaObservableExecutionHook {
      * @return {@link Subscription} subscription that can be modified, decorated, replaced or just returned as a
      *         pass through
      */
+    @Deprecated
     public <T> Subscription onSubscribeReturn(Subscription subscription) {
         // pass through by default
         return subscription;
@@ -103,6 +106,7 @@ public abstract class RxJavaObservableExecutionHook {
      *            Throwable thrown by {@link Observable#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass through
      */
+    @Deprecated
     public <T> Throwable onSubscribeError(Throwable e) {
         // pass through by default
         return e;
@@ -122,6 +126,7 @@ public abstract class RxJavaObservableExecutionHook {
      * @return {@link Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public <T, R> Operator<? extends R, ? super T> onLift(final Operator<? extends R, ? super T> lift) {
         return lift;
     }

--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -45,6 +45,9 @@ import rx.annotations.Experimental;
  * </code></pre>
  * 
  * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Plugins">RxJava Wiki: Plugins</a>
+ * 
+ * Use the {@link RxJavaHooks} features instead which let's you change individual
+ * handlers at runtime.
  */
 public class RxJavaPlugins {
     private final static RxJavaPlugins INSTANCE = new RxJavaPlugins();
@@ -59,7 +62,10 @@ public class RxJavaPlugins {
      * Retrieves the single {@code RxJavaPlugins} instance.
      *
      * @return the single {@code RxJavaPlugins} instance
+     * 
+     * @deprecated use the static methods of {@link RxJavaHooks}.
      */
+    @Deprecated
     public static RxJavaPlugins getInstance() {
         return INSTANCE;
     }

--- a/src/main/java/rx/plugins/RxJavaSchedulersHook.java
+++ b/src/main/java/rx/plugins/RxJavaSchedulersHook.java
@@ -148,6 +148,7 @@ public class RxJavaSchedulersHook {
      * @param action action to schedule
      * @return wrapped action to schedule
      */
+    @Deprecated
     public Action0 onSchedule(Action0 action) {
         return action;
     }

--- a/src/main/java/rx/plugins/RxJavaSingleExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaSingleExecutionHook.java
@@ -51,6 +51,7 @@ public abstract class RxJavaSingleExecutionHook {
      * @return {@link rx.Single.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public <T> Single.OnSubscribe<T> onCreate(Single.OnSubscribe<T> f) {
         return f;
     }
@@ -68,6 +69,7 @@ public abstract class RxJavaSingleExecutionHook {
      * @return {@link rx.Observable.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public <T> Observable.OnSubscribe<T> onSubscribeStart(Single<? extends T> singleInstance, final Observable.OnSubscribe<T> onSubscribe) {
         // pass through by default
         return onSubscribe;
@@ -86,6 +88,7 @@ public abstract class RxJavaSingleExecutionHook {
      * @return {@link Subscription} subscription that can be modified, decorated, replaced or just returned as a
      *         pass through
      */
+    @Deprecated
     public <T> Subscription onSubscribeReturn(Subscription subscription) {
         // pass through by default
         return subscription;
@@ -102,6 +105,7 @@ public abstract class RxJavaSingleExecutionHook {
      *            Throwable thrown by {@link Single#subscribe(Subscriber)}
      * @return Throwable that can be decorated, replaced or just returned as a pass through
      */
+    @Deprecated
     public <T> Throwable onSubscribeError(Throwable e) {
         // pass through by default
         return e;
@@ -121,6 +125,7 @@ public abstract class RxJavaSingleExecutionHook {
      * @return {@link rx.Observable.Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
+    @Deprecated
     public <T, R> Observable.Operator<? extends R, ? super T> onLift(final Observable.Operator<? extends R, ? super T> lift) {
         return lift;
     }

--- a/src/main/java/rx/schedulers/Schedulers.java
+++ b/src/main/java/rx/schedulers/Schedulers.java
@@ -21,8 +21,7 @@ import rx.internal.schedulers.ExecutorScheduler;
 import rx.internal.schedulers.GenericScheduledExecutorService;
 import rx.internal.schedulers.SchedulerLifecycle;
 import rx.internal.util.RxRingBuffer;
-import rx.plugins.RxJavaPlugins;
-import rx.plugins.RxJavaSchedulersHook;
+import rx.plugins.*;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,6 +53,7 @@ public final class Schedulers {
     }
 
     private Schedulers() {
+        @SuppressWarnings("deprecation")
         RxJavaSchedulersHook hook = RxJavaPlugins.getInstance().getSchedulersHook();
 
         Scheduler c = hook.getComputationScheduler();
@@ -105,7 +105,7 @@ public final class Schedulers {
      * @return a {@link Scheduler} that creates new threads
      */
     public static Scheduler newThread() {
-        return getInstance().newThreadScheduler;
+        return RxJavaHooks.onNewThreadScheduler(getInstance().newThreadScheduler);
     }
 
     /**
@@ -120,7 +120,7 @@ public final class Schedulers {
      * @return a {@link Scheduler} meant for computation-bound work
      */
     public static Scheduler computation() {
-        return getInstance().computationScheduler;
+        return RxJavaHooks.onComputationScheduler(getInstance().computationScheduler);
     }
 
     /**
@@ -137,7 +137,7 @@ public final class Schedulers {
      * @return a {@link Scheduler} meant for IO-bound work
      */
     public static Scheduler io() {
-        return getInstance().ioScheduler;
+        return RxJavaHooks.onComputationScheduler(getInstance().ioScheduler);
     }
 
     /**

--- a/src/test/java/rx/observers/SafeSubscriberTest.java
+++ b/src/test/java/rx/observers/SafeSubscriberTest.java
@@ -18,7 +18,6 @@ package rx.observers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
@@ -36,20 +35,13 @@ import rx.plugins.RxJavaErrorHandler;
 import rx.plugins.RxJavaPlugins;
 import rx.subscriptions.Subscriptions;
 
+@SuppressWarnings("deprecation")
 public class SafeSubscriberTest {
     
     @Before
     @After
     public void resetBefore() {
-        RxJavaPlugins ps = RxJavaPlugins.getInstance();
-        
-        try {
-            Method m = ps.getClass().getDeclaredMethod("reset");
-            m.setAccessible(true);
-            m.invoke(ps);
-        } catch (Throwable ex) {
-            ex.printStackTrace();
-        }
+        RxJavaPlugins.getInstance().reset();
     }
 
     @Test

--- a/src/test/java/rx/plugins/RxJavaHooksTest.java
+++ b/src/test/java/rx/plugins/RxJavaHooksTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.plugins;
+
+import java.lang.reflect.Method;
+
+import org.junit.*;
+
+import rx.*;
+import rx.exceptions.*;
+import rx.functions.*;
+import rx.internal.util.UtilityFunctions;
+import rx.observers.TestSubscriber;
+
+public class RxJavaHooksTest {
+
+    static Observable<Integer> createObservable() {
+        return Observable.range(1, 5).map(new Func1<Integer, Integer>() {
+            @Override
+            public Integer call(Integer t) {
+                throw new TestException();
+            }
+        });
+    }
+    
+    @Test
+    public void assemblyTrackingObservable() {
+        RxJavaHooks.enableAssemblyTracking();
+        try {
+            TestSubscriber<Integer> ts = TestSubscriber.create();
+            
+            createObservable().subscribe(ts);
+            
+            ts.assertError(AssemblyStackTraceException.class);
+            
+            Throwable ex = ts.getOnErrorEvents().get(0);
+            
+            Assert.assertTrue("" + ex.getCause(), ex.getCause() instanceof TestException);
+            
+            Assert.assertTrue("" + ex, ex instanceof AssemblyStackTraceException);
+            
+            Assert.assertTrue(ex.getMessage(), ex.getMessage().contains("createObservable"));
+        } finally {
+            RxJavaHooks.resetAssemblyTracking();
+        }
+    }
+    
+    static Single<Integer> createSingle() {
+        return Single.just(1).map(new Func1<Integer, Integer>() {
+            @Override
+            public Integer call(Integer t) {
+                throw new TestException();
+            }
+        });
+    }
+    
+    @Test
+    public void assemblyTrackingSingle() {
+        RxJavaHooks.enableAssemblyTracking();
+        try {
+            TestSubscriber<Integer> ts = TestSubscriber.create();
+            
+            createSingle().subscribe(ts);
+            
+            ts.assertError(AssemblyStackTraceException.class);
+            
+            Throwable ex = ts.getOnErrorEvents().get(0);
+
+            Assert.assertTrue("" + ex, ex instanceof AssemblyStackTraceException);
+
+            Assert.assertTrue("" + ex.getCause(), ex.getCause() instanceof TestException);
+
+            Assert.assertTrue(ex.getMessage(), ex.getMessage().contains("createSingle"));
+        } finally {
+            RxJavaHooks.resetAssemblyTracking();
+        }
+    }
+    
+    static Completable createCompletable() {
+        return Completable.error(new Func0<Throwable>() {
+            @Override
+            public Throwable call() {
+                return new TestException();
+            }
+        });
+    }
+    
+    @Test
+    public void assemblyTrackingCompletable() {
+        RxJavaHooks.enableAssemblyTracking();
+        try {
+            TestSubscriber<Integer> ts = TestSubscriber.create();
+            
+            createCompletable().subscribe(ts);
+            
+            ts.assertError(AssemblyStackTraceException.class);
+            
+            Throwable ex = ts.getOnErrorEvents().get(0);
+
+            Assert.assertTrue("" + ex, ex instanceof AssemblyStackTraceException);
+
+            Assert.assertTrue("" + ex.getCause(), ex.getCause() instanceof TestException);
+
+            Assert.assertTrue(ex.getMessage(), ex.getMessage().contains("createCompletable"));
+        } finally {
+            RxJavaHooks.resetAssemblyTracking();
+        }
+    }
+    
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void lockdown() throws Exception {
+        RxJavaHooks.reset();
+        RxJavaHooks.lockdown();
+        try {
+            Action1 a1 = Actions.empty();
+            Func1 f1 = UtilityFunctions.identity();
+            Func2 f2 = new Func2() {
+                @Override
+                public Object call(Object t1, Object t2) {
+                    return t2;
+                }
+            };
+            
+            for (Method m : RxJavaHooks.class.getMethods()) {
+                if (m.getName().startsWith("setOn")) {
+                    
+                    Method getter = RxJavaHooks.class.getMethod("get" + m.getName().substring(3));
+                    
+                    Object before = getter.invoke(null);
+                    
+                    if (m.getParameterTypes()[0].isAssignableFrom(Func1.class)) {
+                        m.invoke(null, f1);
+                    } else
+                    if (m.getParameterTypes()[0].isAssignableFrom(Action1.class)) {
+                        m.invoke(null, a1);
+                    } else {
+                        m.invoke(null, f2);
+                    }
+                    
+                    Object after = getter.invoke(null);
+                    
+                    Assert.assertSame(m.toString(), before, after);
+                }
+            }
+            
+        } finally {
+            RxJavaHooks.lockdown = false;
+            RxJavaHooks.reset();
+        }
+    }
+}

--- a/src/test/java/rx/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/rx/plugins/RxJavaPluginsTest.java
@@ -28,6 +28,7 @@ import rx.Observable;
 import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
+@SuppressWarnings("deprecation")
 public class RxJavaPluginsTest {
 
     @Before

--- a/src/test/java/rx/schedulers/ResetSchedulersTest.java
+++ b/src/test/java/rx/schedulers/ResetSchedulersTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 public class ResetSchedulersTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void reset() {
         RxJavaPlugins.getInstance().reset();


### PR DESCRIPTION
This PR adds a new, in-between, hook manager class, `RxJavaHooks` that allows runtime hooking of `Observable`, `Single`, `Completable` and `Schedulers` components and is aimed to be more versatile than the `RxJavaPlugins`.

Since `RxJavaPlugins` is public API, it can't be just removed, therefore, `RxJavaHooks` by default delegates to it but that delegation can be completely disabled via `clear()`.
#### Usage

Call the `setOn` methods with an appropriate function to manipulate the object being hooked:

``` java
RxJavaHooks.setOnComputationScheduler(s -> Schedulers.immediate());

RxJavaHooks.setObservableCreate(o -> { System.out.println("Creating: " + o); return o; });
```

You can also get the current hooks via the `getOn` methods, allowing chaining multiple hooks if necessary. Changing and retrieving the hooks are thread safe, although it is recommended you change them in quiet times.

Operator writers should usually not call the `onXXX` methods on `RxJavaHooks` except `RxJavaHooks.onError()`; It is useful when they have to signal a `Throwable` that can't be delivered to a `Subscriber`.

Calling `reset()` will restore the original delegation hooks.

This PR also features a way of tracking the assembly locations, that is where `Observable.create()` was invoked internally or externally, via `enableAssemblyTracking`. It changes the creation hooks of all 3 base types by adding an `OnSubscribeOnAssemblyX` wrapper. This operator will replace the Throwable flowing through `onError` and wraps it via the new `AssemblyStackTraceException`. 

Both the wrapper and the exception contain a string representation of the captured stacktrace, this helps "printing" out that information in a debugging session by simply viewing the field contents.

This tracking can be enabled at any time and affects sequences created afterwards. To stop the tracking, use `resetAssemblyTracking` to restore the default delegate callbacks to `RxJavaPlugins` or `clearAssemblyTracking` to restore the empty hooks (only affecting the `onCreate` hooks).

For frameworks, the `RxJavaHooks` can be locked down, preventing changing the hooks.

If you are using `RxJavaPlugins` existing features, you don't have to do anything; tests will work as before.
#### Performance impact

A default `RxJavaHooks` incurs a 2-4 level indirection in method calls. `onNext` calls are not affected.

A clear `RxJavaHooks` incurs a volatile read (very cheap) followed by a branch (predictable). `onNext` calls are not affected.

A tracking-enabled RxJavaHooks incurs an estimated 1000-3000 cycles overhead for each source creation and operator application. The `AssemblyStackTraceException` itself doesn't fill in its own stacktrace but takes only the captured stacktrace string and has mostly the cost of an object allocation. Due to the in-between nature of tracking, `onXXX` calls get through another indirection at each operator. For example, `range(1, 5).map(v -> v).filter(v -> true).subscribe()` will have 3 extra layers (one for each `.`). I believe these are acceptable overheads because the tracking feature is for tracking down crashes and not performance problems.
#### Discussion

Not all hook methods have been replicated completely on `RxJavaHooks`. For one, I wanted a minimal working prototype that passes existing tests. Second, those that are left out are not even tested (`onSubscribeError`, `onLift`). If the **concept** of this PR is accepted, those can be added along with their unit tests. Also further Javadoc will be added in the same case.

Names and structure are not set in stone.
