### PR TITLE
1.x: Deprecate TestObserver, enhance TestSubscriber a bit

### DIFF
--- a/src/main/java/rx/observers/TestObserver.java
+++ b/src/main/java/rx/observers/TestObserver.java
@@ -24,7 +24,9 @@ import rx.exceptions.CompositeException;
 /**
  * Observer usable for unit testing to perform assertions, inspect received events or wrap a mocked Observer.
  * @param <T> the observed value type
+ * @deprecated use the {@link TestSubscriber} insteand.
  */
+@Deprecated
 public class TestObserver<T> implements Observer<T> {
 
     private final Observer<T> delegate;

--- a/src/test/java/rx/internal/operators/CachedObservableTest.java
+++ b/src/test/java/rx/internal/operators/CachedObservableTest.java
@@ -70,7 +70,7 @@ public class CachedObservableTest {
         assertTrue("Subscribers not retained!", source.hasObservers());
         
         ts.assertNoErrors();
-        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts.getCompletions());
         List<Integer> onNextEvents = ts.getOnNextEvents();
         assertEquals(10, onNextEvents.size());
 
@@ -251,14 +251,14 @@ public class CachedObservableTest {
         source.subscribe(ts);
         
         ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
         Assert.assertEquals(1, ts.getOnErrorEvents().size());
         
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
         source.subscribe(ts2);
         
         ts2.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertTrue(ts2.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts2.getCompletions());
         Assert.assertEquals(1, ts2.getOnErrorEvents().size());
     }
     

--- a/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
@@ -39,7 +39,7 @@ public class OnSubscribeToObservableFutureTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Subscription sub = Observable.from(future).subscribe(new TestObserver<Object>(o));
+        Subscription sub = Observable.from(future).subscribe(new TestSubscriber<Object>(o));
         sub.unsubscribe();
 
         verify(o, times(1)).onNext(value);
@@ -57,7 +57,7 @@ public class OnSubscribeToObservableFutureTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Subscription sub = Observable.from(future).subscribe(new TestObserver<Object>(o));
+        Subscription sub = Observable.from(future).subscribe(new TestSubscriber<Object>(o));
         sub.unsubscribe();
 
         verify(o, never()).onNext(null);
@@ -79,7 +79,7 @@ public class OnSubscribeToObservableFutureTest {
         testSubscriber.unsubscribe();
         Observable.from(future).subscribe(testSubscriber);
         assertEquals(0, testSubscriber.getOnErrorEvents().size());
-        assertEquals(0, testSubscriber.getOnCompletedEvents().size());
+        assertEquals(0, testSubscriber.getCompletions());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class OnSubscribeToObservableFutureTest {
         Subscription sub = futureObservable.subscribeOn(Schedulers.computation()).subscribe(testSubscriber);
         sub.unsubscribe();
         assertEquals(0, testSubscriber.getOnErrorEvents().size());
-        assertEquals(0, testSubscriber.getOnCompletedEvents().size());
+        assertEquals(0, testSubscriber.getCompletions());
         assertEquals(0, testSubscriber.getOnNextEvents().size());
     }
     

--- a/src/test/java/rx/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDelayTest.java
@@ -43,7 +43,6 @@ import rx.Subscription;
 import rx.exceptions.TestException;
 import rx.functions.*;
 import rx.internal.util.RxRingBuffer;
-import rx.observers.TestObserver;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
@@ -657,7 +656,7 @@ public class OperatorDelayTest {
             }
 
         });
-        TestObserver<Integer> observer = new TestObserver<Integer>();
+        TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
         delayed.subscribe(observer);
         // all will be delivered after 500ms since range does not delay between them
         scheduler.advanceTimeBy(500L, TimeUnit.MILLISECONDS);

--- a/src/test/java/rx/internal/operators/OperatorFlatMapTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFlatMapTest.java
@@ -449,7 +449,7 @@ public class OperatorFlatMapTest {
             .subscribe(ts);
 
             ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
-            if (ts.getOnCompletedEvents().isEmpty()) {
+            if (ts.getCompletions() == 0) {
                 System.out.println(ts.getOnNextEvents().size());
             }
             ts.assertTerminalEvent();
@@ -491,7 +491,7 @@ public class OperatorFlatMapTest {
             .subscribe(ts);
 
             ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
-            if (ts.getOnCompletedEvents().isEmpty()) {
+            if (ts.getCompletions() == 0) {
                 System.out.println(ts.getOnNextEvents().size());
             }
             ts.assertTerminalEvent();

--- a/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -281,7 +281,7 @@ public class OperatorMergeMaxConcurrentTest {
         
         ts.assertNoErrors();
         assertEquals(5, ts.getOnNextEvents().size());
-        assertEquals(0, ts.getOnCompletedEvents().size());
+        assertEquals(0, ts.getCompletions());
         
         ts.unsubscribe();
     }

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -486,10 +486,10 @@ public class OperatorMergeTest {
             ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
             ts.assertTerminalEvent();
             ts.assertNoErrors();
-            assertEquals(1, ts.getOnCompletedEvents().size());
+            assertEquals(1, ts.getCompletions());
             List<Integer> onNextEvents = ts.getOnNextEvents();
             assertEquals(30000, onNextEvents.size());
-            //            System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getOnCompletedEvents().size());
+            //            System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getCompletions().size());
         }
     }
 
@@ -531,10 +531,10 @@ public class OperatorMergeTest {
             merge.subscribe(ts);
 
             ts.awaitTerminalEvent();
-            assertEquals(1, ts.getOnCompletedEvents().size());
+            assertEquals(1, ts.getCompletions());
             List<Integer> onNextEvents = ts.getOnNextEvents();
             assertEquals(300, onNextEvents.size());
-            //            System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getOnCompletedEvents().size());
+            //            System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getCompletions().size());
         }
     }
 
@@ -573,10 +573,10 @@ public class OperatorMergeTest {
 
             ts.awaitTerminalEvent();
             ts.assertNoErrors();
-            assertEquals(1, ts.getOnCompletedEvents().size());
+            assertEquals(1, ts.getCompletions());
             List<Integer> onNextEvents = ts.getOnNextEvents();
             assertEquals(30000, onNextEvents.size());
-            //                System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getOnCompletedEvents().size());
+            //                System.out.println("onNext: " + onNextEvents.size() + " onCompleted: " + ts.getCompletions().size());
         }
     }
 
@@ -1034,11 +1034,11 @@ public class OperatorMergeTest {
         source.subscribe(subscriber);
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
         subscriber.assertReceivedOnNext(Collections.<Long>emptyList());
-        assertEquals(Collections.<Notification<Long>>emptyList(), subscriber.getOnCompletedEvents());
+        assertEquals(0, subscriber.getCompletions());
         subscriber.requestMore(1);
         subscriber.assertReceivedOnNext(asList(1L));
 // TODO: it should be acceptable to get a completion event without requests
-//        assertEquals(Collections.<Notification<Long>>emptyList(), subscriber.getOnCompletedEvents());
+//        assertEquals(Collections.<Notification<Long>>emptyList(), subscriber.getCompletions());
 //        subscriber.requestMore(1);
         subscriber.assertTerminalEvent();
     }

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureLatestTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureLatestTest.java
@@ -62,7 +62,7 @@ public class OperatorOnBackpressureLatestTest {
         
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Arrays.asList(1, 2));
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
     }
     @Test
     public void testSynchronousDrop() {

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -299,7 +299,7 @@ public class OperatorPublishTest {
 
         ts1.assertReceivedOnNext(Arrays.<Integer>asList());
         ts1.assertNoErrors();
-        assertTrue(ts1.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts1.getCompletions());
         
         source.connect();
 
@@ -351,13 +351,13 @@ public class OperatorPublishTest {
         
         ts.assertReceivedOnNext(Arrays.<Integer>asList());
         ts.assertNoErrors();
-        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts.getCompletions());
         
         source.connect();
 
         ts.assertReceivedOnNext(Arrays.<Integer>asList());
         ts.assertNoErrors();
-        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts.getCompletions());
         
         ts.requestMore(5);
         

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -905,7 +905,7 @@ public class OperatorReplayTest {
         source.subscribe(ts);
 
         ts.assertNoErrors();
-        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts.getCompletions());
         List<Integer> onNextEvents = ts.getOnNextEvents();
         assertEquals(10, onNextEvents.size());
 
@@ -1090,14 +1090,14 @@ public class OperatorReplayTest {
         source.subscribe(ts);
         
         ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
         Assert.assertEquals(1, ts.getOnErrorEvents().size());
         
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
         source.subscribe(ts2);
         
         ts2.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertTrue(ts2.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts2.getCompletions());
         Assert.assertEquals(1, ts2.getOnErrorEvents().size());
     }
     

--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -752,7 +752,7 @@ public class OperatorRetryTest {
                                     for (Throwable t : ts.getOnErrorEvents()) {
                                         onNextEvents.add(t.toString());
                                     }
-                                    for (int k = 0; k < ts.getOnCompletedEvents().size(); k++) {
+                                    for (int k = 0; k < ts.getCompletions(); k++) {
                                         onNextEvents.add("onCompleted");
                                     }
                                     data.put(j, onNextEvents);

--- a/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
@@ -35,7 +35,6 @@ import rx.Scheduler;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
-import rx.observers.TestObserver;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
@@ -48,7 +47,7 @@ public class OperatorSubscribeOnTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        TestObserver<Integer> observer = new TestObserver<Integer>();
+        TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
 
         final Subscription subscription = Observable
                 .create(new Observable.OnSubscribe<Integer>() {
@@ -80,7 +79,7 @@ public class OperatorSubscribeOnTest {
         latch.countDown();
         doneLatch.await();
         assertEquals(0, observer.getOnErrorEvents().size());
-        assertEquals(1, observer.getOnCompletedEvents().size());
+        assertEquals(1, observer.getCompletions());
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -876,7 +876,7 @@ public class OperatorSwitchTest {
                 throw new AssertionError("Dropped exceptions", new CompositeException(q));
             }
             ts.assertNoErrors();
-            if (ts.getOnCompletedEvents().size() == 0) {
+            if (ts.getCompletions() == 0) {
                 fail("switchAsyncHeavily timed out @ " + j + " (" + ts.getOnNextEvents().size() + " onNexts received, last was " + (System.currentTimeMillis() - lastSeen[0]) + " ms ago");
             }
         }

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -132,7 +132,7 @@ public class OperatorTakeUntilPredicateTest {
         
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Arrays.asList(1, 2, 3, 4, 5));
-        Assert.assertEquals(0, ts.getOnCompletedEvents().size());
+        Assert.assertEquals(0, ts.getCompletions());
     }
     
     @Test

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilTest.java
@@ -15,8 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -281,7 +280,7 @@ public class OperatorTakeUntilTest {
         
         ts.assertReceivedOnNext(Arrays.asList(1));
         ts.assertNoErrors();
-        assertTrue("TestSubscriber completed", ts.getOnCompletedEvents().isEmpty());
+        assertEquals("TestSubscriber completed", 0, ts.getCompletions());
         
         assertFalse("Until still has observers", until.hasObservers());
         assertFalse("TestSubscriber is unsubscribed", ts.isUnsubscribed());

--- a/src/test/java/rx/internal/operators/OperatorToObservableListTest.java
+++ b/src/test/java/rx/internal/operators/OperatorToObservableListTest.java
@@ -121,19 +121,19 @@ public class OperatorToObservableListTest {
         
         assertTrue(ts.getOnNextEvents().isEmpty());
         assertTrue(ts.getOnErrorEvents().isEmpty());
-        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts.getCompletions());
         
         ts.requestMore(1);
         
         ts.assertReceivedOnNext(Collections.singletonList(Arrays.asList(1, 2, 3, 4, 5)));
         assertTrue(ts.getOnErrorEvents().isEmpty());
-        assertEquals(1, ts.getOnCompletedEvents().size());
+        assertEquals(1, ts.getCompletions());
 
         ts.requestMore(1);
 
         ts.assertReceivedOnNext(Collections.singletonList(Arrays.asList(1, 2, 3, 4, 5)));
         assertTrue(ts.getOnErrorEvents().isEmpty());
-        assertEquals(1, ts.getOnCompletedEvents().size());
+        assertEquals(1, ts.getCompletions());
     }
     @Test(timeout = 2000)
     public void testAsyncRequested() {

--- a/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
+++ b/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
@@ -87,19 +87,19 @@ public class OperatorToObservableSortedListTest {
         
         assertTrue(ts.getOnNextEvents().isEmpty());
         assertTrue(ts.getOnErrorEvents().isEmpty());
-        assertTrue(ts.getOnCompletedEvents().isEmpty());
+        assertEquals(0, ts.getCompletions());
         
         ts.requestMore(1);
         
         ts.assertReceivedOnNext(Collections.singletonList(Arrays.asList(1, 2, 3, 4, 5)));
         assertTrue(ts.getOnErrorEvents().isEmpty());
-        assertEquals(1, ts.getOnCompletedEvents().size());
+        assertEquals(1, ts.getCompletions());
 
         ts.requestMore(1);
 
         ts.assertReceivedOnNext(Collections.singletonList(Arrays.asList(1, 2, 3, 4, 5)));
         assertTrue(ts.getOnErrorEvents().isEmpty());
-        assertEquals(1, ts.getOnCompletedEvents().size());
+        assertEquals(1, ts.getCompletions());
     }
     @Test(timeout = 2000)
     public void testAsyncRequested() {

--- a/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
@@ -15,9 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.concurrent.*;
@@ -25,14 +23,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Scheduler;
-import rx.Subscriber;
-import rx.Subscription;
 import rx.functions.Action0;
 import rx.internal.util.RxThreadFactory;
-import rx.observers.TestObserver;
+import rx.observers.*;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.Subscriptions;
 
@@ -56,7 +51,7 @@ public class OperatorUnsubscribeOnTest {
                 }
             });
 
-            TestObserver<Integer> observer = new TestObserver<Integer>();
+            TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
             w
             .subscribeOn(UI_EVENT_LOOP)
             .observeOn(Schedulers.computation())
@@ -101,7 +96,7 @@ public class OperatorUnsubscribeOnTest {
                 }
             });
 
-            TestObserver<Integer> observer = new TestObserver<Integer>();
+            TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
             w
             .subscribeOn(Schedulers.newThread())
             .observeOn(Schedulers.computation())

--- a/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
@@ -155,7 +155,7 @@ public class OperatorWithLatestFromTest {
         
         ts.assertReceivedOnNext(Arrays.asList((1 << 8) + 1));
         ts.assertNoErrors();
-        assertEquals(0, ts.getOnCompletedEvents().size());
+        assertEquals(0, ts.getCompletions());
         
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());

--- a/src/test/java/rx/internal/producers/ProducersTest.java
+++ b/src/test/java/rx/internal/producers/ProducersTest.java
@@ -51,7 +51,7 @@ public class ProducersTest {
         
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Collections.<Integer>emptyList());
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
         
         ts.requestMore(2);
         
@@ -68,7 +68,7 @@ public class ProducersTest {
 
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Collections.<Integer>emptyList());
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
         
         sdp.setValue(1);
         
@@ -89,13 +89,13 @@ public class ProducersTest {
 
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Collections.<Integer>emptyList());
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
         
         sdp.setValue(1);
 
         ts.assertNoErrors();
         ts.assertReceivedOnNext(Collections.<Integer>emptyList());
-        Assert.assertTrue(ts.getOnCompletedEvents().isEmpty());
+        Assert.assertEquals(0, ts.getCompletions());
         
         ts.requestMore(2);
         

--- a/src/test/java/rx/observers/SerializedObserverTest.java
+++ b/src/test/java/rx/observers/SerializedObserverTest.java
@@ -792,7 +792,7 @@ public class SerializedObserverTest {
     @Test
     public void testSerializeNull() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t != null && t == 0) {
@@ -812,7 +812,7 @@ public class SerializedObserverTest {
     
     @Test
     public void testSerializeAllowsOnError() {
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -834,7 +834,7 @@ public class SerializedObserverTest {
     @Test
     public void testSerializeReentrantNullAndComplete() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 serial.get().onCompleted();
@@ -853,13 +853,13 @@ public class SerializedObserverTest {
         
         assertEquals(1, to.getOnErrorEvents().size());
         assertTrue(to.getOnErrorEvents().get(0) instanceof TestException);
-        assertTrue(to.getOnCompletedEvents().isEmpty());
+        assertEquals(0, to.getCompletions());
     }
     
     @Test
     public void testSerializeReentrantNullAndError() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 serial.get().onError(new RuntimeException());
@@ -878,13 +878,13 @@ public class SerializedObserverTest {
         
         assertEquals(1, to.getOnErrorEvents().size());
         assertTrue(to.getOnErrorEvents().get(0) instanceof TestException);
-        assertTrue(to.getOnCompletedEvents().isEmpty());
+        assertEquals(0, to.getCompletions());
     }
     
     @Test
     public void testSerializeDrainPhaseThrows() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t != null && t == 0) {

--- a/src/test/java/rx/observers/TestObserverTest.java
+++ b/src/test/java/rx/observers/TestObserverTest.java
@@ -30,6 +30,7 @@ import rx.Observer;
 import rx.exceptions.TestException;
 import rx.subjects.PublishSubject;
 
+@Deprecated
 public class TestObserverTest {
 
     @Rule


### PR DESCRIPTION
This PR deprecates `TestObserver` in favor of the richer `TestSubscriber`.

In addition, `TestSubscriber` gets 3 new methods and 1 deprecation:
- `getCompletions()` to return the onCompleted count as int instead of Notifications
- `getValueCount()` returns the committed number of onNext events for thread-safe checking of values up to this count
- `awaitValueCount` repeatedly sleeps up to a timeout and waits till the committed onNext count reaches/passes the expected amount.
