### PR TITLE
1.x: fix Completable.onErrorComplete(Func1) not relaying function crash

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -1663,8 +1663,9 @@ public class Completable {
                         try {
                             b = predicate.call(e);
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             e = new CompositeException(Arrays.asList(e, ex));
-                            return;
+                            b = false;
                         }
                         
                         if (b) {

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -4112,4 +4112,29 @@ public class CompletableTest {
         ts.assertCompleted();
     }
 
+    @Test
+    public void onErrorCompleteFunctionThrows() {
+        TestSubscriber<String> ts = new TestSubscriber<String>();
+        
+        error.completable.onErrorComplete(new Func1<Throwable, Boolean>() {
+            @Override
+            public Boolean call(Throwable t) {
+                throw new TestException("Forced inner failure");
+            }
+        }).subscribe(ts);
+
+        ts.assertNoValues();
+        ts.assertNotCompleted();
+        ts.assertError(CompositeException.class);
+        
+        CompositeException composite = (CompositeException)ts.getOnErrorEvents().get(0);
+        
+        List<Throwable> errors = composite.getExceptions();
+        Assert.assertEquals(2, errors.size());
+        
+        Assert.assertTrue(errors.get(0).toString(), errors.get(0) instanceof TestException);
+        Assert.assertEquals(errors.get(0).toString(), null, errors.get(0).getMessage());
+        Assert.assertTrue(errors.get(1).toString(), errors.get(1) instanceof TestException);
+        Assert.assertEquals(errors.get(1).toString(), "Forced inner failure", errors.get(1).getMessage());
+    }
 }


### PR DESCRIPTION
The catch around the predicate didn't actually signal the CompositeException.

Discovered in #4025
