### PR TITLE
2.x: first step switching to the reduced-allocation architecture

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -37,7 +37,7 @@ import io.reactivex.schedulers.Schedulers;
  * 
  * The class follows a similar event pattern as Reactive-Streams: onSubscribe (onError|onComplete)?
  */
-public class Completable {
+public abstract class Completable {
     /**
      * Callback used for building deferred computations that takes a CompletableSubscriber.
      */
@@ -386,7 +386,7 @@ public class Completable {
         try {
             // TODO plugin wrapping onSubscribe
             
-            return new Completable(onSubscribe);
+            return new CompletableWrapper(onSubscribe);
         } catch (NullPointerException ex) {
             throw ex;
         } catch (Throwable ex) {
@@ -984,18 +984,6 @@ public class Completable {
                 });
             }
         });
-    }
-    
-    /** The actual subscription action. */
-    private final CompletableOnSubscribe onSubscribe;
-    
-    /**
-     * Constructs a Completable instance with the given onSubscribe callback.
-     * @param onSubscribe the callback that will receive CompletableSubscribers when they subscribe,
-     * not null (not verified)
-     */
-    protected Completable(CompletableOnSubscribe onSubscribe) {
-        this.onSubscribe = onSubscribe;
     }
     
     /**
@@ -1929,7 +1917,7 @@ public class Completable {
         try {
             // TODO plugin wrapping the subscriber
             
-            onSubscribe.accept(s);
+            subscribeActual(s);
         } catch (NullPointerException ex) {
             throw ex;
         } catch (Throwable ex) {
@@ -1937,6 +1925,8 @@ public class Completable {
             throw toNpe(ex);
         }
     }
+    
+    protected abstract void subscribeActual(CompletableSubscriber s);
 
     /**
      * Subscribes to this Completable and calls back either the onError or onComplete functions.

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -38,7 +38,7 @@ import io.reactivex.schedulers.*;
  * Observable for delivering a sequence of values without backpressure. 
  * @param <T>
  */
-public class Observable<T> {
+public abstract class Observable<T> {
 
     public interface NbpOnSubscribe<T> extends Consumer<Observer<? super T>> {
         
@@ -358,7 +358,7 @@ public class Observable<T> {
     public static <T> Observable<T> create(NbpOnSubscribe<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         // TODO plugin wrapper
-        return new Observable<T>(onSubscribe);
+        return new ObservableWrapper<T>(onSubscribe);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
@@ -1089,12 +1089,6 @@ public class Observable<T> {
     }
 
     
-    protected final NbpOnSubscribe<T> onSubscribe;
-
-    protected Observable(NbpOnSubscribe<T> onSubscribe) {
-        this.onSubscribe = onSubscribe;
-    }
-
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<Boolean> all(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
@@ -2634,10 +2628,15 @@ public class Observable<T> {
         return ls;
     }
 
-    public final void subscribe(Observer<? super T> subscriber) {
-        Objects.requireNonNull(subscriber, "subscriber is null");
-        onSubscribe.accept(subscriber);
+    public final void subscribe(Observer<? super T> observer) {
+        Objects.requireNonNull(observer, "observer is null");
+        
+        // TODO plugin wrappings
+        
+        subscribeActual(observer);
     }
+    
+    protected abstract void subscribeActual(Observer<? super T> observer);
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final Observable<T> subscribeOn(Scheduler scheduler) {

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -36,7 +36,7 @@ import io.reactivex.schedulers.Schedulers;
  * 
  * @param <T> the value type
  */
-public class Single<T> {
+public abstract class Single<T> {
     
     public interface SingleOnSubscribe<T> extends Consumer<SingleSubscriber<? super T>> {
         
@@ -356,7 +356,7 @@ public class Single<T> {
     public static <T> Single<T> create(SingleOnSubscribe<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         // TODO plugin wrapper
-        return new Single<T>(onSubscribe);
+        return new SingleWrapper<T>(onSubscribe);
     }
     
     public static <T> Single<T> defer(final Supplier<? extends Single<? extends T>> singleSupplier) {
@@ -1003,12 +1003,6 @@ public class Single<T> {
         return Flowable.zipArray(zipper, false, 1, sourcePublishers).toSingle();
     }
 
-    protected final SingleOnSubscribe<T> onSubscribe;
-
-    protected Single(SingleOnSubscribe<T> onSubscribe) {
-        this.onSubscribe = onSubscribe;
-    }
-
     @SuppressWarnings("unchecked")
     public final Single<T> ambWith(Single<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
@@ -1374,7 +1368,7 @@ public class Single<T> {
                         throw new NullPointerException("The onLift returned a null subscriber");
                     }
                     // TODO plugin wrapper
-                    onSubscribe.accept(sr);
+                    subscribe(sr);
                 } catch (NullPointerException ex) {
                     throw ex;
                 } catch (Throwable ex) {
@@ -1690,8 +1684,10 @@ public class Single<T> {
     public final void subscribe(SingleSubscriber<? super T> subscriber) {
         Objects.requireNonNull(subscriber, "subscriber is null");
         // TODO plugin wrapper
-        onSubscribe.accept(subscriber);
+        subscribeActual(subscriber);
     }
+    
+    protected abstract void subscribeActual(SingleSubscriber<? super T> subscriber);
     
     public final void subscribe(Subscriber<? super T> s) {
         toFlowable().subscribe(s);

--- a/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
@@ -36,10 +36,6 @@ import io.reactivex.internal.operators.flowable.*;
  */
 public abstract class ConnectableFlowable<T> extends Flowable<T> {
     
-    protected ConnectableFlowable(Publisher<T> onSubscribe) {
-        super(onSubscribe);
-    }
-    
     /**
      * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
      * {@link Flowable} to its {@link Subscriber}s.

--- a/src/main/java/io/reactivex/flowables/GroupedFlowable.java
+++ b/src/main/java/io/reactivex/flowables/GroupedFlowable.java
@@ -12,14 +12,11 @@
  */
 package io.reactivex.flowables;
 
-import org.reactivestreams.Publisher;
-
 import io.reactivex.Flowable;
 
-public class GroupedFlowable<K, T> extends Flowable<T> {
+public abstract class GroupedFlowable<K, T> extends Flowable<T> {
     final K key;
-    protected GroupedFlowable(Publisher<T> onSubscribe, K key) {
-        super(onSubscribe);
+    protected GroupedFlowable(K key) {
         this.key = key;
     }
     

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableWrapper.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableWrapper.java
@@ -1,0 +1,17 @@
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+
+public final class CompletableWrapper extends Completable {
+
+    final CompletableOnSubscribe onSubscribe;
+
+    public CompletableWrapper(CompletableOnSubscribe onSubscribe) {
+        this.onSubscribe = onSubscribe;
+    }
+    
+    @Override
+    protected void subscribeActual(CompletableSubscriber s) {
+        onSubscribe.accept(s);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWrapper.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWrapper.java
@@ -1,0 +1,18 @@
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+
+public final class FlowableWrapper<T> extends Flowable<T> {
+    final Publisher<? extends T> publisher;
+
+    public FlowableWrapper(Publisher<? extends T> publisher) {
+        this.publisher = publisher;
+    }
+    
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        publisher.subscribe(s);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/ObservableScalarSource.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/ObservableScalarSource.java
@@ -26,13 +26,12 @@ import io.reactivex.internal.subscriptions.*;
 public final class ObservableScalarSource<T> extends Flowable<T> {
     private final T value;
     public ObservableScalarSource(final T value) {
-        super(new Publisher<T>() {
-            @Override
-            public void subscribe(Subscriber<? super T> s) {
-                s.onSubscribe(new ScalarSubscription<T>(s, value));
-            }
-        });
         this.value = value;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        s.onSubscribe(new ScalarSubscription<T>(s, value));
     }
     
     public T value() {

--- a/src/main/java/io/reactivex/internal/operators/flowable/OperatorGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/OperatorGroupBy.java
@@ -305,8 +305,13 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedFlowable<
         final State<T, K> state;
         
         protected GroupedUnicast(K key, State<T, K> state) {
-            super(state, key);
+            super(key);
             this.state = state;
+        }
+        
+        @Override
+        protected void subscribeActual(Subscriber<? super T> s) {
+            state.subscribe(s);
         }
         
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/OperatorPublish.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/OperatorPublish.java
@@ -139,14 +139,21 @@ public final class OperatorPublish<T> extends ConnectableFlowable<T> {
         });
     }
 
+    final Publisher<T> onSubscribe;
+    
     private OperatorPublish(Publisher<T> onSubscribe, Publisher<? extends T> source, 
             final AtomicReference<PublishSubscriber<T>> current, int bufferSize) {
-        super(onSubscribe);
+        this.onSubscribe = onSubscribe;
         this.source = source;
         this.current = current;
         this.bufferSize = bufferSize;
     }
 
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        onSubscribe.subscribe(s);
+    }
+    
     @Override
     public void connect(Consumer<? super Disposable> connection) {
         boolean doConnect = false;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpObservableScalarSource.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpObservableScalarSource.java
@@ -24,15 +24,14 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 public final class NbpObservableScalarSource<T> extends Observable<T> {
     private final T value;
     public NbpObservableScalarSource(final T value) {
-        super(new NbpOnSubscribe<T>() {
-            @Override
-            public void accept(Observer<? super T> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
-                s.onNext(value);
-                s.onComplete();
-            }
-        });
         this.value = value;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        s.onSubscribe(EmptyDisposable.INSTANCE);
+        s.onNext(value);
+        s.onComplete();
     }
     
     public T value() {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorGroupBy.java
@@ -181,8 +181,13 @@ public final class NbpOperatorGroupBy<T, K, V> implements NbpOperator<GroupedObs
         final State<T, K> state;
         
         protected GroupedUnicast(K key, State<T, K> state) {
-            super(state, key);
+            super(key);
             this.state = state;
+        }
+        
+        @Override
+        protected void subscribeActual(Observer<? super T> observer) {
+            state.accept(observer);
         }
         
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorPublish.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorPublish.java
@@ -136,12 +136,19 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
         });
     }
 
+    final NbpOnSubscribe<T> onSubscribe;
+    
     private NbpOperatorPublish(NbpOnSubscribe<T> onSubscribe, Observable<? extends T> source, 
             final AtomicReference<PublishSubscriber<T>> current, int bufferSize) {
-        super(onSubscribe);
+        this.onSubscribe = onSubscribe;
         this.source = source;
         this.current = current;
         this.bufferSize = bufferSize;
+    }
+    
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        onSubscribe.accept(observer);
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWrapper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWrapper.java
@@ -1,0 +1,16 @@
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+
+public final class ObservableWrapper<T> extends Observable<T> {
+    final NbpOnSubscribe<T> onSubscribe;
+
+    public ObservableWrapper(NbpOnSubscribe<T> onSubscribe) {
+        this.onSubscribe = onSubscribe;
+    }
+    
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        onSubscribe.accept(observer);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/single/SingleWrapper.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleWrapper.java
@@ -1,0 +1,16 @@
+package io.reactivex.internal.operators.single;
+
+import io.reactivex.Single;
+
+public final class SingleWrapper<T> extends Single<T> {
+    final SingleOnSubscribe<T> onSubscribe;
+
+    public SingleWrapper(io.reactivex.Single.SingleOnSubscribe<T> onSubscribe) {
+        this.onSubscribe = onSubscribe;
+    }
+    
+    @Override
+    protected void subscribeActual(io.reactivex.Single.SingleSubscriber<? super T> subscriber) {
+        onSubscribe.accept(subscriber);
+    }
+}

--- a/src/main/java/io/reactivex/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/observables/ConnectableObservable.java
@@ -36,10 +36,6 @@ import io.reactivex.internal.operators.observable.*;
  */
 public abstract class ConnectableObservable<T> extends Observable<T> {
     
-    protected ConnectableObservable(NbpOnSubscribe<T> onSubscribe) {
-        super(onSubscribe);
-    }
-    
     /**
      * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
      * {@link Flowable} to its {@link Subscriber}s.

--- a/src/main/java/io/reactivex/observables/GroupedObservable.java
+++ b/src/main/java/io/reactivex/observables/GroupedObservable.java
@@ -14,10 +14,11 @@ package io.reactivex.observables;
 
 import io.reactivex.Observable;
 
-public class GroupedObservable<K, T> extends Observable<T> {
+public abstract class GroupedObservable<K, T> extends Observable<T> {
+    
     final K key;
-    protected GroupedObservable(NbpOnSubscribe<T> onSubscribe, K key) {
-        super(onSubscribe);
+    
+    protected GroupedObservable(K key) {
         this.key = key;
     }
     

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -40,8 +40,7 @@ public final class AsyncProcessor<T> extends FlowProcessor<T, T> {
      * @return the new AsyncSubject instance.
      */
     public static <T> AsyncProcessor<T> create() {
-        State<T> state = new State<T>();
-        return new AsyncProcessor<T>(state);
+        return new AsyncProcessor<T>();
     }
     
     /** The state holding onto the latest value or error and the array of subscribers. */
@@ -53,9 +52,8 @@ public final class AsyncProcessor<T> extends FlowProcessor<T, T> {
      */
     boolean done;
     
-    protected AsyncProcessor(State<T> state) {
-        super(state);
-        this.state = state;
+    protected AsyncProcessor() {
+        this.state = new State<T>();
     }
     
     @Override
@@ -168,6 +166,11 @@ public final class AsyncProcessor<T> extends FlowProcessor<T, T> {
             }
         }
         return array;
+    }
+    
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        state.subscribe(s);
     }
     /**
      * The state of the AsyncSubject.

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -28,8 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class BehaviorProcessor<T> extends FlowProcessor<T, T> {
 
     public static <T> BehaviorProcessor<T> create() {
-        State<T> state = new State<T>();
-        return new BehaviorProcessor<T>(state);
+        return new BehaviorProcessor<T>(new State<T>());
     }
     
     // TODO a plain create() would create a method ambiguity with Observable.create with javac
@@ -41,9 +40,14 @@ public final class BehaviorProcessor<T> extends FlowProcessor<T, T> {
     }
     
     final State<T> state;
+    
     protected BehaviorProcessor(State<T> state) {
-        super(state);
         this.state = state;
+    }
+    
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        state.subscribe(s);
     }
     
     @Override

--- a/src/main/java/io/reactivex/processors/FlowProcessor.java
+++ b/src/main/java/io/reactivex/processors/FlowProcessor.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 
 /**
- * Represents a Subscriber and an Observable (Publisher) at the same time, allowing
+ * Represents a Subscriber and an Flowable (Publisher) at the same time, allowing
  * multicasting events from a single source to multiple child Subscribers.
  * <p>All methods except the onSubscribe, onNext, onError and onComplete are thread-safe.
  * Use {@link #toSerialized()} to make these methods thread-safe as well.
@@ -27,10 +27,6 @@ import io.reactivex.Flowable;
  * @param <R> the emission value type
  */
 public abstract class FlowProcessor<T, R> extends Flowable<R> implements Processor<T, R> {
-    
-    protected FlowProcessor(Publisher<R> onSubscribe) {
-        super(onSubscribe);
-    }
     
     /**
      * Returns true if the subject has subscribers.

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -46,8 +46,7 @@ public final class PublishProcessor<T> extends FlowProcessor<T, T> {
      * @return the new PublishSubject
      */
     public static <T> PublishProcessor<T> create() {
-        State<T> state = new State<T>();
-        return new PublishProcessor<T>(state);
+        return new PublishProcessor<T>();
     }
     
     /** Holds the terminal event and manages the array of subscribers. */
@@ -59,9 +58,13 @@ public final class PublishProcessor<T> extends FlowProcessor<T, T> {
      */
     boolean done;
     
-    protected PublishProcessor(State<T> state) {
-        super(state);
-        this.state = state;
+    protected PublishProcessor() {
+        this.state = new State<T>();
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        state.subscribe(s);
     }
     
     @Override

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -88,8 +88,12 @@ public final class ReplayProcessor<T> extends FlowProcessor<T, T> {
     final State<T> state;
     
     protected ReplayProcessor(State<T> state) {
-        super(state);
         this.state = state;
+    }
+    
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        state.subscribe(s);
     }
     
     @Override

--- a/src/main/java/io/reactivex/processors/SerializedProcessor.java
+++ b/src/main/java/io/reactivex/processors/SerializedProcessor.java
@@ -41,13 +41,12 @@ import io.reactivex.plugins.RxJavaPlugins;
      * @param actual the subject wrapped
      */
     public SerializedProcessor(final FlowProcessor<T, R> actual) {
-        super(new Publisher<R>() {
-            @Override
-            public void subscribe(Subscriber<? super R> s) {
-                actual.subscribe(s);
-            }
-        });
         this.actual = actual;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        actual.subscribe(s);
     }
     
     @Override

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -81,10 +81,14 @@ public final class UnicastProcessor<T> extends FlowProcessor<T, T> {
      * @param state the subject state
      */
     protected UnicastProcessor(State<T> state) {
-        super(state);
         this.state = state;
     }
 
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        state.subscribe(s);
+    }
+    
     // TODO may need to have a direct WIP field to avoid clashing on the object header
     /** Pads the WIP counter. */
     static abstract class StatePad0 extends AtomicInteger {

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -35,14 +35,18 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class AsyncSubject<T> extends Subject<T, T> {
     public static <T> AsyncSubject<T> create() {
-        State<T> state = new State<T>();
-        return new AsyncSubject<T>(state);
+        return new AsyncSubject<T>();
     }
     
     final State<T> state;
-    protected AsyncSubject(State<T> state) {
-        super(state);
-        this.state = state;
+    
+    protected AsyncSubject() {
+        this.state = new State<T>();
+    }
+    
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        state.accept(observer);
     }
     
     @Override

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -41,8 +41,12 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     
     final State<T> state;
     protected BehaviorSubject(State<T> state) {
-        super(state);
         this.state = state;
+    }
+    
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        state.accept(observer);
     }
     
     @Override

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -23,16 +23,19 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class PublishSubject<T> extends Subject<T, T> {
     public static <T> PublishSubject<T> create() {
-        State<T> state = new State<T>();
-        return new PublishSubject<T>(state);
+        return new PublishSubject<T>();
     }
     
     final State<T> state;
-    protected PublishSubject(State<T> state) {
-        super(state);
-        this.state = state;
+    protected PublishSubject() {
+        this.state = new State<T>();
     }
-    
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        state.accept(observer);
+    }
+
     @Override
     public void onSubscribe(Disposable d) {
         if (state.done) {

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -87,10 +87,14 @@ public final class ReplaySubject<T> extends Subject<T, T> {
     final State<T> state;
     
     protected ReplaySubject(State<T> state) {
-        super(state);
         this.state = state;
     }
     
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        state.accept(observer);
+    }
+
     @Override
     public void onSubscribe(Disposable s) {
         state.onSubscribe(s);

--- a/src/main/java/io/reactivex/subjects/SerializedSubject.java
+++ b/src/main/java/io/reactivex/subjects/SerializedSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.subjects;
 
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.util.*;
@@ -40,15 +41,15 @@ import io.reactivex.plugins.RxJavaPlugins;
      * @param actual the subject wrapped
      */
     public SerializedSubject(final Subject<T, R> actual) {
-        super(new io.reactivex.Observable.NbpOnSubscribe<R>() {
-            @Override
-            public void accept(io.reactivex.Observer<? super R> s) {
-                actual.subscribe(s);
-            }
-        });
         this.actual = actual;
     }
-    
+
+    @Override
+    protected void subscribeActual(Observer<? super R> observer) {
+        actual.subscribe(observer);
+    }
+
+
     @Override
     public void onSubscribe(Disposable s) {
         // NO-OP

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -26,10 +26,6 @@ import io.reactivex.*;
  */
 public abstract class Subject<T, R> extends Observable<R> implements Observer<T> {
     
-    protected Subject(NbpOnSubscribe<R> onSubscribe) {
-        super(onSubscribe);
-    }
-    
     /**
      * Returns true if the subject has subscribers.
      * <p>The method is thread-safe.

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -80,10 +80,14 @@ public final class UnicastSubject<T> extends Subject<T, T> {
      * @param state the subject state
      */
     protected UnicastSubject(State<T> state) {
-        super(state);
         this.state = state;
     }
 
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        state.accept(observer);
+    }
+    
     // TODO may need to have a direct WIP field to avoid clashing on the object header
     /** Pads the WIP counter. */
     static abstract class StatePad0 extends AtomicInteger {


### PR DESCRIPTION
This is the first step towards the new architecture where operator implementations are themselves of the base type instead of a 2-3 layer indirection as in 1.x.

This PR removes the instance field `onSubscribe` from the base reactive classes and introduces `subscribeActual` to be overridden with the custom operator logic now on. Existing operators are still working through the classical OnSubscribe/Lift indirection and will be updated in subsequent PRs.

Naming and existence of `subscribeActual` is up for (post-merge) discussion. To recap, the method is needed so that the default `subscribe` method can be made final and ensure plugin hooks can be called (once available). The method is protected and only affects operator implementors that chose to extend the base reactive classes directly. 

The alternative is to leave `subscribe` abstract and add a hook to every operator method (for example, see [this](https://github.com/reactor/reactive-streams-commons/blob/master/src/main/java/rsc/publisher/Px.java#L50) and [this](https://github.com/reactor/reactive-streams-commons/blob/master/src/main/java/rsc/publisher/Px.java#L162).
