### PR TITLE
2.x: Update Observable's ops to work with ObservableConsumable

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -43,7 +43,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         
     }
     
-    public interface NbpTransformer<Upstream, Downstream> extends Function<Observable<Upstream>, Observable<Downstream>> {
+    public interface NbpTransformer<Upstream, Downstream> extends Function<Observable<Upstream>, ObservableConsumable<Downstream>> {
         
     }
     
@@ -66,21 +66,21 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     
     static final Object OBJECT = new Object();
     
-    public static <T> Observable<T> amb(Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> amb(Iterable<? extends ObservableConsumable<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return create(new NbpOnSubscribeAmb<T>(null, sources));
     }
     
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> amb(Observable<? extends T>... sources) {
+    public static <T> Observable<T> amb(ObservableConsumable<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
             return empty();
         } else
         if (len == 1) {
-            return (Observable<T>)sources[0];
+            return (Observable<T>)sources[0]; // FIXME wrap()
         }
         return create(new NbpOnSubscribeAmb<T>(sources, null));
     }
@@ -94,22 +94,22 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize, Observable<? extends T>... sources) {
+    public static <T, R> Observable<R> combineLatest(Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize, ObservableConsumable<? extends T>... sources) {
         return combineLatest(sources, combiner, delayError, bufferSize);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> combiner) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, false, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
         return combineLatest(sources, combiner, delayError, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         validateBufferSize(bufferSize);
@@ -120,17 +120,17 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Observable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
+    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, false, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Observable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
+    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
         return combineLatest(sources, combiner, delayError, bufferSize());
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> combineLatest(Observable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
         validateBufferSize(bufferSize);
         Objects.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
@@ -144,7 +144,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2);
     }
@@ -152,8 +152,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, 
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, 
             Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3);
     }
@@ -161,8 +161,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, ObservableConsumable<? extends T4> p4,
             Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4);
     }
@@ -170,9 +170,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, ObservableConsumable<? extends T4> p4,
+            ObservableConsumable<? extends T5> p5,
             Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5);
     }
@@ -180,9 +180,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, ObservableConsumable<? extends T4> p4,
+            ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
             Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6);
     }
@@ -190,10 +190,10 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, ObservableConsumable<? extends T4> p4,
+            ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
+            ObservableConsumable<? extends T7> p7,
             Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7);
     }
@@ -201,10 +201,10 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, ObservableConsumable<? extends T4> p4,
+            ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
+            ObservableConsumable<? extends T7> p7, ObservableConsumable<? extends T8> p8,
             Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8);
     }
@@ -212,68 +212,69 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> combineLatest(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
-            Observable<? extends T3> p3, Observable<? extends T4> p4,
-            Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8,
-            Observable<? extends T9> p9,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
+            ObservableConsumable<? extends T3> p3, ObservableConsumable<? extends T4> p4,
+            ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
+            ObservableConsumable<? extends T7> p7, ObservableConsumable<? extends T8> p8,
+            ObservableConsumable<? extends T9> p9,
             Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
         return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concat(int prefetch, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> concat(int prefetch, Iterable<? extends ObservableConsumable<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMap((Function)Functions.identity(), prefetch);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concat(Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> concat(Iterable<? extends ObservableConsumable<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMap((Function)Functions.identity());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static final <T> Observable<T> concat(Observable<? extends Observable<? extends T>> sources) {
+    public static final <T> Observable<T> concat(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources) {
         return concat(sources, bufferSize());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static final <T> Observable<T> concat(Observable<? extends Observable<? extends T>> sources, int bufferSize) {
-        return sources.concatMap((Function)Functions.identity());
+    public static final <T> Observable<T> concat(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources, int bufferSize) {
+        Objects.requireNonNull(sources, "sources is null");
+        return new NbpOnSubscribeLift<T, ObservableConsumable<? extends T>>(sources, new NbpOperatorConcatMap(Functions.identity(), bufferSize));
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concat(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<T> concat(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2) {
         return concatArray(p1, p2);
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2,
-            Observable<? extends T> p3) {
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2,
+            ObservableConsumable<? extends T> p3) {
         return concatArray(p1, p2, p3);
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2,
-            Observable<? extends T> p3, Observable<? extends T> p4) {
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2,
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4) {
         return concatArray(p1, p2, p3, p4);
     }
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, 
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4,
+            ObservableConsumable<? extends T> p5
     ) {
         return concatArray(p1, p2, p3, p4, p5);
     }
@@ -281,9 +282,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, 
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4,
+            ObservableConsumable<? extends T> p5, ObservableConsumable<? extends T> p6
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6);
     }
@@ -291,10 +292,10 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2,
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6,
-            Observable<? extends T> p7
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2,
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4,
+            ObservableConsumable<? extends T> p5, ObservableConsumable<? extends T> p6,
+            ObservableConsumable<? extends T> p7
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6, p7);
     }
@@ -302,10 +303,10 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6,
-            Observable<? extends T> p7, Observable<? extends T> p8
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, 
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4,
+            ObservableConsumable<? extends T> p5, ObservableConsumable<? extends T> p6,
+            ObservableConsumable<? extends T> p7, ObservableConsumable<? extends T> p8
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6, p7, p8);
     }
@@ -313,18 +314,18 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> concat(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4,
-            Observable<? extends T> p5, Observable<? extends T> p6,
-            Observable<? extends T> p7, Observable<? extends T> p8,
-            Observable<? extends T> p9
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, 
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4,
+            ObservableConsumable<? extends T> p5, ObservableConsumable<? extends T> p6,
+            ObservableConsumable<? extends T> p7, ObservableConsumable<? extends T> p8,
+            ObservableConsumable<? extends T> p9
     ) {
         return concatArray(p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concatArray(int prefetch, Observable<? extends T>... sources) {
+    public static <T> Observable<T> concatArray(int prefetch, ObservableConsumable<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromArray(sources).concatMap((Function)Functions.identity(), prefetch);
     }
@@ -340,24 +341,32 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> concatArray(Observable<? extends T>... sources) {
+    public static <T> Observable<T> concatArray(ObservableConsumable<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         } else
         if (sources.length == 1) {
-            return (Observable<T>)sources[0];
+            return wrap((ObservableConsumable<T>)sources[0]);
         }
         return fromArray(sources).concatMap((Function)Functions.identity());
     }
 
     public static <T> Observable<T> create(ObservableConsumable<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        // TODO plugin wrapper
+        return new ObservableWrapper<T>(onSubscribe);
+    }
+    
+    public static <T> Observable<T> wrap(ObservableConsumable<T> onSubscribe) {
+        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        // TODO plugin wrapper?
+        if (onSubscribe instanceof Observable) {
+            return (Observable<T>)onSubscribe;
+        }
         return new ObservableWrapper<T>(onSubscribe);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> defer(Supplier<? extends Observable<? extends T>> supplier) {
+    public static <T> Observable<T> defer(Supplier<? extends ObservableConsumable<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return create(new NbpOnSubscribeDefer<T>(supplier));
     }
@@ -397,7 +406,6 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         return create(new NbpOnSubscribeArraySource<T>(values));
     }
 
-    // TODO match naming with RxJava 1.x
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> fromCallable(Callable<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
@@ -689,50 +697,50 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, Iterable<? extends ObservableConsumable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, Observable<? extends T>... sources) {
+    public static <T> Observable<T> merge(int maxConcurrency, int bufferSize, ObservableConsumable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(int maxConcurrency, Observable<? extends T>... sources) {
+    public static <T> Observable<T> merge(int maxConcurrency, ObservableConsumable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> merge(Iterable<? extends ObservableConsumable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends Observable<? extends T>> sources, int maxConcurrency) {
+    public static <T> Observable<T> merge(Iterable<? extends ObservableConsumable<? extends T>> sources, int maxConcurrency) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> merge(Observable<? extends Observable<? extends T>> sources) {
-        return sources.flatMap((Function)Functions.identity());
+    public static <T> Observable<T> merge(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources) {
+        return new NbpOnSubscribeLift(sources, new NbpOperatorFlatMap(Functions.identity(), false, Integer.MAX_VALUE, bufferSize()));
     }
 
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends Observable<? extends T>> sources, int maxConcurrency) {
-        return sources.flatMap((Function)Functions.identity(), maxConcurrency);
+    public static <T> Observable<T> merge(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources, int maxConcurrency) {
+        return new NbpOnSubscribeLift(sources, new NbpOperatorFlatMap(Functions.identity(), false, maxConcurrency, bufferSize()));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<T> merge(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), false, 2);
@@ -741,7 +749,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends T> p1, Observable<? extends T> p2, Observable<? extends T> p3) {
+    public static <T> Observable<T> merge(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, Observable<? extends T> p3) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -752,8 +760,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> merge(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4) {
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, 
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -763,55 +771,55 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> merge(Observable<? extends T>... sources) {
+    public static <T> Observable<T> merge(ObservableConsumable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), sources.length);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(boolean delayErrors, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> mergeDelayError(boolean delayErrors, Iterable<? extends ObservableConsumable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, Iterable<? extends ObservableConsumable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, Observable<? extends T>... sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, int bufferSize, ObservableConsumable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, Iterable<? extends Observable<? extends T>> sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, Iterable<? extends ObservableConsumable<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(int maxConcurrency, Observable<? extends T>... sources) {
+    public static <T> Observable<T> mergeDelayError(int maxConcurrency, ObservableConsumable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> mergeDelayError(Observable<? extends Observable<? extends T>> sources) {
-        return sources.flatMap((Function)Functions.identity(), true);
+    public static <T> Observable<T> mergeDelayError(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources) {
+        return new NbpOnSubscribeLift(sources, new NbpOperatorFlatMap(Functions.identity(), true, Integer.MAX_VALUE, bufferSize()));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends Observable<? extends T>> sources, int maxConcurrency) {
-        return sources.flatMap((Function)Functions.identity(), true, maxConcurrency);
+    public static <T> Observable<T> mergeDelayError(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources, int maxConcurrency) {
+        return new NbpOnSubscribeLift(sources, new NbpOperatorFlatMap(Functions.identity(), true, maxConcurrency, bufferSize()));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<T> mergeDelayError(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), true, 2);
@@ -820,7 +828,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends T> p1, Observable<? extends T> p2, Observable<? extends T> p3) {
+    public static <T> Observable<T> mergeDelayError(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, Observable<? extends T> p3) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -831,8 +839,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> mergeDelayError(
-            Observable<? extends T> p1, Observable<? extends T> p2, 
-            Observable<? extends T> p3, Observable<? extends T> p4) {
+            ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, 
+            ObservableConsumable<? extends T> p3, ObservableConsumable<? extends T> p4) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(p3, "p3 is null");
@@ -842,7 +850,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> mergeDelayError(Observable<? extends T>... sources) {
+    public static <T> Observable<T> mergeDelayError(ObservableConsumable<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, sources.length);
     }
 
@@ -884,17 +892,17 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2) {
+    public static <T> Observable<Boolean> sequenceEqual(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2) {
         return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual) {
+    public static <T> Observable<Boolean> sequenceEqual(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual) {
         return sequenceEqual(p1, p2, isEqual, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
+    public static <T> Observable<Boolean> sequenceEqual(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
         Objects.requireNonNull(p1, "p1 is null");
         Objects.requireNonNull(p2, "p2 is null");
         Objects.requireNonNull(isEqual, "isEqual is null");
@@ -903,21 +911,21 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(Observable<? extends T> p1, Observable<? extends T> p2, int bufferSize) {
+    public static <T> Observable<Boolean> sequenceEqual(ObservableConsumable<? extends T> p1, ObservableConsumable<? extends T> p2, int bufferSize) {
         return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> switchOnNext(int bufferSize, Observable<? extends Observable<? extends T>> sources) {
-        return sources.switchMap((Function)Functions.identity(), bufferSize);
+    public static <T> Observable<T> switchOnNext(int bufferSize, ObservableConsumable<? extends ObservableConsumable<? extends T>> sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        return new NbpOnSubscribeLift(sources, new NbpOperatorSwitchMap(Functions.identity(), bufferSize));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T> Observable<T> switchOnNext(Observable<? extends Observable<? extends T>> sources) {
-        return sources.switchMap((Function)Functions.identity());
+    public static <T> Observable<T> switchOnNext(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources) {
+        return switchOnNext(bufferSize(), sources);
     }
 
     @SchedulerSupport(SchedulerKind.COMPUTATION)
@@ -937,12 +945,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends Observable<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
+    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ObservableConsumable<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
         return using(resourceSupplier, sourceSupplier, disposer, true);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends Observable<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
+    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ObservableConsumable<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
         Objects.requireNonNull(disposer, "disposer is null");
@@ -956,18 +964,22 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> zip(Iterable<? extends Observable<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Observable<R> zip(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return create(new NbpOnSubscribeZip<T, R>(null, sources, zipper, bufferSize(), false));
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public static <T, R> Observable<R> zip(Observable<? extends Observable<? extends T>> sources, final Function<Object[], R> zipper) {
+    public static <T, R> Observable<R> zip(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources, final Function<Object[], R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
-        return sources.toList().flatMap(new Function<List<? extends Observable<? extends T>>, Observable<R>>() {
+        Objects.requireNonNull(sources, "sources is null");
+        // FIXME don't want to fiddle with manual type inference, this will be inlined later anyway
+        return new NbpOnSubscribeLift(sources, NbpOperatorToList.<T>defaultInstance())
+                .flatMap(new Function<List<? extends ObservableConsumable<? extends T>>, Observable<R>>() {
             @Override
-            public Observable<R> apply(List<? extends Observable<? extends T>> list) {
+            public Observable<R> apply(List<? extends ObservableConsumable<? extends T>> list) {
                 return zipIterable(zipper, false, bufferSize(), list);
             }
         });
@@ -976,7 +988,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2);
     }
@@ -984,7 +996,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize(), p1, p2);
     }
@@ -992,7 +1004,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, 
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize, p1, p2);
     }
@@ -1000,7 +1012,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3, 
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3, 
             Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3);
     }
@@ -1008,8 +1020,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3,
+            ObservableConsumable<? extends T4> p4,
             Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4);
     }
@@ -1017,8 +1029,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3,
+            ObservableConsumable<? extends T4> p4, ObservableConsumable<? extends T5> p5,
             Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5);
     }
@@ -1026,8 +1038,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3,
+            ObservableConsumable<? extends T4> p4, ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
             Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6);
     }
@@ -1035,9 +1047,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3,
+            ObservableConsumable<? extends T4> p4, ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
+            ObservableConsumable<? extends T7> p7,
             Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7);
     }
@@ -1045,9 +1057,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3,
+            ObservableConsumable<? extends T4> p4, ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
+            ObservableConsumable<? extends T7> p7, ObservableConsumable<? extends T8> p8,
             Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8);
     }
@@ -1055,16 +1067,16 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> zip(
-            Observable<? extends T1> p1, Observable<? extends T2> p2, Observable<? extends T3> p3,
-            Observable<? extends T4> p4, Observable<? extends T5> p5, Observable<? extends T6> p6,
-            Observable<? extends T7> p7, Observable<? extends T8> p8, Observable<? extends T9> p9,
+            ObservableConsumable<? extends T1> p1, ObservableConsumable<? extends T2> p2, ObservableConsumable<? extends T3> p3,
+            ObservableConsumable<? extends T4> p4, ObservableConsumable<? extends T5> p5, ObservableConsumable<? extends T6> p6,
+            ObservableConsumable<? extends T7> p7, ObservableConsumable<? extends T8> p8, ObservableConsumable<? extends T9> p9,
             Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> Observable<R> zipArray(Function<? super Object[], ? extends R> zipper, 
-            boolean delayError, int bufferSize, Observable<? extends T>... sources) {
+            boolean delayError, int bufferSize, ObservableConsumable<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
@@ -1076,7 +1088,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> Observable<R> zipIterable(Function<? super Object[], ? extends R> zipper,
             boolean delayError, int bufferSize, 
-            Iterable<? extends Observable<? extends T>> sources) {
+            Iterable<? extends ObservableConsumable<? extends T>> sources) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         validateBufferSize(bufferSize);
@@ -1092,7 +1104,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> ambWith(Observable<? extends T> other) {
+    public final Observable<T> ambWith(ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
@@ -1220,8 +1232,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     
     @SchedulerSupport(SchedulerKind.NONE)
     public final <TOpening, TClosing> Observable<List<T>> buffer(
-            Observable<? extends TOpening> bufferOpenings, 
-            Function<? super TOpening, ? extends Observable<? extends TClosing>> bufferClosingSelector) {
+            ObservableConsumable<? extends TOpening> bufferOpenings, 
+            Function<? super TOpening, ? extends ObservableConsumable<? extends TClosing>> bufferClosingSelector) {
         return buffer(bufferOpenings, bufferClosingSelector, new Supplier<List<T>>() {
             @Override
             public List<T> get() {
@@ -1232,8 +1244,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <TOpening, TClosing, U extends Collection<? super T>> Observable<U> buffer(
-            Observable<? extends TOpening> bufferOpenings, 
-            Function<? super TOpening, ? extends Observable<? extends TClosing>> bufferClosingSelector,
+            ObservableConsumable<? extends TOpening> bufferOpenings, 
+            Function<? super TOpening, ? extends ObservableConsumable<? extends TClosing>> bufferClosingSelector,
             Supplier<U> bufferSupplier) {
         Objects.requireNonNull(bufferOpenings, "bufferOpenings is null");
         Objects.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
@@ -1242,7 +1254,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<List<T>> buffer(Observable<B> boundary) {
+    public final <B> Observable<List<T>> buffer(ObservableConsumable<B> boundary) {
         /*
          * XXX: javac complains if this is not manually cast, Eclipse is fine
          */
@@ -1255,7 +1267,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<List<T>> buffer(Observable<B> boundary, final int initialCapacity) {
+    public final <B> Observable<List<T>> buffer(ObservableConsumable<B> boundary, final int initialCapacity) {
         return buffer(boundary, new Supplier<List<T>>() {
             @Override
             public List<T> get() {
@@ -1265,14 +1277,14 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(Observable<B> boundary, Supplier<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableConsumable<B> boundary, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundary, "boundary is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return lift(new NbpOperatorBufferExactBoundary<T, U, B>(boundary, bufferSupplier));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<List<T>> buffer(Supplier<? extends Observable<B>> boundarySupplier) {
+    public final <B> Observable<List<T>> buffer(Supplier<? extends ObservableConsumable<B>> boundarySupplier) {
         return buffer(boundarySupplier, new Supplier<List<T>>() {
             @Override
             public List<T> get() {
@@ -1283,7 +1295,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends Observable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends ObservableConsumable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundarySupplier, "boundarySupplier is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return lift(new NbpOperatorBufferBoundarySupplier<T, U, B>(boundarySupplier, bufferSupplier));
@@ -1328,17 +1340,17 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         }, collector);
     }
 
-    public final <R> Observable<R> compose(Function<? super Observable<T>, ? extends Observable<R>> convert) {
-        return to(convert);
+    public final <R> Observable<R> compose(Function<? super Observable<T>, ? extends ObservableConsumable<R>> convert) {
+        return create(to(convert));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends Observable<? extends R>> mapper) {
+    public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper) {
         return concatMap(mapper, 2);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends Observable<? extends R>> mapper, int prefetch) {
+    public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (prefetch <= 0) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
@@ -1368,7 +1380,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> concatWith(Observable<? extends T> other) {
+    public final Observable<T> concatWith(ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concat(this, other);
     }
@@ -1390,7 +1402,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> debounce(Function<? super T, ? extends Observable<U>> debounceSelector) {
+    public final <U> Observable<T> debounce(Function<? super T, ? extends ObservableConsumable<U>> debounceSelector) {
         Objects.requireNonNull(debounceSelector, "debounceSelector is null");
         return lift(new NbpOperatorDebounce<T, U>(debounceSelector));
     }
@@ -1416,12 +1428,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     // TODO a more efficient implementation if necessary
-    public final <U> Observable<T> delay(final Function<? super T, ? extends Observable<U>> itemDelay) {
+    public final <U> Observable<T> delay(final Function<? super T, ? extends ObservableConsumable<U>> itemDelay) {
         Objects.requireNonNull(itemDelay, "itemDelay is null");
         return flatMap(new Function<T, Observable<T>>() {
             @Override
             public Observable<T> apply(final T v) {
-                return itemDelay.apply(v).take(1).map(new Function<U, T>() {
+                return new NbpOperatorTake<U>(itemDelay.apply(v), 1).map(new Function<U, T>() {
                     @Override
                     public T apply(U u) {
                         return v;
@@ -1455,8 +1467,8 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, V> Observable<T> delay(Supplier<? extends Observable<U>> delaySupplier,
-            Function<? super T, ? extends Observable<V>> itemDelay) {
+    public final <U, V> Observable<T> delay(Supplier<? extends ObservableConsumable<U>> delaySupplier,
+            Function<? super T, ? extends ObservableConsumable<V>> itemDelay) {
         return delaySubscription(delaySupplier).delay(itemDelay);
     }
 
@@ -1479,7 +1491,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
      *         until the other Observable emits an element or completes normally.
      */
     @Experimental
-    public final <U> Observable<T> delaySubscription(Observable<U> other) {
+    public final <U> Observable<T> delaySubscription(ObservableConsumable<U> other) {
         Objects.requireNonNull(other, "other is null");
         return create(new NbpOnSubscribeDelaySubscriptionOther<T, U>(this, other));
     }
@@ -1505,11 +1517,11 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> delaySubscription(final Supplier<? extends Observable<U>> delaySupplier) {
+    public final <U> Observable<T> delaySubscription(final Supplier<? extends ObservableConsumable<U>> delaySupplier) {
         Objects.requireNonNull(delaySupplier, "delaySupplier is null");
-        return fromCallable(new Callable<Observable<U>>() {
+        return fromCallable(new Callable<ObservableConsumable<U>>() {
             @Override
-            public Observable<U> call() throws Exception {
+            public ObservableConsumable<U> call() throws Exception {
                 return delaySupplier.get();
             }
         })
@@ -1699,7 +1711,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> endWith(Observable<? extends T> other) {
+    public final Observable<T> endWith(ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(this, other);
     }
@@ -1742,22 +1754,22 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         return take(1).single(defaultValue);
     }
 
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper) {
         return flatMap(mapper, false);
     }
 
 
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, boolean delayError) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, boolean delayError) {
         return flatMap(mapper, delayError, Integer.MAX_VALUE);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, delayErrors, maxConcurrency, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, 
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, 
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (maxConcurrency <= 0) {
@@ -1773,9 +1785,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <R> Observable<R> flatMap(
-            Function<? super T, ? extends Observable<? extends R>> onNextMapper, 
-            Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper, 
-            Supplier<? extends Observable<? extends R>> onCompleteSupplier) {
+            Function<? super T, ? extends ObservableConsumable<? extends R>> onNextMapper, 
+            Function<? super Throwable, ? extends ObservableConsumable<? extends R>> onErrorMapper, 
+            Supplier<? extends ObservableConsumable<? extends R>> onCompleteSupplier) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
@@ -1784,9 +1796,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <R> Observable<R> flatMap(
-            Function<? super T, ? extends Observable<? extends R>> onNextMapper, 
-            Function<Throwable, ? extends Observable<? extends R>> onErrorMapper, 
-            Supplier<? extends Observable<? extends R>> onCompleteSupplier, 
+            Function<? super T, ? extends ObservableConsumable<? extends R>> onNextMapper, 
+            Function<Throwable, ? extends ObservableConsumable<? extends R>> onErrorMapper, 
+            Supplier<? extends ObservableConsumable<? extends R>> onCompleteSupplier, 
             int maxConcurrency) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
@@ -1795,27 +1807,27 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends R>> mapper, int maxConcurrency) {
+    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, int maxConcurrency) {
         return flatMap(mapper, false, maxConcurrency, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> resultSelector) {
         return flatMap(mapper, resultSelector, false, bufferSize(), bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError) {
         return flatMap(mapper, combiner, delayError, bufferSize(), bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency) {
         return flatMap(mapper, combiner, delayError, maxConcurrency, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends Observable<? extends U>> mapper, final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
+    public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(combiner, "combiner is null");
         return flatMap(new Function<T, Observable<R>>() {
@@ -1834,7 +1846,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Observable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
+    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
         return flatMap(mapper, combiner, false, maxConcurrency, bufferSize());
     }
 
@@ -2026,7 +2038,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> mergeWith(Observable<? extends T> other) {
+    public final Observable<T> mergeWith(ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
@@ -2051,7 +2063,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     public final Observable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         validateBufferSize(bufferSize);
-        return lift(new NbpOperatorObserveOn<T>(scheduler, delayError, bufferSize));
+        return new NbpOperatorObserveOn<T>(this, scheduler, delayError, bufferSize);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
@@ -2066,17 +2078,17 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends Observable<? extends T>> resumeFunction) {
+    public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends ObservableConsumable<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
         return lift(new NbpOperatorOnErrorNext<T>(resumeFunction, false));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> onErrorResumeNext(final Observable<? extends T> next) {
+    public final Observable<T> onErrorResumeNext(final ObservableConsumable<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
-        return onErrorResumeNext(new Function<Throwable, Observable<? extends T>>() {
+        return onErrorResumeNext(new Function<Throwable, ObservableConsumable<? extends T>>() {
             @Override
-            public Observable<? extends T> apply(Throwable e) {
+            public ObservableConsumable<? extends T> apply(Throwable e) {
                 return next;
             }
         });
@@ -2101,11 +2113,11 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> onExceptionResumeNext(final Observable<? extends T> next) {
+    public final Observable<T> onExceptionResumeNext(final ObservableConsumable<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
-        return lift(new NbpOperatorOnErrorNext<T>(new Function<Throwable, Observable<? extends T>>() {
+        return lift(new NbpOperatorOnErrorNext<T>(new Function<Throwable, ObservableConsumable<? extends T>>() {
             @Override
-            public Observable<? extends T> apply(Throwable e) {
+            public ObservableConsumable<? extends T> apply(Throwable e) {
                 return next;
             }
         }, true));
@@ -2117,12 +2129,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends Observable<R>> selector) {
+    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector) {
         return publish(selector, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends Observable<R>> selector, int bufferSize) {
+    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, int bufferSize) {
         validateBufferSize(bufferSize);
         Objects.requireNonNull(selector, "selector is null");
         return NbpOperatorPublish.create(this, selector, bufferSize);
@@ -2173,12 +2185,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends Observable<?>> handler) {
+    public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends ObservableConsumable<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
         
-        Function<Observable<Try<Optional<Object>>>, Observable<?>> f = new Function<Observable<Try<Optional<Object>>>, Observable<?>>() {
+        Function<Observable<Try<Optional<Object>>>, ObservableConsumable<?>> f = new Function<Observable<Try<Optional<Object>>>, ObservableConsumable<?>>() {
             @Override
-            public Observable<?> apply(Observable<Try<Optional<Object>>> no) {
+            public ObservableConsumable<?> apply(Observable<Try<Optional<Object>>> no) {
                 return handler.apply(no.map(new Function<Try<Optional<Object>>, Object>() {
                     @Override
                     public Object apply(Try<Optional<Object>> v) {
@@ -2198,7 +2210,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
             @Override
@@ -2209,7 +2221,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, final int bufferSize) {
         Objects.requireNonNull(selector, "selector is null");
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
             @Override
@@ -2220,12 +2232,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.COMPUTATION)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, int bufferSize, long time, TimeUnit unit) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, int bufferSize, long time, TimeUnit unit) {
         return replay(selector, bufferSize, time, unit, Schedulers.computation());
     }
     
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
@@ -2239,7 +2251,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, final int bufferSize, final Scheduler scheduler) {
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
             @Override
             public ConnectableObservable<T> get() {
@@ -2249,18 +2261,18 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         new Function<Observable<T>, Observable<R>>() {
             @Override
             public Observable<R> apply(Observable<T> t) {
-                return selector.apply(t).observeOn(scheduler);
+                return new NbpOperatorObserveOn<R>(selector.apply(t), scheduler, false, bufferSize());
             }
         });
     }
 
     @SchedulerSupport(SchedulerKind.COMPUTATION)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, long time, TimeUnit unit) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, long time, TimeUnit unit) {
         return replay(selector, time, unit, Schedulers.computation());
     }
     
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Observable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -2273,7 +2285,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends Observable<R>> selector, final Scheduler scheduler) {
+    public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, final Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.multicastSelector(new Supplier<ConnectableObservable<T>>() {
@@ -2285,7 +2297,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         new Function<Observable<T>, Observable<R>>() {
             @Override
             public Observable<R> apply(Observable<T> t) {
-                return selector.apply(t).observeOn(scheduler);
+                return new NbpOperatorObserveOn<R>(selector.apply(t), scheduler, false, bufferSize());
             }
         });
     }
@@ -2379,12 +2391,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> retryWhen(
-            final Function<? super Observable<? extends Throwable>, ? extends Observable<?>> handler) {
+            final Function<? super Observable<? extends Throwable>, ? extends ObservableConsumable<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
         
-        Function<Observable<Try<Optional<Object>>>, Observable<?>> f = new Function<Observable<Try<Optional<Object>>>, Observable<?>>() {
+        Function<Observable<Try<Optional<Object>>>, ObservableConsumable<?>> f = new Function<Observable<Try<Optional<Object>>>, ObservableConsumable<?>>() {
             @Override
-            public Observable<?> apply(Observable<Try<Optional<Object>>> no) {
+            public ObservableConsumable<?> apply(Observable<Try<Optional<Object>>> no) {
                 return handler.apply(no
                         .takeWhile(new Predicate<Try<Optional<Object>>>() {
                             @Override
@@ -2430,7 +2442,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> sample(Observable<U> sampler) {
+    public final <U> Observable<T> sample(ObservableConsumable<U> sampler) {
         Objects.requireNonNull(sampler, "sampler is null");
         return lift(new NbpOperatorSampleWithObservable<T>(sampler));
     }
@@ -2546,7 +2558,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> skipUntil(Observable<U> other) {
+    public final <U> Observable<T> skipUntil(ObservableConsumable<U> other) {
         Objects.requireNonNull(other, "other is null");
         return lift(new NbpOperatorSkipUntil<T, U>(other));
     }
@@ -2565,7 +2577,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> startWith(Observable<? extends T> other) {
+    public final Observable<T> startWith(ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
@@ -2641,18 +2653,18 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final Observable<T> switchIfEmpty(Observable<? extends T> other) {
+    public final Observable<T> switchIfEmpty(ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return lift(new NbpOperatorSwitchIfEmpty<T>(other));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> switchMap(Function<? super T, ? extends Observable<? extends R>> mapper) {
+    public final <R> Observable<R> switchMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper) {
         return switchMap(mapper, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <R> Observable<R> switchMap(Function<? super T, ? extends Observable<? extends R>> mapper, int bufferSize) {
+    public final <R> Observable<R> switchMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         validateBufferSize(bufferSize);
         return lift(new NbpOperatorSwitchMap<T, R>(mapper, bufferSize));
@@ -2668,7 +2680,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 //            return lift(s -> CancelledSubscriber.INSTANCE);
             return empty(); 
         }
-        return lift(new NbpOperatorTake<T>(n));
+        return new NbpOperatorTake<T>(this, n);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
@@ -2768,7 +2780,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U> Observable<T> takeUntil(Observable<U> other) {
+    public final <U> Observable<T> takeUntil(ObservableConsumable<U> other) {
         Objects.requireNonNull(other, "other is null");
         return lift(new NbpOperatorTakeUntil<T, U>(other));
     }
@@ -2840,12 +2852,12 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends Observable<V>> timeoutSelector) {
+    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector) {
         return timeout0(null, timeoutSelector, null);
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends Observable<V>> timeoutSelector, Observable<? extends T> other) {
+    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector, ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(null, timeoutSelector, other);
     }
@@ -2856,13 +2868,13 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.COMPUTATION)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Observable<? extends T> other) {
+    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, Schedulers.computation());
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Observable<? extends T> other, Scheduler scheduler) {
+    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ObservableConsumable<? extends T> other, Scheduler scheduler) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
@@ -2872,23 +2884,23 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         return timeout0(timeout, timeUnit, null, scheduler);
     }
     
-    public final <U, V> Observable<T> timeout(Supplier<? extends Observable<U>> firstTimeoutSelector, 
-            Function<? super T, ? extends Observable<V>> timeoutSelector) {
+    public final <U, V> Observable<T> timeout(Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector, 
+            Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector) {
         Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, null);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<T> timeout(
-            Supplier<? extends Observable<U>> firstTimeoutSelector, 
-            Function<? super T, ? extends Observable<V>> timeoutSelector, 
-                    Observable<? extends T> other) {
+            Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector, 
+            Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector, 
+                    ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
         Objects.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, other);
     }
     
-    private Observable<T> timeout0(long timeout, TimeUnit timeUnit, Observable<? extends T> other, 
+    private Observable<T> timeout0(long timeout, TimeUnit timeUnit, ObservableConsumable<? extends T> other, 
             Scheduler scheduler) {
         Objects.requireNonNull(timeUnit, "timeUnit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -2896,9 +2908,9 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     private <U, V> Observable<T> timeout0(
-            Supplier<? extends Observable<U>> firstTimeoutSelector, 
-            Function<? super T, ? extends Observable<V>> timeoutSelector, 
-                    Observable<? extends T> other) {
+            Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector, 
+            Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector, 
+                    ObservableConsumable<? extends T> other) {
         Objects.requireNonNull(timeoutSelector, "timeoutSelector is null");
         return lift(new NbpOperatorTimeout<T, U, V>(firstTimeoutSelector, timeoutSelector, other));
     }
@@ -3320,45 +3332,45 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Observable<B> boundary) {
+    public final <B> Observable<Observable<T>> window(ObservableConsumable<B> boundary) {
         return window(boundary, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Observable<B> boundary, int bufferSize) {
+    public final <B> Observable<Observable<T>> window(ObservableConsumable<B> boundary, int bufferSize) {
         Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundary<T, B>(boundary, bufferSize));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<Observable<T>> window(
-            Observable<U> windowOpen, 
-            Function<? super U, ? extends Observable<V>> windowClose) {
+            ObservableConsumable<U> windowOpen, 
+            Function<? super U, ? extends ObservableConsumable<V>> windowClose) {
         return window(windowOpen, windowClose, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<Observable<T>> window(
-            Observable<U> windowOpen, 
-            Function<? super U, ? extends Observable<V>> windowClose, int bufferSize) {
+            ObservableConsumable<U> windowOpen, 
+            Function<? super U, ? extends ObservableConsumable<V>> windowClose, int bufferSize) {
         Objects.requireNonNull(windowOpen, "windowOpen is null");
         Objects.requireNonNull(windowClose, "windowClose is null");
         return lift(new NbpOperatorWindowBoundarySelector<T, U, V>(windowOpen, windowClose, bufferSize));
     }
     
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Supplier<? extends Observable<B>> boundary) {
+    public final <B> Observable<Observable<T>> window(Supplier<? extends ObservableConsumable<B>> boundary) {
         return window(boundary, bufferSize());
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <B> Observable<Observable<T>> window(Supplier<? extends Observable<B>> boundary, int bufferSize) {
+    public final <B> Observable<Observable<T>> window(Supplier<? extends ObservableConsumable<B>> boundary, int bufferSize) {
         Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundarySupplier<T, B>(boundary, bufferSize));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> withLatestFrom(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
+    public final <U, R> Observable<R> withLatestFrom(ObservableConsumable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(combiner, "combiner is null");
 
@@ -3373,18 +3385,18 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> zipWith(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+    public final <U, R> Observable<R> zipWith(ObservableConsumable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> zipWith(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
+    public final <U, R> Observable<R> zipWith(ObservableConsumable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
         return zip(this, other, zipper, delayError);
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
-    public final <U, R> Observable<R> zipWith(Observable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
+    public final <U, R> Observable<R> zipWith(ObservableConsumable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zip(this, other, zipper, delayError, bufferSize);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpObservableScalarSource.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpObservableScalarSource.java
@@ -38,11 +38,11 @@ public final class NbpObservableScalarSource<T> extends Observable<T> {
         return value;
     }
     
-    public <U> ObservableConsumable<U> scalarFlatMap(final Function<? super T, ? extends Observable<? extends U>> mapper) {
+    public <U> ObservableConsumable<U> scalarFlatMap(final Function<? super T, ? extends ObservableConsumable<? extends U>> mapper) {
         return new ObservableConsumable<U>() {
             @Override
             public void subscribe(Observer<? super U> s) {
-                Observable<? extends U> other;
+                ObservableConsumable<? extends U> other;
                 try {
                     other = mapper.apply(value);
                 } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeAmb.java
@@ -22,10 +22,10 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeAmb<T> implements ObservableConsumable<T> {
-    final Observable<? extends T>[] sources;
-    final Iterable<? extends Observable<? extends T>> sourcesIterable;
+    final ObservableConsumable<? extends T>[] sources;
+    final Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable;
     
-    public NbpOnSubscribeAmb(Observable<? extends T>[] sources, Iterable<? extends Observable<? extends T>> sourcesIterable) {
+    public NbpOnSubscribeAmb(ObservableConsumable<? extends T>[] sources, Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable) {
         this.sources = sources;
         this.sourcesIterable = sourcesIterable;
     }
@@ -33,11 +33,11 @@ public final class NbpOnSubscribeAmb<T> implements ObservableConsumable<T> {
     @Override
     @SuppressWarnings("unchecked")
     public void subscribe(Observer<? super T> s) {
-        Observable<? extends T>[] sources = this.sources;
+        ObservableConsumable<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
             sources = new Observable[8];
-            for (Observable<? extends T> p : sourcesIterable) {
+            for (ObservableConsumable<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
                     Observable<? extends T>[] b = new Observable[count + (count >> 2)];
                     System.arraycopy(sources, 0, b, 0, count);
@@ -74,7 +74,7 @@ public final class NbpOnSubscribeAmb<T> implements ObservableConsumable<T> {
             this.subscribers = new AmbInnerSubscriber[count];
         }
         
-        public void subscribe(Observable<? extends T>[] sources) {
+        public void subscribe(ObservableConsumable<? extends T>[] sources) {
             AmbInnerSubscriber<T>[] as = subscribers;
             int len = as.length;
             for (int i = 0; i < len; i++) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeCombineLatest.java
@@ -28,14 +28,14 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeCombineLatest<T, R> implements ObservableConsumable<R> {
-    final Observable<? extends T>[] sources;
-    final Iterable<? extends Observable<? extends T>> sourcesIterable;
+    final ObservableConsumable<? extends T>[] sources;
+    final Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable;
     final Function<? super Object[], ? extends R> combiner;
     final int bufferSize;
     final boolean delayError;
     
-    public NbpOnSubscribeCombineLatest(Observable<? extends T>[] sources,
-            Iterable<? extends Observable<? extends T>> sourcesIterable,
+    public NbpOnSubscribeCombineLatest(ObservableConsumable<? extends T>[] sources,
+            Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable,
             Function<? super Object[], ? extends R> combiner, int bufferSize,
             boolean delayError) {
         this.sources = sources;
@@ -49,11 +49,11 @@ public final class NbpOnSubscribeCombineLatest<T, R> implements ObservableConsum
     @Override
     @SuppressWarnings("unchecked")
     public void subscribe(Observer<? super R> s) {
-        Observable<? extends T>[] sources = this.sources;
+        ObservableConsumable<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
             sources = new Observable[8];
-            for (Observable<? extends T> p : sourcesIterable) {
+            for (ObservableConsumable<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
                     Observable<? extends T>[] b = new Observable[count + (count >> 2)];
                     System.arraycopy(sources, 0, b, 0, count);
@@ -109,7 +109,7 @@ public final class NbpOnSubscribeCombineLatest<T, R> implements ObservableConsum
             this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
         }
         
-        public void subscribe(Observable<? extends T>[] sources) {
+        public void subscribe(ObservableConsumable<? extends T>[] sources) {
             Observer<T>[] as = subscribers;
             int len = as.length;
             for (int i = 0; i < len; i++) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDefer.java
@@ -18,13 +18,13 @@ import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class NbpOnSubscribeDefer<T> implements ObservableConsumable<T> {
-    final Supplier<? extends Observable<? extends T>> supplier;
-    public NbpOnSubscribeDefer(Supplier<? extends Observable<? extends T>> supplier) {
+    final Supplier<? extends ObservableConsumable<? extends T>> supplier;
+    public NbpOnSubscribeDefer(Supplier<? extends ObservableConsumable<? extends T>> supplier) {
         this.supplier = supplier;
     }
     @Override
     public void subscribe(Observer<? super T> s) {
-        Observable<? extends T> pub;
+        ObservableConsumable<? extends T> pub;
         try {
             pub = supplier.get();
         } catch (Throwable t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeDelaySubscriptionOther.java
@@ -24,10 +24,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <U> the other value type, ignored
  */
 public final class NbpOnSubscribeDelaySubscriptionOther<T, U> implements ObservableConsumable<T> {
-    final Observable<? extends T> main;
-    final Observable<U> other;
+    final ObservableConsumable<? extends T> main;
+    final ObservableConsumable<U> other;
     
-    public NbpOnSubscribeDelaySubscriptionOther(Observable<? extends T> main, Observable<U> other) {
+    public NbpOnSubscribeDelaySubscriptionOther(ObservableConsumable<? extends T> main, ObservableConsumable<U> other) {
         this.main = main;
         this.other = other;
     }
@@ -66,7 +66,7 @@ public final class NbpOnSubscribeDelaySubscriptionOther<T, U> implements Observa
                 }
                 done = true;
                 
-                main.unsafeSubscribe(new Observer<T>() {
+                main.subscribe(new Observer<T>() {
                     @Override
                     public void onSubscribe(Disposable d) {
                         serial.set(d);
@@ -90,6 +90,6 @@ public final class NbpOnSubscribeDelaySubscriptionOther<T, U> implements Observa
             }
         };
         
-        other.unsafeSubscribe(otherSubscriber);
+        other.subscribe(otherSubscriber);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeLift.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeLift.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.Observable.NbpOperator;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -26,13 +25,13 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <T> the upstream value type
  * @param <R> the downstream parameter type
  */
-public final class NbpOnSubscribeLift<R, T> implements ObservableConsumable<R> {
+public final class NbpOnSubscribeLift<R, T> extends Observable<R> {
     /** The actual operator. */
     final NbpOperator<? extends R, ? super T> operator;
     /** The source publisher. */
-    final Observable<? extends T> source;
+    final ObservableConsumable<? extends T> source;
     
-    public NbpOnSubscribeLift(Observable<? extends T> source, NbpOperator<? extends R, ? super T> operator) {
+    public NbpOnSubscribeLift(ObservableConsumable<? extends T> source, NbpOperator<? extends R, ? super T> operator) {
         this.source = source;
         this.operator = operator;
     }
@@ -49,12 +48,12 @@ public final class NbpOnSubscribeLift<R, T> implements ObservableConsumable<R> {
      * Returns the source of this lift publisher.
      * @return the source of this lift publisher
      */
-    public Observable<? extends T> source() {
+    public ObservableConsumable<? extends T> source() {
         return source;
     }
     
     @Override
-    public void subscribe(Observer<? super R> s) {
+    public void subscribeActual(Observer<? super R> s) {
         try {
             if (s == null) {
                 throw new NullPointerException("Operator " + operator + " received a null Subscriber");

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeRedo.java
@@ -22,11 +22,11 @@ import io.reactivex.internal.subscribers.observable.NbpToNotificationSubscriber;
 import io.reactivex.subjects.BehaviorSubject;
 
 public final class NbpOnSubscribeRedo<T> implements ObservableConsumable<T> {
-    final Observable<? extends T> source;
-    final Function<? super Observable<Try<Optional<Object>>>, ? extends Observable<?>> manager;
+    final ObservableConsumable<? extends T> source;
+    final Function<? super Observable<Try<Optional<Object>>>, ? extends ObservableConsumable<?>> manager;
 
-    public NbpOnSubscribeRedo(Observable<? extends T> source,
-            Function<? super Observable<Try<Optional<Object>>>, ? extends Observable<?>> manager) {
+    public NbpOnSubscribeRedo(ObservableConsumable<? extends T> source,
+            Function<? super Observable<Try<Optional<Object>>>, ? extends ObservableConsumable<?>> manager) {
         this.source = source;
         this.manager = manager;
     }
@@ -41,7 +41,7 @@ public final class NbpOnSubscribeRedo<T> implements ObservableConsumable<T> {
 
         s.onSubscribe(parent.arbiter);
 
-        Observable<?> action = manager.apply(subject);
+        ObservableConsumable<?> action = manager.apply(subject);
         
         action.subscribe(new NbpToNotificationSubscriber<Object>(new Consumer<Try<Optional<Object>>>() {
             @Override
@@ -59,12 +59,12 @@ public final class NbpOnSubscribeRedo<T> implements ObservableConsumable<T> {
         private static final long serialVersionUID = -1151903143112844287L;
         final Observer<? super T> actual;
         final BehaviorSubject<Try<Optional<Object>>> subject;
-        final Observable<? extends T> source;
+        final ObservableConsumable<? extends T> source;
         final MultipleAssignmentDisposable arbiter;
         
         final AtomicInteger wip = new AtomicInteger();
         
-        public RedoSubscriber(Observer<? super T> actual, BehaviorSubject<Try<Optional<Object>>> subject, Observable<? extends T> source) {
+        public RedoSubscriber(Observer<? super T> actual, BehaviorSubject<Try<Optional<Object>>> subject, ObservableConsumable<? extends T> source) {
             this.actual = actual;
             this.subject = subject;
             this.source = source;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeSequenceEqual.java
@@ -23,12 +23,12 @@ import io.reactivex.internal.disposables.ArrayCompositeResource;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 
 public final class NbpOnSubscribeSequenceEqual<T> implements ObservableConsumable<Boolean> {
-    final Observable<? extends T> first;
-    final Observable<? extends T> second;
+    final ObservableConsumable<? extends T> first;
+    final ObservableConsumable<? extends T> second;
     final BiPredicate<? super T, ? super T> comparer;
     final int bufferSize;
     
-    public NbpOnSubscribeSequenceEqual(Observable<? extends T> first, Observable<? extends T> second,
+    public NbpOnSubscribeSequenceEqual(ObservableConsumable<? extends T> first, ObservableConsumable<? extends T> second,
             BiPredicate<? super T, ? super T> comparer, int bufferSize) {
         this.first = first;
         this.second = second;
@@ -48,14 +48,14 @@ public final class NbpOnSubscribeSequenceEqual<T> implements ObservableConsumabl
         final Observer<? super Boolean> actual;
         final BiPredicate<? super T, ? super T> comparer;
         final ArrayCompositeResource<Disposable> resources;
-        final Observable<? extends T> first;
-        final Observable<? extends T> second;
+        final ObservableConsumable<? extends T> first;
+        final ObservableConsumable<? extends T> second;
         final EqualSubscriber<T>[] subscribers;
         
         volatile boolean cancelled;
         
         public EqualCoordinator(Observer<? super Boolean> actual, int bufferSize,
-                Observable<? extends T> first, Observable<? extends T> second,
+                ObservableConsumable<? extends T> first, ObservableConsumable<? extends T> second,
                 BiPredicate<? super T, ? super T> comparer) {
             this.actual = actual;
             this.first = first;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeUsing.java
@@ -25,12 +25,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeUsing<T, D> implements ObservableConsumable<T> {
     final Supplier<? extends D> resourceSupplier;
-    final Function<? super D, ? extends Observable<? extends T>> sourceSupplier;
+    final Function<? super D, ? extends ObservableConsumable<? extends T>> sourceSupplier;
     final Consumer<? super D> disposer;
     final boolean eager;
     
     public NbpOnSubscribeUsing(Supplier<? extends D> resourceSupplier,
-            Function<? super D, ? extends Observable<? extends T>> sourceSupplier, 
+            Function<? super D, ? extends ObservableConsumable<? extends T>> sourceSupplier, 
             Consumer<? super D> disposer,
             boolean eager) {
         this.resourceSupplier = resourceSupplier;
@@ -50,7 +50,7 @@ public final class NbpOnSubscribeUsing<T, D> implements ObservableConsumable<T> 
             return;
         }
         
-        Observable<? extends T> source;
+        ObservableConsumable<? extends T> source;
         try {
             source = sourceSupplier.apply(resource);
         } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOnSubscribeZip.java
@@ -25,14 +25,14 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOnSubscribeZip<T, R> implements ObservableConsumable<R> {
     
-    final Observable<? extends T>[] sources;
-    final Iterable<? extends Observable<? extends T>> sourcesIterable;
+    final ObservableConsumable<? extends T>[] sources;
+    final Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable;
     final Function<? super Object[], ? extends R> zipper;
     final int bufferSize;
     final boolean delayError;
     
-    public NbpOnSubscribeZip(Observable<? extends T>[] sources,
-            Iterable<? extends Observable<? extends T>> sourcesIterable,
+    public NbpOnSubscribeZip(ObservableConsumable<? extends T>[] sources,
+            Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable,
             Function<? super Object[], ? extends R> zipper,
             int bufferSize,
             boolean delayError) {
@@ -46,11 +46,11 @@ public final class NbpOnSubscribeZip<T, R> implements ObservableConsumable<R> {
     @Override
     @SuppressWarnings("unchecked")
     public void subscribe(Observer<? super R> s) {
-        Observable<? extends T>[] sources = this.sources;
+        ObservableConsumable<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
             sources = new Observable[8];
-            for (Observable<? extends T> p : sourcesIterable) {
+            for (ObservableConsumable<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
                     Observable<? extends T>[] b = new Observable[count + (count >> 2)];
                     System.arraycopy(sources, 0, b, 0, count);
@@ -93,7 +93,7 @@ public final class NbpOnSubscribeZip<T, R> implements ObservableConsumable<R> {
             this.delayError = delayError;
         }
         
-        public void subscribe(Observable<? extends T>[] sources, int bufferSize) {
+        public void subscribe(ObservableConsumable<? extends T>[] sources, int bufferSize) {
             ZipSubscriber<T, R>[] s = subscribers;
             int len = s.length;
             for (int i = 0; i < len; i++) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundary.java
@@ -16,8 +16,8 @@ package io.reactivex.internal.operators.observable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Observable;
 import io.reactivex.Observable.NbpOperator;
+import io.reactivex.ObservableConsumable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
@@ -31,11 +31,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>, Open, Close> implements NbpOperator<U, T> {
     final Supplier<U> bufferSupplier;
-    final Observable<? extends Open> bufferOpen;
-    final Function<? super Open, ? extends Observable<? extends Close>> bufferClose;
+    final ObservableConsumable<? extends Open> bufferOpen;
+    final Function<? super Open, ? extends ObservableConsumable<? extends Close>> bufferClose;
 
-    public NbpOperatorBufferBoundary(Observable<? extends Open> bufferOpen,
-            Function<? super Open, ? extends Observable<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
+    public NbpOperatorBufferBoundary(ObservableConsumable<? extends Open> bufferOpen,
+            Function<? super Open, ? extends ObservableConsumable<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
         this.bufferOpen = bufferOpen;
         this.bufferClose = bufferClose;
         this.bufferSupplier = bufferSupplier;
@@ -51,8 +51,8 @@ public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>,
     
     static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, Open, Close>
     extends NbpQueueDrainSubscriber<T, U, U> implements Disposable {
-        final Observable<? extends Open> bufferOpen;
-        final Function<? super Open, ? extends Observable<? extends Close>> bufferClose;
+        final ObservableConsumable<? extends Open> bufferOpen;
+        final Function<? super Open, ? extends ObservableConsumable<? extends Close>> bufferClose;
         final Supplier<U> bufferSupplier;
         final SetCompositeResource<Disposable> resources;
         
@@ -63,8 +63,8 @@ public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>,
         final AtomicInteger windows = new AtomicInteger();
 
         public BufferBoundarySubscriber(Observer<? super U> actual, 
-                Observable<? extends Open> bufferOpen,
-                Function<? super Open, ? extends Observable<? extends Close>> bufferClose,
+                ObservableConsumable<? extends Open> bufferOpen,
+                Function<? super Open, ? extends ObservableConsumable<? extends Close>> bufferClose,
                 Supplier<U> bufferSupplier) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferOpen = bufferOpen;
@@ -164,7 +164,7 @@ public final class NbpOperatorBufferBoundary<T, U extends Collection<? super T>,
                 return;
             }
 
-            Observable<? extends Close> p;
+            ObservableConsumable<? extends Close> p;
             
             try {
                 p = bufferClose.apply(window);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferBoundarySupplier.java
@@ -29,10 +29,10 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? super T>, B> implements NbpOperator<U, T> {
-    final Supplier<? extends Observable<B>> boundarySupplier;
+    final Supplier<? extends ObservableConsumable<B>> boundarySupplier;
     final Supplier<U> bufferSupplier;
     
-    public NbpOperatorBufferBoundarySupplier(Supplier<? extends Observable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
+    public NbpOperatorBufferBoundarySupplier(Supplier<? extends ObservableConsumable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         this.boundarySupplier = boundarySupplier;
         this.bufferSupplier = bufferSupplier;
     }
@@ -46,7 +46,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
     extends NbpQueueDrainSubscriber<T, U, U> implements Observer<T>, Disposable {
         /** */
         final Supplier<U> bufferSupplier;
-        final Supplier<? extends Observable<B>> boundarySupplier;
+        final Supplier<? extends ObservableConsumable<B>> boundarySupplier;
         
         Disposable s;
         
@@ -60,7 +60,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
         U buffer;
         
         public BufferBondarySupplierSubscriber(Observer<? super U> actual, Supplier<U> bufferSupplier,
-                Supplier<? extends Observable<B>> boundarySupplier) {
+                Supplier<? extends ObservableConsumable<B>> boundarySupplier) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
             this.boundarySupplier = boundarySupplier;
@@ -94,7 +94,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
             }
             buffer = b;
             
-            Observable<B> boundary;
+            ObservableConsumable<B> boundary;
             
             try {
                 boundary = boundarySupplier.get();
@@ -199,7 +199,7 @@ public final class NbpOperatorBufferBoundarySupplier<T, U extends Collection<? s
                 return;
             }
             
-            Observable<B> boundary;
+            ObservableConsumable<B> boundary;
             
             try {
                 boundary = boundarySupplier.get();

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorBufferExactBoundary.java
@@ -27,10 +27,10 @@ import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorBufferExactBoundary<T, U extends Collection<? super T>, B> implements NbpOperator<U, T> {
-    final Observable<B> boundary;
+    final ObservableConsumable<B> boundary;
     final Supplier<U> bufferSupplier;
     
-    public NbpOperatorBufferExactBoundary(Observable<B> boundary, Supplier<U> bufferSupplier) {
+    public NbpOperatorBufferExactBoundary(ObservableConsumable<B> boundary, Supplier<U> bufferSupplier) {
         this.boundary = boundary;
         this.bufferSupplier = bufferSupplier;
     }
@@ -44,7 +44,7 @@ public final class NbpOperatorBufferExactBoundary<T, U extends Collection<? supe
     extends NbpQueueDrainSubscriber<T, U, U> implements Observer<T>, Disposable {
         /** */
         final Supplier<U> bufferSupplier;
-        final Observable<B> boundary;
+        final ObservableConsumable<B> boundary;
         
         Disposable s;
         
@@ -53,7 +53,7 @@ public final class NbpOperatorBufferExactBoundary<T, U extends Collection<? supe
         U buffer;
         
         public BufferExactBondarySubscriber(Observer<? super U> actual, Supplier<U> bufferSupplier,
-                Observable<B> boundary) {
+                ObservableConsumable<B> boundary) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
             this.boundary = boundary;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorConcatMap.java
@@ -25,9 +25,9 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
-    final Function<? super T, ? extends Observable<? extends U>> mapper;
+    final Function<? super T, ? extends ObservableConsumable<? extends U>> mapper;
     final int bufferSize;
-    public NbpOperatorConcatMap(Function<? super T, ? extends Observable<? extends U>> mapper, int bufferSize) {
+    public NbpOperatorConcatMap(Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, int bufferSize) {
         this.mapper = mapper;
         this.bufferSize = Math.max(8, bufferSize);
     }
@@ -44,7 +44,7 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
         private static final long serialVersionUID = 8828587559905699186L;
         final Observer<? super U> actual;
         final SerialDisposable sa;
-        final Function<? super T, ? extends Observable<? extends U>> mapper;
+        final Function<? super T, ? extends ObservableConsumable<? extends U>> mapper;
         final Observer<U> inner;
         final Queue<T> queue;
         final int bufferSize;
@@ -56,7 +56,7 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
         volatile long index;
         
         public SourceSubscriber(Observer<? super U> actual, SerialDisposable sa,
-                Function<? super T, ? extends Observable<? extends U>> mapper, int bufferSize) {
+                Function<? super T, ? extends ObservableConsumable<? extends U>> mapper, int bufferSize) {
             this.actual = actual;
             this.sa = sa;
             this.mapper = mapper;
@@ -129,7 +129,7 @@ public final class NbpOperatorConcatMap<T, U> implements NbpOperator<U, T> {
                 RxJavaPlugins.onError(new IllegalStateException("Queue is empty?!"));
                 return;
             }
-            Observable<? extends U> p;
+            ObservableConsumable<? extends U> p;
             try {
                 p = mapper.apply(o);
             } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorDebounce.java
@@ -25,9 +25,9 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
-    final Function<? super T, ? extends Observable<U>> debounceSelector;
+    final Function<? super T, ? extends ObservableConsumable<U>> debounceSelector;
 
-    public NbpOperatorDebounce(Function<? super T, ? extends Observable<U>> debounceSelector) {
+    public NbpOperatorDebounce(Function<? super T, ? extends ObservableConsumable<U>> debounceSelector) {
         this.debounceSelector = debounceSelector;
     }
     
@@ -39,7 +39,7 @@ public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
     static final class DebounceSubscriber<T, U> 
     implements Observer<T>, Disposable {
         final Observer<? super T> actual;
-        final Function<? super T, ? extends Observable<U>> debounceSelector;
+        final Function<? super T, ? extends ObservableConsumable<U>> debounceSelector;
         
         volatile boolean gate;
 
@@ -57,7 +57,7 @@ public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
         boolean done;
 
         public DebounceSubscriber(Observer<? super T> actual,
-                Function<? super T, ? extends Observable<U>> debounceSelector) {
+                Function<? super T, ? extends ObservableConsumable<U>> debounceSelector) {
             this.actual = actual;
             this.debounceSelector = debounceSelector;
         }
@@ -86,7 +86,7 @@ public final class NbpOperatorDebounce<T, U> implements NbpOperator<T, T> {
                 d.dispose();
             }
             
-            Observable<U> p;
+            ObservableConsumable<U> p;
             
             try {
                 p = debounceSelector.apply(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorFlatMap.java
@@ -16,8 +16,8 @@ package io.reactivex.internal.operators.observable;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.Observable;
 import io.reactivex.Observable.NbpOperator;
+import io.reactivex.ObservableConsumable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
@@ -27,13 +27,13 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.Pow2;
 
 public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
-    final Function<? super T, ? extends Observable<? extends U>> mapper;
+    final Function<? super T, ? extends ObservableConsumable<? extends U>> mapper;
     final boolean delayErrors;
     final int maxConcurrency;
     final int bufferSize;
     
     public NbpOperatorFlatMap( 
-            Function<? super T, ? extends Observable<? extends U>> mapper,
+            Function<? super T, ? extends ObservableConsumable<? extends U>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         this.mapper = mapper;
         this.delayErrors = delayErrors;
@@ -51,7 +51,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
         private static final long serialVersionUID = -2117620485640801370L;
         
         final Observer<? super U> actual;
-        final Function<? super T, ? extends Observable<? extends U>> mapper;
+        final Function<? super T, ? extends ObservableConsumable<? extends U>> mapper;
         final boolean delayErrors;
         final int maxConcurrency;
         final int bufferSize;
@@ -78,11 +78,11 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
         long lastId;
         int lastIndex;
         
-        Queue<Observable<? extends U>> sources;
+        Queue<ObservableConsumable<? extends U>> sources;
         
         int wip;
         
-        public MergeSubscriber(Observer<? super U> actual, Function<? super T, ? extends Observable<? extends U>> mapper,
+        public MergeSubscriber(Observer<? super U> actual, Function<? super T, ? extends ObservableConsumable<? extends U>> mapper,
                 boolean delayErrors, int maxConcurrency, int bufferSize) {
             this.actual = actual;
             this.mapper = mapper;
@@ -90,7 +90,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
             this.maxConcurrency = maxConcurrency;
             this.bufferSize = bufferSize;
             if (maxConcurrency != Integer.MAX_VALUE) {
-                sources = new ArrayDeque<Observable<? extends U>>(maxConcurrency);
+                sources = new ArrayDeque<ObservableConsumable<? extends U>>(maxConcurrency);
             }
             this.subscribers = new AtomicReference<InnerSubscriber<?, ?>[]>(EMPTY);
         }
@@ -110,7 +110,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
             if (done) {
                 return;
             }
-            Observable<? extends U> p;
+            ObservableConsumable<? extends U> p;
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {
@@ -135,7 +135,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
             }
         }
         
-        void subscribeInner(Observable<? extends U> p) {
+        void subscribeInner(ObservableConsumable<? extends U> p) {
             InnerSubscriber<T, U> inner = new InnerSubscriber<T, U>(this, uniqueId++);
             addInner(inner);
             p.subscribe(inner);
@@ -413,7 +413,7 @@ public final class NbpOperatorFlatMap<T, U> implements NbpOperator<U, T> {
                 
                 if (innerCompleted) {
                     if (maxConcurrency != Integer.MAX_VALUE) {
-                        Observable<? extends U> p;
+                        ObservableConsumable<? extends U> p;
                         synchronized (this) {
                             p = sources.poll();
                             if (p == null) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorMapNotification.java
@@ -19,31 +19,31 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Observable<? extends R>, T>{
+public final class NbpOperatorMapNotification<T, R> implements NbpOperator<ObservableConsumable<? extends R>, T>{
 
-    final Function<? super T, ? extends Observable<? extends R>> onNextMapper;
-    final Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper;
-    final Supplier<? extends Observable<? extends R>> onCompleteSupplier;
+    final Function<? super T, ? extends ObservableConsumable<? extends R>> onNextMapper;
+    final Function<? super Throwable, ? extends ObservableConsumable<? extends R>> onErrorMapper;
+    final Supplier<? extends ObservableConsumable<? extends R>> onCompleteSupplier;
 
-    public NbpOperatorMapNotification(Function<? super T, ? extends Observable<? extends R>> onNextMapper, 
-            Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper, 
-            Supplier<? extends Observable<? extends R>> onCompleteSupplier) {
+    public NbpOperatorMapNotification(Function<? super T, ? extends ObservableConsumable<? extends R>> onNextMapper, 
+            Function<? super Throwable, ? extends ObservableConsumable<? extends R>> onErrorMapper, 
+            Supplier<? extends ObservableConsumable<? extends R>> onCompleteSupplier) {
         this.onNextMapper = onNextMapper;
         this.onErrorMapper = onErrorMapper;
         this.onCompleteSupplier = onCompleteSupplier;
     }
     
     @Override
-    public Observer<? super T> apply(Observer<? super Observable<? extends R>> t) {
+    public Observer<? super T> apply(Observer<? super ObservableConsumable<? extends R>> t) {
         return new MapNotificationSubscriber<T, R>(t, onNextMapper, onErrorMapper, onCompleteSupplier);
     }
     
     static final class MapNotificationSubscriber<T, R>
     implements Observer<T> {
-        final Observer<? super Observable<? extends R>> actual;
-        final Function<? super T, ? extends Observable<? extends R>> onNextMapper;
-        final Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper;
-        final Supplier<? extends Observable<? extends R>> onCompleteSupplier;
+        final Observer<? super ObservableConsumable<? extends R>> actual;
+        final Function<? super T, ? extends ObservableConsumable<? extends R>> onNextMapper;
+        final Function<? super Throwable, ? extends ObservableConsumable<? extends R>> onErrorMapper;
+        final Supplier<? extends ObservableConsumable<? extends R>> onCompleteSupplier;
         
         Disposable s;
         
@@ -51,10 +51,10 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         volatile boolean done;
 
-        public MapNotificationSubscriber(Observer<? super Observable<? extends R>> actual,
-                Function<? super T, ? extends Observable<? extends R>> onNextMapper,
-                Function<? super Throwable, ? extends Observable<? extends R>> onErrorMapper,
-                Supplier<? extends Observable<? extends R>> onCompleteSupplier) {
+        public MapNotificationSubscriber(Observer<? super ObservableConsumable<? extends R>> actual,
+                Function<? super T, ? extends ObservableConsumable<? extends R>> onNextMapper,
+                Function<? super Throwable, ? extends ObservableConsumable<? extends R>> onErrorMapper,
+                Supplier<? extends ObservableConsumable<? extends R>> onCompleteSupplier) {
             this.actual = actual;
             this.onNextMapper = onNextMapper;
             this.onErrorMapper = onErrorMapper;
@@ -72,7 +72,7 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         @Override
         public void onNext(T t) {
-            Observable<? extends R> p;
+            ObservableConsumable<? extends R> p;
             
             try {
                 p = onNextMapper.apply(t);
@@ -91,7 +91,7 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         @Override
         public void onError(Throwable t) {
-            Observable<? extends R> p;
+            ObservableConsumable<? extends R> p;
             
             try {
                 p = onErrorMapper.apply(t);
@@ -111,7 +111,7 @@ public final class NbpOperatorMapNotification<T, R> implements NbpOperator<Obser
         
         @Override
         public void onComplete() {
-            Observable<? extends R> p;
+            ObservableConsumable<? extends R> p;
             
             try {
                 p = onCompleteSupplier.get();

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorOnErrorNext.java
@@ -21,10 +21,10 @@ import io.reactivex.functions.Function;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
-    final Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier;
+    final Function<? super Throwable, ? extends ObservableConsumable<? extends T>> nextSupplier;
     final boolean allowFatal;
     
-    public NbpOperatorOnErrorNext(Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier, boolean allowFatal) {
+    public NbpOperatorOnErrorNext(Function<? super Throwable, ? extends ObservableConsumable<? extends T>> nextSupplier, boolean allowFatal) {
         this.nextSupplier = nextSupplier;
         this.allowFatal = allowFatal;
     }
@@ -38,7 +38,7 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
     
     static final class OnErrorNextSubscriber<T> implements Observer<T> {
         final Observer<? super T> actual;
-        final Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier;
+        final Function<? super Throwable, ? extends ObservableConsumable<? extends T>> nextSupplier;
         final boolean allowFatal;
         final MultipleAssignmentDisposable arbiter;
         
@@ -46,7 +46,7 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
         
         boolean done;
         
-        public OnErrorNextSubscriber(Observer<? super T> actual, Function<? super Throwable, ? extends Observable<? extends T>> nextSupplier, boolean allowFatal) {
+        public OnErrorNextSubscriber(Observer<? super T> actual, Function<? super Throwable, ? extends ObservableConsumable<? extends T>> nextSupplier, boolean allowFatal) {
             this.actual = actual;
             this.nextSupplier = nextSupplier;
             this.allowFatal = allowFatal;
@@ -83,7 +83,7 @@ public final class NbpOperatorOnErrorNext<T> implements NbpOperator<T, T> {
                 return;
             }
             
-            Observable<? extends T> p;
+            ObservableConsumable<? extends T> p;
             
             try {
                 p = nextSupplier.apply(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorPublish.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorPublish.java
@@ -31,7 +31,7 @@ import io.reactivex.observables.ConnectableObservable;
  */
 public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
     /** The source observable. */
-    final Observable<? extends T> source;
+    final ObservableConsumable<? extends T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
     final AtomicReference<PublishSubscriber<T>> current;
     
@@ -45,7 +45,7 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
      * @param bufferSize the size of the prefetch buffer
      * @return the connectable observable
      */
-    public static <T> ConnectableObservable<T> create(Observable<? extends T> source, final int bufferSize) {
+    public static <T> ConnectableObservable<T> create(ObservableConsumable<? extends T> source, final int bufferSize) {
         // the current connection to source needs to be shared between the operator and its onSubscribe call
         final AtomicReference<PublishSubscriber<T>> curr = new AtomicReference<PublishSubscriber<T>>();
         ObservableConsumable<T> onSubscribe = new ObservableConsumable<T>() {
@@ -115,8 +115,8 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
         return new NbpOperatorPublish<T>(onSubscribe, source, curr, bufferSize);
     }
 
-    public static <T, R> Observable<R> create(final Observable<? extends T> source, 
-            final Function<? super Observable<T>, ? extends Observable<R>> selector, final int bufferSize) {
+    public static <T, R> Observable<R> create(final ObservableConsumable<? extends T> source, 
+            final Function<? super Observable<T>, ? extends ObservableConsumable<R>> selector, final int bufferSize) {
         return create(new ObservableConsumable<R>() {
             @Override
             public void subscribe(Observer<? super R> sr) {
@@ -138,7 +138,7 @@ public final class NbpOperatorPublish<T> extends ConnectableObservable<T> {
 
     final ObservableConsumable<T> onSubscribe;
     
-    private NbpOperatorPublish(ObservableConsumable<T> onSubscribe, Observable<? extends T> source, 
+    private NbpOperatorPublish(ObservableConsumable<T> onSubscribe, ObservableConsumable<? extends T> source, 
             final AtomicReference<PublishSubscriber<T>> current, int bufferSize) {
         this.onSubscribe = onSubscribe;
         this.source = source;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorReplay.java
@@ -55,12 +55,12 @@ public final class NbpOperatorReplay<T> extends ConnectableObservable<T> {
      */
     public static <U, R> Observable<R> multicastSelector(
             final Supplier<? extends ConnectableObservable<U>> connectableFactory,
-            final Function<? super Observable<U>, ? extends Observable<R>> selector) {
+            final Function<? super Observable<U>, ? extends ObservableConsumable<R>> selector) {
         return Observable.create(new ObservableConsumable<R>() {
             @Override
             public void subscribe(Observer<? super R> child) {
                 ConnectableObservable<U> co;
-                Observable<R> observable;
+                ObservableConsumable<R> observable;
                 try {
                     co = connectableFactory.get();
                     observable = selector.apply(co);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSampleWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSampleWithObservable.java
@@ -22,9 +22,9 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorSampleWithObservable<T> implements NbpOperator<T, T> {
-    final Observable<?> other;
+    final ObservableConsumable<?> other;
     
-    public NbpOperatorSampleWithObservable(Observable<?> other) {
+    public NbpOperatorSampleWithObservable(ObservableConsumable<?> other) {
         this.other = other;
     }
     
@@ -40,7 +40,7 @@ public final class NbpOperatorSampleWithObservable<T> implements NbpOperator<T, 
         private static final long serialVersionUID = -3517602651313910099L;
 
         final Observer<? super T> actual;
-        final Observable<?> sampler;
+        final ObservableConsumable<?> sampler;
         
         final AtomicReference<Disposable> other = new AtomicReference<Disposable>();
         
@@ -51,7 +51,7 @@ public final class NbpOperatorSampleWithObservable<T> implements NbpOperator<T, 
         
         Disposable s;
         
-        public SamplePublisherSubscriber(Observer<? super T> actual, Observable<?> other) {
+        public SamplePublisherSubscriber(Observer<? super T> actual, ObservableConsumable<?> other) {
             this.actual = actual;
             this.sampler = other;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSkipUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSkipUntil.java
@@ -23,8 +23,8 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorSkipUntil<T, U> implements NbpOperator<T, T> {
-    final Observable<U> other;
-    public NbpOperatorSkipUntil(Observable<U> other) {
+    final ObservableConsumable<U> other;
+    public NbpOperatorSkipUntil(ObservableConsumable<U> other) {
         this.other = other;
     }
     

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchIfEmpty.java
@@ -18,8 +18,8 @@ import io.reactivex.Observable.NbpOperator;
 import io.reactivex.disposables.*;
 
 public final class NbpOperatorSwitchIfEmpty<T> implements NbpOperator<T, T> {
-    final Observable<? extends T> other;
-    public NbpOperatorSwitchIfEmpty(Observable<? extends T> other) {
+    final ObservableConsumable<? extends T> other;
+    public NbpOperatorSwitchIfEmpty(ObservableConsumable<? extends T> other) {
         this.other = other;
     }
     
@@ -32,12 +32,12 @@ public final class NbpOperatorSwitchIfEmpty<T> implements NbpOperator<T, T> {
     
     static final class SwitchIfEmptySubscriber<T> implements Observer<T> {
         final Observer<? super T> actual;
-        final Observable<? extends T> other;
+        final ObservableConsumable<? extends T> other;
         final SerialDisposable arbiter;
         
         boolean empty;
         
-        public SwitchIfEmptySubscriber(Observer<? super T> actual, Observable<? extends T> other) {
+        public SwitchIfEmptySubscriber(Observer<? super T> actual, ObservableConsumable<? extends T> other) {
             this.actual = actual;
             this.other = other;
             this.empty = true;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorSwitchMap.java
@@ -28,10 +28,10 @@ import io.reactivex.internal.util.Pow2;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
-    final Function<? super T, ? extends Observable<? extends R>> mapper;
+    final Function<? super T, ? extends ObservableConsumable<? extends R>> mapper;
     final int bufferSize;
 
-    public NbpOperatorSwitchMap(Function<? super T, ? extends Observable<? extends R>> mapper, int bufferSize) {
+    public NbpOperatorSwitchMap(Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, int bufferSize) {
         this.mapper = mapper;
         this.bufferSize = bufferSize;
     }
@@ -45,7 +45,7 @@ public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
         /** */
         private static final long serialVersionUID = -3491074160481096299L;
         final Observer<? super R> actual;
-        final Function<? super T, ? extends Observable<? extends R>> mapper;
+        final Function<? super T, ? extends ObservableConsumable<? extends R>> mapper;
         final int bufferSize;
         
         
@@ -66,7 +66,7 @@ public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
         
         volatile long unique;
         
-        public SwitchMapSubscriber(Observer<? super R> actual, Function<? super T, ? extends Observable<? extends R>> mapper, int bufferSize) {
+        public SwitchMapSubscriber(Observer<? super R> actual, Function<? super T, ? extends ObservableConsumable<? extends R>> mapper, int bufferSize) {
             this.actual = actual;
             this.mapper = mapper;
             this.bufferSize = bufferSize;
@@ -91,7 +91,7 @@ public final class NbpOperatorSwitchMap<T, R> implements NbpOperator<R, T> {
                 inner.cancel();
             }
             
-            Observable<? extends R> p;
+            ObservableConsumable<? extends R> p;
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTake.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTake.java
@@ -13,20 +13,22 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.Observable.NbpOperator;
+import io.reactivex.*;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class NbpOperatorTake<T> implements NbpOperator<T, T> {
+public final class NbpOperatorTake<T> extends Observable<T> {
+    final ObservableConsumable<? extends T> source;
     final long limit;
-    public NbpOperatorTake(long limit) {
+    public NbpOperatorTake(ObservableConsumable<? extends T> source, long limit) {
+        this.source = source;
         this.limit = limit;
     }
     
     @Override
-    public Observer<? super T> apply(Observer<? super T> t) {
-        return new TakeSubscriber<T>(t, limit);
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new TakeSubscriber<T>(observer, limit));
     }
     
     static final class TakeSubscriber<T> implements Observer<T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTakeUntil.java
@@ -23,8 +23,8 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class NbpOperatorTakeUntil<T, U> implements NbpOperator<T, T> {
-    final Observable<? extends U> other;
-    public NbpOperatorTakeUntil(Observable<? extends U> other) {
+    final ObservableConsumable<? extends U> other;
+    public NbpOperatorTakeUntil(ObservableConsumable<? extends U> other) {
         this.other = other;
     }
     @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeout.java
@@ -28,12 +28,12 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
-    final Supplier<? extends Observable<U>> firstTimeoutSelector; 
-    final Function<? super T, ? extends Observable<V>> timeoutSelector; 
-    final Observable<? extends T> other;
+    final Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector; 
+    final Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector; 
+    final ObservableConsumable<? extends T> other;
 
-    public NbpOperatorTimeout(Supplier<? extends Observable<U>> firstTimeoutSelector,
-            Function<? super T, ? extends Observable<V>> timeoutSelector, Observable<? extends T> other) {
+    public NbpOperatorTimeout(Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector,
+            Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector, ObservableConsumable<? extends T> other) {
         this.firstTimeoutSelector = firstTimeoutSelector;
         this.timeoutSelector = timeoutSelector;
         this.other = other;
@@ -51,8 +51,8 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
     
     static final class TimeoutSubscriber<T, U, V> implements Observer<T>, Disposable, OnTimeout {
         final Observer<? super T> actual;
-        final Supplier<? extends Observable<U>> firstTimeoutSelector; 
-        final Function<? super T, ? extends Observable<V>> timeoutSelector; 
+        final Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector; 
+        final Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector; 
 
         Disposable s;
         
@@ -68,8 +68,8 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
         };
 
         public TimeoutSubscriber(Observer<? super T> actual, 
-                Supplier<? extends Observable<U>> firstTimeoutSelector,
-                Function<? super T, ? extends Observable<V>> timeoutSelector) {
+                Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector,
+                Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector) {
             this.actual = actual;
             this.firstTimeoutSelector = firstTimeoutSelector;
             this.timeoutSelector = timeoutSelector;
@@ -84,7 +84,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
             
             Observer<? super T> a = actual;
             
-            Observable<U> p;
+            ObservableConsumable<U> p;
             
             if (firstTimeoutSelector != null) {
                 try {
@@ -124,7 +124,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
                 d.dispose();
             }
             
-            Observable<V> p;
+            ObservableConsumable<V> p;
             
             try {
                 p = timeoutSelector.apply(t);
@@ -228,9 +228,9 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
     
     static final class TimeoutOtherSubscriber<T, U, V> implements Observer<T>, Disposable, OnTimeout {
         final Observer<? super T> actual;
-        final Supplier<? extends Observable<U>> firstTimeoutSelector; 
-        final Function<? super T, ? extends Observable<V>> timeoutSelector;
-        final Observable<? extends T> other;
+        final Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector; 
+        final Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector;
+        final ObservableConsumable<? extends T> other;
         final NbpFullArbiter<T> arbiter;
         
         Disposable s;
@@ -249,8 +249,8 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
         };
 
         public TimeoutOtherSubscriber(Observer<? super T> actual,
-                Supplier<? extends Observable<U>> firstTimeoutSelector,
-                Function<? super T, ? extends Observable<V>> timeoutSelector, Observable<? extends T> other) {
+                Supplier<? extends ObservableConsumable<U>> firstTimeoutSelector,
+                Function<? super T, ? extends ObservableConsumable<V>> timeoutSelector, ObservableConsumable<? extends T> other) {
             this.actual = actual;
             this.firstTimeoutSelector = firstTimeoutSelector;
             this.timeoutSelector = timeoutSelector;
@@ -271,7 +271,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
             Observer<? super T> a = actual;
             
             if (firstTimeoutSelector != null) {
-                Observable<U> p;
+                ObservableConsumable<U> p;
                 
                 try {
                     p = firstTimeoutSelector.get();
@@ -315,7 +315,7 @@ public final class NbpOperatorTimeout<T, U, V> implements NbpOperator<T, T> {
                 d.dispose();
             }
             
-            Observable<V> p;
+            ObservableConsumable<V> p;
             
             try {
                 p = timeoutSelector.apply(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorTimeoutTimed.java
@@ -30,9 +30,9 @@ public final class NbpOperatorTimeoutTimed<T> implements NbpOperator<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;
-    final Observable<? extends T> other;
+    final ObservableConsumable<? extends T> other;
     
-    public NbpOperatorTimeoutTimed(long timeout, TimeUnit unit, Scheduler scheduler, Observable<? extends T> other) {
+    public NbpOperatorTimeoutTimed(long timeout, TimeUnit unit, Scheduler scheduler, ObservableConsumable<? extends T> other) {
         this.timeout = timeout;
         this.unit = unit;
         this.scheduler = scheduler;
@@ -56,7 +56,7 @@ public final class NbpOperatorTimeoutTimed<T> implements NbpOperator<T, T> {
         final long timeout;
         final TimeUnit unit;
         final Scheduler.Worker worker;
-        final Observable<? extends T> other;
+        final ObservableConsumable<? extends T> other;
         
         Disposable s; 
         
@@ -79,7 +79,7 @@ public final class NbpOperatorTimeoutTimed<T> implements NbpOperator<T, T> {
         volatile boolean done;
         
         public TimeoutTimedOtherSubscriber(Observer<? super T> actual, long timeout, TimeUnit unit, Worker worker,
-                Observable<? extends T> other) {
+                ObservableConsumable<? extends T> other) {
             this.actual = actual;
             this.timeout = timeout;
             this.unit = unit;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundary.java
@@ -28,10 +28,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class NbpOperatorWindowBoundary<T, B> implements NbpOperator<Observable<T>, T> {
-    final Observable<B> other;
+    final ObservableConsumable<B> other;
     final int bufferSize;
     
-    public NbpOperatorWindowBoundary(Observable<B> other, int bufferSize) {
+    public NbpOperatorWindowBoundary(ObservableConsumable<B> other, int bufferSize) {
         this.other = other;
         this.bufferSize = bufferSize;
     }
@@ -45,7 +45,7 @@ public final class NbpOperatorWindowBoundary<T, B> implements NbpOperator<Observ
     extends NbpQueueDrainSubscriber<T, Object, Observable<T>> 
     implements Disposable {
         
-        final Observable<B> other;
+        final ObservableConsumable<B> other;
         final int bufferSize;
         
         Disposable s;
@@ -63,7 +63,7 @@ public final class NbpOperatorWindowBoundary<T, B> implements NbpOperator<Observ
         
         final AtomicLong windows = new AtomicLong();
         
-        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, Observable<B> other,
+        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, ObservableConsumable<B> other,
                 int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
             this.other = other;

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySelector.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.Observable;
 import io.reactivex.Observable.NbpOperator;
+import io.reactivex.ObservableConsumable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
@@ -31,11 +32,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOperator<Observable<T>, T> {
-    final Observable<B> open;
-    final Function<? super B, ? extends Observable<V>> close;
+    final ObservableConsumable<B> open;
+    final Function<? super B, ? extends ObservableConsumable<V>> close;
     final int bufferSize;
     
-    public NbpOperatorWindowBoundarySelector(Observable<B> open, Function<? super B, ? extends Observable<V>> close,
+    public NbpOperatorWindowBoundarySelector(ObservableConsumable<B> open, Function<? super B, ? extends ObservableConsumable<V>> close,
             int bufferSize) {
         this.open = open;
         this.close = close;
@@ -52,8 +53,8 @@ public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOper
     static final class WindowBoundaryMainSubscriber<T, B, V>
     extends NbpQueueDrainSubscriber<T, Object, Observable<T>>
     implements Disposable {
-        final Observable<B> open;
-        final Function<? super B, ? extends Observable<V>> close;
+        final ObservableConsumable<B> open;
+        final Function<? super B, ? extends ObservableConsumable<V>> close;
         final int bufferSize;
         final SetCompositeResource<Disposable> resources;
 
@@ -71,7 +72,7 @@ public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOper
         final AtomicLong windows = new AtomicLong();
 
         public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual,
-                Observable<B> open, Function<? super B, ? extends Observable<V>> close, int bufferSize) {
+                ObservableConsumable<B> open, Function<? super B, ? extends ObservableConsumable<V>> close, int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
             this.open = open;
             this.close = close;
@@ -259,7 +260,7 @@ public final class NbpOperatorWindowBoundarySelector<T, B, V> implements NbpOper
                         ws.add(w);
                         a.onNext(w);
                         
-                        Observable<V> p;
+                        ObservableConsumable<V> p;
                         
                         try {
                             p = close.apply(wo.open);

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWindowBoundarySupplier.java
@@ -29,10 +29,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperator<Observable<T>, T> {
-    final Supplier<? extends Observable<B>> other;
+    final Supplier<? extends ObservableConsumable<B>> other;
     final int bufferSize;
     
-    public NbpOperatorWindowBoundarySupplier(Supplier<? extends Observable<B>> other, int bufferSize) {
+    public NbpOperatorWindowBoundarySupplier(Supplier<? extends ObservableConsumable<B>> other, int bufferSize) {
         this.other = other;
         this.bufferSize = bufferSize;
     }
@@ -46,7 +46,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
     extends NbpQueueDrainSubscriber<T, Object, Observable<T>> 
     implements Disposable {
         
-        final Supplier<? extends Observable<B>> other;
+        final Supplier<? extends ObservableConsumable<B>> other;
         final int bufferSize;
         
         Disposable s;
@@ -64,7 +64,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
         
         final AtomicLong windows = new AtomicLong();
 
-        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, Supplier<? extends Observable<B>> other,
+        public WindowBoundaryMainSubscriber(Observer<? super Observable<T>> actual, Supplier<? extends ObservableConsumable<B>> other,
                 int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
             this.other = other;
@@ -86,7 +86,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
                 return;
             }
             
-            Observable<B> p;
+            ObservableConsumable<B> p;
             
             try {
                 p = other.get();
@@ -230,7 +230,7 @@ public final class NbpOperatorWindowBoundarySupplier<T, B> implements NbpOperato
                             continue;
                         }
                         
-                        Observable<B> p;
+                        ObservableConsumable<B> p;
 
                         try {
                             p = other.get();

--- a/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/NbpOperatorWithLatestFrom.java
@@ -26,8 +26,8 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class NbpOperatorWithLatestFrom<T, U, R> implements NbpOperator<R, T> {
     final BiFunction<? super T, ? super U, ? extends R> combiner;
-    final Observable<? extends U> other;
-    public NbpOperatorWithLatestFrom(BiFunction<? super T, ? super U, ? extends R> combiner, Observable<? extends U> other) {
+    final ObservableConsumable<? extends U> other;
+    public NbpOperatorWithLatestFrom(BiFunction<? super T, ? super U, ? extends R> combiner, ObservableConsumable<? extends U> other) {
         this.combiner = combiner;
         this.other = other;
     }


### PR DESCRIPTION
This PR updates the `Observable` method signatures to accept `ObservableConsumable`, similar to how `Flowable` methods accept `Publisher`.

The architecture switch may take a couple of more PRs. I'll try to limit the change amount in each.
