### PR TITLE
1.x: Publish code coverage results to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: false
 # script for build and release via Travis to Bintray
 script: gradle/buildViaTravis.sh
 
+# Code coverage
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 # cache between builds
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Learn more about RxJava on the <a href="https://github.com/ReactiveX/RxJava/wiki
 ## Master Build Status
 
 <a href='https://travis-ci.org/ReactiveX/RxJava/builds'><img src='https://travis-ci.org/ReactiveX/RxJava.svg?branch=1.x'></a>
+[![codecov.io](http://codecov.io/github/ReactiveX/RxJava/coverage.svg?branch=1.x)](http://codecov.io/github/ReactiveX/RxJava?branch=1.x)
+
 
 ## Communication
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'
 
 apply plugin: 'java'
+apply plugin: 'jacoco'
 apply plugin: 'nebula.rxjava-project'
 
 dependencies {
@@ -46,3 +47,16 @@ if (project.hasProperty('release.useLastTag')) {
 test{
      maxHeapSize = "2g"
 }
+
+jacoco {
+    toolVersion = '0.7.7.201606060606' // See http://www.eclemma.org/jacoco/.
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+}
+
+build.dependsOn jacocoTestReport


### PR DESCRIPTION
This is an example built in my repo: https://codecov.io/gh/zsxwing/RxJava/
