### PR TITLE
1.x: fix ReplaySubject anomaly around caughtUp by removing that optimization

### DIFF
--- a/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -17,20 +17,16 @@ package rx.subjects;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.*;
 
 import rx.*;
+import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.Observer;
 import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -159,86 +155,33 @@ public class ReplaySubjectBoundedConcurrencyTest {
     }
 
     @Test
-    public void testReplaySubjectConcurrentSubscriptions() throws InterruptedException {
+    public void unboundedReplaySubjectConcurrentSubscriptionsLoop() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            System.out.println(i + " --------------------------------------------------------------- ");
+            unboundedReplaySubjectConcurrentSubscriptions();
+        }
+    }
+    
+    @Test
+    public void unboundedReplaySubjectConcurrentSubscriptions() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.createUnbounded();
-        Thread source = new Thread(new Runnable() {
+        
+        ReplaySubjectConcurrencyTest.concurrencyTest(replay);
+    }
 
-            @Override
-            public void run() {
-                Observable.create(new OnSubscribe<Long>() {
-
-                    @Override
-                    public void call(Subscriber<? super Long> o) {
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        o.onCompleted();
-                    }
-                }).subscribe(replay);
-            }
-        });
-
-        // used to collect results of each thread
-        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<List<Long>>());
-        final List<Thread> threads = Collections.synchronizedList(new ArrayList<Thread>());
-
-        for (int i = 1; i <= 200; i++) {
-            final int count = i;
-            if (count == 20) {
-                // start source data after we have some already subscribed
-                // and while others are in process of subscribing
-                source.start();
-            }
-            if (count == 100) {
-                // wait for source to finish then keep adding after it's done
-                source.join();
-            }
-            Thread t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    List<Long> values = replay.toList().toBlocking().last();
-                    listOfListsOfValues.add(values);
-                    System.out.println("Finished thread: " + count);
-                }
-            });
-            t.start();
-            System.out.println("Started thread: " + i);
-            threads.add(t);
+    @Test
+    public void unboundedTimeReplaySubjectConcurrentSubscriptionsLoop() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            System.out.println(i + " --------------------------------------------------------------- ");
+            unboundedTimeReplaySubjectConcurrentSubscriptions();
         }
-
-        // wait for all threads to complete
-        for (Thread t : threads) {
-            t.join();
-        }
-
-        // assert all threads got the same results
-        List<Long> sums = new ArrayList<Long>();
-        for (List<Long> values : listOfListsOfValues) {
-            long v = 0;
-            for (long l : values) {
-                v += l;
-            }
-            sums.add(v);
-        }
-
-        long expected = sums.get(0);
-        boolean success = true;
-        for (long l : sums) {
-            if (l != expected) {
-                success = false;
-                System.out.println("FAILURE => Expected " + expected + " but got: " + l);
-            }
-        }
-
-        if (success) {
-            System.out.println("Success! " + sums.size() + " each had the same sum of " + expected);
-        } else {
-            throw new RuntimeException("Concurrency Bug");
-        }
-
+    }
+    
+    @Test
+    public void unboundedTimeReplaySubjectConcurrentSubscriptions() throws InterruptedException {
+        final ReplaySubject<Long> replay = ReplaySubject.createUnboundedTime();
+        
+        ReplaySubjectConcurrencyTest.concurrencyTest(replay);
     }
 
     /**


### PR DESCRIPTION
Adding the backpressure support to `ReplaySubject` exposed a race condition around the `caughtUp` optimization.

The problem occurs when the source thread has caught up after `drain()` returned true but at the same time, a concurrent `drain()` starts running (due to a subscribe() process finishing or requesting on top of the previous `Long.MAX_VALUE`). This concurrent drain may think the replay hasn't started yet (by finding `rp.node` null) or seeing that the buffer has more elements (that may get double emitted).

The current solution is to remove this optimization until we come up with a correct optimization.

Related: #4028.
