### PR TITLE
1.x: coverage improvements, small adjustments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ apply plugin: 'jacoco'
 apply plugin: 'nebula.rxjava-project'
 
 dependencies {
-    testCompile 'junit:junit-dep:4.10'
-    testCompile 'org.mockito:mockito-core:1.8.5'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 
     perfCompile 'org.openjdk.jmh:jmh-core:1.11.3'
     perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.11.3'

--- a/src/main/java/rx/Notification.java
+++ b/src/main/java/rx/Notification.java
@@ -158,15 +158,24 @@ public final class Notification<T> {
      * @param observer the target observer to call onXXX methods on based on the kind of this Notification instance
      */
     public void accept(Observer<? super T> observer) {
-        if (isOnNext()) {
+        switch (kind) {
+        case OnNext:
             observer.onNext(getValue());
-        } else if (isOnCompleted()) {
-            observer.onCompleted();
-        } else if (isOnError()) {
+            break;
+        case OnError:
             observer.onError(getThrowable());
+            break;
+        case OnCompleted:
+            observer.onCompleted();
+            break;
+        default:
+            throw new AssertionError("Uncovered case: " + kind);
         }
     }
 
+    /**
+     * Specifies the kind of the notification: an element, an error or a completion notification.
+     */
     public enum Kind {
         OnNext, OnError, OnCompleted
     }
@@ -211,19 +220,11 @@ public final class Notification<T> {
             return false;
         }
 
-        if (hasValue() && !getValue().equals(notification.getValue())) {
+        if (!(value == notification.value || (value != null && value.equals(notification.value)))) {
             return false;
         }
 
-        if (hasThrowable() && !getThrowable().equals(notification.getThrowable())) {
-            return false;
-        }
-
-        if (!hasValue() && !hasThrowable() && notification.hasValue()) {
-            return false;
-        }
-
-        if (!hasValue() && !hasThrowable() && notification.hasThrowable()) {
+        if (!(throwable == notification.throwable || (throwable != null && throwable.equals(notification.throwable)))) {
             return false;
         }
 

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -3280,7 +3280,8 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * 
+     * @param <R> the result type
      * @param ws
      *            an array of source Observables
      * @param zipFunction

--- a/src/main/java/rx/Scheduler.java
+++ b/src/main/java/rx/Scheduler.java
@@ -130,8 +130,9 @@ public abstract class Scheduler {
                 long startInNanos = firstStartInNanos;
                 @Override
                 public void call() {
+                    action.call();
+
                     if (!mas.isUnsubscribed()) {
-                        action.call();
                         
                         long nextTick;
                         

--- a/src/test/java/rx/NotificationTest.java
+++ b/src/test/java/rx/NotificationTest.java
@@ -16,65 +16,204 @@
 
 package rx;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
+import org.junit.*;
+
+import rx.exceptions.TestException;
 
 public class NotificationTest {
-	
-	@Test
-	public void testOnNextIntegerNotificationDoesNotEqualNullNotification(){
-		final Notification<Integer> integerNotification = Notification.createOnNext(1);
-		final Notification<Integer> nullNotification = Notification.createOnNext(null);
-		Assert.assertFalse(integerNotification.equals(nullNotification));
-	}
-	
-	@Test
-	public void testOnNextNullNotificationDoesNotEqualIntegerNotification(){
-		final Notification<Integer> integerNotification = Notification.createOnNext(1);
-		final Notification<Integer> nullNotification = Notification.createOnNext(null);
-		Assert.assertFalse(nullNotification.equals(integerNotification));
-	}
-	
-	@Test
-	public void testOnNextIntegerNotificationsWhenEqual(){
-		final Notification<Integer> integerNotification = Notification.createOnNext(1);
-		final Notification<Integer> integerNotification2 = Notification.createOnNext(1);
-		Assert.assertTrue(integerNotification.equals(integerNotification2));
-	}
-	
-	@Test
-	public void testOnNextIntegerNotificationsWhenNotEqual(){
-		final Notification<Integer> integerNotification = Notification.createOnNext(1);
-		final Notification<Integer> integerNotification2 = Notification.createOnNext(2);
-		Assert.assertFalse(integerNotification.equals(integerNotification2));
-	}
-	
-	@Test
-	public void testOnErrorIntegerNotificationDoesNotEqualNullNotification(){
-		final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
-		final Notification<Integer> nullNotification = Notification.createOnError(null);
-		Assert.assertFalse(integerNotification.equals(nullNotification));
-	}
-	
-	@Test
-	public void testOnErrorNullNotificationDoesNotEqualIntegerNotification(){
-		final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
-		final Notification<Integer> nullNotification = Notification.createOnError(null);
-		Assert.assertFalse(nullNotification.equals(integerNotification));
-	}
 
-	@Test
-	public void testOnErrorIntegerNotificationsWhenEqual(){
-		final Exception exception = new Exception();
-		final Notification<Integer> onErrorNotification = Notification.createOnError(exception);
-		final Notification<Integer> onErrorNotification2 = Notification.createOnError(exception);
-		Assert.assertTrue(onErrorNotification.equals(onErrorNotification2));
-	}
-	
-	@Test
-	public void testOnErrorIntegerNotificationWhenNotEqual(){
-		final Notification<Integer> onErrorNotification = Notification.createOnError(new Exception());
-		final Notification<Integer> onErrorNotification2 = Notification.createOnError(new Exception());
-		Assert.assertFalse(onErrorNotification.equals(onErrorNotification2));
-	}
+    @Test
+    public void testOnNextIntegerNotificationDoesNotEqualNullNotification(){
+        final Notification<Integer> integerNotification = Notification.createOnNext(1);
+        final Notification<Integer> nullNotification = Notification.createOnNext(null);
+        Assert.assertFalse(integerNotification.equals(nullNotification));
+    }
+
+    @Test
+    public void testOnNextNullNotificationDoesNotEqualIntegerNotification(){
+        final Notification<Integer> integerNotification = Notification.createOnNext(1);
+        final Notification<Integer> nullNotification = Notification.createOnNext(null);
+        Assert.assertFalse(nullNotification.equals(integerNotification));
+    }
+
+    @Test
+    public void testOnNextIntegerNotificationsWhenEqual(){
+        final Notification<Integer> integerNotification = Notification.createOnNext(1);
+        final Notification<Integer> integerNotification2 = Notification.createOnNext(1);
+        Assert.assertTrue(integerNotification.equals(integerNotification2));
+    }
+
+    @Test
+    public void testOnNextIntegerNotificationsWhenNotEqual(){
+        final Notification<Integer> integerNotification = Notification.createOnNext(1);
+        final Notification<Integer> integerNotification2 = Notification.createOnNext(2);
+        Assert.assertFalse(integerNotification.equals(integerNotification2));
+    }
+
+    @Test
+    public void testOnErrorIntegerNotificationDoesNotEqualNullNotification(){
+        final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
+        final Notification<Integer> nullNotification = Notification.createOnError(null);
+        Assert.assertFalse(integerNotification.equals(nullNotification));
+    }
+
+    @Test
+    public void testOnErrorNullNotificationDoesNotEqualIntegerNotification(){
+        final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
+        final Notification<Integer> nullNotification = Notification.createOnError(null);
+        Assert.assertFalse(nullNotification.equals(integerNotification));
+    }
+
+    @Test
+    public void testOnErrorIntegerNotificationsWhenEqual(){
+        final Exception exception = new Exception();
+        final Notification<Integer> onErrorNotification = Notification.createOnError(exception);
+        final Notification<Integer> onErrorNotification2 = Notification.createOnError(exception);
+        Assert.assertTrue(onErrorNotification.equals(onErrorNotification2));
+    }
+
+    @Test
+    public void testOnErrorIntegerNotificationWhenNotEqual(){
+        final Notification<Integer> onErrorNotification = Notification.createOnError(new Exception());
+        final Notification<Integer> onErrorNotification2 = Notification.createOnError(new Exception());
+        Assert.assertFalse(onErrorNotification.equals(onErrorNotification2));
+    }
+
+    @Test
+    public void createWithClass() {
+        Notification<Integer> n = Notification.createOnCompleted(Integer.class);
+        Assert.assertTrue(n.isOnCompleted());
+        Assert.assertFalse(n.hasThrowable());
+        Assert.assertFalse(n.hasValue());
+    }
+
+    @Test
+    public void accept() {
+        @SuppressWarnings("unchecked")
+        Observer<Object> o = mock(Observer.class);
+
+        Notification.createOnNext(1).accept(o);
+        Notification.createOnError(new TestException()).accept(o);
+        Notification.createOnCompleted().accept(o);
+
+        verify(o).onNext(1);
+        verify(o).onError(any(TestException.class));
+        verify(o).onCompleted();
+    }
+
+    /** Strip the &#64;NNNNNN from the string. */
+    static String stripAt(String s) {
+        int index = s.indexOf('@');
+        if (index >= 0) {
+            int j = s.indexOf(' ', index);
+            if (j >= 0) {
+                return s.substring(0, index) + s.substring(j);
+            }
+            return s.substring(0, index);
+        }
+        return s;
+    }
+
+    @Test
+    public void toStringVariants() {
+        Assert.assertEquals("[rx.Notification OnNext 1]", stripAt(Notification.createOnNext(1).toString()));
+        Assert.assertEquals("[rx.Notification OnError Forced failure]", stripAt(Notification.createOnError(new TestException("Forced failure")).toString()));
+        Assert.assertEquals("[rx.Notification OnCompleted]", stripAt(Notification.createOnCompleted().toString()));
+    }
+
+    @Test
+    public void hashCodeWorks() {
+        Notification<Integer> n1 = Notification.createOnNext(1);
+        Notification<Integer> n1a = Notification.createOnNext(1);
+        Notification<Integer> n2 = Notification.createOnNext(2);
+        Notification<Integer> e1 = Notification.createOnError(new TestException());
+        Notification<Integer> c1 = Notification.createOnCompleted();
+
+        Assert.assertEquals(n1.hashCode(), n1a.hashCode());
+
+        Set<Notification<Integer>> set = new HashSet<Notification<Integer>>();
+
+        set.add(n1);
+        set.add(n2);
+        set.add(e1);
+        set.add(c1);
+
+        Assert.assertTrue(set.contains(n1));
+        Assert.assertTrue(set.contains(n1a));
+        Assert.assertTrue(set.contains(n2));
+        Assert.assertTrue(set.contains(e1));
+        Assert.assertTrue(set.contains(c1));
+    }
+
+    @Test
+    public void equalsWorks() {
+        Notification<Integer> z1 = Notification.createOnNext(null);
+        Notification<Integer> z1a = Notification.createOnNext(null);
+
+        
+        Notification<Integer> n1 = Notification.createOnNext(1);
+        Notification<Integer> n1a = Notification.createOnNext(new Integer(1)); // make unique reference
+        Notification<Integer> n2 = Notification.createOnNext(2);
+        Notification<Integer> e1 = Notification.createOnError(new TestException());
+        Notification<Integer> e2 = Notification.createOnError(new TestException());
+        Notification<Integer> c1 = Notification.createOnCompleted();
+        Notification<Integer> c2 = Notification.createOnCompleted();
+
+        Assert.assertEquals(n1, n1a);
+        Assert.assertNotEquals(n1, n2);
+        Assert.assertNotEquals(n2, n1);
+
+        Assert.assertNotEquals(n1, e1);
+        Assert.assertNotEquals(e1, n1);
+        Assert.assertNotEquals(e1, c1);
+        Assert.assertNotEquals(n1, c1);
+        Assert.assertNotEquals(c1, n1);
+        Assert.assertNotEquals(c1, e1);
+
+        Assert.assertEquals(e1, e1);
+        Assert.assertEquals(e1, e2);
+
+        Assert.assertEquals(c1, c2);
+
+        Assert.assertFalse(n1.equals(null));
+        Assert.assertFalse(n1.equals(1));
+        
+        Assert.assertEquals(z1a, z1);
+        Assert.assertEquals(z1, z1a);
+    }
+    
+    @Test
+    public void contentChecks() {
+        Notification<Integer> z1 = Notification.createOnNext(null);
+        Notification<Integer> n1 = Notification.createOnNext(1);
+        Notification<Integer> e1 = Notification.createOnError(new TestException());
+        Notification<Integer> e2 = Notification.createOnError(null);
+        Notification<Integer> c1 = Notification.createOnCompleted();
+
+        Assert.assertFalse(z1.hasValue());
+        Assert.assertFalse(z1.hasThrowable());
+        Assert.assertFalse(z1.isOnCompleted());
+        
+        Assert.assertTrue(n1.hasValue());
+        Assert.assertFalse(n1.hasThrowable());
+        Assert.assertFalse(n1.isOnCompleted());
+        
+        Assert.assertFalse(e1.hasValue());
+        Assert.assertTrue(e1.hasThrowable());
+        Assert.assertFalse(e1.isOnCompleted());
+
+        Assert.assertFalse(e2.hasValue());
+        Assert.assertFalse(e2.hasThrowable());
+        Assert.assertFalse(e2.isOnCompleted());
+
+        Assert.assertFalse(c1.hasValue());
+        Assert.assertFalse(c1.hasThrowable());
+        Assert.assertTrue(c1.isOnCompleted());
+
+    }
 }

--- a/src/test/java/rx/ObservableConversionTest.java
+++ b/src/test/java/rx/ObservableConversionTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/exceptions/TestException.java
+++ b/src/test/java/rx/exceptions/TestException.java
@@ -33,4 +33,14 @@ public final class TestException extends RuntimeException {
     public TestException(String message) {
         super(message);
     }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        String thisMessage = getMessage();
+        String otherMessage = ((TestException)o).getMessage();
+        return thisMessage == otherMessage || (thisMessage != null && thisMessage.equals(otherMessage));
+    }
 }

--- a/src/test/java/rx/internal/operators/BlockingOperatorLatestTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorLatestTest.java
@@ -19,7 +19,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -868,10 +868,10 @@ public class OperatorSwitchTest {
                             });
                 }
             })
-            .timeout(20, TimeUnit.SECONDS)
+            .timeout(30, TimeUnit.SECONDS)
             .subscribe(ts);
             
-            ts.awaitTerminalEvent(45, TimeUnit.SECONDS);
+            ts.awaitTerminalEvent(60, TimeUnit.SECONDS);
             if (!q.isEmpty()) {
                 throw new AssertionError("Dropped exceptions", new CompositeException(q));
             }

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -1000,6 +1000,7 @@ public class OperatorZipTest {
 
     @Test
     public void testZipEmptyArray() {
+        @SuppressWarnings("unchecked")
         Observable<Integer>[] ws = new Observable[0];
         Observable<Integer> o = Observable.zip(ws, new FuncN<Integer>() {
             @Override
@@ -1018,6 +1019,7 @@ public class OperatorZipTest {
     @Test
     public void testZipArraySingleItem() {
         final Integer expected = 0;
+        @SuppressWarnings("unchecked")
         Observable<Integer>[] ws = new Observable[]{ Observable.just(expected) };
 
         Observable<Integer> o = Observable.zip(ws, new FuncN<Integer>() {
@@ -1038,6 +1040,7 @@ public class OperatorZipTest {
     public void testZipBigArray() {
         final int size = 20;
         Integer expected = 0;
+        @SuppressWarnings("unchecked")
         Observable<Integer>[] ws = new Observable[size];
 
         for (int i = 0, wsLength = ws.length; i < wsLength; i++) {

--- a/src/test/java/rx/observers/CompletableSubscriberTest.java
+++ b/src/test/java/rx/observers/CompletableSubscriberTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.*;
+
+import rx.Completable.CompletableSubscriber;
+import rx.exceptions.*;
+import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+
+public class CompletableSubscriberTest {
+
+    @Test
+    public void childOnSubscribeThrows() {
+        
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        
+        SafeCompletableSubscriber safe = new SafeCompletableSubscriber(new CompletableSubscriber() {
+            
+            @Override
+            public void onSubscribe(Subscription d) {
+                throw new TestException();
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                error.set(e);
+                
+            }
+            
+            @Override
+            public void onCompleted() {
+                
+            }
+        });
+        
+        safe.onSubscribe(Subscriptions.empty());
+        
+        Assert.assertTrue("" + error.get(), error.get() instanceof TestException);
+        
+        Assert.assertTrue(safe.isUnsubscribed());
+    }
+    
+    @Test
+    public void unsubscribeComposes() {
+        
+        SafeCompletableSubscriber safe = new SafeCompletableSubscriber(new CompletableSubscriber() {
+            
+            @Override
+            public void onSubscribe(Subscription d) {
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+            }
+            
+            @Override
+            public void onCompleted() {
+                
+            }
+        });
+        
+        Subscription empty = Subscriptions.empty();
+        safe.onSubscribe(empty);
+        
+        Assert.assertFalse(empty.isUnsubscribed());
+        Assert.assertFalse(safe.isUnsubscribed());
+        
+        safe.unsubscribe();
+        
+        Assert.assertTrue(empty.isUnsubscribed());
+        Assert.assertTrue(safe.isUnsubscribed());
+    }
+    
+    @Test
+    public void childOnErrorThrows() {
+        
+        SafeCompletableSubscriber safe = new SafeCompletableSubscriber(new CompletableSubscriber() {
+            
+            @Override
+            public void onSubscribe(Subscription d) {
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+            
+            @Override
+            public void onCompleted() {
+                
+            }
+        });
+        
+        safe.onSubscribe(Subscriptions.empty());
+        
+        try {
+            safe.onError(new IOException());
+            Assert.fail("Didn't throw a fatal exception");
+        } catch (OnErrorFailedException ex) {
+            CompositeException ce = (CompositeException)ex.getCause();
+            
+            List<Throwable> list = ce.getExceptions();
+            Assert.assertEquals(2, list.size());
+            
+            Assert.assertTrue("" + list.get(0), list.get(0) instanceof IOException);
+            Assert.assertTrue("" + list.get(1), list.get(1) instanceof TestException);
+        }
+    }
+    
+    @Test
+    public void preventsCompleteError() {
+
+        final boolean[] calls = { false, false };
+        
+        SafeCompletableSubscriber safe = new SafeCompletableSubscriber(new CompletableSubscriber() {
+            
+            @Override
+            public void onSubscribe(Subscription d) {
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                calls[0] = true;
+            }
+            
+            @Override
+            public void onCompleted() {
+                calls[1] = true;
+            }
+        });
+        
+        safe.onSubscribe(Subscriptions.empty());
+
+        safe.onCompleted();
+        safe.onError(new TestException());
+        
+        Assert.assertTrue(safe.isUnsubscribed());
+        Assert.assertFalse(calls[0]);
+        Assert.assertTrue(calls[1]);
+    }
+    
+    @Test
+    public void preventsErrorComplete() {
+
+        final boolean[] calls = { false, false };
+        
+        SafeCompletableSubscriber safe = new SafeCompletableSubscriber(new CompletableSubscriber() {
+            
+            @Override
+            public void onSubscribe(Subscription d) {
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                calls[0] = true;
+            }
+            
+            @Override
+            public void onCompleted() {
+                calls[1] = true;
+            }
+        });
+        
+        safe.onSubscribe(Subscriptions.empty());
+
+        safe.onError(new TestException());
+        safe.onCompleted();
+        
+        Assert.assertTrue(safe.isUnsubscribed());
+        Assert.assertTrue(calls[0]);
+        Assert.assertFalse(calls[1]);
+    }
+}

--- a/src/test/java/rx/observers/SafeObserverTest.java
+++ b/src/test/java/rx/observers/SafeObserverTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import rx.Subscriber;
 import rx.exceptions.*;
 import rx.functions.Action0;

--- a/src/test/java/rx/observers/SubscribersTest.java
+++ b/src/test/java/rx/observers/SubscribersTest.java
@@ -23,8 +23,10 @@ import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
+import rx.Subscriber;
 import rx.exceptions.*;
 import rx.functions.*;
+import rx.subscriptions.Subscriptions;
 
 public class SubscribersTest {
     @Test
@@ -184,5 +186,27 @@ public class SubscribersTest {
         
         Action1<Throwable> throwAction = Actions.empty();
         Subscribers.create(Actions.empty(), throwAction).onCompleted();
+    }
+    
+    @Test
+    public void shareSubscriptionButNullSubscriber() {
+        Subscriber<Integer> s = new Subscriber<Integer>(null, true) {
+            @Override
+            public void onNext(Integer t) {
+                
+            }
+            
+            @Override
+            public void onError(Throwable e) {
+                
+            }
+            
+            @Override
+            public void onCompleted() {
+                
+            }
+        };
+        
+        s.add(Subscriptions.empty());
     }
 }

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -335,9 +335,9 @@ public class TestSubscriberTest {
     @Test
     public void testDifferentError() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.onError(new TestException());
+        ts.onError(new TestException("First error"));
         try {
-            ts.assertError(new TestException());
+            ts.assertError(new TestException("Other error"));
         } catch (AssertionError ex) {
             // expected
             return;

--- a/src/test/java/rx/schedulers/NewThreadSchedulerTest.java
+++ b/src/test/java/rx/schedulers/NewThreadSchedulerTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
@@ -24,8 +24,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.*;
 
 import rx.*;
-import rx.Observable.OnSubscribe;
 import rx.Observable;
+import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.functions.*;
 import rx.observers.TestSubscriber;
@@ -222,7 +222,6 @@ public class ReplaySubjectConcurrencyTest {
         for (Thread t : threads) {
             t.join();
         }
-
         StringBuilder sb = new StringBuilder();
 
         // assert all threads got the same results

--- a/src/test/java/rx/subscriptions/MultipleAssignmentSubscriptionTest.java
+++ b/src/test/java/rx/subscriptions/MultipleAssignmentSubscriptionTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static rx.subscriptions.Subscriptions.create;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
- update to JUnit 4.12
- remove deprecated use of `junit.framework.Assert`
- update to Mockito 1.10.19
- Notification.accept() now uses switch (note that Jacoco can't properly cover enum switches as it only sees the default and impossible path is not taken).
- in `Scheduler.schedulePeriodically`, move the unsubscribe check after the action to prevent unnecessary schedule of the next iteration.
- remove the inner counted loop from `SerializedObserver` as being unnecessary
- increate timeout in `OperatorSwitchTest`
- add `CompletableSubscriberTest`
- extend `Scheduler`, `SerializedObserver`, 
