### PR TITLE
1.x: add package-info.java to the public packages

### DIFF
--- a/src/main/java/rx/annotations/package-info.java
+++ b/src/main/java/rx/annotations/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Method annotations for indicating experimental and beta operators.
+ * Annotations for indicating experimental and beta operators, classes, methods, types or fields.
  */
 package rx.annotations;

--- a/src/main/java/rx/annotations/package-info.java
+++ b/src/main/java/rx/annotations/package-info.java
@@ -1,20 +1,20 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Method annotations for indicating experimental and beta operators.
  */
-package rx.schedulers;
+package rx.annotations;

--- a/src/main/java/rx/exceptions/package-info.java
+++ b/src/main/java/rx/exceptions/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Exception handling utilities, safe subscriber exception classes, 
+ * lifecycle exception classes.
  */
-package rx.schedulers;
+package rx.exceptions;

--- a/src/main/java/rx/functions/package-info.java
+++ b/src/main/java/rx/functions/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Functional interfaces of functions and actions of arity 0 to 9 and related
+ * utility classes.
  */
-package rx.schedulers;
+package rx.functions;

--- a/src/main/java/rx/observables/package-info.java
+++ b/src/main/java/rx/observables/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Classes extending the Observable base reactive class, synchronous and
+ * asynchronous event generators.
  */
-package rx.schedulers;
+package rx.observables;

--- a/src/main/java/rx/observers/package-info.java
+++ b/src/main/java/rx/observers/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Default wrappers and implementations for the base reactive consumer classes and interfaces;
+ * utility classes for creating them from callbacks.
  */
-package rx.schedulers;
+package rx.observers;

--- a/src/main/java/rx/package-info.java
+++ b/src/main/java/rx/package-info.java
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 /**
- * <p>Rx Observables</p>
+ * Base reactive classes: Observable, Single and Completable; base reactive consumers;
+ * other common base interfaces.
  * 
  * <p>A library that enables subscribing to and composing asynchronous events and
  * callbacks.</p>

--- a/src/main/java/rx/plugins/package-info.java
+++ b/src/main/java/rx/plugins/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Callback types and a central plugin handler class to hook into the lifecycle
+ * of the base reactive types and schedulers.
  */
-package rx.schedulers;
+package rx.plugins;

--- a/src/main/java/rx/schedulers/package-info.java
+++ b/src/main/java/rx/schedulers/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Scheduler implementations, value+time record classes and the standard factory class to 
+ * return standard RxJava schedulers or wrap any Executor-based (thread pool) instances.
  */
 package rx.schedulers;

--- a/src/main/java/rx/singles/package-info.java
+++ b/src/main/java/rx/singles/package-info.java
@@ -1,20 +1,20 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Classes extending the Single base reactive class.
  */
-package rx.schedulers;
+package rx.singles;

--- a/src/main/java/rx/subjects/package-info.java
+++ b/src/main/java/rx/subjects/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Classes extending the Observable base reactive class and implementing
+ * the Observer interface at the same time (aka hot Observables).
  */
-package rx.schedulers;
+package rx.subjects;

--- a/src/main/java/rx/subscriptions/package-info.java
+++ b/src/main/java/rx/subscriptions/package-info.java
@@ -1,20 +1,22 @@
 /**
- * Copyright 2014 Netflix, Inc.
- * 
+ * Copyright 2016 Netflix, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * Utility class to return standard RxJava schedulers or wrap any Executor-based
- * (thread pool) instances.
+ * Default implementations for Subscription-based resource management
+ * (Subscription container types) and utility classes to construct
+ * Subscriptions from callbacks and other types.
  */
-package rx.schedulers;
+package rx.subscriptions;


### PR DESCRIPTION
This PR adds the missing `package-info.java` files to the public packages.

(http://reactivex.io/RxJava/javadoc/ looks awkward with all those empty descriptions).
