### PR TITLE
1.x: ignore .pmd file in root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ bin/
 # Scala build
 *.cache
 /.nb-gradle/private/
+
+# PMD local rules
+.pmd


### PR DESCRIPTION
The PMD tool in local IDE tends to create this custom file. Add a rule to ignore it.
