### PR TITLE
2.x: Dereference atomic ref before identity comparison.

### DIFF
--- a/src/main/java/io/reactivex/internal/subscribers/observable/NbpDisposableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/NbpDisposableSubscriber.java
@@ -44,7 +44,7 @@ public abstract class NbpDisposableSubscriber<T> implements Observer<T>, Disposa
     }
     
     public final boolean isDisposed() {
-        return s == DisposableHelper.DISPOSED;
+        return s.get() == DisposableHelper.DISPOSED;
     }
     
     @Override


### PR DESCRIPTION
This returns false 100% of the time otherwise.
