### PR TITLE
2.x: Do not leak the DISPOSED marker instance into public API.

### DIFF
--- a/src/main/java/io/reactivex/disposables/Disposables.java
+++ b/src/main/java/io/reactivex/disposables/Disposables.java
@@ -61,7 +61,7 @@ public final class Disposables {
     }
 
     public static Disposable disposed() {
-        return DisposableHelper.DISPOSED;
+        return EmptyDisposable.INSTANCE;
     }
     
     /** Wraps a Future instance. */

--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -25,6 +25,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 public enum DisposableHelper {
     ;
     
+    /**
+     * Marker instance compared by identity for indicating a previously referenced
+     * {@link Disposable} was disposed. DO NOT USE this instance as an arbitrary, empty disposable!
+     */
     public static final Disposable DISPOSED = Disposed.INSTANCE;
     
     public static boolean isDisposed(Disposable d) {


### PR DESCRIPTION
If this were to be used by public code it could have have Very Bad™ effects by causing operators to think that they already disposed resources when they actually had not. Since `Disposable` is stateless it's safe for `disposed()` and `empty()` to be synonymous, although that might change in the future so both methods are retained.
