### PR TITLE
Rename Throwable parameter from exception to throwable

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -1366,7 +1366,7 @@ public class Observable<T> {
      *  <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
-     * @param exception
+     * @param throwable
      *            the particular Throwable to pass to {@link Observer#onError onError}
      * @param <T>
      *            the type of the items (ostensibly) emitted by the Observable
@@ -1374,8 +1374,8 @@ public class Observable<T> {
      *         the Observer subscribes to it
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
-    public static <T> Observable<T> error(Throwable exception) {
-        return create(new OnSubscribeThrow<T>(exception));
+    public static <T> Observable<T> error(Throwable throwable) {
+        return create(new OnSubscribeThrow<T>(throwable));
     }
 
     /**


### PR DESCRIPTION
- Exception extends Throwable so it's incorrect to generalize the Throwable as `exception`
