### PR TITLE
1.x: exclude some text files from license checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ test{
      maxHeapSize = "2g"
 }
 
+license {
+    excludes(["**/*.md", "**/*.txt", "**/unsafe/*.java", "**/atomic/*.java", "**/Beta.java", "**/Experimental.java"])
+}
+
 jacoco {
     toolVersion = '0.7.7.201606060606' // See http://www.eclemma.org/jacoco/.
 }


### PR DESCRIPTION
By default, the `license` plugin warns about MDs and text files. In addition, this excluded the JCTools queues and the beta/experimental annotations because they kept their original license header.
