### PR TITLE
1.x: update map() and filter() to implement OnSubscribe directly

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5816,7 +5816,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/filter.html">ReactiveX operators documentation: Filter</a>
      */
     public final Observable<T> filter(Func1<? super T, Boolean> predicate) {
-        return lift(new OperatorFilter<T>(predicate));
+        return create(new OnSubscribeFilter<T>(this, predicate));
     }
 
     /**
@@ -6623,7 +6623,7 @@ public class Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
     public final <R> Observable<R> map(Func1<? super T, ? extends R> func) {
-        return lift(new OperatorMap<T, R>(func));
+        return create(new OnSubscribeMap<T, R>(this, func));
     }
     
     private <R> Observable<R> mapNotification(Func1<? super T, ? extends R> onNext, Func1<? super Throwable, ? extends R> onError, Func0<? extends R> onCompleted) {

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1413,7 +1413,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
     public final <R> Single<R> map(Func1<? super T, ? extends R> func) {
-        return lift(new OperatorMap<T, R>(func));
+        return create(new SingleOnSubscribeMap<T, R>(this, func));
     }
 
     /**

--- a/src/main/java/rx/internal/operators/SingleOnSubscribeMap.java
+++ b/src/main/java/rx/internal/operators/SingleOnSubscribeMap.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import rx.*;
+import rx.exceptions.*;
+import rx.functions.Func1;
+import rx.internal.util.RxJavaPluginUtils;
+
+/**
+ * Applies a function of your choosing to every item emitted by an {@code Single}, and emits the results of
+ * this transformation as a new {@code Single}.
+ * 
+ * @param <T> the input value type
+ * @param <R> the return value type
+ */
+public final class SingleOnSubscribeMap<T, R> implements Single.OnSubscribe<R> {
+
+    final Single<T> source;
+    
+    final Func1<? super T, ? extends R> transformer;
+
+    public SingleOnSubscribeMap(Single<T> source, Func1<? super T, ? extends R> transformer) {
+        this.source = source;
+        this.transformer = transformer;
+    }
+    
+    @Override
+    public void call(final SingleSubscriber<? super R> o) {
+        MapSubscriber<T, R> parent = new MapSubscriber<T, R>(o, transformer);
+        o.add(parent);
+        source.subscribe(parent);
+    }
+    
+    static final class MapSubscriber<T, R> extends SingleSubscriber<T> {
+        
+        final SingleSubscriber<? super R> actual;
+        
+        final Func1<? super T, ? extends R> mapper;
+
+        boolean done;
+        
+        public MapSubscriber(SingleSubscriber<? super R> actual, Func1<? super T, ? extends R> mapper) {
+            this.actual = actual;
+            this.mapper = mapper;
+        }
+        
+        @Override
+        public void onSuccess(T t) {
+            R result;
+            
+            try {
+                result = mapper.call(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                unsubscribe();
+                onError(OnErrorThrowable.addValueAsLastCause(ex, t));
+                return;
+            }
+            
+            actual.onSuccess(result);
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPluginUtils.handleException(e);
+                return;
+            }
+            done = true;
+            
+            actual.onError(e);
+        }
+    }
+
+}
+

--- a/src/perf/java/rx/operators/OperatorMapPerf.java
+++ b/src/perf/java/rx/operators/OperatorMapPerf.java
@@ -17,17 +17,9 @@ package rx.operators;
 
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
 
-import rx.Observable.Operator;
 import rx.functions.Func1;
-import rx.internal.operators.OperatorMap;
 import rx.jmh.InputWithIncrementingInteger;
 
 @BenchmarkMode(Mode.Throughput)
@@ -49,7 +41,7 @@ public class OperatorMapPerf {
 
     @Benchmark
     public void mapPassThruViaLift(Input input) throws InterruptedException {
-        input.observable.lift(MAP_OPERATOR).subscribe(input.observer);
+        input.observable.map(IDENTITY_FUNCTION).subscribe(input.observer);
     }
 
     @Benchmark
@@ -63,7 +55,4 @@ public class OperatorMapPerf {
             return value;
         }
     };
-
-    private static final Operator<Integer, Integer> MAP_OPERATOR = new OperatorMap<Integer, Integer>(IDENTITY_FUNCTION);
-
 }

--- a/src/test/java/rx/ObservableConversionTest.java
+++ b/src/test/java/rx/ObservableConversionTest.java
@@ -31,8 +31,8 @@ import rx.Observable.Operator;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.functions.Func1;
 import rx.functions.Func2;
-import rx.internal.operators.OperatorFilter;
-import rx.internal.operators.OperatorMap;
+import rx.internal.operators.OnSubscribeFilter;
+import rx.internal.operators.OnSubscribeMap;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
@@ -76,11 +76,11 @@ public class ObservableConversionTest {
         }
         
         public final CylonDetectorObservable<T> beep(Func1<? super T, Boolean> predicate) {
-            return lift(new OperatorFilter<T>(predicate));
+            return create(new OnSubscribeFilter<T>(Observable.create(onSubscribe), predicate));
         }
         
         public final <R> CylonDetectorObservable<R> boop(Func1<? super T, ? extends R> func) {
-            return lift(new OperatorMap<T, R>(func));
+            return create(new OnSubscribeMap<T, R>(Observable.create(onSubscribe), func));
         }
 
         public CylonDetectorObservable<String> DESTROY() {

--- a/src/test/java/rx/internal/operators/OperatorMapTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMapTest.java
@@ -57,14 +57,14 @@ public class OperatorMapTest {
         Map<String, String> m2 = getMap("Two");
         Observable<Map<String, String>> observable = Observable.just(m1, m2);
 
-        Observable<String> m = observable.lift(new OperatorMap<Map<String, String>, String>(new Func1<Map<String, String>, String>() {
+        Observable<String> m = observable.map(new Func1<Map<String, String>, String>() {
 
             @Override
             public String call(Map<String, String> map) {
                 return map.get("firstName");
             }
 
-        }));
+        });
         m.subscribe(stringObserver);
 
         verify(stringObserver, never()).onError(any(Throwable.class));
@@ -155,7 +155,7 @@ public class OperatorMapTest {
     @Test
     public void testMapWithError() {
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
-        Observable<String> m = w.lift(new OperatorMap<String, String>(new Func1<String, String>() {
+        Observable<String> m = w.map(new Func1<String, String>() {
             @Override
             public String call(String s) {
                 if ("fail".equals(s)) {
@@ -163,7 +163,7 @@ public class OperatorMapTest {
                 }
                 return s;
             }
-        })).doOnError(new Action1<Throwable>() {
+        }).doOnError(new Action1<Throwable>() {
 
             @Override
             public void call(Throwable t1) {


### PR DESCRIPTION
This change reduces the indirection and allocation count when using `map` or `filter`.
