### PR TITLE
2.x: prepare the operator-fusion enhancement

### DIFF
--- a/src/main/java/io/reactivex/internal/fuseable/QueueDisposable.java
+++ b/src/main/java/io/reactivex/internal/fuseable/QueueDisposable.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.fuseable;
+
+import java.util.Queue;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * An interface extending Queue and Disposable and allows negotiating
+ * the fusion mode between subsequent operators of the {@code Observable} base reactive type.
+ * <p>
+ * The negotiation happens in subscription time when the upstream
+ * calls the {@code onSubscribe} with an instance of this interface. The
+ * downstream has then the obligation to call {@link #requestFusion(int)}
+ * with the appropriate mode before calling {@code request()}.
+ * <p>
+ * In <b>synchronous fusion</b>, all upstream values are either already available or is generated
+ * when {@link #poll()} is called synchronously. When the {@link #poll()} returns null, 
+ * that is the indication if a terminated stream. In this mode, the upstream won't call the onXXX methods.
+ * <p>
+ * In <b>asynchronous fusion</b>, upstream values may become available to {@link #poll()} eventually.
+ * Upstream signals onError() and onComplete() as usual but onNext may not actually contain
+ * the upstream value but have {@code null} instead. Downstream should treat such onNext as indication
+ * that {@link #poll()} can be called.
+ * <p>
+ * The general rules for consuming the {@link Queue} interface:
+ * <ul>
+ * <li> {@link #poll()} has to be called sequentially (from within a serializing drain-loop).</li>
+ * <li>In addition, callers of {@link #poll()} should be prepared to catch exceptions.</li>
+ * <li>Due to how computation attaches to the {@link #poll()}, {@link #poll()} may return
+ * {@code null} even if a preceding {@link #isEmpty()} returned false.</li>
+ * </ul>
+ * <p>
+ * Implementations should only allow calling the following methods and the rest of the
+ * {@link Queue} interface methods should throw {@link UnsupportedOperationException}:
+ * <ul>
+ * <li>{@link #poll()}</li>
+ * <li>{@link #isEmpty()}</li>
+ * <li>{@link #clear()}</li>
+ * </ul>
+ * @param <T> the value type transmitted through the queue
+ */
+public interface QueueDisposable<T> extends Queue<T>, Disposable {
+    /**
+     * Returned by the {@link #requestFusion(int)} if the upstream doesn't support
+     * the requested mode.
+     */
+    int NONE = 0;
+    
+    /**
+     * Request a synchronous fusion mode and can be returned by {@link #requestFusion(int)}
+     * for an accepted mode.
+     * <p>
+     * In synchronous fusion, all upstream values are either already available or is generated
+     * when {@link #poll()} is called synchronously. When the {@link #poll()} returns null, 
+     * that is the indication if a terminated stream. 
+     * In this mode, the upstream won't call the onXXX methods and callers of 
+     * {@link #poll()} should be prepared to catch exceptions. Note that {@link #poll()} has 
+     * to be called sequentially (from within a serializing drain-loop).
+     */
+    int SYNC = 1;
+    
+    /**
+     * Request an asynchronous fusion mode and can be returned by {@link #requestFusion(int)}
+     * for an accepted mode.
+     * <p>
+     * In asynchronous fusion, upstream values may become available to {@link #poll()} eventually.
+     * Upstream signals onError() and onComplete() as usual but onNext may not actually contain
+     * the upstream value but have {@code null} instead. Downstream should treat such onNext as indication
+     * that {@link #poll()} can be called. Note that {@link #poll()} has to be called sequentially
+     * (from within a serializing drain-loop). In addition, callers of {@link #poll()} should be 
+     * prepared to catch exceptions.
+     */
+    int ASYNC = 2;
+    
+    /**
+     * Request any of the {@link #SYNC} or {@link #ASYNC} modes. 
+     */
+    int ANY = SYNC | ASYNC;
+    
+    /**
+     * Used in binary or combination with the other constants as an input to {@link #requestFusion(int)}
+     * indicating that the {@link #poll()} will be called behind an asynchronous boundary and thus
+     * may change the non-trivial computation locations attached to the {@link #poll()} chain of
+     * fused operators.
+     * <p>
+     * For example, fusing map() and observeOn() may move the computation of the map's function over to
+     * the thread run after the observeOn(), which is generally unexpected.
+     */
+    int BOUNDARY = 4;
+
+    /**
+     * Request a fusion mode from the upstream.
+     * <p>
+     * This should be called before {@code onSubscribe} returns.
+     * <p>
+     * Calling this method multiple times or after {@code onSubscribe} finished is not allowed
+     * and may result in undefined behavior.
+     * <p>
+     * @param mode the requested fusion mode, allowed values are {@link #SYNC}, {@link #ASYNC},
+     * {@link #ANY} combined with {@link #BOUNDARY} (e.g., {@code requestFusion(SYNC | BOUNDARY)}).
+     * @return the established fusion mode: {@link #NONE}, {@link #SYNC}, {@link #ASYNC}.
+     */
+    int requestFusion(int mode);
+}

--- a/src/main/java/io/reactivex/internal/fuseable/QueueSubscription.java
+++ b/src/main/java/io/reactivex/internal/fuseable/QueueSubscription.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.fuseable;
+
+import java.util.Queue;
+
+import org.reactivestreams.Subscription;
+
+/**
+ * An interface extending Queue and Subscription and allows negotiating
+ * the fusion mode between subsequent operators  of the {@code Flowable} base reactive type.
+ * <p>
+ * The negotiation happens in subscription time when the upstream
+ * calls the {@code onSubscribe} with an instance of this interface. The
+ * downstream has then the obligation to call {@link #requestFusion(int)}
+ * with the appropriate mode before calling {@code request()}.
+ * <p>
+ * In <b>synchronous fusion</b>, all upstream values are either already available or is generated
+ * when {@link #poll()} is called synchronously. When the {@link #poll()} returns null, 
+ * that is the indication if a terminated stream. Downstream should not call {@link #request(long)}
+ * in this mode. In this mode, the upstream won't call the onXXX methods.
+ * <p>
+ * In <b>asynchronous fusion</b>, upstream values may become available to {@link #poll()} eventually.
+ * Upstream signals onError() and onComplete() as usual but onNext may not actually contain
+ * the upstream value but have {@code null} instead. Downstream should treat such onNext as indication
+ * that {@link #poll()} can be called. In this mode, the downstream still has to call {@link #request(long)}
+ * to indicate it is prepared to receive more values.
+ * <p>
+ * The general rules for consuming the {@link Queue} interface:
+ * <ul>
+ * <li> {@link #poll()} has to be called sequentially (from within a serializing drain-loop).</li>
+ * <li>In addition, callers of {@link #poll()} should be prepared to catch exceptions.</li>
+ * <li>Due to how computation attaches to the {@link #poll()}, {@link #poll()} may return
+ * {@code null} even if a preceding {@link #isEmpty()} returned false.</li>
+ * </ul>
+ * <p>
+ * Implementations should only allow calling the following methods and the rest of the
+ * {@link Queue} interface methods should throw {@link UnsupportedOperationException}:
+ * <ul>
+ * <li>{@link #poll()}</li>
+ * <li>{@link #isEmpty()}</li>
+ * <li>{@link #clear()}</li>
+ * </ul>
+ * @param <T> the value type transmitted through the queue
+ */
+public interface QueueSubscription<T> extends Queue<T>, Subscription {
+    /**
+     * Returned by the {@link #requestFusion(int)} if the upstream doesn't support
+     * the requested mode.
+     */
+    int NONE = 0;
+    
+    /**
+     * Request a synchronous fusion mode and can be returned by {@link #requestFusion(int)}
+     * for an accepted mode.
+     * <p>
+     * In synchronous fusion, all upstream values are either already available or is generated
+     * when {@link #poll()} is called synchronously. When the {@link #poll()} returns null, 
+     * that is the indication if a terminated stream. Downstream should not call {@link #request(long)}
+     * in this mode. In this mode, the upstream won't call the onXXX methods and callers of 
+     * {@link #poll()} should be prepared to catch exceptions. Note that {@link #poll()} has 
+     * to be called sequentially (from within a serializing drain-loop).
+     */
+    int SYNC = 1;
+    
+    /**
+     * Request an asynchronous fusion mode and can be returned by {@link #requestFusion(int)}
+     * for an accepted mode.
+     * <p>
+     * In asynchronous fusion, upstream values may become available to {@link #poll()} eventually.
+     * Upstream signals onError() and onComplete() as usual but onNext may not actually contain
+     * the upstream value but have {@code null} instead. Downstream should treat such onNext as indication
+     * that {@link #poll()} can be called. Note that {@link #poll()} has to be called sequentially
+     * (from within a serializing drain-loop). In addition, callers of {@link #poll()} should be 
+     * prepared to catch exceptions. In this mode, the downstream still has to call {@link #request(long)}
+     * to indicate it is prepared to receive more values.
+     */
+    int ASYNC = 2;
+    
+    /**
+     * Request any of the {@link #SYNC} or {@link #ASYNC} modes. 
+     */
+    int ANY = SYNC | ASYNC;
+    
+    /**
+     * Used in binary or combination with the other constants as an input to {@link #requestFusion(int)}
+     * indicating that the {@link #poll()} will be called behind an asynchronous boundary and thus
+     * may change the non-trivial computation locations attached to the {@link #poll()} chain of
+     * fused operators.
+     * <p>
+     * For example, fusing map() and observeOn() may move the computation of the map's function over to
+     * the thread run after the observeOn(), which is generally unexpected.
+     */
+    int BOUNDARY = 4;
+
+    /**
+     * Request a fusion mode from the upstream.
+     * <p>
+     * This should be called before {@code onSubscribe} returns or even
+     * calls {@link #request(long)}.
+     * <p>
+     * Calling this method multiple times or after {@code onSubscribe} finished is not allowed
+     * and may result in undefined behavior.
+     * <p>
+     * @param mode the requested fusion mode, allowed values are {@link #SYNC}, {@link #ASYNC},
+     * {@link #ANY} combined with {@link #BOUNDARY} (e.g., {@code requestFusion(SYNC | BOUNDARY)}).
+     * @return the established fusion mode: {@link #NONE}, {@link #SYNC}, {@link #ASYNC}.
+     */
+    int requestFusion(int mode);
+}

--- a/src/main/java/io/reactivex/internal/fuseable/ScalarCallable.java
+++ b/src/main/java/io/reactivex/internal/fuseable/ScalarCallable.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.fuseable;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A marker interface indicating that a scalar, constant value
+ * is held by the implementing reactive type which can be
+ * safely extracted during assembly time can be used for
+ * optimiziation.
+ * <p>
+ * Implementors of {@link #call()} should not throw any exception.
+ * <p>
+ * Design note: the interface extends {@link Callable} because if a scalar
+ * is safe to extract during assembly time, it is also safe to extract at
+ * subscription time or later. This allows optimizations to deal with such
+ * single-element sources uniformly.
+ * <p>
+ * @param <T> the scalar value type held by the implementing reactive type
+ */
+public interface ScalarCallable<T> extends Callable<T> {
+
+    // overridden to remove the throws Exception
+    @Override
+    T call();
+}

--- a/src/main/java/io/reactivex/internal/fuseable/package-info.java
+++ b/src/main/java/io/reactivex/internal/fuseable/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Base interfaces and types for supporting operator-fusion.
+ */
+package io.reactivex.internal.fuseable;

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/ConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/ConditionalSubscriber.java
@@ -24,7 +24,9 @@ import org.reactivestreams.Subscriber;
  * to avoid requesting 1 on behalf of a dropped value.
  * 
  * @param <T> the value type
+ * @deprecated the interface will be moved to internal.fuseable and its method renamed.
  */
+@Deprecated
 public interface ConditionalSubscriber<T> extends Subscriber<T> {
     /**
      * Conditionally takes the value.


### PR DESCRIPTION
This PR adds 3 operator-fusion related interfaces: 
- `QueueSubscription` will support fusion for `Flowable` - avoid creating queues, avoid cost of multiple enqueue-dequeue, reduce `request()` overhead
- `QueueDisposable` will support fusion for `Observable` - avoid creating queues, avoid cost of multiple enqueue-dequeue
- `ScalarCallable` - indicate a scalar constant source

In addition `ConditionalSubscriber` is marked and will be moved to the new package and its method renamed to `tryOnNext`.

Unlike Reactor-Core (and Rsc), there is no `Fuseable` marker interface. The ability of fusing is indicated by calling `onSubscribe` with the above `QueueX` enabled instances and then called back via `requestFusion`. This allows having less duplicated code compared to Reactor/Rsc - at the cost of usually one extra field to store the `QueueX` value that may be null.
