### PR TITLE
2.x: make sure the helper returns true if the pre-swap value was null

### DIFF
--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -84,8 +84,10 @@ public enum DisposableHelper {
         Disposable current = field.get();
         if (current != DISPOSED) {
             current = field.getAndSet(DISPOSED);
-            if (current != null && current != DISPOSED) {
-                current.dispose();
+            if (current != DISPOSED) {
+                if (current != null) {
+                    current.dispose();
+                }
                 return true;
             }
         }

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -182,8 +182,10 @@ public enum SubscriptionHelper {
         Subscription current = field.get();
         if (current != CANCELLED) {
             current = field.getAndSet(CANCELLED);
-            if (current != null && current != CANCELLED) { // FIXME return true if current was null?
-                current.cancel();
+            if (current != CANCELLED) {
+                if (current != null) {
+                    current.cancel();
+                }
                 return true;
             }
         }


### PR DESCRIPTION
The original behavior was somewhat inconsistent: if the target was null before the cancel/dispose, the method didn't return true indicating a successful swap for the current thread. Now that many `cancelled` flag has been removed, it has to consistently trigger the remaining cleanup actions.
