### PR TITLE
2.x: Case IO acronym like a word.

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Scheduler that creates and caches a set of thread pools and reuses them if possible.
  */
-public final class IOScheduler extends Scheduler implements SchedulerLifecycle {
+public final class IoScheduler extends Scheduler implements SchedulerLifecycle {
     private static final String WORKER_THREAD_NAME_PREFIX = "RxCachedThreadScheduler-";
     private static final RxThreadFactory WORKER_THREAD_FACTORY =
             new RxThreadFactory(WORKER_THREAD_NAME_PREFIX);
@@ -146,7 +146,7 @@ public final class IOScheduler extends Scheduler implements SchedulerLifecycle {
         NONE.shutdown();
     }
     
-    public IOScheduler() {
+    public IoScheduler() {
         this.pool = new AtomicReference<CachedWorkerPool>(NONE);
         start();
     }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -36,7 +36,7 @@ public final class RxJavaPlugins {
     
     static volatile Function<Scheduler, Scheduler> onInitSingleHandler;
     
-    static volatile Function<Scheduler, Scheduler> onInitIOHandler;
+    static volatile Function<Scheduler, Scheduler> onInitIoHandler;
 
     static volatile Function<Scheduler, Scheduler> onInitNewThreadHandler;
     
@@ -44,7 +44,7 @@ public final class RxJavaPlugins {
     
     static volatile Function<Scheduler, Scheduler> onSingleHandler;
     
-    static volatile Function<Scheduler, Scheduler> onIOHandler;
+    static volatile Function<Scheduler, Scheduler> onIoHandler;
 
     static volatile Function<Scheduler, Scheduler> onNewThreadHandler;
 
@@ -85,8 +85,8 @@ public final class RxJavaPlugins {
         return onInitComputationHandler;
     }
 
-    public static Function<Scheduler, Scheduler> getInitIOSchedulerHandler() {
-        return onInitIOHandler;
+    public static Function<Scheduler, Scheduler> getInitIoSchedulerHandler() {
+        return onInitIoHandler;
     }
 
     public static Function<Scheduler, Scheduler> getInitNewThreadSchedulerHandler() {
@@ -97,8 +97,8 @@ public final class RxJavaPlugins {
         return onInitSingleHandler;
     }
 
-    public static Function<Scheduler, Scheduler> getIOSchedulerHandler() {
-        return onIOHandler;
+    public static Function<Scheduler, Scheduler> getIoSchedulerHandler() {
+        return onIoHandler;
     }
 
     public static Function<Scheduler, Scheduler> getNewThreadSchedulerHandler() {
@@ -129,8 +129,8 @@ public final class RxJavaPlugins {
         return f.apply(defaultScheduler); // JIT will skip this
     }
 
-    public static Scheduler initIOScheduler(Scheduler defaultScheduler) {
-        Function<Scheduler, Scheduler> f = onInitIOHandler;
+    public static Scheduler initIoScheduler(Scheduler defaultScheduler) {
+        Function<Scheduler, Scheduler> f = onInitIoHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -198,8 +198,8 @@ public final class RxJavaPlugins {
         error.printStackTrace();
     }
     
-    public static Scheduler onIOScheduler(Scheduler defaultScheduler) {
-        Function<Scheduler, Scheduler> f = onIOHandler;
+    public static Scheduler onIoScheduler(Scheduler defaultScheduler) {
+        Function<Scheduler, Scheduler> f = onIoHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -292,8 +292,8 @@ public final class RxJavaPlugins {
         setComputationSchedulerHandler(null);
         setInitComputationSchedulerHandler(null);
         
-        setIOSchedulerHandler(null);
-        setInitIOSchedulerHandler(null);
+        setIoSchedulerHandler(null);
+        setInitIoSchedulerHandler(null);
 
         setSingleSchedulerHandler(null);
         setInitSingleSchedulerHandler(null);
@@ -331,11 +331,11 @@ public final class RxJavaPlugins {
         onInitComputationHandler = handler;
     }
 
-    public static void setInitIOSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setInitIoSchedulerHandler(Function<Scheduler, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
-        onInitIOHandler = handler;
+        onInitIoHandler = handler;
     }
 
     public static void setInitNewThreadSchedulerHandler(Function<Scheduler, Scheduler> handler) {
@@ -353,11 +353,11 @@ public final class RxJavaPlugins {
         onInitSingleHandler = handler;
     }
 
-    public static void setIOSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setIoSchedulerHandler(Function<Scheduler, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
-        onIOHandler = handler;
+        onIoHandler = handler;
     }
 
     public static void setNewThreadSchedulerHandler(Function<Scheduler, Scheduler> handler) {

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -46,7 +46,7 @@ public final class Schedulers {
         
         COMPUTATION = RxJavaPlugins.initComputationScheduler(new ComputationScheduler());
         
-        IO = RxJavaPlugins.initIOScheduler(new IOScheduler());
+        IO = RxJavaPlugins.initIoScheduler(new IoScheduler());
         
         TRAMPOLINE = TrampolineScheduler.instance();
         
@@ -58,7 +58,7 @@ public final class Schedulers {
     }
     
     public static Scheduler io() {
-        return RxJavaPlugins.onIOScheduler(IO);
+        return RxJavaPlugins.onIoScheduler(IO);
     }
     
     public static TestScheduler test() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -24,7 +24,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.flowable.TestHelper;
-import io.reactivex.internal.schedulers.IOScheduler;
+import io.reactivex.internal.schedulers.IoScheduler;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -191,7 +191,7 @@ public class FlowableMergeMaxConcurrentTest {
     }
     @Test//(timeout = 20000)
     public void testSimpleAsyncLoop() {
-        IOScheduler ios = (IOScheduler)Schedulers.io();
+        IoScheduler ios = (IoScheduler)Schedulers.io();
         int c = ios.size();
         for (int i = 0; i < 200; i++) {
             testSimpleAsync();

--- a/src/test/java/io/reactivex/internal/operators/observable/NbpOperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/NbpOperatorMergeMaxConcurrentTest.java
@@ -26,7 +26,7 @@ import io.reactivex.ObservableConsumable;
 import io.reactivex.Observer;
 import io.reactivex.flowable.TestHelper;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.schedulers.IOScheduler;
+import io.reactivex.internal.schedulers.IoScheduler;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
@@ -192,7 +192,7 @@ public class NbpOperatorMergeMaxConcurrentTest {
     }
     @Test//(timeout = 20000)
     public void testSimpleAsyncLoop() {
-        IOScheduler ios = (IOScheduler)Schedulers.io();
+        IoScheduler ios = (IoScheduler)Schedulers.io();
         int c = ios.size();
         for (int i = 0; i < 200; i++) {
             testSimpleAsync();


### PR DESCRIPTION
This is already being done in the library, and is fairly [standard practice](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case).
