### PR TITLE
1.x: provide an explanation why certain tests are ignored

### DIFF
--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -192,7 +192,7 @@ public class BackpressureTests {
     }
 
     @Test
-    @Ignore // the test is non-deterministic and can't be made deterministic
+    @Ignore("The test is non-deterministic and can't be made deterministic")
     public void testFlatMapAsync() {
         int NUM = (int) (RxRingBuffer.SIZE * 2.1);
         AtomicInteger c = new AtomicInteger();

--- a/src/test/java/rx/IntervalDemo.java
+++ b/src/test/java/rx/IntervalDemo.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 import rx.functions.Action0;
 import rx.functions.Action1;
 
-@Ignore
-// since this doesn't do any automatic testing
+@Ignore("Since this doesn't do any automatic testing")
 public class IntervalDemo {
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorFlatMapTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFlatMapTest.java
@@ -430,7 +430,7 @@ public class OperatorFlatMapTest {
         verify(o, never()).onError(any(Throwable.class));
     }
     
-    @Ignore // don't care for any reordering
+    @Ignore("Don't care for any reordering")
     @Test(timeout = 10000)
     public void flatMapRangeAsyncLoop() {
         for (int i = 0; i < 2000; i++) {

--- a/src/test/java/rx/observers/SerializedObserverTest.java
+++ b/src/test/java/rx/observers/SerializedObserverTest.java
@@ -336,7 +336,7 @@ public class SerializedObserverTest {
      * 
      * @throws InterruptedException
      */
-    @Ignore
+    @Ignore("Demonstrates thread starvation problem. Read JavaDoc")
     @Test
     public void testThreadStarvation() throws InterruptedException {
 


### PR DESCRIPTION
During code reading I've found some tests that are ignored but don't have a record why they are being ignored. Some of them have meaningful explanations present as line comments, so I decided to make them the parameters of `@Ignore` annotation, so it will be correct.
