### PR TITLE
Refactor ConditionalSubscriber, add base fuseable Subscribers

### DIFF
--- a/src/main/java/io/reactivex/internal/fuseable/ConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/fuseable/ConditionalSubscriber.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.subscribers.flowable;
+package io.reactivex.internal.fuseable;
 
 import org.reactivestreams.Subscriber;
 
@@ -24,14 +24,12 @@ import org.reactivestreams.Subscriber;
  * to avoid requesting 1 on behalf of a dropped value.
  * 
  * @param <T> the value type
- * @deprecated the interface will be moved to internal.fuseable and its method renamed.
  */
-@Deprecated
 public interface ConditionalSubscriber<T> extends Subscriber<T> {
     /**
      * Conditionally takes the value.
      * @param t the value to deliver
      * @return true if the value has been accepted, false if the value has been rejected
      */
-    boolean onNextIf(T t);
+    boolean tryOnNext(T t);
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.Predicate;
-import io.reactivex.internal.subscribers.flowable.ConditionalSubscriber;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public final class FlowableFilter<T> extends Flowable<T> {
@@ -54,13 +54,13 @@ public final class FlowableFilter<T> extends Flowable<T> {
         
         @Override
         public void onNext(T t) {
-            if (!onNextIf(t)) {
+            if (!tryOnNext(t)) {
                 subscription.request(1);
             }
         }
         
         @Override
-        public boolean onNextIf(T t) {
+        public boolean tryOnNext(T t) {
             boolean b;
             try {
                 b = filter.test(t);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
-import io.reactivex.internal.subscribers.flowable.ConditionalSubscriber;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
@@ -170,7 +170,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
                         return;
                     }
                     while (r != 0 && i < len) {
-                        boolean b = s.onNextIf(a[i]);
+                        boolean b = s.tryOnNext(a[i]);
                         if (cancelled) {
                             return;
                         }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import java.util.*;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Base class for a fuseable intermediate subscriber.
+ * @param <T> the upstream value type
+ * @param <R> the downstream value type
+ */
+public abstract class BasicFuseableConditionalSubscriber<T, R> implements ConditionalSubscriber<T>, QueueSubscription<R> {
+
+    /** The downstream subscriber. */
+    protected final ConditionalSubscriber<? super R> actual;
+    
+    /** The upstream subscription. */
+    protected Subscription s;
+    
+    /** The upstream's QueueSubscription if not null. */
+    protected QueueSubscription<T> qs;
+    
+    /** Flag indicating no further onXXX event should be accepted. */
+    protected boolean done;
+    
+    /** Holds the established fusion mode of the upstream. */
+    protected int sourceMode;
+    
+    /**
+     * Construct a BasicFuseableSubscriber by wrapping the given subscriber.
+     * @param actual the subscriber, not null (not verified)
+     */
+    public BasicFuseableConditionalSubscriber(ConditionalSubscriber<? super R> actual) {
+        this.actual = actual;
+    }
+    
+    // final: fixed protocol steps to support fuseable and non-fuseable upstream
+    @SuppressWarnings("unchecked")
+    public final void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            
+            this.s = s;
+            if (s instanceof QueueSubscription) {
+                this.qs = (QueueSubscription<T>)s;
+            }
+            
+            if (beforeDownstream()) {
+                
+                actual.onSubscribe(this);
+                
+                afterDownstream();
+            }
+            
+        }
+    }
+    
+    /**
+     * Override this to perform actions before the call {@code actual.onSubscribe(this)} happens.
+     * @return true if onSubscribe should continue with the call
+     */
+    protected boolean beforeDownstream() {
+        return true;
+    }
+    
+    /**
+     * Override this to perform actions after the call to {@code actual.onSubscribe(this)} happened.
+     */
+    protected void afterDownstream() {
+        // default no-op
+    }
+
+    // -----------------------------------
+    // Convenience and state-aware methods
+    // -----------------------------------
+
+    /**
+     * Emits the value to the actual subscriber if {@link #done} is false. 
+     * @param value the value to signal
+     */
+    protected final void next(R value) {
+        if (done) {
+            return;
+        }
+        actual.onNext(value);
+    }
+    
+    /**
+     * Tries to emit the value to the actual subscriber if {@link #done} is false
+     * and returns the response from the {@link ConditionalSubscriber#tryOnNext(Object)}
+     * call.
+     * @param value the value to signal
+     * @return the response from the actual subscriber: true indicates accepted value,
+     * false indicates dropped value
+     */
+    protected final boolean tryNext(R value) {
+        if (done) {
+            return false;
+        }
+        return actual.tryOnNext(value);
+    }
+    
+    /**
+     * Emits the throwable to the actual subscriber if {@link #done} is false,
+     * signals the throwable to {@link RxJavaPlugins#onError(Throwable)} otherwise.
+     * @param t the throwable t signal
+     */
+    protected final void error(Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        done = true;
+        actual.onError(t);
+    }
+    
+    /**
+     * Rethrows the throwable if it is a fatal exception or calls {@link #error(Throwable)}.
+     * @param t the throwable to rethrow or signal to the actual subscriber
+     */
+    protected final void fail(Throwable t) {
+        Exceptions.throwIfFatal(t);
+        error(t);
+    }
+    
+    /**
+     * Calls the upstream's QueueSubscription.requestFusion with the mode and
+     * saves the established mode in {@link #sourceMode}.
+     * <p>
+     * If the upstream doesn't support fusion ({@link #qs} is null), the method
+     * returns {@link QueueSubscription#NONE}.
+     * @param mode the fusion mode requested
+     * @return the established fusion mode
+     */
+    protected final int transitiveFusion(int mode) {
+        QueueSubscription<T> qs = this.qs;
+        if (qs != null) {
+            int m = qs.requestFusion(mode);
+            if (m != NONE) {
+                sourceMode = m;
+            }
+            return m;
+        }
+        return NONE;
+    }
+
+    /**
+     * Calls the upstream's QueueSubscription.requestFusion with the mode and
+     * saves the established mode in {@link #sourceMode} if that mode doesn't
+     * have the {@link QueueSubscription#BOUNDARY} flag set.
+     * <p>
+     * If the upstream doesn't support fusion ({@link #qs} is null), the method
+     * returns {@link QueueSubscription#NONE}.
+     * @param mode the fusion mode requested
+     * @return the established fusion mode
+     */
+    protected final int transitiveBoundaryFusion(int mode) {
+        QueueSubscription<T> qs = this.qs;
+        if (qs != null) {
+            if ((mode & BOUNDARY) == 0) {
+                int m = qs.requestFusion(mode);
+                if (m != NONE) {
+                    sourceMode = m;
+                }
+                return m;
+            }
+        }
+        return NONE;
+    }
+
+    // --------------------------------------------------------------
+    // Default implementation of the RS and QS protocol (overridable)
+    // --------------------------------------------------------------
+    
+    @Override
+    public void request(long n) {
+        s.request(n);
+    }
+    
+    @Override
+    public void cancel() {
+        s.cancel();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        return qs.isEmpty();
+    }
+    
+    @Override
+    public final int size() {
+        return qs.size();
+    }
+    
+    @Override
+    public void clear() {
+        qs.clear();
+    }
+    
+    // -----------------------------------------------------------
+    // The rest of the Queue interface methods shouldn't be called
+    // -----------------------------------------------------------
+    
+    @Override
+    public final boolean add(R e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean addAll(Collection<? extends R> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean contains(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final R element() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Iterator<R> iterator() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean offer(R e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final R peek() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final R remove() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean remove(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Object[] toArray() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public <U extends Object> U[] toArray(U[] a) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableSubscriber.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import java.util.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Base class for a fuseable intermediate subscriber.
+ * @param <T> the upstream value type
+ * @param <R> the downstream value type
+ */
+public abstract class BasicFuseableSubscriber<T, R> implements Subscriber<T>, QueueSubscription<R> {
+
+    /** The downstream subscriber. */
+    protected final Subscriber<? super R> actual;
+    
+    /** The upstream subscription. */
+    protected Subscription s;
+    
+    /** The upstream's QueueSubscription if not null. */
+    protected QueueSubscription<T> qs;
+    
+    /** Flag indicating no further onXXX event should be accepted. */
+    protected boolean done;
+    
+    /** Holds the established fusion mode of the upstream. */
+    protected int sourceMode;
+    
+    /**
+     * Construct a BasicFuseableSubscriber by wrapping the given subscriber.
+     * @param actual the subscriber, not null (not verified)
+     */
+    public BasicFuseableSubscriber(Subscriber<? super R> actual) {
+        this.actual = actual;
+    }
+    
+    // final: fixed protocol steps to support fuseable and non-fuseable upstream
+    @SuppressWarnings("unchecked")
+    public final void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            
+            this.s = s;
+            if (s instanceof QueueSubscription) {
+                this.qs = (QueueSubscription<T>)s;
+            }
+            
+            if (beforeDownstream()) {
+                
+                actual.onSubscribe(this);
+                
+                afterDownstream();
+            }
+            
+        }
+    }
+    
+    /**
+     * Override this to perform actions before the call {@code actual.onSubscribe(this)} happens.
+     * @return true if onSubscribe should continue with the call
+     */
+    protected boolean beforeDownstream() {
+        return true;
+    }
+    
+    /**
+     * Override this to perform actions after the call to {@code actual.onSubscribe(this)} happened.
+     */
+    protected void afterDownstream() {
+        // default no-op
+    }
+
+    // -----------------------------------
+    // Convenience and state-aware methods
+    // -----------------------------------
+
+    /**
+     * Emits the value to the actual subscriber if {@link #done} is false. 
+     * @param value the value to signal
+     */
+    protected final void next(R value) {
+        if (done) {
+            return;
+        }
+        actual.onNext(value);
+    }
+    
+    /**
+     * Emits the throwable to the actual subscriber if {@link #done} is false,
+     * signals the throwable to {@link RxJavaPlugins#onError(Throwable)} otherwise.
+     * @param t the throwable t signal
+     */
+    protected final void error(Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        done = true;
+        actual.onError(t);
+    }
+    
+    /**
+     * Rethrows the throwable if it is a fatal exception or calls {@link #error(Throwable)}.
+     * @param t the throwable to rethrow or signal to the actual subscriber
+     */
+    protected final void fail(Throwable t) {
+        Exceptions.throwIfFatal(t);
+        error(t);
+    }
+    
+    /**
+     * Calls the upstream's QueueSubscription.requestFusion with the mode and
+     * saves the established mode in {@link #sourceMode}.
+     * <p>
+     * If the upstream doesn't support fusion ({@link #qs} is null), the method
+     * returns {@link QueueSubscription#NONE}.
+     * @param mode the fusion mode requested
+     * @return the established fusion mode
+     */
+    protected final int transitiveFusion(int mode) {
+        QueueSubscription<T> qs = this.qs;
+        if (qs != null) {
+            int m = qs.requestFusion(mode);
+            if (m != NONE) {
+                sourceMode = m;
+            }
+            return m;
+        }
+        return NONE;
+    }
+
+    /**
+     * Calls the upstream's QueueSubscription.requestFusion with the mode and
+     * saves the established mode in {@link #sourceMode} if that mode doesn't
+     * have the {@link QueueSubscription#BOUNDARY} flag set.
+     * <p>
+     * If the upstream doesn't support fusion ({@link #qs} is null), the method
+     * returns {@link QueueSubscription#NONE}.
+     * @param mode the fusion mode requested
+     * @return the established fusion mode
+     */
+    protected final int transitiveBoundaryFusion(int mode) {
+        QueueSubscription<T> qs = this.qs;
+        if (qs != null) {
+            if ((mode & BOUNDARY) == 0) {
+                int m = qs.requestFusion(mode);
+                if (m != NONE) {
+                    sourceMode = m;
+                }
+                return m;
+            }
+        }
+        return NONE;
+    }
+
+    // --------------------------------------------------------------
+    // Default implementation of the RS and QS protocol (overridable)
+    // --------------------------------------------------------------
+    
+    @Override
+    public void request(long n) {
+        s.request(n);
+    }
+    
+    @Override
+    public void cancel() {
+        s.cancel();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        return qs.isEmpty();
+    }
+    
+    @Override
+    public final int size() {
+        return qs.size();
+    }
+    
+    @Override
+    public void clear() {
+        qs.clear();
+    }
+    
+    // -----------------------------------------------------------
+    // The rest of the Queue interface methods shouldn't be called
+    // -----------------------------------------------------------
+    
+    @Override
+    public final boolean add(R e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean addAll(Collection<? extends R> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean contains(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final R element() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Iterator<R> iterator() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean offer(R e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final R peek() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final R remove() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean remove(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Object[] toArray() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public <U extends Object> U[] toArray(U[] a) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+}


### PR DESCRIPTION
This PR refactors `ConditionalSubscriber` and renames its method to `tryOnNext`. In addition, two new abstract subscriber types were added: `BasicFuseableSubscriber` and `BasicFuseableConditionalSubscriber` to help writing operators that support fusion (queue and/or conditional).
