### PR TITLE
Switch some Observable ops to direct, map fuseable

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1099,7 +1099,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> all(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return lift(new NbpOperatorAll<T>(predicate));
+        return (new ObservableAll<T>(this, predicate));
     }
 
     @SuppressWarnings("unchecked")
@@ -1112,7 +1112,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> any(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return lift(new NbpOperatorAny<T>(predicate));
+        return new ObservableAny<T>(this, predicate);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1149,7 +1149,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
             throw new IllegalArgumentException("skip > 0 required but it was " + count);
         }
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return lift(new NbpOperatorBuffer<T, U>(count, skip, bufferSupplier));
+        return new ObservableBuffer<T, U>(this, count, skip, bufferSupplier);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1182,7 +1182,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return lift(new NbpOperatorBufferTimed<T, U>(timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
+        return new ObservableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false);
     }
 
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
@@ -1217,7 +1217,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         if (count <= 0) {
             throw new IllegalArgumentException("count > 0 required but it was " + count);
         }
-        return lift(new NbpOperatorBufferTimed<T, U>(timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
+        return new ObservableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize);
     }
 
     @SchedulerSupport(SchedulerSupport.CUSTOM)
@@ -1250,7 +1250,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         Objects.requireNonNull(bufferOpenings, "bufferOpenings is null");
         Objects.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return lift(new NbpOperatorBufferBoundary<T, U, TOpening, TClosing>(bufferOpenings, bufferClosingSelector, bufferSupplier));
+        return new ObservableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1280,7 +1280,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableConsumable<B> boundary, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundary, "boundary is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return lift(new NbpOperatorBufferExactBoundary<T, U, B>(boundary, bufferSupplier));
+        return new ObservableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1298,7 +1298,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends ObservableConsumable<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundarySupplier, "boundarySupplier is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return lift(new NbpOperatorBufferBoundarySupplier<T, U, B>(boundarySupplier, bufferSupplier));
+        return new ObservableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/disposables/CompositeDisposable.java
@@ -70,7 +70,7 @@ public final class CompositeDisposable implements Disposable {
         return disposed;
     }
     
-    public void add(Disposable d) {
+    public boolean add(Disposable d) {
         Objects.requireNonNull(d, "d is null");
         if (!disposed) {
             synchronized (this) {
@@ -81,14 +81,15 @@ public final class CompositeDisposable implements Disposable {
                         resources = set;
                     }
                     set.add(d);
-                    return;
+                    return true;
                 }
             }
         }
         d.dispose();
+        return false;
     }
 
-    public void addAll(Disposable... ds) {
+    public boolean addAll(Disposable... ds) {
         Objects.requireNonNull(ds, "ds is null");
         if (!disposed) {
             synchronized (this) {
@@ -102,48 +103,40 @@ public final class CompositeDisposable implements Disposable {
                         Objects.requireNonNull(d, "d is null");
                         set.add(d);
                     }
-                    return;
+                    return true;
                 }
             }
         }
         for (Disposable d : ds) {
             d.dispose();
         }
+        return false;
     }
 
-    public void remove(Disposable d) {
-        Objects.requireNonNull(d, "Disposable item is null");
-        if (disposed) {
-            return;
+    public boolean remove(Disposable d) {
+        if (delete(d)) {
+            d.dispose();
+            return true;
         }
-        synchronized (this) {
-            if (disposed) {
-                return;
-            }
-            
-            OpenHashSet<Disposable> set = resources;
-            if (set == null || !set.remove(d)) {
-                return;
-            }
-        }
-        d.dispose();
+        return false;
     }
     
-    public void delete(Disposable d) {
+    public boolean delete(Disposable d) {
         Objects.requireNonNull(d, "Disposable item is null");
         if (disposed) {
-            return;
+            return false;
         }
         synchronized (this) {
             if (disposed) {
-                return;
+                return false;
             }
             
             OpenHashSet<Disposable> set = resources;
             if (set == null || !set.remove(d)) {
-                return;
+                return false;
             }
         }
+        return true;
     }
     
     public void clear() {

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
@@ -17,6 +17,7 @@ import java.util.*;
 
 import org.reactivestreams.Subscription;
 
+import io.reactivex.internal.functions.Objects;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.Exceptions;
@@ -117,12 +118,8 @@ public abstract class BasicFuseableConditionalSubscriber<T, R> implements Condit
         return actual.tryOnNext(value);
     }
     
-    /**
-     * Emits the throwable to the actual subscriber if {@link #done} is false,
-     * signals the throwable to {@link RxJavaPlugins#onError(Throwable)} otherwise.
-     * @param t the throwable t signal
-     */
-    protected final void error(Throwable t) {
+    @Override
+    public void onError(Throwable t) {
         if (done) {
             RxJavaPlugins.onError(t);
             return;
@@ -137,7 +134,27 @@ public abstract class BasicFuseableConditionalSubscriber<T, R> implements Condit
      */
     protected final void fail(Throwable t) {
         Exceptions.throwIfFatal(t);
-        error(t);
+        s.cancel();
+        onError(t);
+    }
+    
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        done = true;
+        actual.onComplete();
+    }
+    
+    /**
+     * Checks if the value is null and if so, throws a NullPointerException.
+     * @param value the value to check
+     * @param message the message to indicate the source of the value
+     * @return the value if not null
+     */
+    protected final <V> V nullCheck(V value, String message) {
+        return Objects.requireNonNull(value, message);
     }
     
     /**

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -47,7 +47,7 @@ public class FlowableOnBackpressureDropTest {
         ts.awaitTerminalEvent();
     }
 
-    @Test(timeout = 500)
+    @Test(timeout = 5000)
     public void testFixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);


### PR DESCRIPTION
- Switch a few `Observable` operators to direct implementations (reduces allocation)
- Update `map` to support operator fusion; there are no sources or consumer yet though.
- Adjust `BasicFuseableX` to have different default conveniences
- Modify `CompositeResource` to indicate success of the mutator methods
- increase timeout of `FlowableOnBackpressureDropTest.testFixBackpressureWithBuffer`
