### PR TITLE
2.x: run Findbugs on main only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ findbugs {
     toolVersion = '3.0.1'
     effort = 'max'
     reportLevel = 'low'
+    sourceSets = [sourceSets.main]
 }
 
 findbugsMain {


### PR DESCRIPTION
Don't run findbugs for the perf and test packages.
