### PR TITLE
Refactor private constructor checker into a utility class

### DIFF
--- a/src/test/java/rx/EventStreamTest.java
+++ b/src/test/java/rx/EventStreamTest.java
@@ -15,13 +15,11 @@
  */
 package rx;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import org.junit.Test;
 
 public class EventStreamTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(EventStream.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(EventStream.class);
     }
 }

--- a/src/test/java/rx/TestUtil.java
+++ b/src/test/java/rx/TestUtil.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx;
+
+import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+
+/**
+ * Common test utility methods.
+ */
+public enum TestUtil {
+    ;
+    
+    /**
+     * Verifies that the given class has a private constructor that
+     * throws IllegalStateException("No instances!") upon instantiation.
+     * @param clazz the target class to check
+     */
+    public static void checkUtilityClass(Class<?> clazz) {
+        PrivateConstructorChecker
+            .forClass(clazz)
+            .expectedTypeOfException(IllegalStateException.class)
+            .expectedExceptionMessage("No instances!")
+            .check();
+    }
+}

--- a/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -15,29 +15,21 @@
  */
 package rx.exceptions;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+import static org.junit.Assert.*;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
-import rx.Single;
-import rx.SingleSubscriber;
-import rx.Subscriber;
-import rx.Observable;
-import rx.Observer;
-import rx.functions.Action1;
-import rx.functions.Func1;
+import rx.*;
+import rx.functions.*;
 import rx.observables.GroupedObservable;
 import rx.subjects.PublishSubject;
 
 public class ExceptionsTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Exceptions.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Exceptions.class);
     }
 
     @Test(expected = OnErrorNotImplementedException.class)

--- a/src/test/java/rx/functions/ActionsTest.java
+++ b/src/test/java/rx/functions/ActionsTest.java
@@ -15,15 +15,14 @@
  */
 package rx.functions;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.Test;
+
+import rx.TestUtil;
 
 public class ActionsTest {
 
@@ -274,6 +273,6 @@ public class ActionsTest {
     
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Actions.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Actions.class);
     }
 }

--- a/src/test/java/rx/functions/FunctionsTest.java
+++ b/src/test/java/rx/functions/FunctionsTest.java
@@ -15,19 +15,19 @@
  */
 package rx.functions;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import rx.TestUtil;
 
 public class FunctionsTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Functions.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Functions.class);
     }
     
     @Test(expected = RuntimeException.class)

--- a/src/test/java/rx/internal/operators/BackpressureUtilsTest.java
+++ b/src/test/java/rx/internal/operators/BackpressureUtilsTest.java
@@ -15,15 +15,16 @@
  */
 package rx.internal.operators;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import rx.TestUtil;
 
 public class BackpressureUtilsTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(BackpressureUtils.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(BackpressureUtils.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/BlockingOperatorLatestTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorLatestTest.java
@@ -15,17 +15,13 @@
  */
 package rx.internal.operators;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
-import java.util.Iterator;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-
-import org.junit.Test;
+import org.junit.*;
 
 import rx.Observable;
+import rx.TestUtil;
 import rx.observables.BlockingObservable;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
@@ -33,7 +29,7 @@ import rx.subjects.PublishSubject;
 public class BlockingOperatorLatestTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(BlockingOperatorLatest.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(BlockingOperatorLatest.class);
     }
 
     @Test(timeout = 1000)

--- a/src/test/java/rx/internal/operators/BlockingOperatorMostRecentTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorMostRecentTest.java
@@ -15,30 +15,24 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static rx.internal.operators.BlockingOperatorMostRecent.mostRecent;
-
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
 
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.*;
 
-import rx.Observable;
+import rx.*;
 import rx.exceptions.TestException;
 import rx.observables.BlockingObservable;
 import rx.schedulers.TestScheduler;
-import rx.subjects.PublishSubject;
-import rx.subjects.Subject;
+import rx.subjects.*;
 
 public class BlockingOperatorMostRecentTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(BlockingOperatorMostRecent.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(BlockingOperatorMostRecent.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/BlockingOperatorNextTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorNextTest.java
@@ -15,32 +15,21 @@
  */
 package rx.internal.operators;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+import static org.junit.Assert.*;
+import static rx.internal.operators.BlockingOperatorNext.next;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.*;
 
+import rx.*;
 import rx.Observable;
-import rx.Subscriber;
 import rx.exceptions.TestException;
 import rx.observables.BlockingObservable;
 import rx.schedulers.Schedulers;
-import rx.subjects.BehaviorSubject;
-import rx.subjects.PublishSubject;
-import rx.subjects.Subject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static rx.internal.operators.BlockingOperatorNext.next;
+import rx.subjects.*;
 
 public class BlockingOperatorNextTest {
 
@@ -74,7 +63,7 @@ public class BlockingOperatorNextTest {
 
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(BlockingOperatorNext.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(BlockingOperatorNext.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/BlockingOperatorToFutureTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorToFutureTest.java
@@ -15,31 +15,23 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static rx.internal.operators.BlockingOperatorToFuture.toFuture;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
+import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
-import rx.Subscriber;
 import rx.exceptions.TestException;
 
 public class BlockingOperatorToFutureTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(BlockingOperatorToFuture.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(BlockingOperatorToFuture.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
@@ -18,15 +18,12 @@ package rx.internal.operators;
 import static org.junit.Assert.assertEquals;
 import static rx.internal.operators.BlockingOperatorToIterator.toIterator;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import java.util.Iterator;
 
 import org.junit.Test;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Subscriber;
 import rx.exceptions.TestException;
 import rx.internal.operators.BlockingOperatorToIterator.SubscriberIterator;
 import rx.internal.util.RxRingBuffer;
@@ -34,7 +31,7 @@ import rx.internal.util.RxRingBuffer;
 public class BlockingOperatorToIteratorTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(BlockingOperatorToIterator.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(BlockingOperatorToIterator.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
@@ -19,21 +19,19 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
 import rx.*;
-import rx.observers.*;
+import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
 public class OnSubscribeToObservableFutureTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(OnSubscribeToObservableFuture.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(OnSubscribeToObservableFuture.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorSequenceEqualTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSequenceEqualTest.java
@@ -16,24 +16,19 @@
 package rx.internal.operators;
 
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
-import rx.Observable;
-import rx.Observer;
+import rx.*;
 import rx.exceptions.TestException;
 import rx.functions.Func2;
 
 public class OperatorSequenceEqualTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(OperatorSequenceEqual.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(OperatorSequenceEqual.class);
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/SingleOperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/SingleOperatorZipTest.java
@@ -15,13 +15,13 @@
  */
 package rx.internal.operators;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import org.junit.Test;
+
+import rx.TestUtil;
 
 public class SingleOperatorZipTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(SingleOperatorZip.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(SingleOperatorZip.class);
     }
 }

--- a/src/test/java/rx/internal/util/PlatformDependentTest.java
+++ b/src/test/java/rx/internal/util/PlatformDependentTest.java
@@ -15,13 +15,13 @@
  */
 package rx.internal.util;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import org.junit.Test;
+
+import rx.TestUtil;
 
 public class PlatformDependentTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(PlatformDependent.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(PlatformDependent.class);
     }
 }

--- a/src/test/java/rx/internal/util/UtilityFunctionsTest.java
+++ b/src/test/java/rx/internal/util/UtilityFunctionsTest.java
@@ -15,18 +15,13 @@
  */
 package rx.internal.util;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import org.junit.Test;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
-import static org.junit.Assert.fail;
+import rx.TestUtil;
 
 public class UtilityFunctionsTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(UtilityFunctions.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(UtilityFunctions.class);
     }
 }

--- a/src/test/java/rx/internal/util/unsafe/Pow2Test.java
+++ b/src/test/java/rx/internal/util/unsafe/Pow2Test.java
@@ -15,13 +15,13 @@
  */
 package rx.internal.util.unsafe;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import org.junit.Test;
+
+import rx.TestUtil;
 
 public class Pow2Test {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Pow2.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Pow2.class);
     }
 }

--- a/src/test/java/rx/internal/util/unsafe/UnsafeAccessTest.java
+++ b/src/test/java/rx/internal/util/unsafe/UnsafeAccessTest.java
@@ -15,13 +15,13 @@
  */
 package rx.internal.util.unsafe;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import org.junit.Test;
+
+import rx.TestUtil;
 
 public class UnsafeAccessTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(UnsafeAccess.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(UnsafeAccess.class);
     }
 }

--- a/src/test/java/rx/observers/ObserversTest.java
+++ b/src/test/java/rx/observers/ObserversTest.java
@@ -18,24 +18,21 @@ package rx.observers;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import java.io.IOException;
-import java.lang.reflect.*;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 
-import rx.Observer;
+import rx.*;
 import rx.exceptions.*;
 import rx.functions.*;
 
 public class ObserversTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Observers.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Observers.class);
     }
     
     @Test

--- a/src/test/java/rx/observers/SubscribersTest.java
+++ b/src/test/java/rx/observers/SubscribersTest.java
@@ -18,14 +18,11 @@ package rx.observers;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
-import java.lang.reflect.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
-import rx.Subscriber;
+import rx.*;
 import rx.exceptions.*;
 import rx.functions.*;
 import rx.subscriptions.Subscriptions;
@@ -33,7 +30,7 @@ import rx.subscriptions.Subscriptions;
 public class SubscribersTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Subscribers.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Subscribers.class);
     }
     
     @Test

--- a/src/test/java/rx/plugins/RxJavaHooksTest.java
+++ b/src/test/java/rx/plugins/RxJavaHooksTest.java
@@ -15,8 +15,6 @@
  */
 package rx.plugins;
 
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
-
 import java.lang.reflect.Method;
 
 import org.junit.*;
@@ -40,7 +38,7 @@ public class RxJavaHooksTest {
     
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(RxJavaHooks.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(RxJavaHooks.class);
     }
 
     @Test

--- a/src/test/java/rx/subscriptions/SubscriptionsTest.java
+++ b/src/test/java/rx/subscriptions/SubscriptionsTest.java
@@ -15,24 +15,19 @@
  */
 package rx.subscriptions;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static rx.subscriptions.Subscriptions.create;
-
-import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
 
 import org.junit.Test;
 
-import rx.Subscription;
+import rx.*;
 import rx.functions.Action0;
 
 public class SubscriptionsTest {
     @Test
     public void constructorShouldBePrivate() {
-        PrivateConstructorChecker.forClass(Subscriptions.class).expectedTypeOfException(IllegalStateException.class).expectedExceptionMessage("No instances!").check();
+        TestUtil.checkUtilityClass(Subscriptions.class);
     }
 
     @Test


### PR DESCRIPTION
Move into `TestUtil.checkUtilityClass()`.
