### PR TITLE
2.x: enable fuseable sources, adjust operators

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -61,12 +61,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /** A never observable instance as there is no need to instantiate this more than once. */
-    static final Flowable<Object> NEVER = create(new Publisher<Object>() {
+    static final Flowable<Object> NEVER = new Flowable<Object>() { // FIXME factor out
         @Override
-        public void subscribe(Subscriber<? super Object> s) {
+        public void subscribeActual(Subscriber<? super Object> s) {
             s.onSubscribe(EmptySubscription.INSTANCE);
         }
-    });
+    };
 
     public static <T> Flowable<T> amb(Iterable<? extends Publisher<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
@@ -1186,6 +1186,22 @@ public abstract class Flowable<T> implements Publisher<T> {
         });
     }
 
+    /**
+     * Hides the identity of this Flowable and its Subscription.
+     * <p>Allows hiding extra features such as {@link Processor}'s
+     * {@link Subscriber} methods or preventing certain identity-based 
+     * optimizations (fusion).
+     * @return the new Flowable instance
+     * 
+     * @since 2.0
+     */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> hide() {
+        return new FlowableHide<T>(this);
+    }
+
+    
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<List<T>> buffer(int count) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -14,13 +14,14 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
-import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.internal.util.*;
 
 public final class FlowableFromIterable<T> extends Flowable<T> {
     
@@ -32,102 +33,323 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
         Iterator<? extends T> it;
-        try {
-            it = source.iterator();
-        } catch (Throwable e) {
-            EmptySubscription.error(e, s);
-            return;
-        }
         boolean hasNext;
         try {
+            it = source.iterator();
+
             hasNext = it.hasNext();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }
+        
         if (!hasNext) {
             EmptySubscription.complete(s);
             return;
         }
-        s.onSubscribe(new IteratorSourceSubscription<T>(it, s));
+        
+        if (s instanceof ConditionalSubscriber) {
+            s.onSubscribe(new IteratorConditionalSubscription<T>(
+                    (ConditionalSubscriber<? super T>)s, it));
+        } else {
+            s.onSubscribe(new IteratorSubscription<T>(s, it));
+        }
+        
     }
     
-    static final class IteratorSourceSubscription<T> extends AtomicLong implements Subscription {
+    static abstract class BaseRangeSubscription<T> extends BasicQueueSubscription<T> {
         /** */
-        private static final long serialVersionUID = 8931425802102883003L;
+        private static final long serialVersionUID = -2252972430506210021L;
+
         final Iterator<? extends T> it;
-        final Subscriber<? super T> subscriber;
         
         volatile boolean cancelled;
         
-        public IteratorSourceSubscription(Iterator<? extends T> it, Subscriber<? super T> subscriber) {
+        boolean once;
+        
+        public BaseRangeSubscription(Iterator<? extends T> it) {
             this.it = it;
-            this.subscriber = subscriber;
         }
+        
         @Override
-        public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
-                return;
+        public final int requestFusion(int mode) {
+            return mode & SYNC;
+        }
+
+        @Override
+        public final T poll() {
+            if (!once) {
+                once = true;
+            } else {
+                if (!it.hasNext()) {
+                    return null;
+                }
             }
-            if (BackpressureHelper.add(this, n) != 0L) {
-                return;
+            return Objects.requireNonNull(it.next(), "Iterator.next() returned a null value");
+        }
+
+        
+        @Override
+        public final boolean isEmpty() {
+            return !it.hasNext();
+        }
+
+        @Override
+        public final void clear() {
+            // nothing to do
+        }
+
+        @Override
+        public final void request(long n) {
+            if (SubscriptionHelper.validateRequest(n)) {
+                if (BackpressureHelper.add(this, n) == 0L) {
+                    if (n == Long.MAX_VALUE) {
+                        fastPath();
+                    } else {
+                        slowPath(n);
+                    }
+                }
             }
-            long r = n;
-            long r0 = n;
-            final Subscriber<? super T> subscriber = this.subscriber;
-            final Iterator<? extends T> it = this.it;
+        }
+        
+
+        @Override
+        public final void cancel() {
+            cancelled = true;
+        }
+        
+        abstract void fastPath();
+        
+        abstract void slowPath(long r);
+    }
+    
+    static final class IteratorSubscription<T> extends BaseRangeSubscription<T> {
+
+        /** */
+        private static final long serialVersionUID = -6022804456014692607L;
+
+        final Subscriber<? super T> actual;
+        
+        public IteratorSubscription(Subscriber<? super T> actual, Iterator<? extends T> it) {
+            super(it);
+            this.actual = actual;
+        }
+
+        @Override
+        void fastPath() {
+            Iterator<? extends T> it = this.it;
+            Subscriber<? super T> a = actual;
             for (;;) {
                 if (cancelled) {
                     return;
                 }
+                
+                T t = it.next();
 
-                long e = 0L;
-                while (r != 0L) {
-                    T v;
-                    try {
-                        v = it.next();
-                    } catch (Throwable ex) {
-                        subscriber.onError(ex);
-                        return;
+                if (cancelled) {
+                    return;
+                }
+
+                if (t == null) {
+                    a.onError(new NullPointerException("Iterator.next() returned a null value"));
+                    return;
+                } else {
+                    a.onNext(t);
+                }
+
+                if (cancelled) {
+                    return;
+                }
+
+                if (!it.hasNext()) {
+                    if (!cancelled) {
+                        a.onComplete();
                     }
-                    
-                    if (v == null) {
-                        subscriber.onError(new NullPointerException("Iterator returned a null element"));
-                        return;
-                    }
-                    
-                    subscriber.onNext(v);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        void slowPath(long r) {
+            long e = 0L;
+            Iterator<? extends T> it = this.it;
+            Subscriber<? super T> a = actual;
+            
+            for (;;) {
+                
+                while (e != r) {
                     
                     if (cancelled) {
                         return;
                     }
                     
-                    boolean hasNext;
-                    try {
-                        hasNext = it.hasNext();
-                    } catch (Throwable ex) {
-                        subscriber.onError(ex);
+                    T t = it.next();
+
+                    if (cancelled) {
                         return;
                     }
-                    if (!hasNext) {
-                        subscriber.onComplete();
+
+                    if (t == null) {
+                        a.onError(new NullPointerException("Iterator.next() returned a null value"));
+                        return;
+                    } else {
+                        a.onNext(t);
+                    }
+                    
+                    if (cancelled) {
+                        return;
+                    }
+
+                    if (!it.hasNext()) {
+                        if (!cancelled) {
+                            a.onComplete();
+                        }
                         return;
                     }
                     
-                    r--;
-                    e--;
+                    e++;
                 }
-                if (e != 0L && r0 != Long.MAX_VALUE) {
-                    r = addAndGet(e);
-                }
-                if (r == 0L) {
-                    break;
+                
+                r = get();
+                if (e == r) {
+                    
+                    if (cancelled) {
+                        return;
+                    }
+
+                    if (!it.hasNext()) {
+                        if (!cancelled) {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    r = addAndGet(-e);
+                    if (r == 0L) {
+                        return;
+                    }
+                    e = 0L;
                 }
             }
         }
-        @Override
-        public void cancel() {
-            cancelled = true;
+        
+    }
+    
+    static final class IteratorConditionalSubscription<T> extends BaseRangeSubscription<T> {
+
+        /** */
+        private static final long serialVersionUID = -6022804456014692607L;
+
+        final ConditionalSubscriber<? super T> actual;
+        
+        public IteratorConditionalSubscription(ConditionalSubscriber<? super T> actual, Iterator<? extends T> it) {
+            super(it);
+            this.actual = actual;
         }
+
+        @Override
+        void fastPath() {
+            Iterator<? extends T> it = this.it;
+            ConditionalSubscriber<? super T> a = actual;
+            for (;;) {
+                if (cancelled) {
+                    return;
+                }
+                
+                T t = it.next();
+
+                if (cancelled) {
+                    return;
+                }
+
+                if (t == null) {
+                    a.onError(new NullPointerException("Iterator.next() returned a null value"));
+                    return;
+                } else {
+                    a.tryOnNext(t);
+                }
+
+                if (cancelled) {
+                    return;
+                }
+
+                if (!it.hasNext()) {
+                    if (!cancelled) {
+                        a.onComplete();
+                    }
+                    return;
+                }
+            }
+        }
+
+        @Override
+        void slowPath(long r) {
+            long e = 0L;
+            Iterator<? extends T> it = this.it;
+            ConditionalSubscriber<? super T> a = actual;
+            
+            for (;;) {
+                
+                while (e != r) {
+                    
+                    if (cancelled) {
+                        return;
+                    }
+                    
+                    T t = it.next();
+
+                    if (cancelled) {
+                        return;
+                    }
+
+                    boolean b;
+                    if (t == null) {
+                        a.onError(new NullPointerException("Iterator.next() returned a null value"));
+                        return;
+                    } else {
+                        b = a.tryOnNext(t);
+                    }
+                    
+                    if (cancelled) {
+                        return;
+                    }
+
+                    if (!it.hasNext()) {
+                        if (!cancelled) {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (b) {
+                        e++;
+                    }
+                }
+                
+                r = get();
+                if (e == r) {
+                    
+                    if (cancelled) {
+                        return;
+                    }
+
+                    if (!it.hasNext()) {
+                        if (!cancelled) {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    r = addAndGet(-e);
+                    if (r == 0L) {
+                        return;
+                    }
+                    e = 0L;
+                }
+            }
+        }
+        
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Hides the identity of the wrapped Flowable and its Subscription.
+ * @param <T> the value type
+ * 
+ * @since 2.0
+ */
+public class FlowableHide<T> extends FlowableSource<T, T> {
+    
+    public FlowableHide(Publisher<T> source) {
+        super(source);
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new HideSubscriber<T>(s));
+    }
+
+    static final class HideSubscriber<T> implements Subscriber<T>, Subscription {
+        
+        final Subscriber<? super T> actual;
+        
+        Subscription s;
+
+        public HideSubscriber(Subscriber<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSource.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSource.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Objects;
+
+/**
+ * Abstract base class for operators that take an upstream
+ * source {@link Publisher}.
+ *
+ * @param <T> the upstream value type
+ * @param <R> the output value type
+ */
+public abstract class FlowableSource<T, R> extends Flowable<R> {
+    
+    /**
+     * The upstream source Publisher.
+     */
+    protected final Publisher<T> source;
+    
+    /**
+     * Constructs a FlowableSource wrapping the given non-null (verified)
+     * source Publisher.
+     * @param source the source (upstream) Publisher instance, not null (verified)
+     */
+    public FlowableSource(Publisher<T> source) {
+        this.source = Objects.requireNonNull(source, "source is null");
+    }
+    
+    /**
+     * Returns the source Publisher.
+     * <p>
+     * This method is intended to discover the assembly
+     * graph of sequences.
+     * @return the source Publisher
+     */
+    public final Publisher<T> source() {
+        return source;
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscriptions/BasicQueueSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/BasicQueueSubscription.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.reactivex.internal.fuseable.QueueSubscription;
+
+/**
+ * Base class extending AtomicLong (wip or request accounting) and QueueSubscription (fusion).
+ *
+ * @param <T> the value type
+ */
+public abstract class BasicQueueSubscription<T> extends AtomicLong implements QueueSubscription<T> {
+
+    /** */
+    private static final long serialVersionUID = -6671519529404341862L;
+
+    @Override
+    public final boolean add(T e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean addAll(Collection<? extends T> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean contains(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final T element() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Iterator<T> iterator() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean offer(T e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final T peek() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final T remove() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean remove(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final int size() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Object[] toArray() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final <U extends Object> U[] toArray(U[] a) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+}

--- a/src/test/java/io/reactivex/flowable/FuseableTest.java
+++ b/src/test/java/io/reactivex/flowable/FuseableTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.flowable;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FuseableTest {
+
+    @Test
+    public void syncRange() {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.setInitialFusionMode(QueueSubscription.SYNC);
+        
+        Flowable.range(1, 10).subscribe(ts);
+        
+        ts.assertFusionMode(QueueSubscription.SYNC)
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    @Test
+    public void syncArray() {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.setInitialFusionMode(QueueSubscription.SYNC);
+        
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).subscribe(ts);
+        
+        ts.assertFusionMode(QueueSubscription.SYNC)
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void syncIterable() {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.setInitialFusionMode(QueueSubscription.SYNC);
+        
+        Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).subscribe(ts);
+        
+        ts.assertFusionMode(QueueSubscription.SYNC)
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    @Test
+    public void syncRangeHidden() {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.setInitialFusionMode(QueueSubscription.SYNC);
+        
+        Flowable.range(1, 10).hide().subscribe(ts);
+        
+        ts.assertNotFuseable()
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    @Test
+    public void syncArrayHidden() {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.setInitialFusionMode(QueueSubscription.SYNC);
+        
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        .hide().subscribe(ts);
+        
+        ts.assertNotFuseable()
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void syncIterableHidden() {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.setInitialFusionMode(QueueSubscription.SYNC);
+        
+        Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        .hide().subscribe(ts);
+        
+        ts.assertNotFuseable()
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+}


### PR DESCRIPTION
- adds an operator `hide` to allow hiding and breaking optimizations
- update `filter` to support fusions: queue and conditional
- `range` now supports fusion: sync-queue and conditional
- `fromArray` now supports fusion: sync-queue and conditional
- `fromIterable` now supports fusion: sync-queue and conditional
- enhanced `TestSubscriber` methods to return this - allows chaining the assertions
- extended `TestSubscriber` to act as a consumer for queue-fusion
- introduced `FlowableSource` as an intermediate type for operators: allows discovering the upstream in a standard way, allows the IDE to generate a constructor with a source value.
- added `BasicQueueSubscription` that locks down unused `Queue` methods plus is a container for an atomic long value useful for request/wip tracking.
