### PR TITLE
2.x: Enable fusion-consumers

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
@@ -68,7 +68,7 @@ public final class CompletableConcat extends Completable {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(prefetch);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
@@ -82,7 +82,7 @@ public final class CompletableMerge extends Completable {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 set.add(Disposables.from(s));
                 actual.onSubscribe(this);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
@@ -50,7 +50,7 @@ public final class FlowableAll<T> extends Flowable<Boolean> {
         }
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAmb.java
@@ -95,7 +95,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             
@@ -172,7 +172,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
             Subscription s = get();
             if (s != null) {
                 s.request(n);
-            } else if (SubscriptionHelper.validateRequest(n)) {
+            } else if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(missedRequested, n);
                 s = get();
                 if (s != null && s != SubscriptionHelper.CANCELLED) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
@@ -47,7 +47,7 @@ public final class FlowableAny<T> extends Flowable<Boolean> {
         }
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -96,7 +96,7 @@ public final class FlowableBuffer<T, U extends Collection<? super T>> extends Fl
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }
@@ -137,7 +137,7 @@ public final class FlowableBuffer<T, U extends Collection<? super T>> extends Fl
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 long m = BackpressureHelper.multiplyCap(n, count);
                 s.request(m);
             }
@@ -173,7 +173,7 @@ public final class FlowableBuffer<T, U extends Collection<? super T>> extends Fl
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }
@@ -231,7 +231,7 @@ public final class FlowableBuffer<T, U extends Collection<? super T>> extends Fl
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             // requesting the first set of buffers must happen only once

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -77,7 +77,7 @@ extends Flowable<U> {
         }
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
 
                 BufferOpenSubscriber<T, U, Open, Close> bos = new BufferOpenSubscriber<T, U, Open, Close>(this);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
@@ -67,7 +67,7 @@ extends Flowable<U> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -64,7 +64,7 @@ extends Flowable<U> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -106,7 +106,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;
@@ -283,7 +283,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
     
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;
@@ -459,7 +459,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -275,7 +275,7 @@ public final class FlowableCache<T> extends Flowable<T> {
         }
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
@@ -66,7 +66,7 @@ public final class FlowableCollect<T, U> extends Flowable<U> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -128,7 +128,7 @@ public final class FlowableCombineLatest<T, R> extends Flowable<R> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -27,7 +27,8 @@ import io.reactivex.internal.util.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableConcatMap<T, R> extends FlowableSource<T, R> {
-final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
     
     final int prefetch;
     
@@ -59,18 +60,14 @@ final Function<? super T, ? extends Publisher<? extends R>> mapper;
     
     public static <T, R> Subscriber<T> subscribe(Subscriber<? super R> s, Function<? super T, ? extends Publisher<? extends R>> mapper, 
             int prefetch, ErrorMode errorMode) {
-        Subscriber<T> parent = null;
         switch (errorMode) {
         case BOUNDARY:
-            parent = new ConcatMapDelayed<T, R>(s, mapper, prefetch, false);
-            break;
+            return new ConcatMapDelayed<T, R>(s, mapper, prefetch, false);
         case END:
-            parent = new ConcatMapDelayed<T, R>(s, mapper, prefetch, true);
-            break;
+            return new ConcatMapDelayed<T, R>(s, mapper, prefetch, true);
         default:
-            parent = new ConcatMapImmediate<T, R>(s, mapper, prefetch);
+            return new ConcatMapImmediate<T, R>(s, mapper, prefetch);
         }
-        return parent;
     }
     
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCount.java
@@ -47,7 +47,7 @@ public final class FlowableCount<T> extends Flowable<Long> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -66,7 +66,7 @@ public final class FlowableDebounce<T, U> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -134,7 +134,7 @@ public final class FlowableDebounce<T, U> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -73,7 +73,7 @@ public final class FlowableDebounceTimed<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -134,7 +134,7 @@ public final class FlowableDebounceTimed<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -71,7 +71,7 @@ public final class FlowableDelay<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
@@ -45,7 +45,7 @@ public final class FlowableDematerialize<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -135,7 +135,7 @@ public final class FlowableDistinct<T, K> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -70,7 +70,7 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAt.java
@@ -54,7 +54,7 @@ public final class FlowableElementAt<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -1,0 +1,436 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
+
+    final Function<? super T, ? extends Iterable<? extends R>> mapper;
+
+    final int prefetch;
+
+    public FlowableFlattenIterable(Publisher<T> source,
+            Function<? super T, ? extends Iterable<? extends R>> mapper, int prefetch) {
+        super(source);
+        if (prefetch <= 0) {
+            throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+        }
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.prefetch = prefetch;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void subscribeActual(Subscriber<? super R> s) {
+        if (source instanceof Callable) {
+            T v;
+
+            try {
+                v = ((Callable<T>)source).call();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptySubscription.error(ex, s);
+                return;
+            }
+
+            if (v == null) {
+                EmptySubscription.complete(s);
+                return;
+            }
+
+            Iterator<? extends R> it;
+
+            try {
+                Iterable<? extends R> iter = mapper.apply(v);
+
+                it = iter.iterator();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptySubscription.error(ex, s);
+                return;
+            }
+
+            FlowableFromIterable.subscribe(s, it);
+
+            return;
+        }
+        source.subscribe(new FlattenIterableSubscriber<T, R>(s, mapper, prefetch));
+    }
+
+    static final class FlattenIterableSubscriber<T, R>
+    extends BasicIntQueueSubscription<R>
+    implements Subscriber<T> {
+
+        /** */
+        private static final long serialVersionUID = -3096000382929934955L;
+
+        final Subscriber<? super R> actual;
+
+        final Function<? super T, ? extends Iterable<? extends R>> mapper;
+
+        final int prefetch;
+
+        final int limit;
+
+        final AtomicLong requested;
+
+        Subscription s;
+
+        Queue<T> queue;
+
+        volatile boolean done;
+
+        volatile boolean cancelled;
+
+        final AtomicReference<Throwable> error;
+
+        Iterator<? extends R> current;
+
+        int consumed;
+
+        int fusionMode;
+
+        public FlattenIterableSubscriber(Subscriber<? super R> actual,
+                Function<? super T, ? extends Iterable<? extends R>> mapper, int prefetch) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.prefetch = prefetch;
+            this.limit = prefetch - (prefetch >> 2);
+            this.error = new AtomicReference<Throwable>();
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked")
+                    QueueSubscription<T> qs = (QueueSubscription<T>) s;
+
+                    int m = qs.requestFusion(ANY);
+
+                    if (m == SYNC) {
+                        fusionMode = m;
+                        this.queue = qs;
+                        done = true;
+
+                        actual.onSubscribe(this);
+
+                        return;
+                    } else
+                        if (m == ASYNC) {
+                            fusionMode = m;
+                            this.queue = qs;
+
+                            actual.onSubscribe(this);
+
+                            s.request(prefetch);
+                            return;
+                        }
+                }
+
+                queue = new SpscArrayQueue<T>(prefetch);
+
+                actual.onSubscribe(this);
+
+                s.request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (fusionMode != ASYNC) {
+                if (!queue.offer(t)) {
+                    onError(new IllegalStateException("Queue is full?!"));
+                    return;
+                }
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (Exceptions.addThrowable(error, t)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+
+                if (getAndIncrement() == 0) {
+                    queue.clear();
+                }
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            final Subscriber<? super R> a = actual;
+            final Queue<T> q = queue;
+            final boolean replenish = fusionMode != SYNC;
+
+            int missed = 1;
+
+            Iterator<? extends R> it = current;
+
+            for (;;) {
+
+                if (it == null) {
+
+                    boolean d = done;
+
+                    T t;
+
+                    t = q.poll();
+
+                    boolean empty = t == null;
+
+                    if (checkTerminated(d, empty, a, q)) {
+                        return;
+                    }
+
+                    if (t != null) {
+                        Iterable<? extends R> iterable;
+
+                        boolean b;
+
+                        try {
+                            iterable = mapper.apply(t);
+
+                            it = iterable.iterator();
+
+                            b = it.hasNext();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            onError(ex);
+                            it = null;
+                            continue;
+                        }
+
+                        if (!b) {
+                            it = null;
+                            consumedOne(replenish);
+                            continue;
+                        }
+
+                        current = it;
+                    }
+                }
+
+                if (it != null) {
+                    long r = requested.get();
+                    long e = 0L;
+
+                    while (e != r) {
+                        if (checkTerminated(done, false, a, q)) {
+                            return;
+                        }
+
+                        R v;
+
+                        try {
+                            v = it.next();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            onError(ex);
+                            continue;
+                        }
+
+                        a.onNext(v);
+
+                        if (checkTerminated(done, false, a, q)) {
+                            return;
+                        }
+
+                        e++;
+
+                        boolean b;
+
+                        try {
+                            b = it.hasNext();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            onError(ex);
+                            continue;
+                        }
+
+                        if (!b) {
+                            consumedOne(replenish);
+                            it = null;
+                            current = null;
+                            break;
+                        }
+                    }
+
+                    if (e == r) {
+                        boolean d = done;
+                        boolean empty;
+
+                        try {
+                            empty = q.isEmpty() && it == null;
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            onError(ex);
+                            empty = true;
+                        }
+
+                        if (checkTerminated(d, empty, a, q)) {
+                            return;
+                        }
+                    }
+
+                    if (e != 0L) {
+                        if (r != Long.MAX_VALUE) {
+                            requested.addAndGet(-e);
+                        }
+                    }
+
+                    if (it == null) {
+                        continue;
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        void consumedOne(boolean enabled) {
+            if (enabled) {
+                int c = consumed + 1;
+                if (c == limit) {
+                    consumed = 0;
+                    s.request(c);
+                } else {
+                    consumed = c;
+                }
+            }
+        }
+
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, Queue<?> q) {
+            if (cancelled) {
+                current = null;
+                q.clear();
+                return true;
+            }
+            if (d) {
+                if (error != null) {
+                    Throwable e = Exceptions.terminate(error);
+
+                    current = null;
+                    q.clear();
+
+                    a.onError(e);
+                    return true;
+                } else
+                    if (empty) {
+                        a.onComplete();
+                        return true;
+                    }
+            }
+            return false;
+        }
+
+        @Override
+        public void clear() {
+            current = null;
+            queue.clear();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            Iterator<? extends R> it = current;
+            if (it != null) {
+                return it.hasNext();
+            }
+            return queue.isEmpty(); // estimate
+        }
+
+        @Override
+        public R poll() {
+            Iterator<? extends R> it = current;
+            for (;;) {
+                if (it == null) {
+                    T v = queue.poll();
+                    if (v == null) {
+                        return null;
+                    }
+
+                    it = mapper.apply(v).iterator();
+
+                    if (!it.hasNext()) {
+                        continue;
+                    }
+                    current = it;
+                }
+
+                R r = it.next();
+
+                if (!it.hasNext()) {
+                    current = null;
+                }
+
+                return r;
+            }
+        }
+
+        @Override
+        public int requestFusion(int requestedMode) {
+            if ((requestedMode & SYNC) != 0 && fusionMode == SYNC) {
+                return SYNC;
+            }
+            return NONE;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -143,16 +143,16 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
                         actual.onSubscribe(this);
 
                         return;
-                    } else
-                        if (m == ASYNC) {
-                            fusionMode = m;
-                            this.queue = qs;
+                    }
+                    if (m == ASYNC) {
+                        fusionMode = m;
+                        this.queue = qs;
 
-                            actual.onSubscribe(this);
+                        actual.onSubscribe(this);
 
-                            s.request(prefetch);
-                            return;
-                        }
+                        s.request(prefetch);
+                        return;
+                    }
                 }
 
                 queue = new SpscArrayQueue<T>(prefetch);
@@ -165,11 +165,9 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
 
         @Override
         public void onNext(T t) {
-            if (fusionMode != ASYNC) {
-                if (!queue.offer(t)) {
-                    onError(new IllegalStateException("Queue is full?!"));
-                    return;
-                }
+            if (fusionMode != ASYNC && !queue.offer(t)) {
+                onError(new IllegalStateException("Queue is full?!"));
+                return;
             }
             drain();
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -83,7 +83,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
 
         @Override
         public final void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 if (BackpressureHelper.add(this, n) == 0L) {
                     if (n == Long.MAX_VALUE) {
                         fastPath();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
@@ -76,7 +76,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             if (BackpressureHelper.add(this, n) != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -86,7 +86,7 @@ public final class FlowableGroupBy<T, K, V> extends Flowable<GroupedFlowable<K, 
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(bufferSize);
@@ -177,7 +177,7 @@ public final class FlowableGroupBy<T, K, V> extends Flowable<GroupedFlowable<K, 
 
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }
@@ -352,7 +352,7 @@ public final class FlowableGroupBy<T, K, V> extends Flowable<GroupedFlowable<K, 
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             BackpressureHelper.add(requested, n);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
@@ -56,7 +56,7 @@ public class FlowableHide<T> extends FlowableSource<T, T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
@@ -45,7 +45,7 @@ public final class FlowableIgnoreElements<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
@@ -65,7 +65,7 @@ public final class FlowableInterval extends Flowable<Long> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
@@ -71,7 +71,7 @@ public final class FlowableIntervalRange extends Flowable<Long> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -83,7 +83,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }
@@ -183,7 +183,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMaterialize.java
@@ -59,7 +59,7 @@ public final class FlowableMaterialize<T> extends Flowable<Try<Optional<T>>> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }
@@ -122,7 +122,7 @@ public final class FlowableMaterialize<T> extends Flowable<Try<Optional<T>>> {
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             BackpressureHelper.add(this, n);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -197,8 +197,7 @@ final Scheduler scheduler;
         public final void run() {
             if (outputFused) {
                 runBackfused();
-            } else
-            if (sourceMode == SYNC) {
+            } else if (sourceMode == SYNC) {
                 runSync();
             } else {
                 runAsync();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -14,188 +14,687 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Queue;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
 
-import io.reactivex.*;
+import io.reactivex.Scheduler;
+import io.reactivex.Scheduler.Worker;
 import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.internal.queue.*;
-import io.reactivex.internal.schedulers.TrampolineScheduler;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
-import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableObserveOn<T> extends Flowable<T> {
+public final class FlowableObserveOn<T> extends FlowableSource<T, T> {
+final Scheduler scheduler;
     
-    final Publisher<T> source;
-    final Scheduler scheduler;
     final boolean delayError;
-    final int bufferSize;
-    public FlowableObserveOn(Publisher<T> source, Scheduler scheduler, boolean delayError, int bufferSize) {
-        this.source = source;
-        this.scheduler = scheduler;
-        this.delayError = delayError;
-        this.bufferSize = bufferSize;
-    }
     
+    final int prefetch;
+    
+    public FlowableObserveOn(
+            Publisher<T> source, 
+            Scheduler scheduler, 
+            boolean delayError,
+            int prefetch) {
+        super(source);
+        if (prefetch <= 0) {
+            throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+        }
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+        this.delayError = delayError;
+        this.prefetch = prefetch;
+    }
+
     @Override
-    protected void subscribeActual(Subscriber<? super T> s) {
-        if (scheduler instanceof TrampolineScheduler) {
-            source.subscribe(s);
+    public void subscribeActual(Subscriber<? super T> s) {
+
+// FIXME add macro-optimization
+//        if (PublisherSubscribeOnValue.scalarScheduleOn(source, s, scheduler)) {
+//            return;
+//        }
+
+        Worker worker;
+        
+        try {
+            worker = scheduler.createWorker();
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            EmptySubscription.error(e, s);
             return;
         }
         
-        Scheduler.Worker w = scheduler.createWorker();
+        if (worker == null) {
+            EmptySubscription.error(new NullPointerException("The scheduler returned a null Function"), s);
+            return;
+        }
         
-        source.subscribe(new ObserveOnSubscriber<T>(s, w, delayError, bufferSize));
+        if (s instanceof ConditionalSubscriber) {
+            ConditionalSubscriber<? super T> cs = (ConditionalSubscriber<? super T>) s;
+            source.subscribe(new PublisherObserveOnConditionalSubscriber<T>(cs, worker, delayError, prefetch));
+            return;
+        }
+        source.subscribe(new PublisherObserveOnSubscriber<T>(s, worker, delayError, prefetch));
     }
-    
-    /**
-     * Pads the base atomic integer used for wip counting.
-     */
-    static class Padding0 extends AtomicInteger {
+
+    static abstract class BaseObserveOnSubscriber<T>
+    extends BasicIntQueueSubscription<T>
+    implements Runnable, Subscriber<T> {
         /** */
-        private static final long serialVersionUID = 3172843496016154809L;
+        private static final long serialVersionUID = -8241002408341274697L;
+
+        final Worker worker;
         
-        volatile long p01, p02, p03, p04, p05, p06, p07;
-    }
-    
-    /**
-     * Contains the requested amount.
-     */
-    static class Padding1 extends Padding0 {
-        /** */
-        private static final long serialVersionUID = 7659422588548271214L;
-        
-        final AtomicLong requested = new AtomicLong();
-    }
-    
-    /**
-     * Pads the requested amount away from the effectively constant fields
-     */
-    static class Padding2 extends Padding1 {
-        /** */
-        private static final long serialVersionUID = 227348361328175380L;
-        volatile long p11, p12, p13, p14, p15, p16, p17;
-    }
-    
-    static final class ObserveOnSubscriber<T> extends Padding2 implements Subscriber<T>, Subscription, Runnable {
-        /** */
-        private static final long serialVersionUID = 6576896619930983584L;
-        final Subscriber<? super T> actual;
-        final Scheduler.Worker worker;
         final boolean delayError;
-        final int bufferSize;
-        final Queue<T> queue;
+        
+        final int prefetch;
+        
+        final int limit;
+        
+        final AtomicLong requested;
         
         Subscription s;
         
-        Throwable error;
-        volatile boolean done;
+        Queue<T> queue;
         
         volatile boolean cancelled;
         
-        public ObserveOnSubscriber(Subscriber<? super T> actual, Scheduler.Worker worker, boolean delayError, int bufferSize) {
-            this.actual = actual;
+        volatile boolean done;
+        
+        Throwable error;
+
+        int sourceMode;
+        
+        long produced;
+        
+        boolean outputFused;
+        
+        public BaseObserveOnSubscriber(
+                Worker worker,
+                boolean delayError,
+                int prefetch) {
             this.worker = worker;
             this.delayError = delayError;
-            this.bufferSize = bufferSize;
-            Queue<T> q;
-            if (Pow2.isPowerOfTwo(bufferSize)) {
-                q = new SpscArrayQueue<T>(bufferSize);
+            this.prefetch = prefetch;
+            this.requested = new AtomicLong();
+            
+            if (prefetch != Integer.MAX_VALUE) {
+                this.limit = prefetch - (prefetch >> 2);
             } else {
-                q = new SpscExactArrayQueue<T>(bufferSize);
+                this.limit = Integer.MAX_VALUE;
             }
-            this.queue = q;
         }
         
-        @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
-                this.s = s;
-                actual.onSubscribe(this);
-                s.request(bufferSize);
+        final void initialRequest() {
+            if (prefetch == Integer.MAX_VALUE) {
+                s.request(Long.MAX_VALUE);
+            } else {
+                s.request(prefetch);
             }
         }
         
         @Override
-        public void onNext(T t) {
-            if (done) {
+        public final void onNext(T t) {
+            if (sourceMode == ASYNC) {
+                trySchedule();
+                return;
+            }
+            if (!queue.offer(t)) {
+                s.cancel();
+                
+                error = new MissingBackpressureException("Queue is full?!");
+                done = true;
+            }
+            trySchedule();
+        }
+        
+        @Override
+        public final void onError(Throwable t) {
+            error = t;
+            done = true;
+            trySchedule();
+        }
+        
+        @Override
+        public final void onComplete() {
+            done = true;
+            trySchedule();
+        }
+        
+        @Override
+        public final void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                trySchedule();
+            }
+        }
+        
+        @Override
+        public final void cancel() {
+            if (cancelled) {
                 return;
             }
             
-            if (!queue.offer(t)) {
-                s.cancel();
-                onError(new MissingBackpressureException("Queue full?!"));
+            cancelled = true;
+            s.cancel();
+            worker.dispose();
+            
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+
+        final void trySchedule() {
+            if (getAndIncrement() != 0) {
                 return;
             }
-            schedule();
+            worker.schedule(this);
         }
         
         @Override
-        public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            error = t;
-            done = true;
-            schedule();
-        }
-        
-        @Override
-        public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-            schedule();
-        }
-        
-        @Override
-        public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
-                BackpressureHelper.add(requested, n);
-                schedule();
+        public final void run() {
+            if (outputFused) {
+                runBackfused();
+            } else
+            if (sourceMode == SYNC) {
+                runSync();
+            } else {
+                runAsync();
             }
         }
         
-        @Override
-        public void cancel() {
-            if (!cancelled) {
-                cancelled = true;
-                s.cancel();
+        abstract void runBackfused();
+        
+        abstract void runSync();
+        
+        abstract void runAsync();
+        
+        final boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a) {
+            if (cancelled) {
+                queue.clear();
+                return true;
+            }
+            if (d) {
+                if (delayError) {
+                    if (empty) {
+                        Throwable e = error;
+                        if (e != null) {
+                            doError(a, e);
+                        } else {
+                            doComplete(a);
+                        }
+                        return true;
+                    }
+                } else {
+                    Throwable e = error;
+                    if (e != null) {
+                        queue.clear();
+                        doError(a, e);
+                        return true;
+                    } else
+                    if (empty) {
+                        doComplete(a);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        final void doComplete(Subscriber<?> a) {
+            try {
+                a.onComplete();
+            } finally {
                 worker.dispose();
             }
         }
         
-        void schedule() {
-            if (getAndIncrement() == 0) {
-                worker.schedule(this);
+        final void doError(Subscriber<?> a, Throwable e) {
+            try {
+                a.onError(e);
+            } finally {
+                worker.dispose();
+            }
+        }
+
+        @Override
+        public final int requestFusion(int requestedMode) {
+            if ((requestedMode & ASYNC) != 0) {
+                outputFused = true;
+                return ASYNC;
+            }
+            return NONE;
+        }
+
+        @Override
+        public final void clear() {
+            queue.clear();
+        }
+        
+        @Override
+        public final boolean isEmpty() {
+            return queue.isEmpty();
+        }
+    }
+    
+    static final class PublisherObserveOnSubscriber<T> extends BaseObserveOnSubscriber<T>
+    implements Subscriber<T> {
+        /** */
+        private static final long serialVersionUID = -4547113800637756442L;
+
+        final Subscriber<? super T> actual;
+        
+        public PublisherObserveOnSubscriber(
+                Subscriber<? super T> actual,
+                Worker worker,
+                boolean delayError,
+                int prefetch) {
+            super(worker, delayError, prefetch);
+            this.actual = actual;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked")
+                    QueueSubscription<T> f = (QueueSubscription<T>) s;
+                    
+                    int m = f.requestFusion(ANY | BOUNDARY);
+                    
+                    if (m == SYNC) {
+                        sourceMode = SYNC;
+                        queue = f;
+                        done = true;
+                        
+                        actual.onSubscribe(this);
+                        return;
+                    } else
+                    if (m == ASYNC) {
+                        sourceMode = ASYNC;
+                        queue = f;
+                        
+                        actual.onSubscribe(this);
+                        
+                        initialRequest();
+                        
+                        return;
+                    }
+                }
+                
+                queue = new SpscArrayQueue<T>(prefetch);
+
+                actual.onSubscribe(this);
+
+                initialRequest();
             }
         }
         
         @Override
-        public void run() {
+        void runSync() {
+            int missed = 1;
+
+            final Subscriber<? super T> a = actual;
+            final Queue<T> q = queue;
+
+            long e = produced;
+
+            for (;;) {
+
+                long r = requested.get();
+
+                while (e != r) {
+                    T v;
+
+                    try {
+                        v = q.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        doError(a, ex);
+                        return;
+                    }
+
+                    if (cancelled) {
+                        return;
+                    }
+                    if (v == null) {
+                        doComplete(a);
+                        return;
+                    }
+
+                    a.onNext(v);
+
+                    e++;
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        return;
+                    }
+
+                    boolean empty;
+
+                    try {
+                        empty = q.isEmpty();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        doError(a, ex);
+                        return;
+                    }
+
+                    if (empty) {
+                        doComplete(a);
+                        return;
+                    }
+                }
+
+                int w = get();
+                if (missed == w) {
+                    produced = e;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+
+        @Override
+        void runAsync() {
+            int missed = 1;
+
+            final Subscriber<? super T> a = actual;
+            final Queue<T> q = queue;
+
+            long e = produced;
+
+            for (;;) {
+
+                long r = requested.get();
+
+                while (e != r) {
+                    boolean d = done;
+                    T v;
+
+                    try {
+                        v = q.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+
+                        s.cancel();
+                        q.clear();
+
+                        doError(a, ex);
+                        return;
+                    }
+
+                    boolean empty = v == null;
+
+                    if (checkTerminated(d, empty, a)) {
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(v);
+
+                    e++;
+                    if (e == limit) {
+                        if (r != Long.MAX_VALUE) {
+                            r = requested.addAndGet(-e);
+                        }
+                        s.request(e);
+                        e = 0L;
+                    }
+                }
+
+                if (e == r) {
+                    boolean d = done;
+                    boolean empty;
+                    try {
+                        empty = q.isEmpty();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+
+                        s.cancel();
+                        q.clear();
+
+                        doError(a, ex);
+                        return;
+                    }
+
+                    if (checkTerminated(d, empty, a)) {
+                        return;
+                    }
+                }
+
+                int w = get();
+                if (missed == w) {
+                    produced = e;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+
+        @Override
+        void runBackfused() {
             int missed = 1;
             
-            final Queue<T> q = queue;
-            final Subscriber<? super T> a = actual;
-            
             for (;;) {
-                if (checkTerminated(done, q.isEmpty(), a)) {
+                
+                if (cancelled) {
                     return;
                 }
                 
+                boolean d = done;
+                
+                actual.onNext(null);
+                
+                if (d) {
+                    Throwable e = error;
+                    if (e != null) {
+                        actual.onError(e);
+                    } else {
+                        actual.onComplete();
+                    }
+                    return;
+                }
+                
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public T poll() {
+            T v = queue.poll();
+            if (v != null && sourceMode != SYNC) {
+                long p = produced + 1;
+                if (p == limit) {
+                    produced = 0;
+                    s.request(p);
+                } else {
+                    produced = p;
+                }
+            }
+            return v;
+        }
+        
+    }
+
+    static final class PublisherObserveOnConditionalSubscriber<T>
+    extends BaseObserveOnSubscriber<T> {
+        /** */
+        private static final long serialVersionUID = 644624475404284533L;
+
+        final ConditionalSubscriber<? super T> actual;
+        
+        long consumed;
+
+        public PublisherObserveOnConditionalSubscriber(
+                ConditionalSubscriber<? super T> actual,
+                Worker worker,
+                boolean delayError,
+                int prefetch) {
+            super(worker, delayError, prefetch);
+            this.actual = actual;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked")
+                    QueueSubscription<T> f = (QueueSubscription<T>) s;
+                    
+                    int m = f.requestFusion(ANY | BOUNDARY);
+                    
+                    if (m == SYNC) {
+                        sourceMode = SYNC;
+                        queue = f;
+                        done = true;
+                        
+                        actual.onSubscribe(this);
+                        return;
+                    } else
+                    if (m == ASYNC) {
+                        sourceMode = ASYNC;
+                        queue = f;
+                        
+                        actual.onSubscribe(this);
+                        
+                        initialRequest();
+                        
+                        return;
+                    }
+                }
+
+                queue = new SpscArrayQueue<T>(prefetch);
+                
+                actual.onSubscribe(this);
+
+                initialRequest();
+            }
+        }
+
+        @Override
+        void runSync() {
+            int missed = 1;
+            
+            final ConditionalSubscriber<? super T> a = actual;
+            final Queue<T> q = queue;
+
+            long e = produced;
+
+            for (;;) {
+                
                 long r = requested.get();
-                long e = 0L;
                 
                 while (e != r) {
-                    boolean d = done;
-                    T v = q.poll();
-                    boolean empty = v == null;
+                    T v;
+                    try {
+                        v = q.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        doError(a, ex);
+                        return;
+                    }
 
+                    if (cancelled) {
+                        return;
+                    }
+                    if (v == null) {
+                        doComplete(a);
+                        return;
+                    }
+                    
+                    if (a.tryOnNext(v)) {
+                        e++;
+                    }
+                }
+                
+                if (e == r) {
+                    if (cancelled) {
+                        return;
+                    }
+                    
+                    boolean empty;
+                    
+                    try {
+                        empty = q.isEmpty();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        doError(a, ex);
+                        return;
+                    }
+                    
+                    if (empty) {
+                        doComplete(a);
+                        return;
+                    }
+                }
+
+                int w = get();
+                if (missed == w) {
+                    produced = e;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+        
+        @Override
+        void runAsync() {
+            int missed = 1;
+            
+            final ConditionalSubscriber<? super T> a = actual;
+            final Queue<T> q = queue;
+            
+            long emitted = produced;
+            long polled = consumed;
+            
+            for (;;) {
+                
+                long r = requested.get();
+                
+                while (emitted != r) {
+                    boolean d = done;
+                    T v;
+                    try {
+                        v = q.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+
+                        s.cancel();
+                        q.clear();
+                        
+                        doError(a, ex);
+                        return;
+                    }
+                    boolean empty = v == null;
+                    
                     if (checkTerminated(d, empty, a)) {
                         return;
                     }
@@ -203,20 +702,76 @@ public final class FlowableObserveOn<T> extends Flowable<T> {
                     if (empty) {
                         break;
                     }
+
+                    if (a.tryOnNext(v)) {
+                        emitted++;
+                    }
                     
-                    a.onNext(v);
+                    polled++;
                     
-                    e++;
+                    if (polled == limit) {
+                        s.request(polled);
+                        polled = 0L;
+                    }
                 }
+                
+                if (emitted == r) {
+                    boolean d = done;
+                    boolean empty;
+                    try {
+                        empty = q.isEmpty();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+
+                        s.cancel();
+                        q.clear();
+                        
+                        doError(a, ex);
+                        return;
+                    }
+
+                    if (checkTerminated(d, empty, a)) {
+                        return;
+                    }
+                }
+                
+                int w = get();
+                if (missed == w) {
+                    produced = emitted;
+                    consumed = polled;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+
+        }
+        
+        @Override
+        void runBackfused() {
+            int missed = 1;
+            
+            for (;;) {
                 
                 if (cancelled) {
                     return;
                 }
-                if (e != 0L) {
-                    if (r != Long.MAX_VALUE) {
-                        requested.addAndGet(-e);
+                
+                boolean d = done;
+                
+                actual.onNext(null);
+                
+                if (d) {
+                    Throwable e = error;
+                    if (e != null) {
+                        actual.onError(e);
+                    } else {
+                        actual.onComplete();
                     }
-                    s.request(e);
+                    return;
                 }
                 
                 missed = addAndGet(-missed);
@@ -226,38 +781,19 @@ public final class FlowableObserveOn<T> extends Flowable<T> {
             }
         }
         
-        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a) {
-            if (cancelled) {
-                s.cancel();
-                worker.dispose();
-                return true;
-            }
-            if (d) {
-                Throwable e = error;
-                if (delayError) {
-                    if (empty) {
-                        if (e != null) {
-                            a.onError(e);
-                        } else {
-                            a.onComplete();
-                        }
-                        worker.dispose();
-                        return true;
-                    }
+        @Override
+        public T poll() {
+            T v = queue.poll();
+            if (v != null && sourceMode != SYNC) {
+                long p = consumed + 1;
+                if (p == limit) {
+                    consumed = 0;
+                    s.request(p);
                 } else {
-                    if (e != null) {
-                        a.onError(e);
-                        worker.dispose();
-                        return true;
-                    } else
-                    if (empty) {
-                        a.onComplete();
-                        worker.dispose();
-                        return true;
-                    }
+                    consumed = p;
                 }
             }
-            return false;
+            return v;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -507,9 +507,9 @@ final Scheduler scheduler;
                 if (d) {
                     Throwable e = error;
                     if (e != null) {
-                        actual.onError(e);
+                        doError(actual, e);
                     } else {
-                        actual.onComplete();
+                        doComplete(actual);
                     }
                     return;
                 }
@@ -767,9 +767,9 @@ final Scheduler scheduler;
                 if (d) {
                     Throwable e = error;
                     if (e != null) {
-                        actual.onError(e);
+                        doError(actual, e);
                     } else {
-                        actual.onComplete();
+                        doComplete(actual);
                     }
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -84,7 +84,7 @@ public final class FlowableOnBackpressureBuffer<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -122,7 +122,7 @@ public final class FlowableOnBackpressureBuffer<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -67,7 +67,7 @@ public final class FlowableOnBackpressureDrop<T> extends Flowable<T> implements 
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -116,7 +116,7 @@ public final class FlowableOnBackpressureDrop<T> extends Flowable<T> implements 
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatest.java
@@ -57,7 +57,7 @@ public final class FlowableOnBackpressureLatest<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -85,7 +85,7 @@ public final class FlowableOnBackpressureLatest<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
@@ -63,7 +63,7 @@ public final class FlowableOnErrorReturn<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }
@@ -136,7 +136,7 @@ public final class FlowableOnErrorReturn<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             BackpressureHelper.add(this, n);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
@@ -82,7 +82,7 @@ public final class FlowableRange extends Flowable<Integer> {
 
         @Override
         public final void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 if (BackpressureHelper.add(this, n) == 0L) {
                     if (n == Long.MAX_VALUE) {
                         fastPath();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -57,7 +57,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 subscriber.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -610,7 +610,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> {
         @Override
         public void request(long n) {
             // ignore negative requests
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             // In general, RxJava doesn't prevent concurrent requests (with each other or with

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
@@ -57,7 +57,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 if (other.get() == null) {
@@ -97,7 +97,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
@@ -68,7 +68,7 @@ public final class FlowableSampleTimed<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 if (timer.get() == null) {
@@ -105,7 +105,7 @@ public final class FlowableSampleTimed<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
@@ -47,7 +47,7 @@ public final class FlowableScan<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
@@ -68,7 +68,7 @@ public final class FlowableScanSeed<T, R> extends Flowable<R> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqual.java
@@ -85,7 +85,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
 
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             if (once.compareAndSet(false, true)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingle.java
@@ -54,7 +54,7 @@ public final class FlowableSingle<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkip.java
@@ -44,7 +44,7 @@ public final class FlowableSkip<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 long n = remaining;
                 this.s = s;
                 actual.onSubscribe(this);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLast.java
@@ -50,7 +50,7 @@ public final class FlowableSkipLast<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimed.java
@@ -75,7 +75,7 @@ public final class FlowableSkipLastTimed<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -108,7 +108,7 @@ public final class FlowableSkipLastTimed<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipUntil.java
@@ -41,7 +41,7 @@ public final class FlowableSkipUntil<T, U> extends Flowable<T> {
             Subscription s;
             @Override
             public void onSubscribe(Subscription s) {
-                if (SubscriptionHelper.validateSubscription(this.s, s)) {
+                if (SubscriptionHelper.validate(this.s, s)) {
                     this.s = s;
                     if (frc.setResource(1, s)) {
                         s.request(Long.MAX_VALUE);
@@ -94,7 +94,7 @@ public final class FlowableSkipUntil<T, U> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 if (frc.setResource(0, s)) {
                     if (compareAndSet(false, true)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
@@ -44,7 +44,7 @@ public final class FlowableSkipWhile<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
@@ -70,7 +70,7 @@ public final class FlowableSubscribeOn<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 lazySet(Thread.currentThread());
                 actual.onSubscribe(this);
@@ -102,7 +102,7 @@ public final class FlowableSubscribeOn<T> extends Flowable<T> {
         
         @Override
         public void request(final long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             if (Thread.currentThread() == get()) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -80,7 +80,7 @@ public final class FlowableSwitchMap<T, R> extends Flowable<R> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }
@@ -147,7 +147,7 @@ public final class FlowableSwitchMap<T, R> extends Flowable<R> {
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             BackpressureHelper.add(requested, n);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
@@ -49,7 +49,7 @@ public final class FlowableTake<T> extends Flowable<T> {
         }
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.subscription, s)) {
+            if (SubscriptionHelper.validate(this.subscription, s)) {
                 subscription = s;
                 actual.onSubscribe(this);
             }
@@ -60,6 +60,7 @@ public final class FlowableTake<T> extends Flowable<T> {
                 boolean stop = remaining == 0;
                 actual.onNext(t);
                 if (stop) {
+                    subscription.cancel();
                     onComplete();
                 }
             }
@@ -76,13 +77,12 @@ public final class FlowableTake<T> extends Flowable<T> {
         public void onComplete() {
             if (!done) {
                 done = true;
-                subscription.cancel();
                 actual.onComplete();
             }
         }
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLast.java
@@ -57,7 +57,7 @@ public final class FlowableTakeLast<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -85,7 +85,7 @@ public final class FlowableTakeLast<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOne.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOne.java
@@ -43,7 +43,7 @@ public final class FlowableTakeLastOne<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimed.java
@@ -82,7 +82,7 @@ public final class FlowableTakeLastTimed<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -136,7 +136,7 @@ public final class FlowableTakeLastTimed<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 drain();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntil.java
@@ -91,7 +91,7 @@ public final class FlowableTakeUntil<T, U> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 if (frc.setResource(0, s)) {
                     if (compareAndSet(false, true)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
@@ -44,7 +44,7 @@ public final class FlowableTakeUntilPredicate<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
@@ -47,7 +47,7 @@ public final class FlowableTakeWhile<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -83,7 +83,7 @@ public final class FlowableThrottleFirstTimed<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);
@@ -157,7 +157,7 @@ public final class FlowableThrottleFirstTimed<T> extends Flowable<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
@@ -55,7 +55,7 @@ public final class FlowableTimeInterval<T> extends Flowable<Timed<T>> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 lastTime = scheduler.now(unit);
                 this.s = s;
                 actual.onSubscribe(this);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -79,7 +79,7 @@ public final class FlowableTimeout<T, U, V> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;
@@ -257,7 +257,7 @@ public final class FlowableTimeout<T, U, V> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -95,7 +95,7 @@ public final class FlowableTimeoutTimed<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 if (arbiter.setSubscription(s)) {
                     actual.onSubscribe(arbiter);
@@ -221,7 +221,7 @@ public final class FlowableTimeoutTimed<T> extends Flowable<T> {
 
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 scheduleTimeout(0L);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimer.java
@@ -58,7 +58,7 @@ public final class FlowableTimer extends Flowable<Long> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 requested = true;
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
@@ -71,7 +71,7 @@ implements Supplier<U> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
                 s.request(Long.MAX_VALUE);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -49,7 +49,7 @@ public final class FlowableUnsubscribeOn<T> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
@@ -89,7 +89,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
@@ -13,267 +13,551 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.ArrayDeque;
+import java.util.*;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 
-public final class FlowableWindow<T> extends Flowable<Flowable<T>> {
-    final Publisher<T> source;
-    final long count;
-    final long skip;
-    final int capacityHint;
+public final class FlowableWindow<T> extends FlowableSource<T, Flowable<T>> {
+    final long size;
     
-    public FlowableWindow(Publisher<T> source, long count, long skip, int capacityHint) {
-        this.source = source;
-        this.count = count;
+    final long skip;
+    
+    final int bufferSize;
+    
+    public FlowableWindow(Publisher<T> source, long size, long skip,  int bufferSize) {
+        super(source);
+        this.size = size;
         this.skip = skip;
-        this.capacityHint = capacityHint;
+        this.bufferSize = bufferSize;
     }
     
     @Override
-    protected void subscribeActual(Subscriber<? super Flowable<T>> s) {
-        if (count == skip) {
-            source.subscribe(new WindowExactSubscriber<T>(s, count, capacityHint));
+    public void subscribeActual(Subscriber<? super Flowable<T>> s) {
+        if (skip == size) {
+            source.subscribe(new WindowExactSubscriber<T>(s, size, bufferSize));
+        } else
+        if (skip > size) {
+            source.subscribe(new WindowSkipSubscriber<T>(s, size, skip, bufferSize));
         } else {
-            source.subscribe(new WindowSkipSubscriber<T>(s, count, skip, capacityHint));
+            source.subscribe(new WindowOverlapSubscriber<T>(s, size, skip, bufferSize));
         }
     }
-    
-    
+
     static final class WindowExactSubscriber<T>
     extends AtomicInteger
     implements Subscriber<T>, Subscription, Runnable {
-        /** */
-        private static final long serialVersionUID = -7481782523886138128L;
-        final Subscriber<? super Flowable<T>> actual;
-        final long count;
-        final int capacityHint;
         
-        long size;
+        /** */
+        private static final long serialVersionUID = -2365647875069161133L;
+
+        final Subscriber<? super Flowable<T>> actual;
+
+        final long size;
+
+        final AtomicBoolean once;
+        
+        final int bufferSize;
+
+        long index;
         
         Subscription s;
         
         UnicastProcessor<T> window;
         
-        volatile boolean cancelled;
+        boolean done;
         
-        public WindowExactSubscriber(Subscriber<? super Flowable<T>> actual, long count, int capacityHint) {
+        public WindowExactSubscriber(Subscriber<? super Flowable<T>> actual, long size, int bufferSize) {
+            super(1);
             this.actual = actual;
-            this.count = count;
-            this.capacityHint = capacityHint;
+            this.size = size;
+            this.once = new AtomicBoolean();
+            this.bufferSize = bufferSize;
         }
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
-
                 actual.onSubscribe(this);
             }
         }
         
         @Override
         public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            
+            long i = index;
+            
             UnicastProcessor<T> w = window;
-            if (w == null && !cancelled) {
-                w = UnicastProcessor.create(capacityHint, this);
+            if (i == 0) {
+                getAndIncrement();
+                
+                w = new UnicastProcessor<T>(bufferSize, this);
                 window = w;
+                
                 actual.onNext(w);
             }
-
+            
+            i++;
+            
             w.onNext(t);
-            if (++size >= count) {
-                size = 0;
+            
+            if (i == size) {
+                index = 0;
                 window = null;
                 w.onComplete();
-                if (cancelled) {
-                    s.cancel();
-                }
+            } else {
+                index = i;
             }
         }
         
         @Override
         public void onError(Throwable t) {
-            UnicastProcessor<T> w = window;
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            Processor<T, T> w = window;
             if (w != null) {
                 window = null;
                 w.onError(t);
             }
+            
             actual.onError(t);
         }
         
         @Override
         public void onComplete() {
-            UnicastProcessor<T> w = window;
+            if (done) {
+                return;
+            }
+
+            Processor<T, T> w = window;
             if (w != null) {
                 window = null;
                 w.onComplete();
             }
+            
             actual.onComplete();
         }
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
-                long m = BackpressureHelper.multiplyCap(n, count);
-                s.request(m);
+            if (SubscriptionHelper.validate(n)) {
+                long u = BackpressureHelper.multiplyCap(size, n);
+                s.request(u);
             }
         }
         
         @Override
         public void cancel() {
-            cancelled = true;
+            if (once.compareAndSet(false, true)) {
+                run();
+            }
         }
-        
+
         @Override
         public void run() {
-            if (cancelled) {
+            if (decrementAndGet() == 0) {
                 s.cancel();
             }
         }
     }
     
-    static final class WindowSkipSubscriber<T> extends AtomicBoolean 
+    static final class WindowSkipSubscriber<T> 
+    extends AtomicInteger
     implements Subscriber<T>, Subscription, Runnable {
+        
         /** */
-        private static final long serialVersionUID = 3366976432059579510L;
+        private static final long serialVersionUID = -8792836352386833856L;
+
         final Subscriber<? super Flowable<T>> actual;
-        final long count;
+
+        final long size;
+        
         final long skip;
-        final int capacityHint;
-        final ArrayDeque<UnicastProcessor<T>> windows;
+
+        final AtomicBoolean once;
+
+        final AtomicBoolean firstRequest;
         
+        final int bufferSize;
+
         long index;
-        
-        volatile boolean cancelled;
-        
-        /** Counts how many elements were emitted to the very first window in windows. */
-        long firstEmission;
         
         Subscription s;
         
-        final AtomicInteger wip = new AtomicInteger();
+        UnicastProcessor<T> window;
         
-        public WindowSkipSubscriber(Subscriber<? super Flowable<T>> actual, long count, long skip, int capacityHint) {
+        boolean done;
+        
+        public WindowSkipSubscriber(Subscriber<? super Flowable<T>> actual, long size, long skip, int bufferSize) {
+            super(1);
             this.actual = actual;
-            this.count = count;
+            this.size = size;
             this.skip = skip;
-            this.capacityHint = capacityHint;
-            this.windows = new ArrayDeque<UnicastProcessor<T>>();
+            this.once = new AtomicBoolean();
+            this.firstRequest = new AtomicBoolean();
+            this.bufferSize = bufferSize;
         }
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
-
                 actual.onSubscribe(this);
             }
         }
-
+        
         @Override
         public void onNext(T t) {
-            final ArrayDeque<UnicastProcessor<T>> ws = windows;
+            if (done) {
+                return;
+            }
             
             long i = index;
             
-            long s = skip;
-            
-            if (i % s == 0 && !cancelled) {
-                wip.getAndIncrement();
-                UnicastProcessor<T> w = UnicastProcessor.create(capacityHint, this);
-                ws.offer(w);
+            UnicastProcessor<T> w = window;
+            if (i == 0) {
+                getAndIncrement();
+                
+                
+                w = new UnicastProcessor<T>(bufferSize, this);
+                window = w;
+                
                 actual.onNext(w);
             }
-
-            long c = firstEmission + 1;
             
-            for (UnicastProcessor<T> w : ws) {
+            i++;
+            
+            if (w != null) {
                 w.onNext(t);
             }
             
-            if (c >= count) {
-                ws.poll().onComplete();
-                if (ws.isEmpty() && cancelled) {
-                    this.s.cancel();
-                    return;
-                }
-                firstEmission = c - s;
-            } else {
-                firstEmission = c;
+            if (i == size) {
+                window = null;
+                w.onComplete();
             }
             
-            index = i + 1;
+            if (i == skip) {
+                index = 0;
+            } else {
+                index = i;
+            }
         }
         
         @Override
         public void onError(Throwable t) {
-            final ArrayDeque<UnicastProcessor<T>> ws = windows;
-            while (!ws.isEmpty()) {
-                ws.poll().onError(t);
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
             }
+            Processor<T, T> w = window;
+            if (w != null) {
+                window = null;
+                w.onError(t);
+            }
+            
             actual.onError(t);
         }
         
         @Override
         public void onComplete() {
-            final ArrayDeque<UnicastProcessor<T>> ws = windows;
-            while (!ws.isEmpty()) {
-                ws.poll().onComplete();
+            if (done) {
+                return;
             }
+
+            Processor<T, T> w = window;
+            if (w != null) {
+                window = null;
+                w.onComplete();
+            }
+            
             actual.onComplete();
         }
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
-                return;
-            }
-         // requesting the first set of buffers must happen only once
-            if (!get() && compareAndSet(false, true)) {
-                
-                if (count < skip) {
-                    // don't request the first gap after n buffers
-                    long m = BackpressureHelper.multiplyCap(n, count);
-                    s.request(m);
+            if (SubscriptionHelper.validate(n)) {
+                if (!firstRequest.get() && firstRequest.compareAndSet(false, true)) {
+                    long u = BackpressureHelper.multiplyCap(size, n);
+                    long v = BackpressureHelper.multiplyCap(skip - size, n - 1);
+                    long w = BackpressureHelper.addCap(u, v);
+                    s.request(w);
                 } else {
-                    // request 1 full and n - 1 skip gaps
-                    long m = BackpressureHelper.multiplyCap(n - 1, skip);
-                    long k = BackpressureHelper.addCap(count, m);
-                    s.request(k);
-                }
-                
-            } else {
-                
-                if (count < skip) {
-                    // since this isn't the first, request n buffers and n gaps
-                    long m = BackpressureHelper.multiplyCap(n, count + skip);
-                    s.request(m);
-                } else {
-                    // request the remaining n * skip
-                    long m = BackpressureHelper.multiplyCap(n, skip);
-                    s.request(m);
+                    long u = BackpressureHelper.multiplyCap(skip, n);
+                    s.request(u);
                 }
             }
         }
         
         @Override
         public void cancel() {
-            cancelled = true;
+            if (once.compareAndSet(false, true)) {
+                run();
+            }
+        }
+
+        @Override
+        public void run() {
+            if (decrementAndGet() == 0) {
+                s.cancel();
+            }
+        }
+    }
+
+    static final class WindowOverlapSubscriber<T> 
+    extends AtomicInteger
+    implements Subscriber<T>, Subscription, Runnable {
+        
+        /** */
+        private static final long serialVersionUID = 2428527070996323976L;
+
+        final Subscriber<? super Flowable<T>> actual;
+
+        final Queue<UnicastProcessor<T>> queue;
+        
+        final long size;
+        
+        final long skip;
+
+        final ArrayDeque<UnicastProcessor<T>> windows;
+
+        final AtomicBoolean once;
+
+        final AtomicBoolean firstRequest;
+
+        final AtomicLong requested;
+
+        final AtomicInteger wip;
+        
+        final int bufferSize;
+
+        long index;
+        
+        long produced;
+        
+        Subscription s;
+        
+        volatile boolean done;
+        Throwable error;
+        
+        volatile boolean cancelled;
+        
+        public WindowOverlapSubscriber(Subscriber<? super Flowable<T>> actual, long size, long skip, int bufferSize) {
+            super(1);
+            this.actual = actual;
+            this.size = size;
+            this.skip = skip;
+            this.queue = new SpscLinkedArrayQueue<UnicastProcessor<T>>(bufferSize);
+            this.windows = new ArrayDeque<UnicastProcessor<T>>();
+            this.once = new AtomicBoolean();
+            this.firstRequest = new AtomicBoolean();
+            this.requested = new AtomicLong();
+            this.wip = new AtomicInteger();
+            this.bufferSize = bufferSize;
         }
         
         @Override
-        public void run() {
-            if (wip.decrementAndGet() == 0) {
-                if (cancelled) {
-                    s.cancel();
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            
+            long i = index;
+            
+            if (i == 0) {
+                if (!cancelled) {
+                    getAndIncrement();
+                    
+                    UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize, this);
+                    
+                    windows.offer(w);
+                    
+                    queue.offer(w);
+                    drain();
                 }
+            }
+            
+            i++;
+
+            for (Processor<T, T> w : windows) {
+                w.onNext(t);
+            }
+            
+            long p = produced + 1;
+            if (p == size) {
+                produced = p - skip;
+                
+                Processor<T, T> w = windows.poll();
+                if (w != null) {
+                    w.onComplete();
+                }
+            } else {
+                produced = p;
+            }
+            
+            if (i == skip) {
+                index = 0;
+            } else {
+                index = i;
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+
+            for (Processor<T, T> w : windows) {
+                w.onError(t);
+            }
+            windows.clear();
+            
+            error = t;
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+
+            for (Processor<T, T> w : windows) {
+                w.onComplete();
+            }
+            windows.clear();
+            
+            done = true;
+            drain();
+        }
+        
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+            
+            final Subscriber<? super Flowable<T>> a = actual;
+            final Queue<UnicastProcessor<T>> q = queue;
+            int missed = 1;
+            
+            for (;;) {
+                
+                long r = requested.get();
+                long e = 0;
+                
+                while (e != r) {
+                    boolean d = done;
+                    
+                    UnicastProcessor<T> t = q.poll();
+                    
+                    boolean empty = t == null;
+                    
+                    if (checkTerminated(d, empty, a, q)) {
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(t);
+                    
+                    e++;
+                }
+                
+                if (e == r) {
+                    if (checkTerminated(done, q.isEmpty(), a, q)) {
+                        return;
+                    }
+                }
+                
+                if (e != 0L && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
+                }
+                
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, Queue<?> q) {
+            if (cancelled) {
+                q.clear();
+                return true;
+            }
+            
+            if (d) {
+                Throwable e = error;
+                
+                if (e != null) {
+                    q.clear();
+                    a.onError(e);
+                    return true;
+                } else
+                if (empty) {
+                    a.onComplete();
+                    return true;
+                }
+            }
+            
+            return false;
+        }
+        
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                
+                if (!firstRequest.get() && firstRequest.compareAndSet(false, true)) {
+                    long u = BackpressureHelper.multiplyCap(skip, n - 1);
+                    long v = BackpressureHelper.addCap(size, u);
+                    s.request(v);
+                } else {
+                    long u = BackpressureHelper.multiplyCap(skip, n);
+                    s.request(u);
+                }
+                
+                drain();
+            }
+        }
+        
+        @Override
+        public void cancel() {
+            cancelled = true;
+            if (once.compareAndSet(false, true)) {
+                run();
+            }
+        }
+
+        @Override
+        public void run() {
+            if (decrementAndGet() == 0) {
+                s.cancel();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -74,7 +74,7 @@ public final class FlowableWindowBoundary<T, B> extends Flowable<Flowable<T>> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;
@@ -86,7 +86,7 @@ public final class FlowableWindowBoundary<T, B> extends Flowable<Flowable<T>> {
                 return;
             }
             
-            UnicastProcessor<T> w = UnicastProcessor.create(bufferSize);
+            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
             
             long r = requested();
             if (r != 0L) {
@@ -217,7 +217,7 @@ public final class FlowableWindowBoundary<T, B> extends Flowable<Flowable<T>> {
                             continue;
                         }
                         
-                        w = UnicastProcessor.create(bufferSize);
+                        w = new UnicastProcessor<T>(bufferSize);
                         
                         long r = requested();
                         if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -82,7 +82,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends Flowable<Flow
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             
@@ -251,7 +251,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends Flowable<Flow
                         }
                         
 
-                        w = UnicastProcessor.create(bufferSize);
+                        w = new UnicastProcessor<T>(bufferSize);
                         
                         long r = requested();
                         if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -75,7 +75,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends Flowable<Flowabl
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;
@@ -103,7 +103,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends Flowable<Flowabl
                 return;
             }
             
-            UnicastProcessor<T> w = UnicastProcessor.create(bufferSize);
+            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
             
             long r = requested();
             if (r != 0L) {
@@ -251,7 +251,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends Flowable<Flowabl
                             return;
                         }
                         
-                        w = UnicastProcessor.create(bufferSize);
+                        w = new UnicastProcessor<T>(bufferSize);
                         
                         long r = requested();
                         if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -106,12 +106,12 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             this.s = s;
             
-            window = UnicastProcessor.<T>create(bufferSize);
+            window = new UnicastProcessor<T>(bufferSize);
             
             Subscriber<? super Flowable<T>> a = actual;
             a.onSubscribe(this);
@@ -256,7 +256,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
                     if (o == NEXT) {
                         w.onComplete();
                         if (!term) {
-                            w = UnicastProcessor.create(bufferSize);
+                            w = new UnicastProcessor<T>(bufferSize);
                             window = w;
                             
                             long r = requested();
@@ -337,7 +337,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             
@@ -351,7 +351,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
                 return;
             }
             
-            UnicastProcessor<T> w = UnicastProcessor.create(bufferSize);
+            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
             window = w;
             
             long r = requested();
@@ -405,7 +405,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
                     long r = requested();
                     
                     if (r != 0L) {
-                        w = UnicastProcessor.create(bufferSize);
+                        w = new UnicastProcessor<T>(bufferSize);
                         window = w;
                         actual.onNext(w);
                         if (r != Long.MAX_VALUE) {
@@ -537,7 +537,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
                     if (isHolder) {
                         ConsumerIndexHolder consumerIndexHolder = (ConsumerIndexHolder) o;
                         if (producerIndex == consumerIndexHolder.index) {
-                            w = UnicastProcessor.create(bufferSize);
+                            w = new UnicastProcessor<T>(bufferSize);
                             window = w;
                             
                             long r = requested();
@@ -570,7 +570,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
                         long r = requested();
                         
                         if (r != 0L) {
-                            w = UnicastProcessor.create(bufferSize);
+                            w = new UnicastProcessor<T>(bufferSize);
                             window = w;
                             actual.onNext(w);
                             if (r != Long.MAX_VALUE) {
@@ -664,7 +664,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (!SubscriptionHelper.validate(this.s, s)) {
                 return;
             }
             
@@ -678,7 +678,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
             
             long r = requested();
             if (r != 0L) {
-                final UnicastProcessor<T> w = UnicastProcessor.create(bufferSize);
+                final UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
                 windows.add(w);
                 
                 actual.onNext(w);
@@ -834,7 +834,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
                             
                             long r = requested();
                             if (r != 0L) {
-                                final UnicastProcessor<T> w = UnicastProcessor.create(bufferSize);
+                                final UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
                                 ws.add(w);
                                 a.onNext(w);
                                 if (r != Long.MAX_VALUE) {
@@ -876,7 +876,7 @@ public final class FlowableWindowTimed<T> extends Flowable<Flowable<T>> {
         @Override
         public void run() {
 
-            UnicastProcessor<T> w = UnicastProcessor.create(bufferSize);
+            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
             
             SubjectWork<T> sw = new SubjectWork<T>(w, true);
             if (!cancelled) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
@@ -86,7 +86,7 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
         
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validateSubscription(this.s, s)) {
+            if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
@@ -57,7 +57,7 @@ public abstract class BasicFuseableConditionalSubscriber<T, R> implements Condit
     @SuppressWarnings("unchecked")
     @Override
     public final void onSubscribe(Subscription s) {
-        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+        if (SubscriptionHelper.validate(this.s, s)) {
             
             this.s = s;
             if (s instanceof QueueSubscription) {

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableSubscriber.java
@@ -57,7 +57,7 @@ public abstract class BasicFuseableSubscriber<T, R> implements Subscriber<T>, Qu
     @SuppressWarnings("unchecked")
     @Override
     public final void onSubscribe(Subscription s) {
-        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+        if (SubscriptionHelper.validate(this.s, s)) {
             
             this.s = s;
             if (s instanceof QueueSubscription) {

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/FullArbiterSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/FullArbiterSubscriber.java
@@ -33,7 +33,7 @@ public final class FullArbiterSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+        if (SubscriptionHelper.validate(this.s, s)) {
             this.s = s;
             arbiter.setSubscription(s);
         }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/QueueDrainSubscriber.java
@@ -206,7 +206,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
     }
     
     public final void requested(long n) {
-        if (SubscriptionHelper.validateRequest(n)) {
+        if (SubscriptionHelper.validate(n)) {
             BackpressureHelper.add(requested, n);
         }
     }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriberResourceWrapper.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriberResourceWrapper.java
@@ -74,7 +74,7 @@ public final class SubscriberResourceWrapper<T> extends AtomicReference<Disposab
     
     @Override
     public void request(long n) {
-        if (SubscriptionHelper.validateRequest(n)) {
+        if (SubscriptionHelper.validate(n)) {
             subscription.get().request(n);
         }
     }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriptionLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriptionLambdaSubscriber.java
@@ -48,7 +48,7 @@ public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Sub
             EmptySubscription.error(e, actual);
             return;
         }
-        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+        if (SubscriptionHelper.validate(this.s, s)) {
             this.s = s;
             actual.onSubscribe(this);
         }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/ToNotificationSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/ToNotificationSubscriber.java
@@ -30,7 +30,7 @@ public final class ToNotificationSubscriber<T> implements Subscriber<T> {
     
     @Override
     public void onSubscribe(Subscription s) {
-        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+        if (SubscriptionHelper.validate(this.s, s)) {
             this.s = s;
             s.request(Long.MAX_VALUE);
         }

--- a/src/main/java/io/reactivex/internal/subscriptions/AsyncSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/AsyncSubscription.java
@@ -50,7 +50,7 @@ public final class AsyncSubscription extends AtomicLong implements Subscription,
         Subscription s = actual.get();
         if (s != null) {
             s.request(n);
-        } else if (SubscriptionHelper.validateRequest(n)) {
+        } else if (SubscriptionHelper.validate(n)) {
             BackpressureHelper.add(this, n);
             s = actual.get();
             if (s != null) {

--- a/src/main/java/io/reactivex/internal/subscriptions/BasicIntQueueSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/BasicIntQueueSubscription.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.internal.fuseable.QueueSubscription;
+
+/**
+ * Base class extending AtomicInteger (wip or request accounting) and QueueSubscription (fusion).
+ *
+ * @param <T> the value type
+ */
+public abstract class BasicIntQueueSubscription<T> extends AtomicInteger implements QueueSubscription<T> {
+
+    /** */
+    private static final long serialVersionUID = -6671519529404341862L;
+
+    @Override
+    public final boolean add(T e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean addAll(Collection<? extends T> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean contains(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final T element() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Iterator<T> iterator() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean offer(T e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final T peek() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final T remove() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean remove(Object o) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final int size() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final Object[] toArray() {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final <U extends Object> U[] toArray(U[] a) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscriptions/BooleanSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/BooleanSubscription.java
@@ -26,7 +26,7 @@ public final class BooleanSubscription extends AtomicBoolean implements Subscrip
 
     @Override
     public void request(long n) {
-        SubscriptionHelper.validateRequest(n);
+        SubscriptionHelper.validate(n);
     }
     
     @Override

--- a/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
@@ -59,7 +59,7 @@ public class DeferredScalarSubscription<T> extends BasicQueueSubscription<T> {
     
     @Override
     public void request(long n) {
-        if (SubscriptionHelper.validateRequest(n)) {
+        if (SubscriptionHelper.validate(n)) {
             for (;;) {
                 long state = get();
                 if (state == HAS_REQUEST_NO_VALUE || state == HAS_REQUEST_HAS_VALUE || state == CANCELLED) {
@@ -100,6 +100,7 @@ public class DeferredScalarSubscription<T> extends BasicQueueSubscription<T> {
             if (state == HAS_REQUEST_NO_VALUE) {
                 // no need to CAS in the terminal state because complete() is called at most once
                 if (fusionState == EMPTY) {
+                    value = v;
                     fusionState = HAS_VALUE;
                 }
                 actual.onNext(v);

--- a/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
@@ -28,7 +28,7 @@ public enum EmptySubscription implements QueueSubscription<Object> {
     
     @Override
     public void request(long n) {
-        SubscriptionHelper.validateRequest(n);
+        SubscriptionHelper.validate(n);
     }
     @Override
     public void cancel() {

--- a/src/main/java/io/reactivex/internal/subscriptions/FullArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/FullArbiter.java
@@ -62,7 +62,7 @@ public final class FullArbiter<T> extends FullArbiterPad2 implements Subscriptio
 
     @Override
     public void request(long n) {
-        if (SubscriptionHelper.validateRequest(n)) {
+        if (SubscriptionHelper.validate(n)) {
             BackpressureHelper.add(missedRequested, n);
             queue.offer(REQUEST, REQUEST);
             drain();

--- a/src/main/java/io/reactivex/internal/subscriptions/ScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/ScalarSubscription.java
@@ -46,7 +46,7 @@ public final class ScalarSubscription<T> extends AtomicInteger implements QueueS
     
     @Override
     public void request(long n) {
-        if (!SubscriptionHelper.validateRequest(n)) {
+        if (!SubscriptionHelper.validate(n)) {
             return;
         }
         if (compareAndSet(NO_REQUEST, REQUESTED)) {

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
@@ -25,230 +25,295 @@ package io.reactivex.internal.subscriptions;
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-import java.util.Queue;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.Subscription;
 
 import io.reactivex.internal.functions.Objects;
-import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.util.BackpressureHelper;
-import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Arbitrates requests and cancellation between Subscriptions.
  */
-public final class SubscriptionArbiter extends AtomicInteger implements Subscription {
+public class SubscriptionArbiter extends AtomicInteger implements Subscription {
     /** */
     private static final long serialVersionUID = -2189523197179400958L;
     
-    final Queue<Subscription> missedSubscription = new MpscLinkedQueue<Subscription>();
-    
+    /**
+     * The current subscription which may null if no Subscriptions have been set.
+     */
     Subscription actual;
+
+    /**
+     * The current outstanding request amount.
+     */
     long requested;
-    
+
+    final AtomicReference<Subscription> missedSubscription;
+
+    final AtomicLong missedRequested;
+
+    final AtomicLong missedProduced;
+
     volatile boolean cancelled;
 
-    final AtomicLong missedRequested = new AtomicLong();
+    protected boolean unbounded;
     
-    final AtomicLong missedProduced = new AtomicLong();
-
-    private long addRequested(long n) {
-        long r = requested;
-        long u = BackpressureHelper.addCap(r, n);
-        requested = u;
-        return r;
+    public SubscriptionArbiter() {
+        missedSubscription = new AtomicReference<Subscription>();
+        missedRequested = new AtomicLong();
+        missedProduced = new AtomicLong();
     }
     
-    @Override
-    public void request(final long n) {
-        if (!SubscriptionHelper.validateRequest(n)) {
-            return;
-        }
-        if (cancelled) {
-            return;
-        }
-        
-        if (get() == 0 && compareAndSet(0, 1)) {
-            addRequested(n);
-            Subscription s = actual;
-            if (s != null) {
-                s.request(n);
-            }
-            if (decrementAndGet() == 0) {
-                return;
-            }
-        } else {
-            BackpressureHelper.add(missedRequested, n);
-            if (getAndIncrement() != 0) {
-                return;
-            }
-        }
-        int missed = 1;
-        for (;;) {
-            SubscriptionArbiter.this.drain();
-            
-            missed = addAndGet(-missed);
-            if (missed == 0) {
-                return;
-            }
-        }
-    }
-
-    public void produced(final long n) {
-        if (n <= 0) {
-            RxJavaPlugins.onError(new IllegalArgumentException("n > 0 required but it was " + n));
-            return;
-        }
-        
-        if (get() == 0 && compareAndSet(0, 1)) {
-            long r = requested;
-            if (r != Long.MAX_VALUE) {
-                long u = r - n;
-                if (u < 0L) {
-                    RxJavaPlugins.onError(new IllegalArgumentException("More produced than requested: " + u));
-                    u = 0;
-                }
-                requested = u;
-            }
-            if (decrementAndGet() == 0) {
-                return;
-            }
-        } else {
-            BackpressureHelper.add(missedProduced, n);
-            if (getAndIncrement() != 0) {
-                return;
-            }
-        }
-        int missed = 1;
-        for (;;) {
-            SubscriptionArbiter.this.drain();
-            
-            missed = addAndGet(-missed);
-            if (missed == 0) {
-                return;
-            }
-        }
+    /**
+     * When setting a new subscription via set(), should
+     * the previous subscription be cancelled?
+     * @return true if cancellation is needed
+     */
+    protected boolean shouldCancelCurrent() {
+        return true;
     }
     
-    public void setSubscription(final Subscription s) {
-        Objects.requireNonNull(s, "s is null");
+    /**
+     * Atomically sets a new subscription.
+     * @param s the subscription to set, not null (verified)
+     */
+    public final void setSubscription(Subscription s) {
         if (cancelled) {
             s.cancel();
             return;
         }
+
+        Objects.requireNonNull(s, "s is null");
         
         if (get() == 0 && compareAndSet(0, 1)) {
             Subscription a = actual;
-            if (a != null) {
+            
+            if (a != null && shouldCancelCurrent()) {
                 a.cancel();
             }
+            
             actual = s;
+            
             long r = requested;
             if (r != 0L) {
                 s.request(r);
             }
+            
             if (decrementAndGet() == 0) {
                 return;
             }
-        } else {
-            missedSubscription.offer(s);
-            if (getAndIncrement() != 0) {
-                return;
-            }
-        }
-        int missed = 1;
-        for (;;) {
-            SubscriptionArbiter.this.drain();
-            
-            missed = addAndGet(-missed);
-            if (missed == 0) {
-                return;
-            }
-        }
-    }
-    
-    @Override
-    public void cancel() {
-        if (cancelled) {
+
+            drainLoop();
+
             return;
         }
-        cancelled = true;
-        
-        if (get() == 0 && compareAndSet(0, 1)) {
-            Subscription a = actual;
-            if (a != null) {
-                actual = null;
-                a.cancel();
+
+        Subscription a = missedSubscription.getAndSet(s);
+        if (a != null && shouldCancelCurrent()) {
+            a.cancel();
+        }
+        drain();
+    }
+
+    @Override
+    public final void request(long n) {
+        if (SubscriptionHelper.validate(n)) {
+            if (unbounded) {
+                return;
             }
+            if (get() == 0 && compareAndSet(0, 1)) {
+                long r = requested;
+
+                if (r != Long.MAX_VALUE) {
+                    r = BackpressureHelper.addCap(r, n);
+                    requested = r;
+                    if (r == Long.MAX_VALUE) {
+                        unbounded = true;
+                    }
+                }
+                Subscription a = actual;
+                if (a != null) {
+                    a.request(n);
+                }
+
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+
+                drainLoop();
+
+                return;
+            }
+
+            BackpressureHelper.add(missedRequested, n);
+
+            drain();
+        }
+    }
+
+    public final void producedOne() {
+        if (unbounded) {
+            return;
+        }
+        if (get() == 0 && compareAndSet(0, 1)) {
+            long r = requested;
+
+            if (r != Long.MAX_VALUE) {
+                r--;
+                if (r < 0L) {
+                    SubscriptionHelper.reportMoreProduced(r);
+                    r = 0;
+                }
+                requested = r;
+            } else {
+                unbounded = true;
+            }
+
             if (decrementAndGet() == 0) {
                 return;
             }
-        } else {
-            if (getAndIncrement() != 0) {
+
+            drainLoop();
+
+            return;
+        }
+
+        BackpressureHelper.add(missedProduced, 1L);
+
+        drain();
+    }
+
+    public final void produced(long n) {
+        if (unbounded) {
+            return;
+        }
+        if (get() == 0 && compareAndSet(0, 1)) {
+            long r = requested;
+
+            if (r != Long.MAX_VALUE) {
+                long u = r - n;
+                if (u < 0L) {
+                    SubscriptionHelper.reportMoreProduced(u);
+                    u = 0;
+                }
+                requested = u;
+            } else {
+                unbounded = true;
+            }
+
+            if (decrementAndGet() == 0) {
                 return;
             }
+
+            drainLoop();
+
+            return;
         }
+
+        BackpressureHelper.add(missedProduced, n);
+
+        drain();
+    }
+
+    @Override
+    public void cancel() {
+        if (!cancelled) {
+            cancelled = true;
+
+            drain();
+        }
+    }
+
+    final void drain() {
+        if (getAndIncrement() != 0) {
+            return;
+        }
+        drainLoop();
+    }
+
+    final void drainLoop() {
         int missed = 1;
-        for (;;) {
-            SubscriptionArbiter.this.drain();
-            
+
+        for (; ; ) {
+
+            Subscription ms = missedSubscription.get();
+
+            if (ms != null) {
+                ms = missedSubscription.getAndSet(null);
+            }
+
+            long mr = missedRequested.get();
+            if (mr != 0L) {
+                mr = missedRequested.getAndSet(0L);
+            }
+
+            long mp = missedProduced.get();
+            if (mp != 0L) {
+                mp = missedProduced.getAndSet(0L);
+            }
+
+            Subscription a = actual;
+
+            if (cancelled) {
+                if (a != null) {
+                    a.cancel();
+                    actual = null;
+                }
+                if (ms != null) {
+                    ms.cancel();
+                }
+            } else {
+                long r = requested;
+                if (r != Long.MAX_VALUE) {
+                    long u = BackpressureHelper.addCap(r, mr);
+
+                    if (u != Long.MAX_VALUE) {
+                        long v = u - mp;
+                        if (v < 0L) {
+                            SubscriptionHelper.reportMoreProduced(v);
+                            v = 0;
+                        }
+                        r = v;
+                    } else {
+                        r = u;
+                    }
+                    requested = r;
+                }
+
+                if (ms != null) {
+                    if (a != null && shouldCancelCurrent()) {
+                        a.cancel();
+                    }
+                    actual = ms;
+                    if (r != 0L) {
+                        ms.request(r);
+                    }
+                } else if (mr != 0L && a != null) {
+                    a.request(mr);
+                }
+            }
+
             missed = addAndGet(-missed);
             if (missed == 0) {
                 return;
             }
         }
     }
-    
-    public boolean isCancelled() {
-        return cancelled;
+
+    /**
+     * Returns true if the arbiter runs in unbounded mode.
+     * @return true if the arbiter runs in unbounded mode
+     */
+    public final boolean isUnbounded() {
+        return unbounded;
     }
     
-    void drain() {
-        long mr = missedRequested.getAndSet(0L);
-        long mp = missedProduced.getAndSet(0L);
-        Subscription ms = missedSubscription.poll();
-        boolean c = cancelled;
-        
-        long r = requested;
-        if (r != Long.MAX_VALUE && !c) {
-            long u = r + mr;
-            if (u < 0L) {
-                r = Long.MAX_VALUE;
-                requested = Long.MAX_VALUE;
-            } else {
-                long v = u - mp;
-                if (v < 0L) {
-                    RxJavaPlugins.onError(new IllegalStateException("More produced than requested: " + v));
-                    v = 0L;
-                }
-                r = v;
-                requested = v;
-            }
-        }
-
-        Subscription a = actual;
-        if (c && a != null) {
-            actual = null;
-            a.cancel();
-        }
-        
-        if (ms == null) {
-            if (a != null && mr != 0L) {
-                a.request(mr);
-            }
-        } else {
-            if (c) {
-                ms.cancel();
-            } else {
-                if (a != null) {
-                    a.cancel();
-                }
-                actual = ms;
-                if (r != 0L) {
-                    ms.request(r);
-                }
-            }
-        }
+    /**
+     * Returns true if the arbiter has been cancelled.
+     * @return true if the arbiter has been cancelled
+     */
+    public final boolean isCancelled() {
+        return cancelled;
     }
 }

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -21,7 +21,7 @@ import io.reactivex.internal.functions.Objects;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * Utility methods to validate Subscriptions and Disposables in the various onSubscribe calls.
+ * Utility methods to validate Subscriptions in the various onSubscribe calls.
  */
 public enum SubscriptionHelper {
     ;
@@ -38,7 +38,7 @@ public enum SubscriptionHelper {
      * @param next the next Subscription, expected to be non-null
      * @return true if the validation succeeded
      */
-    public static boolean validateSubscription(Subscription current, Subscription next) {
+    public static boolean validate(Subscription current, Subscription next) {
         if (next == null) {
             RxJavaPlugins.onError(new NullPointerException("next is null"));
             return false;
@@ -63,7 +63,7 @@ public enum SubscriptionHelper {
      * @param n the request amount
      * @return false if n is non-positive.
      */
-    public static boolean validateRequest(long n) {
+    public static boolean validate(long n) {
         if (n <= 0) {
             RxJavaPlugins.onError(new IllegalArgumentException("n > 0 required but it was " + n));
             return false;
@@ -71,6 +71,9 @@ public enum SubscriptionHelper {
         return true;
     }
     
+    public static void reportMoreProduced(long n) {
+        RxJavaPlugins.onError(new IllegalStateException("More produced than requested: " + n));
+    }
     /**
      * Check if the given subscription is the common cancelled subscription.
      * @param d the subscription to check

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -327,7 +327,7 @@ public final class AsyncProcessor<T> extends FlowProcessor<T> {
         
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             for (;;) {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -341,7 +341,7 @@ public final class BehaviorProcessor<T> extends FlowProcessor<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -319,7 +319,7 @@ public final class PublishProcessor<T> extends FlowProcessor<T> {
         
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(this, n);
             }
         }

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -362,7 +362,7 @@ public final class ReplayProcessor<T> extends FlowProcessor<T> {
         }
         @Override
         public void request(long n) {
-            if (SubscriptionHelper.validateRequest(n)) {
+            if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 state.buffer.replay(this);
             }

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -118,10 +118,8 @@ public final class UnicastProcessor<T> extends FlowProcessor<T> {
                 e++;
             }
             
-            if (r == e) {
-                if (checkTerminated(done, q.isEmpty(), a, q)) {
-                    return;
-                }
+            if (r == e && checkTerminated(done, q.isEmpty(), a, q)) {
+                return;
             }
             
             if (e != 0 && r != Long.MAX_VALUE) {

--- a/src/main/java/io/reactivex/subscribers/AsyncSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/AsyncSubscriber.java
@@ -122,7 +122,7 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Disposable {
      * @param n the request amount, must be positive
      */
     protected final void request(long n) {
-        if (!SubscriptionHelper.validateRequest(n)) {
+        if (!SubscriptionHelper.validate(n)) {
             return;
         }
         Subscription a = s.get();

--- a/src/main/java/io/reactivex/subscribers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultObserver.java
@@ -21,7 +21,7 @@ public abstract class DefaultObserver<T> implements Subscriber<T> {
     private Subscription s;
     @Override
     public final void onSubscribe(Subscription s) {
-        if (SubscriptionHelper.validateSubscription(this.s, s)) {
+        if (SubscriptionHelper.validate(this.s, s)) {
             this.s = s;
             onStart();
         }

--- a/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
@@ -52,7 +52,7 @@ public final class SerializedSubscriber<T> implements Subscriber<T>, Subscriptio
     }
     @Override
     public void onSubscribe(Subscription s) {
-        if (SubscriptionHelper.validateSubscription(this.subscription, s)) {
+        if (SubscriptionHelper.validate(this.subscription, s)) {
             this.subscription = s;
             actual.onSubscribe(this);
         }

--- a/src/main/java/io/reactivex/subscribers/Subscribers.java
+++ b/src/main/java/io/reactivex/subscribers/Subscribers.java
@@ -191,7 +191,7 @@ public final class Subscribers {
             Subscription s;
             @Override
             public void onSubscribe(Subscription s) {
-                if (!SubscriptionHelper.validateSubscription(this.s, s)) {
+                if (!SubscriptionHelper.validate(this.s, s)) {
                     return;
                 }
                 this.s = s;

--- a/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
@@ -47,7 +47,7 @@ public class FlowableBackpressureTests {
 
         @Override
         public void request(long n) {
-            if (!SubscriptionHelper.validateRequest(n)) {
+            if (!SubscriptionHelper.validate(n)) {
                 return;
             }
             if (compareAndSet(false, true)) {
@@ -688,7 +688,7 @@ public class FlowableBackpressureTests {
 
                     @Override
                     public void request(long n) {
-                        if (!SubscriptionHelper.validateRequest(n)) {
+                        if (!SubscriptionHelper.validate(n)) {
                             return;
                         }
                         if (threadsSeen != null) {

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -30,11 +30,10 @@ import io.reactivex.Flowable.Transformer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.*;
-import io.reactivex.subscribers.DefaultObserver;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.subscribers.*;
 
 public class FlowableTests {
 
@@ -446,7 +445,7 @@ public class FlowableTests {
         ConnectableFlowable<String> connectable = Flowable.<String>create(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 count.incrementAndGet();
                 new Thread(new Runnable() {
                     @Override
@@ -484,7 +483,7 @@ public class FlowableTests {
         ConnectableFlowable<String> o = Flowable.<String>create(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                    observer.onSubscribe(EmptySubscription.INSTANCE);
+                    observer.onSubscribe(new BooleanSubscription());
                     new Thread(new Runnable() {
 
                         @Override
@@ -537,7 +536,7 @@ public class FlowableTests {
         Flowable<String> o = Flowable.<String>create(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                    observer.onSubscribe(EmptySubscription.INSTANCE);
+                    observer.onSubscribe(new BooleanSubscription());
                     new Thread(new Runnable() {
                         @Override
                         public void run() {
@@ -582,7 +581,7 @@ public class FlowableTests {
         Flowable<String> o = Flowable.<String>create(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
@@ -661,7 +660,7 @@ public class FlowableTests {
         Flowable.create(new Publisher<Object>() {
             @Override
             public void subscribe(final Subscriber<? super Object> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingOperatorNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingOperatorNextTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.BlockingFlowable;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.Schedulers;
 
@@ -237,7 +237,7 @@ public class BlockingOperatorNextTest {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> o) {
-                o.onSubscribe(EmptySubscription.INSTANCE);
+                o.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingOperatorToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingOperatorToIteratorTest.java
@@ -22,7 +22,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 
 public class BlockingOperatorToIteratorTest {
 
@@ -51,7 +51,7 @@ public class BlockingOperatorToIteratorTest {
 
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 observer.onNext("one");
                 observer.onError(new TestException());
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -28,7 +28,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.*;
@@ -64,7 +64,7 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 observer.onNext("one");
                 observer.onNext("two");
                 observer.onNext("three");
@@ -120,7 +120,7 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 10);
                 push(observer, "two", 90);
                 push(observer, "three", 110);
@@ -152,7 +152,7 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 97);
                 push(observer, "two", 98);
                 /**
@@ -186,7 +186,7 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 10);
                 push(observer, "two", 60);
                 push(observer, "three", 110);
@@ -199,7 +199,7 @@ public class FlowableBufferTest {
         Flowable<Object> openings = Flowable.create(new Publisher<Object>() {
             @Override
             public void subscribe(Subscriber<Object> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, new Object(), 50);
                 push(observer, new Object(), 200);
                 complete(observer, 250);
@@ -212,7 +212,7 @@ public class FlowableBufferTest {
                 return Flowable.create(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         push(observer, new Object(), 100);
                         complete(observer, 101);
                     }
@@ -237,7 +237,7 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 10);
                 push(observer, "two", 60);
                 push(observer, "three", 110);
@@ -253,7 +253,7 @@ public class FlowableBufferTest {
                 return Flowable.create(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         push(observer, new Object(), 100);
                         push(observer, new Object(), 200);
                         push(observer, new Object(), 300);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -87,7 +87,7 @@ public class FlowableCacheTest {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override
@@ -220,7 +220,7 @@ public class FlowableCacheTest {
         Flowable<Integer> firehose = Flowable.create(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(EmptySubscription.INSTANCE);
+                t.onSubscribe(new BooleanSubscription());
                 for (int i = 0; i < m; i++) {
                     t.onNext(i);
                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -28,7 +28,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.DefaultObserver;
@@ -84,7 +84,7 @@ public class FlowableConcatTest {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in an observable
                 observer.onNext(odds);
                 observer.onNext(even);
@@ -356,7 +356,7 @@ public class FlowableConcatTest {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in an observable
                 observer.onNext(Flowable.create(w1));
                 observer.onNext(Flowable.create(w2));
@@ -704,7 +704,7 @@ public class FlowableConcatTest {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(EmptySubscription.INSTANCE);
+                s.onSubscribe(new BooleanSubscription());
                 s.onNext("hello");
                 s.onComplete();
                 s.onComplete();
@@ -731,7 +731,7 @@ public class FlowableConcatTest {
                 Flowable<Integer> observable = Flowable.just(t)
                         .subscribeOn(sch)
                 ;
-                FlowProcessor<Integer> subject = UnicastProcessor.create();
+                FlowProcessor<Integer> subject = new UnicastProcessor<Integer>();
                 observable.subscribe(subject);
                 return subject;
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.TestSubscriber;
@@ -48,7 +48,7 @@ public class FlowableDebounceTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
                 publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
                 publishNext(observer, 900, "three");   // Should be skipped since onCompleted will arrive before the timeout expires.
@@ -74,7 +74,7 @@ public class FlowableDebounceTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 // all should be skipped since they are happening faster than the 200ms timeout
                 publishNext(observer, 100, "a");    // Should be skipped
                 publishNext(observer, 200, "b");    // Should be skipped
@@ -104,7 +104,7 @@ public class FlowableDebounceTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 Exception error = new TestException();
                 publishNext(observer, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
                 publishNext(observer, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
@@ -22,7 +22,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 
 public class FlowableDoOnSubscribeTest {
 
@@ -71,7 +71,7 @@ public class FlowableDoOnSubscribeTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(EmptySubscription.INSTANCE);
+                s.onSubscribe(new BooleanSubscription());
                 onSubscribed.incrementAndGet();
                 sref.set(s);
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -186,7 +186,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void subscribe(final Subscriber<? super Event> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 System.out.println("*** Subscribing to EventStream ***");
                 subscribeCounter.incrementAndGet();
                 new Thread(new Runnable() {
@@ -598,7 +598,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(EmptySubscription.INSTANCE);
+                sub.onSubscribe(new BooleanSubscription());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -677,7 +677,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(EmptySubscription.INSTANCE);
+                sub.onSubscribe(new BooleanSubscription());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -769,7 +769,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(EmptySubscription.INSTANCE);
+                sub.onSubscribe(new BooleanSubscription());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -846,7 +846,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(EmptySubscription.INSTANCE);
+                sub.onSubscribe(new BooleanSubscription());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -903,7 +903,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(EmptySubscription.INSTANCE);
+                sub.onSubscribe(new BooleanSubscription());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -1433,7 +1433,7 @@ public class FlowableGroupByTest {
                 new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> subscriber) {
-                        subscriber.onSubscribe(EmptySubscription.INSTANCE);
+                        subscriber.onSubscribe(new BooleanSubscription());
                         subscriber.onNext(0);
                         subscriber.onNext(1);
                         subscriber.onError(e);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -24,10 +24,9 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Optional;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultObserver;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.subscribers.*;
 
 public class FlowableMaterializeTest {
 
@@ -232,7 +231,7 @@ public class FlowableMaterializeTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -27,7 +27,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.LongConsumer;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.subscribers.DefaultObserver;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -224,7 +224,7 @@ public class FlowableMergeDelayErrorTest {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in an observable
                 observer.onNext(o1);
                 observer.onNext(o2);
@@ -322,7 +322,7 @@ public class FlowableMergeDelayErrorTest {
 
         @Override
         public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             observer.onNext("hello");
             observer.onComplete();
         }
@@ -333,7 +333,7 @@ public class FlowableMergeDelayErrorTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -357,7 +357,7 @@ public class FlowableMergeDelayErrorTest {
 
         @Override
         public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             boolean errorThrown = false;
             for (String s : valuesToReturn) {
                 if (s == null) {
@@ -388,7 +388,7 @@ public class FlowableMergeDelayErrorTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -441,7 +441,7 @@ public class FlowableMergeDelayErrorTest {
         Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
-                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onSubscribe(new BooleanSubscription());
                 try {
                     t1.onNext(0);
                 } catch (Throwable swallow) {
@@ -513,7 +513,7 @@ public class FlowableMergeDelayErrorTest {
             Flowable<Flowable<String>> parentObservable = Flowable.create(new Publisher<Flowable<String>>() {
                 @Override
                 public void subscribe(Subscriber<? super Flowable<String>> op) {
-                    op.onSubscribe(EmptySubscription.INSTANCE);
+                    op.onSubscribe(new BooleanSubscription());
                     op.onNext(Flowable.create(o1));
                     op.onNext(Flowable.create(o2));
                     op.onError(new NullPointerException("throwing exception in parent"));
@@ -540,7 +540,7 @@ public class FlowableMergeDelayErrorTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -24,7 +24,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.internal.schedulers.IoScheduler;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -97,7 +97,7 @@ public class FlowableMergeMaxConcurrentTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> t1) {
-            t1.onSubscribe(EmptySubscription.INSTANCE);
+            t1.onSubscribe(new BooleanSubscription());
             new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -77,7 +77,7 @@ public class FlowableMergeTest {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in an observable
                 observer.onNext(o1);
                 observer.onNext(o2);
@@ -270,7 +270,11 @@ public class FlowableMergeTest {
         // to make sure after o1.onNextBeingSent and o2.onNextBeingSent are hit that the following
         // onNext is invoked.
 
-        Thread.sleep(300);
+        int timeout = 10;
+        
+        while (timeout-- > 0 && concurrentCounter.get() != 1) {
+            Thread.sleep(100);
+        }
 
         try { // in try/finally so threads are released via latch countDown even if assertion fails
             assertEquals(1, concurrentCounter.get());
@@ -362,7 +366,7 @@ public class FlowableMergeTest {
 
         @Override
         public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             observer.onNext("hello");
             observer.onComplete();
         }
@@ -374,7 +378,7 @@ public class FlowableMergeTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -405,7 +409,7 @@ public class FlowableMergeTest {
 
         @Override
         public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             for (String s : valuesToReturn) {
                 if (s == null) {
                     System.out.println("throwing exception");
@@ -570,7 +574,7 @@ public class FlowableMergeTest {
             public void subscribe(final Subscriber<? super Integer> s) {
                 Worker inner = Schedulers.newThread().createWorker();
                 final AsyncSubscription as = new AsyncSubscription();
-                as.setSubscription(EmptySubscription.INSTANCE);
+                as.setSubscription(new BooleanSubscription());
                 as.setResource(inner);
                 
                 s.onSubscribe(as);
@@ -620,7 +624,7 @@ public class FlowableMergeTest {
             public void subscribe(final Subscriber<? super Integer> s) {
                 Worker inner = Schedulers.newThread().createWorker();
                 final AsyncSubscription as = new AsyncSubscription();
-                as.setSubscription(EmptySubscription.INSTANCE);
+                as.setSubscription(new BooleanSubscription());
                 as.setResource(inner);
                 
                 s.onSubscribe(as);
@@ -1070,7 +1074,7 @@ public class FlowableMergeTest {
 
                     @Override
                     public void subscribe(Subscriber<? super Integer> s) {
-                        s.onSubscribe(EmptySubscription.INSTANCE);
+                        s.onSubscribe(new BooleanSubscription());
                         if (i < 500) {
                             try {
                                 Thread.sleep(1);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -29,7 +29,7 @@ import io.reactivex.*;
 import io.reactivex.Optional;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.DefaultObserver;
@@ -541,7 +541,7 @@ public class FlowableObserveOnTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> o) {
-                o.onSubscribe(EmptySubscription.INSTANCE);
+                o.onSubscribe(new BooleanSubscription());
                 for (int i = 0; i < Flowable.bufferSize() + 10; i++) {
                     o.onNext(i);
                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Flowable.Operator;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
@@ -39,7 +39,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
 
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 observer.onNext("one");
                 observer.onError(new Throwable("injected failure"));
                 observer.onNext("two");
@@ -285,7 +285,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
             System.out.println("TestObservable subscribed to ...");
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
@@ -188,7 +188,7 @@ public class FlowableOnErrorReturnTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> subscriber) {
-            subscriber.onSubscribe(EmptySubscription.INSTANCE);
+            subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaObservableTest.java
@@ -23,7 +23,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -225,7 +225,7 @@ public class FlowableOnExceptionResumeNextViaObservableTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -26,7 +26,7 @@ import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -39,7 +39,7 @@ public class FlowablePublishTest {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override
@@ -370,7 +370,7 @@ public class FlowablePublishTest {
         Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(EmptySubscription.INSTANCE);
+                t.onSubscribe(new BooleanSubscription());
                 calls.getAndIncrement();
             }
         });

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -27,7 +27,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -70,7 +70,7 @@ public class FlowableRepeatTest {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(EmptySubscription.INSTANCE);
+                sub.onSubscribe(new BooleanSubscription());
                 counter.incrementAndGet();
                 sub.onNext(1);
                 sub.onNext(2);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -32,7 +32,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.operators.flowable.FlowableReplay.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
@@ -902,7 +902,7 @@ public class FlowableReplayTest {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override
@@ -1037,7 +1037,7 @@ public class FlowableReplayTest {
         Flowable<Integer> firehose = Flowable.create(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(EmptySubscription.INSTANCE);
+                t.onSubscribe(new BooleanSubscription());
                 for (int i = 0; i < m; i++) {
                     t.onNext(i);
                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -48,7 +48,7 @@ public class FlowableRetryTest {
 
             @Override
             public void subscribe(Subscriber<? super String> t1) {
-                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onSubscribe(new BooleanSubscription());
                 System.out.println(count.get() + " @ " + String.valueOf(last - System.currentTimeMillis()));
                 last = System.currentTimeMillis();
                 if (count.getAndDecrement() == 0) {
@@ -243,7 +243,7 @@ public class FlowableRetryTest {
         Publisher<Integer> onSubscribe = new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> subscriber) {
-                subscriber.onSubscribe(EmptySubscription.INSTANCE);
+                subscriber.onSubscribe(new BooleanSubscription());
                 final int emit = inc.incrementAndGet();
                 subscriber.onNext(emit);
                 subscriber.onComplete();
@@ -531,7 +531,7 @@ public class FlowableRetryTest {
         Publisher<String> onSubscribe = new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(EmptySubscription.INSTANCE);
+                s.onSubscribe(new BooleanSubscription());
                 subsCount.incrementAndGet();
                 s.onError(new RuntimeException("failed"));
             }
@@ -550,7 +550,7 @@ public class FlowableRetryTest {
         Publisher<String> onSubscribe = new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(EmptySubscription.INSTANCE);
+                s.onSubscribe(new BooleanSubscription());
                 subsCount.incrementAndGet();
                 s.onError(new RuntimeException("failed"));
             }
@@ -881,7 +881,7 @@ public class FlowableRetryTest {
 
             @Override
             public void subscribe(Subscriber<? super String> o) {
-                o.onSubscribe(EmptySubscription.INSTANCE);
+                o.onSubscribe(new BooleanSubscription());
                 for(int i=0; i<NUM_MSG; i++) {
                     o.onNext("msg:" + count.incrementAndGet());
                 }   

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -30,10 +30,9 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.DefaultObserver;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.subscribers.*;
 
 public class FlowableRetryWithPredicateTest {
     BiPredicate<Integer, Throwable> retryTwice = new BiPredicate<Integer, Throwable>() {
@@ -75,7 +74,7 @@ public class FlowableRetryWithPredicateTest {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
-                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onSubscribe(new BooleanSubscription());
                 count++;
                 t1.onNext(0);
                 t1.onNext(1);
@@ -110,7 +109,7 @@ public class FlowableRetryWithPredicateTest {
         Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
-                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onSubscribe(new BooleanSubscription());
                 t1.onNext(0);
                 t1.onNext(1);
                 t1.onError(new TestException());
@@ -139,7 +138,7 @@ public class FlowableRetryWithPredicateTest {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
-                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onSubscribe(new BooleanSubscription());
                 count++;
                 t1.onNext(0);
                 t1.onNext(1);
@@ -176,7 +175,7 @@ public class FlowableRetryWithPredicateTest {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
-                t1.onSubscribe(EmptySubscription.INSTANCE);
+                t1.onSubscribe(new BooleanSubscription());
                 count++;
                 t1.onNext(0);
                 t1.onNext(1);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -23,7 +23,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 
@@ -47,7 +47,7 @@ public class FlowableSampleTest {
         Flowable<Long> source = Flowable.create(new Publisher<Long>() {
             @Override
             public void subscribe(final Subscriber<? super Long> observer1) {
-                observer1.onSubscribe(EmptySubscription.INSTANCE);
+                observer1.onSubscribe(new BooleanSubscription());
                 innerScheduler.schedule(new Runnable() {
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
@@ -24,7 +24,7 @@ import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.subscribers.DefaultObserver;
 
 public class FlowableSerializeTest {
@@ -220,7 +220,7 @@ public class FlowableSerializeTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             System.out.println("TestSingleThreadedObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -271,7 +271,7 @@ public class FlowableSerializeTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             System.out.println("TestMultiThreadedObservable subscribed to ...");
             final NullPointerException npe = new NullPointerException();
             t = new Thread(new Runnable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -44,7 +44,7 @@ public class FlowableSubscribeOnTest {
             @Override
             public void subscribe(
                     final Subscriber<? super Integer> subscriber) {
-                subscriber.onSubscribe(EmptySubscription.INSTANCE);
+                subscriber.onSubscribe(new BooleanSubscription());
                 scheduled.countDown();
                 try {
                     try {
@@ -96,7 +96,7 @@ public class FlowableSubscribeOnTest {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(EmptySubscription.INSTANCE);
+                s.onSubscribe(new BooleanSubscription());
                 s.onError(new RuntimeException("fail"));
             }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -52,11 +52,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 50, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 70, "one");
                         publishNext(observer, 100, "two");
                         publishCompleted(observer, 200);
@@ -81,11 +81,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 10, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 0, "one");
                         publishNext(observer, 10, "two");
                         publishCompleted(observer, 20);
@@ -95,7 +95,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 100, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 0, "three");
                         publishNext(observer, 10, "four");
                         publishCompleted(observer, 20);
@@ -127,11 +127,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 50, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(final Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 60, "one");
                         publishNext(observer, 100, "two");
                     }
@@ -140,7 +140,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 200, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(final Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 0, "three");
                         publishNext(observer, 100, "four");
                     }
@@ -186,11 +186,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 50, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(final Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 50, "one");
                         publishNext(observer, 100, "two");
                     }
@@ -199,7 +199,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 200, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 0, "three");
                         publishNext(observer, 100, "four");
                     }
@@ -245,11 +245,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 50, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 50, "one");
                         publishNext(observer, 100, "two");
                     }
@@ -258,7 +258,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 130, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishCompleted(observer, 0);
                     }
                 }));
@@ -266,7 +266,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 150, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 50, "three");
                     }
                 }));
@@ -299,11 +299,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 50, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 50, "one");
                         publishNext(observer, 100, "two");
                     }
@@ -312,7 +312,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 130, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishError(observer, 0, new TestException());
                     }
                 }));
@@ -320,7 +320,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 150, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 50, "three");
                     }
                 }));
@@ -382,11 +382,11 @@ public class FlowableSwitchTest {
         Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 0, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 10, "1-one");
                         publishNext(observer, 20, "1-two");
                         // The following events will be ignored
@@ -397,7 +397,7 @@ public class FlowableSwitchTest {
                 publishNext(observer, 25, Flowable.create(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         publishNext(observer, 10, "2-one");
                         publishNext(observer, 20, "2-two");
                         publishNext(observer, 30, "2-three");
@@ -457,7 +457,7 @@ public class FlowableSwitchTest {
             public void onStart() {
                 requested = 3;
                 request(3);
-                testSubscriber.onSubscribe(EmptySubscription.INSTANCE);
+                testSubscriber.onSubscribe(new BooleanSubscription());
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -112,7 +112,7 @@ public class FlowableTakeTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 observer.onNext("one");
                 observer.onError(new Throwable("test failed"));
             }
@@ -240,7 +240,7 @@ public class FlowableTakeTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -23,7 +23,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Predicate;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.*;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -103,7 +103,7 @@ public class FlowableTakeWhileTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 observer.onNext("one");
                 observer.onError(new Throwable("test failed"));
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -24,7 +24,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 
@@ -46,7 +46,7 @@ public class FlowableThrottleFirstTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 publishNext(observer, 100, "one");    // publish as it's first
                 publishNext(observer, 300, "two");    // skip as it's last within the first 400
                 publishNext(observer, 900, "three");   // publish
@@ -74,7 +74,7 @@ public class FlowableThrottleFirstTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 Exception error = new TestException();
                 publishNext(observer, 100, "one");    // Should be published since it is first
                 publishNext(observer, 200, "two");    // Should be skipped since onError will arrive before the timeout expires

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -24,7 +24,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.TestSubscriber;
@@ -242,7 +242,7 @@ public class FlowableTimeoutTests {
 
                     @Override
                     public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(EmptySubscription.INSTANCE);
+                        subscriber.onSubscribe(new BooleanSubscription());
                         try {
                             timeoutSetuped.countDown();
                             exit.await();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -30,7 +30,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -328,7 +328,7 @@ public class FlowableTimeoutWithSelectorTest {
                     return Flowable.create(new Publisher<Integer>() {
                         @Override
                         public void subscribe(Subscriber<? super Integer> subscriber) {
-                            subscriber.onSubscribe(EmptySubscription.INSTANCE);
+                            subscriber.onSubscribe(new BooleanSubscription());
                             enteredTimeoutOne.countDown();
                             // force the timeout message be sent after observer.onNext(2)
                             while (true) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -294,13 +294,15 @@ public class FlowableWindowWithSizeTest {
     public void testBackpressureOuterInexact() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>((Long)null);
         
-        Flowable.range(1, 5).window(2, 1)
+        Flowable.range(1, 5)
+        .window(2, 1)
         .map(new Function<Flowable<Integer>, Flowable<List<Integer>>>() {
             @Override
             public Flowable<List<Integer>> apply(Flowable<Integer> t) {
                 return t.toList();
             }
-        }).concatMap(new Function<Flowable<List<Integer>>, Publisher<List<Integer>>>() {
+        })
+        .concatMap(new Function<Flowable<List<Integer>>, Publisher<List<Integer>>>() {
             @Override
             public Publisher<List<Integer>> apply(Flowable<List<Integer>> v) {
                 return v;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndObservableTest.java
@@ -23,7 +23,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.DefaultObserver;
@@ -48,7 +48,7 @@ public class FlowableWindowWithStartEndObservableTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 10);
                 push(observer, "two", 60);
                 push(observer, "three", 110);
@@ -61,7 +61,7 @@ public class FlowableWindowWithStartEndObservableTest {
         Flowable<Object> openings = Flowable.create(new Publisher<Object>() {
             @Override
             public void subscribe(Subscriber<? super Object> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, new Object(), 50);
                 push(observer, new Object(), 200);
                 complete(observer, 250);
@@ -74,7 +74,7 @@ public class FlowableWindowWithStartEndObservableTest {
                 return Flowable.create(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         push(observer, new Object(), 100);
                         complete(observer, 101);
                     }
@@ -99,7 +99,7 @@ public class FlowableWindowWithStartEndObservableTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 10);
                 push(observer, "two", 60);
                 push(observer, "three", 110);
@@ -116,7 +116,7 @@ public class FlowableWindowWithStartEndObservableTest {
                 return Flowable.create(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(EmptySubscription.INSTANCE);
+                        observer.onSubscribe(new BooleanSubscription());
                         int c = calls++;
                         if (c == 0) {
                             push(observer, new Object(), 100);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -24,7 +24,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.DefaultObserver;
 import io.reactivex.subscribers.TestSubscriber;
@@ -49,7 +49,7 @@ public class FlowableWindowWithTimeTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 10);
                 push(observer, "two", 90);
                 push(observer, "three", 110);
@@ -83,7 +83,7 @@ public class FlowableWindowWithTimeTest {
         Flowable<String> source = Flowable.create(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 push(observer, "one", 98);
                 push(observer, "two", 99);
                 push(observer, "three", 99); // FIXME happens after the window is open

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -623,7 +623,7 @@ public class FlowableZipTest {
         public void subscribe(Subscriber<? super String> observer) {
             // just store the variable where it can be accessed so we can manually trigger it
             this.observer = observer;
-            observer.onSubscribe(EmptySubscription.INSTANCE);
+            observer.onSubscribe(new BooleanSubscription());
         }
 
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -263,7 +263,11 @@ public class ObservableMergeTest {
         // to make sure after o1.onNextBeingSent and o2.onNextBeingSent are hit that the following
         // onNext is invoked.
 
-        Thread.sleep(300);
+        int timeout = 10;
+        
+        while (timeout-- > 0 && concurrentCounter.get() != 1) {
+            Thread.sleep(100);
+        }
 
         try { // in try/finally so threads are released via latch countDown even if assertion fails
             assertEquals(1, concurrentCounter.get());

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -368,7 +368,7 @@ public abstract class AbstractSchedulerTests {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(EmptySubscription.INSTANCE);
+                observer.onSubscribe(new BooleanSubscription());
                 for (int i = 0; i < count; i++) {
                     final int v = i;
                     new Thread(new Runnable() {
@@ -430,7 +430,7 @@ public abstract class AbstractSchedulerTests {
 
                             @Override
                             public void subscribe(Subscriber<? super String> observer) {
-                                observer.onSubscribe(EmptySubscription.INSTANCE);
+                                observer.onSubscribe(new BooleanSubscription());
                                 observer.onNext("value_after_map-" + v);
                                 observer.onComplete();
                             }


### PR DESCRIPTION
This PR enables fusion-consumers such as `observeOn`, `flatMap`, `zip`, `concatMap`; makes `UnicastProcessor` async-fuseable (used by `window`); fixes a few hidden issues with operators and has convenience renames of `SubscriptionHelper.validateX`. In addition, it features the new `FlowableFlattenIterable` used by `flatMapIterable` and `concatMapIterable`.
