### PR TITLE
2.x: enable op-fusion on GroupBy, doOnX, fix mistakes in map and filter

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -18,7 +18,9 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.subscribers.flowable.*;
+import io.reactivex.internal.util.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableDoOnEach<T> extends Flowable<T> {
@@ -41,19 +43,20 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
     
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new DoOnEachSubscriber<T>(s, onNext, onError, onComplete, onAfterTerminate));
+        if (s instanceof ConditionalSubscriber) {
+            source.subscribe(new DoOnEachConditionalSubscriber<T>(
+                    (ConditionalSubscriber<? super T>)s, onNext, onError, onComplete, onAfterTerminate));
+        } else {
+            source.subscribe(new DoOnEachSubscriber<T>(
+                    s, onNext, onError, onComplete, onAfterTerminate));
+        }
     }
     
-    static final class DoOnEachSubscriber<T> implements Subscriber<T>, Subscription {
-        final Subscriber<? super T> actual;
+    static final class DoOnEachSubscriber<T> extends BasicFuseableSubscriber<T, T> {
         final Consumer<? super T> onNext;
         final Consumer<? super Throwable> onError;
         final Runnable onComplete;
         final Runnable onAfterTerminate;
-        
-        Subscription s;
-        
-        boolean done;
         
         public DoOnEachSubscriber(
                 Subscriber<? super T> actual,
@@ -61,7 +64,7 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
                 Consumer<? super Throwable> onError, 
                 Runnable onComplete,
                 Runnable onAfterTerminate) {
-            this.actual = actual;
+            super(actual);
             this.onNext = onNext;
             this.onError = onError;
             this.onComplete = onComplete;
@@ -69,23 +72,20 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
         }
         
         @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(this.s, s)) {
-                this.s = s;
-                actual.onSubscribe(this);
-            }
-        }
-        
-        @Override
         public void onNext(T t) {
             if (done) {
                 return;
             }
+            
+            if (sourceMode != NONE) {
+                actual.onNext(null);
+                return;
+            }
+            
             try {
                 onNext.accept(t);
             } catch (Throwable e) {
-                s.cancel();
-                onError(e);
+                fail(e);
                 return;
             }
             
@@ -103,6 +103,7 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
             try {
                 onError.accept(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 relay = false;
             }
@@ -126,7 +127,7 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
             try {
                 onComplete.run();
             } catch (Throwable e) {
-                onError(e);
+                fail(e);
                 return;
             }
             
@@ -138,17 +139,164 @@ public final class FlowableDoOnEach<T> extends Flowable<T> {
                 RxJavaPlugins.onError(e);
             }
         }
-        
-        
+
         @Override
-        public void request(long n) {
-            s.request(n);
-        }
-        
-        @Override
-        public void cancel() {
-            s.cancel();
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
         }
 
+        @Override
+        public T poll() {
+            T v = qs.poll();
+            
+            if (v != null) {
+                try {
+                    onNext.accept(v);
+                } finally {
+                    onAfterTerminate.run();
+                }
+            } else {
+                if (sourceMode == SYNC) {
+                    onComplete.run();
+                    
+                    onAfterTerminate.run();
+                }
+            }
+            return v;
+        }
+    }
+    
+    static final class DoOnEachConditionalSubscriber<T> extends BasicFuseableConditionalSubscriber<T, T> {
+        final Consumer<? super T> onNext;
+        final Consumer<? super Throwable> onError;
+        final Runnable onComplete;
+        final Runnable onAfterTerminate;
+        
+        public DoOnEachConditionalSubscriber(
+                ConditionalSubscriber<? super T> actual,
+                Consumer<? super T> onNext, 
+                Consumer<? super Throwable> onError, 
+                Runnable onComplete,
+                Runnable onAfterTerminate) {
+            super(actual);
+            this.onNext = onNext;
+            this.onError = onError;
+            this.onComplete = onComplete;
+            this.onAfterTerminate = onAfterTerminate;
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            
+            if (sourceMode != NONE) {
+                actual.onNext(null);
+                return;
+            }
+            
+            try {
+                onNext.accept(t);
+            } catch (Throwable e) {
+                fail(e);
+                return;
+            }
+            
+            actual.onNext(t);
+        }
+        
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            
+            if (sourceMode != NONE) {
+                return actual.tryOnNext(null);
+            }
+            
+            try {
+                onNext.accept(t);
+            } catch (Throwable e) {
+                fail(e);
+                return false;
+            }
+            
+            return actual.tryOnNext(t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            boolean relay = true;
+            try {
+                onError.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                actual.onError(new CompositeException(e, t));
+                relay = false;
+            }
+            if (relay) {
+                actual.onError(t);
+            }
+            
+            try {
+                onAfterTerminate.run();
+            } catch (Throwable e) {
+                RxJavaPlugins.onError(e);
+            }
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            try {
+                onComplete.run();
+            } catch (Throwable e) {
+                fail(e);
+                return;
+            }
+            
+            actual.onComplete();
+            
+            try {
+                onAfterTerminate.run();
+            } catch (Throwable e) {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public T poll() {
+            T v = qs.poll();
+            
+            if (v != null) {
+                try {
+                    onNext.accept(v);
+                } finally {
+                    onAfterTerminate.run();
+                }
+            } else {
+                if (sourceMode == SYNC) {
+                    onComplete.run();
+                    
+                    onAfterTerminate.run();
+                }
+            }
+            return v;
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -54,6 +54,13 @@ public final class FlowableFilter<T> extends FlowableSource<T, T> {
         
         @Override
         public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            if (sourceMode != NONE) {
+                actual.onNext(null);
+                return true;
+            }
             boolean b;
             try {
                 b = filter.test(t);
@@ -117,10 +124,10 @@ public final class FlowableFilter<T> extends FlowableSource<T, T> {
                 return false;
             }
 
-            if (sourceMode == ASYNC) {
-                actual.onNext(null);
-                return true;
+            if (sourceMode != NONE) {
+                return actual.tryOnNext(null);
             }
+            
             boolean b;
             try {
                 b = filter.test(t);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -52,7 +52,7 @@ public final class FlowableMap<T, U> extends Flowable<U> {
                 return;
             }
             
-            if (sourceMode == ASYNC) {
+            if (sourceMode != NONE) {
                 actual.onNext(null);
                 return;
             }
@@ -94,7 +94,7 @@ public final class FlowableMap<T, U> extends Flowable<U> {
                 return;
             }
             
-            if (sourceMode == ASYNC) {
+            if (sourceMode != NONE) {
                 actual.onNext(null);
                 return;
             }
@@ -116,15 +116,14 @@ public final class FlowableMap<T, U> extends Flowable<U> {
                 return false;
             }
             
-            if (sourceMode == ASYNC) {
-                actual.onNext(null);
-                return true;
+            if (sourceMode != NONE) {
+                return actual.tryOnNext(null);
             }
             
             U v;
             
             try {
-                v = mapper.apply(t);
+                v = nullCheck(mapper.apply(t), "The mapper function returned a null value.");
             } catch (Throwable ex) {
                 fail(ex);
                 return true;

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -795,14 +795,25 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * @return this
      */
     public final TestSubscriber<T> assertFusionMode(int mode) {
-        if (establishedFusionMode != mode) {
+        int m = establishedFusionMode;
+        if (m != mode) {
             if (qs != null) {
-                throw new AssertionError("Fusion mode different. Expected: " + mode + ", actual: " + establishedFusionMode);
+                throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
+                + ", actual: " + fusionModeToString(m));
             } else {
                 throw new AssertionError("Upstream is not fuseable");
             }
         }
         return this;
+    }
+    
+    private String fusionModeToString(int mode) {
+        switch (mode) {
+        case QueueSubscription.NONE : return "NONE";
+        case QueueSubscription.SYNC : return "SYNC";
+        case QueueSubscription.ASYNC : return "ASYNC";
+        default: return "Unknown(" + mode + ")";
+        }
     }
     
     /**


### PR DESCRIPTION
This short PR enables operator fusion on `groupBy` and on the `doOnNext`, `doOnError`, `doOnComplete` and `doOnEach` operators.

In addition, it fixes small mistakes in `map` and `filter` and adds a method to `TestSubscriber` to print better fusion-assertion failure message.
