### PR TITLE
2.x: measure overhead of toBlocking() first and last

### DIFF
--- a/src/perf/java/io/reactivex/BlockingPerf.java
+++ b/src/perf/java/io/reactivex/BlockingPerf.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+import io.reactivex.flowables.BlockingFlowable;
+import io.reactivex.observables.BlockingObservable;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class BlockingPerf {
+    @Param({ "1", "1000", "1000000" })
+    public int times;
+    
+    Flowable<Integer> flowable;
+    
+    BlockingFlowable<Integer> flowableBlocking;
+    
+    Observable<Integer> observable;
+
+    BlockingObservable<Integer> observableBlocking;
+
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[times];
+        Arrays.fill(array, 777);
+        
+        flowable = Flowable.fromArray(array);
+        
+        flowableBlocking = flowable.toBlocking();
+        
+        observable = Observable.fromArray(array);
+        
+        observableBlocking = observable.toBlocking();
+    }
+    
+    @Benchmark
+    public Object flowableFirst() {
+        return flowable.toBlocking().first();
+    }
+
+    @Benchmark
+    public Object flowableLast() {
+        return flowable.toBlocking().last();
+    }
+
+    @Benchmark
+    public Object flowableBlockingFirst() {
+        return flowableBlocking.first();
+    }
+
+    @Benchmark
+    public Object flowableBlockingLast() {
+        return flowableBlocking.last();
+    }
+    
+    @Benchmark
+    public Object observableFirst() {
+        return observable.toBlocking().first();
+    }
+
+    @Benchmark
+    public Object observableLast() {
+        return observable.toBlocking().last();
+    }
+
+    @Benchmark
+    public Object observableBlockingFirst() {
+        return observableBlocking.first();
+    }
+
+    @Benchmark
+    public Object observableBlockingLast() {
+        return observableBlocking.last();
+    }
+}

--- a/src/perf/java/io/reactivex/EachTypeFlatMapPerf.java
+++ b/src/perf/java/io/reactivex/EachTypeFlatMapPerf.java
@@ -84,28 +84,28 @@ public class EachTypeFlatMapPerf {
     
     @Benchmark
     public void bpRange(Blackhole bh) {
-        bpRange.subscribe(new LatchedObserver<Integer>(bh));
+        bpRange.subscribe(new PerfSubscriber(bh));
     }
     @Benchmark
     public void bpRangeMapJust(Blackhole bh) {
-        bpRangeMapJust.subscribe(new LatchedObserver<Integer>(bh));
+        bpRangeMapJust.subscribe(new PerfSubscriber(bh));
     }
     @Benchmark
     public void bpRangeMapRange(Blackhole bh) {
-        bpRangeMapRange.subscribe(new LatchedObserver<Integer>(bh));
+        bpRangeMapRange.subscribe(new PerfSubscriber(bh));
     }
 
     @Benchmark
     public void nbpRange(Blackhole bh) {
-        nbpRange.subscribe(new LatchedNbpObserver<Integer>(bh));
+        nbpRange.subscribe(new PerfObserver(bh));
     }
     @Benchmark
     public void nbpRangeMapJust(Blackhole bh) {
-        nbpRangeMapJust.subscribe(new LatchedNbpObserver<Integer>(bh));
+        nbpRangeMapJust.subscribe(new PerfObserver(bh));
     }
     @Benchmark
     public void nbpRangeMapRange(Blackhole bh) {
-        nbpRangeMapRange.subscribe(new LatchedNbpObserver<Integer>(bh));
+        nbpRangeMapRange.subscribe(new PerfObserver(bh));
     }
 
     @Benchmark

--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -78,8 +78,8 @@ public abstract class InputWithIncrementingInteger {
 
     }
 
-    public LatchedObserver<Integer> newLatchedObserver() {
-        return new LatchedObserver<Integer>(bh);
+    public PerfSubscriber newLatchedObserver() {
+        return new PerfSubscriber(bh);
     }
 
     public Subscriber<Integer> newSubscriber() {

--- a/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
+++ b/src/perf/java/io/reactivex/OperatorFlatMapPerf.java
@@ -52,7 +52,7 @@ public class OperatorFlatMapPerf {
 
     @Benchmark
     public void flatMapIntPassthruAsync(Input input) throws InterruptedException {
-        LatchedObserver<Integer> latchedObserver = input.newLatchedObserver();
+        PerfSubscriber latchedObserver = input.newLatchedObserver();
         input.observable.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer i) {

--- a/src/perf/java/io/reactivex/OperatorMergePerf.java
+++ b/src/perf/java/io/reactivex/OperatorMergePerf.java
@@ -37,7 +37,7 @@ public class OperatorMergePerf {
                         return Flowable.just(v);
                     }
                 });
-        LatchedObserver<Integer> o = input.newLatchedObserver();
+        PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
 
         if (input.size == 1) {
@@ -56,7 +56,7 @@ public class OperatorMergePerf {
                     return Flowable.range(0, input.size);
             }
         });
-        LatchedObserver<Integer> o = input.newLatchedObserver();
+        PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         
         if (input.size == 1) {
@@ -74,7 +74,7 @@ public class OperatorMergePerf {
                     return Flowable.range(0, input.size);
             }
         });
-        LatchedObserver<Integer> o = input.newLatchedObserver();
+        PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         if (input.size == 1) {
             while (o.latch.getCount() != 0);
@@ -91,7 +91,7 @@ public class OperatorMergePerf {
                     return Flowable.range(0, input.size).subscribeOn(Schedulers.computation());
             }
         });
-        LatchedObserver<Integer> o = input.newLatchedObserver();
+        PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         if (input.size == 1) {
             while (o.latch.getCount() != 0);
@@ -102,7 +102,7 @@ public class OperatorMergePerf {
 
     @Benchmark
     public void mergeTwoAsyncStreamsOfN(final InputThousand input) throws InterruptedException {
-        LatchedObserver<Integer> o = input.newLatchedObserver();
+        PerfSubscriber o = input.newLatchedObserver();
         Flowable<Integer> ob = Flowable.range(0, input.size).subscribeOn(Schedulers.computation());
         Flowable.merge(ob, ob).subscribe(o);
         if (input.size == 1) {
@@ -114,7 +114,7 @@ public class OperatorMergePerf {
 
     @Benchmark
     public void mergeNSyncStreamsOf1(final InputForMergeN input) throws InterruptedException {
-        LatchedObserver<Integer> o = input.newLatchedObserver();
+        PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(input.observables).subscribe(o);
         if (input.size == 1) {
             while (o.latch.getCount() != 0);
@@ -141,8 +141,8 @@ public class OperatorMergePerf {
             }
         }
 
-        public LatchedObserver<Integer> newLatchedObserver() {
-            return new LatchedObserver<Integer>(bh);
+        public PerfSubscriber newLatchedObserver() {
+            return new PerfSubscriber(bh);
         }
     }
 

--- a/src/perf/java/io/reactivex/PerfObserver.java
+++ b/src/perf/java/io/reactivex/PerfObserver.java
@@ -19,10 +19,10 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import io.reactivex.disposables.Disposable;
 
-public final class LatchedNbpObserver<T> implements Observer<T> {
+public final class PerfObserver implements Observer<Object> {
     final CountDownLatch cdl;
     final Blackhole bh;
-    public LatchedNbpObserver(Blackhole bh) {
+    public PerfObserver(Blackhole bh) {
         this.bh = bh;
         this.cdl = new CountDownLatch(1);
     }
@@ -31,7 +31,7 @@ public final class LatchedNbpObserver<T> implements Observer<T> {
         
     }
     @Override
-    public void onNext(T value) {
+    public void onNext(Object value) {
         bh.consume(value);
     }
     @Override

--- a/src/perf/java/io/reactivex/PerfSubscriber.java
+++ b/src/perf/java/io/reactivex/PerfSubscriber.java
@@ -16,18 +16,22 @@ package io.reactivex;
 import java.util.concurrent.CountDownLatch;
 
 import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.*;
 
-import io.reactivex.subscribers.DefaultObserver;
-
-public class LatchedObserver<T> extends DefaultObserver<T> {
+public class PerfSubscriber implements Subscriber<Object> {
 
     public CountDownLatch latch = new CountDownLatch(1);
     private final Blackhole bh;
 
-    public LatchedObserver(Blackhole bh) {
+    public PerfSubscriber(Blackhole bh) {
         this.bh = bh;
     }
 
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+    
     @Override
     public void onComplete() {
         latch.countDown();
@@ -39,7 +43,7 @@ public class LatchedObserver<T> extends DefaultObserver<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(Object t) {
         bh.consume(t);
     }
 

--- a/src/perf/java/io/reactivex/RangePerf.java
+++ b/src/perf/java/io/reactivex/RangePerf.java
@@ -49,7 +49,7 @@ public class RangePerf {
     
     @Benchmark
     public Object rangeSync(Blackhole bh) {
-        LatchedObserver<Integer> lo = new LatchedObserver<Integer>(bh);
+        PerfSubscriber lo = new PerfSubscriber(bh);
         
         range.subscribe(lo);
         
@@ -58,7 +58,7 @@ public class RangePerf {
 
 //    @Benchmark
     public void rangeAsync(Blackhole bh) throws Exception {
-        LatchedObserver<Integer> lo = new LatchedObserver<Integer>(bh);
+        PerfSubscriber lo = new PerfSubscriber(bh);
         
         rangeAsync.subscribe(lo);
         
@@ -71,7 +71,7 @@ public class RangePerf {
 
 //    @Benchmark
     public void rangePipeline(Blackhole bh) throws Exception {
-        LatchedObserver<Integer> lo = new LatchedObserver<Integer>(bh);
+        PerfSubscriber lo = new PerfSubscriber(bh);
         
         rangeAsyncPipeline.subscribe(lo);
         

--- a/src/perf/java/io/reactivex/RxVsStreamPerf.java
+++ b/src/perf/java/io/reactivex/RxVsStreamPerf.java
@@ -85,32 +85,32 @@ public class RxVsStreamPerf {
     
     @Benchmark
     public void range(Blackhole bh) {
-        range.subscribe(new LatchedObserver<Integer>(bh));
+        range.subscribe(new PerfSubscriber(bh));
     }
 
     @Benchmark
     public void rangeNbp(Blackhole bh) {
-        rangeNbp.subscribe(new LatchedNbpObserver<Integer>(bh));
+        rangeNbp.subscribe(new PerfObserver(bh));
     }
 
     @Benchmark
     public void rangeFlatMap(Blackhole bh) {
-        rangeFlatMap.subscribe(new LatchedObserver<Integer>(bh));
+        rangeFlatMap.subscribe(new PerfSubscriber(bh));
     }
 
     @Benchmark
     public void rangeNbpFlatMap(Blackhole bh) {
-        rangeNbpFlatMap.subscribe(new LatchedNbpObserver<Integer>(bh));
+        rangeNbpFlatMap.subscribe(new PerfObserver(bh));
     }
     
     @Benchmark
     public void rangeFlatMapJust(Blackhole bh) {
-        rangeFlatMapJust.subscribe(new LatchedObserver<Integer>(bh));
+        rangeFlatMapJust.subscribe(new PerfSubscriber(bh));
     }
 
     @Benchmark
     public void rangeNbpFlatMapJust(Blackhole bh) {
-        rangeNbpFlatMapJust.subscribe(new LatchedNbpObserver<Integer>(bh));
+        rangeNbpFlatMapJust.subscribe(new PerfObserver(bh));
     }
 
 }


### PR DESCRIPTION
This updates the perf classes a bit and adds a blocking benchmark.

![image](https://cloud.githubusercontent.com/assets/1269832/16580974/5ff08e54-42a7-11e6-889e-cfbb5c0bdecb.png)
