### PR TITLE
2.x: reduce overhead of blocking first/last/single

### DIFF
--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingFirstSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingFirstSubscriber.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+/**
+ * Blocks until the upstream signals its first value or completes.
+ *
+ * @param <T> the value type
+ */
+public final class BlockingFirstSubscriber<T> extends BlockingSingleSubscriber<T> {
+
+    @Override
+    public void onNext(T t) {
+        if (value == null) {
+            value = t;
+            s.cancel();
+            countDown();
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (value == null) {
+            error = t;
+        }
+        countDown();
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingLastSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingLastSubscriber.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+/**
+ * Blocks until the upstream signals its last value or completes.
+ *
+ * @param <T> the value type
+ */
+public final class BlockingLastSubscriber<T> extends BlockingSingleSubscriber<T> {
+
+    @Override
+    public void onNext(T t) {
+        value = t;
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        value = null;
+        error = t;
+        countDown();
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingSingleSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingSingleSubscriber.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.subscribers.flowable;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.util.Exceptions;
+
+public abstract class BlockingSingleSubscriber<T> extends CountDownLatch
+implements Subscriber<T>, Disposable {
+
+    T value;
+    Throwable error;
+    
+    Subscription s;
+    
+    volatile boolean cancelled;
+
+    public BlockingSingleSubscriber() {
+        super(1);
+    }
+
+    @Override
+    public final void onSubscribe(Subscription s) {
+        this.s = s;
+        if (!cancelled) {
+            s.request(Long.MAX_VALUE);
+            if (cancelled) {
+                s.cancel();
+            }
+        }
+    }
+    
+    @Override
+    public final void onComplete() {
+        countDown();
+    }
+    
+    @Override
+    public final void dispose() {
+        cancelled = true;
+        Subscription s = this.s;
+        if (s != null) {
+            s.cancel();
+        }
+    }
+    
+    @Override
+    public final boolean isDisposed() {
+        return cancelled;
+    }
+    
+    /**
+     * Block until the first value arrives and return it, otherwise
+     * return null for an empty source and rethrow any exception.
+     * @return the first value or null if the source is empty
+     */
+    public final T blockingGet() {
+        if (getCount() != 0) {
+            try {
+                await();
+            } catch (InterruptedException ex) {
+                dispose();
+                throw Exceptions.propagate(ex);
+            }
+        }
+        
+        Throwable e = error;
+        if (e != null) {
+            Exceptions.propagate(e);
+        }
+        return value;
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BlockingFirstObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BlockingFirstObserver.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.observable;
+
+/**
+ * Blocks until the upstream signals its first value or completes.
+ *
+ * @param <T> the value type
+ */
+public final class BlockingFirstObserver<T> extends BlockingSingleObserver<T> {
+
+    @Override
+    public void onNext(T t) {
+        if (value == null) {
+            value = t;
+            d.dispose();
+            countDown();
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (value == null) {
+            error = t;
+        }
+        countDown();
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BlockingLastObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BlockingLastObserver.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.observable;
+
+/**
+ * Blocks until the upstream signals its last value or completes.
+ *
+ * @param <T> the value type
+ */
+public final class BlockingLastObserver<T> extends BlockingSingleObserver<T> {
+
+    @Override
+    public void onNext(T t) {
+        value = t;
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        value = null;
+        error = t;
+        countDown();
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BlockingSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BlockingSingleObserver.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.subscribers.observable;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.util.Exceptions;
+
+public abstract class BlockingSingleObserver<T> extends CountDownLatch
+implements Observer<T>, Disposable {
+
+    T value;
+    Throwable error;
+    
+    Disposable d;
+    
+    volatile boolean cancelled;
+
+    public BlockingSingleObserver() {
+        super(1);
+    }
+
+    @Override
+    public final void onSubscribe(Disposable d) {
+        this.d = d;
+        if (cancelled) {
+            d.dispose();
+        }
+    }
+    
+    @Override
+    public final void onComplete() {
+        countDown();
+    }
+    
+    @Override
+    public final void dispose() {
+        cancelled = true;
+        Disposable d = this.d;
+        if (d != null) {
+            d.dispose();
+        }
+    }
+    
+    @Override
+    public final boolean isDisposed() {
+        return cancelled;
+    }
+    
+    /**
+     * Block until the first value arrives and return it, otherwise
+     * return null for an empty source and rethrow any exception.
+     * @return the first value or null if the source is empty
+     */
+    public final T blockingGet() {
+        if (getCount() != 0) {
+            try {
+                await();
+            } catch (InterruptedException ex) {
+                dispose();
+                throw Exceptions.propagate(ex);
+            }
+        }
+        
+        Throwable e = error;
+        if (e != null) {
+            Exceptions.propagate(e);
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
Optimize the reception, less allocation, less overhead in general.

Benchmark comparison (i7 4790, Windows 7 x64, Java 8u92)

![image](https://cloud.githubusercontent.com/assets/1269832/16583761/065268fc-42b8-11e6-86a1-4ac91da80c97.png)
