### PR TITLE
1.x: improve coverage of rx.Observable methods

### DIFF
--- a/src/main/java/rx/Notification.java
+++ b/src/main/java/rx/Notification.java
@@ -158,18 +158,12 @@ public final class Notification<T> {
      * @param observer the target observer to call onXXX methods on based on the kind of this Notification instance
      */
     public void accept(Observer<? super T> observer) {
-        switch (kind) {
-        case OnNext:
+        if (kind == Kind.OnNext) {
             observer.onNext(getValue());
-            break;
-        case OnError:
-            observer.onError(getThrowable());
-            break;
-        case OnCompleted:
+        } else if (kind == Kind.OnCompleted) {
             observer.onCompleted();
-            break;
-        default:
-            throw new AssertionError("Uncovered case: " + kind);
+        } else {
+            observer.onError(getThrowable());
         }
     }
 

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -10702,7 +10702,8 @@ public class Observable<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Observable}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code timeInterval} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     *  <dd>{@code timeInterval} does not operate on any particular scheduler but uses the current time
+     *  from the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      * 
      * @return an Observable that emits time interval information items
@@ -10722,7 +10723,8 @@ public class Observable<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Observable}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>The operator does not operate on any particular scheduler but uses the current time
+     *  from the specified {@link Scheduler}.</dd>
      * </dl>
      * 
      * @param scheduler
@@ -11006,7 +11008,8 @@ public class Observable<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Observable}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code timestamp} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     *  <dd>{@code timestamp} does not operate on any particular scheduler but uses the current time
+     *  from the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      * 
      * @return an Observable that emits timestamped items from the source Observable
@@ -11026,7 +11029,8 @@ public class Observable<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Observable}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>The operator does not operate on any particular scheduler but uses the current time
+     *  from the specified {@link Scheduler}.</dd>
      * </dl>
      * 
      * @param scheduler

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9825,7 +9825,7 @@ public class Observable<T> {
                 Exceptions.throwIfFatal(e2);
                 // if this happens it means the onError itself failed (perhaps an invalid function implementation)
                 // so we are unable to propagate the error correctly and will just throw
-                RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
+                RuntimeException r = new OnErrorFailedException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
                 // TODO could the hook be the cause of the error in the on error handling.
                 RxJavaHooks.onObservableError(r);
                 // TODO why aren't we throwing the hook's return value.
@@ -10702,14 +10702,14 @@ public class Observable<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Observable}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code timeInterval} operates by default on the {@code immediate} {@link Scheduler}.</dd>
+     *  <dd>{@code timeInterval} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      * 
      * @return an Observable that emits time interval information items
      * @see <a href="http://reactivex.io/documentation/operators/timeinterval.html">ReactiveX operators documentation: TimeInterval</a>
      */
     public final Observable<TimeInterval<T>> timeInterval() {
-        return timeInterval(Schedulers.immediate());
+        return timeInterval(Schedulers.computation());
     }
 
     /**
@@ -11006,14 +11006,14 @@ public class Observable<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Observable}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code timestamp} operates by default on the {@code immediate} {@link Scheduler}.</dd>
+     *  <dd>{@code timestamp} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      * 
      * @return an Observable that emits timestamped items from the source Observable
      * @see <a href="http://reactivex.io/documentation/operators/timestamp.html">ReactiveX operators documentation: Timestamp</a>
      */
     public final Observable<Timestamped<T>> timestamp() {
-        return timestamp(Schedulers.immediate());
+        return timestamp(Schedulers.computation());
     }
 
     /**

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9781,6 +9781,9 @@ public class Observable<T> {
         if (observer instanceof Subscriber) {
             return subscribe((Subscriber<? super T>)observer);
         }
+        if (observer == null) {
+            throw new NullPointerException("observer is null");
+        }
         return subscribe(new ObserverSubscriber<T>(observer));
     }
 

--- a/src/main/java/rx/internal/operators/DeferredScalarSubscriber.java
+++ b/src/main/java/rx/internal/operators/DeferredScalarSubscriber.java
@@ -85,7 +85,7 @@ public abstract class DeferredScalarSubscriber<T, R> extends Subscriber<T> {
     
     /**
      * Atomically switches to the terminal state and emits the value if
-     * there is a request for it or stores it for retrieval by {@link #downstreamRequest(long)}.
+     * there is a request for it or stores it for retrieval by {@code downstreamRequest(long)}.
      * @param value the value to complete with
      */
     protected final void complete(R value) {

--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -31,7 +31,7 @@ package rx.internal.operators;
  * limitations under the License.
  */
 
-import static rx.Observable.create;
+import static rx.Observable.create; // NOPMD
 
 import java.util.concurrent.atomic.*;
 

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -73,7 +73,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
     
     @Override
     public Subscriber<? super T> call(Subscriber<? super GroupedObservable<K, V>> child) {
-        final GroupBySubscriber<T, K, V> parent;
+        final GroupBySubscriber<T, K, V> parent; // NOPMD
         try {
             parent = new GroupBySubscriber<T, K, V>(child, keySelector, valueSelector, bufferSize, delayError, mapFactory);
         } catch (Throwable ex) {

--- a/src/main/java/rx/internal/util/SynchronizedQueue.java
+++ b/src/main/java/rx/internal/util/SynchronizedQueue.java
@@ -115,10 +115,7 @@ public class SynchronizedQueue<T> implements Queue<T>, Cloneable {
             return false;
         }
         SynchronizedQueue<?> other = (SynchronizedQueue<?>) obj;
-        if (!list.equals(other.list)) {
-            return false;
-        }
-        return true;
+        return list.equals(other.list);
     }
 
     @Override

--- a/src/test/java/rx/NotificationTest.java
+++ b/src/test/java/rx/NotificationTest.java
@@ -18,6 +18,7 @@ package rx;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
 
 import java.util.*;
 
@@ -31,42 +32,42 @@ public class NotificationTest {
     public void testOnNextIntegerNotificationDoesNotEqualNullNotification(){
         final Notification<Integer> integerNotification = Notification.createOnNext(1);
         final Notification<Integer> nullNotification = Notification.createOnNext(null);
-        Assert.assertFalse(integerNotification.equals(nullNotification));
+        assertFalse(integerNotification.equals(nullNotification));
     }
 
     @Test
     public void testOnNextNullNotificationDoesNotEqualIntegerNotification(){
         final Notification<Integer> integerNotification = Notification.createOnNext(1);
         final Notification<Integer> nullNotification = Notification.createOnNext(null);
-        Assert.assertFalse(nullNotification.equals(integerNotification));
+        assertFalse(nullNotification.equals(integerNotification));
     }
 
     @Test
     public void testOnNextIntegerNotificationsWhenEqual(){
         final Notification<Integer> integerNotification = Notification.createOnNext(1);
         final Notification<Integer> integerNotification2 = Notification.createOnNext(1);
-        Assert.assertTrue(integerNotification.equals(integerNotification2));
+        assertTrue(integerNotification.equals(integerNotification2));
     }
 
     @Test
     public void testOnNextIntegerNotificationsWhenNotEqual(){
         final Notification<Integer> integerNotification = Notification.createOnNext(1);
         final Notification<Integer> integerNotification2 = Notification.createOnNext(2);
-        Assert.assertFalse(integerNotification.equals(integerNotification2));
+        assertFalse(integerNotification.equals(integerNotification2));
     }
 
     @Test
     public void testOnErrorIntegerNotificationDoesNotEqualNullNotification(){
         final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
         final Notification<Integer> nullNotification = Notification.createOnError(null);
-        Assert.assertFalse(integerNotification.equals(nullNotification));
+        assertFalse(integerNotification.equals(nullNotification));
     }
 
     @Test
     public void testOnErrorNullNotificationDoesNotEqualIntegerNotification(){
         final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
         final Notification<Integer> nullNotification = Notification.createOnError(null);
-        Assert.assertFalse(nullNotification.equals(integerNotification));
+        assertFalse(nullNotification.equals(integerNotification));
     }
 
     @Test
@@ -74,22 +75,22 @@ public class NotificationTest {
         final Exception exception = new Exception();
         final Notification<Integer> onErrorNotification = Notification.createOnError(exception);
         final Notification<Integer> onErrorNotification2 = Notification.createOnError(exception);
-        Assert.assertTrue(onErrorNotification.equals(onErrorNotification2));
+        assertTrue(onErrorNotification.equals(onErrorNotification2));
     }
 
     @Test
     public void testOnErrorIntegerNotificationWhenNotEqual(){
         final Notification<Integer> onErrorNotification = Notification.createOnError(new Exception());
         final Notification<Integer> onErrorNotification2 = Notification.createOnError(new Exception());
-        Assert.assertFalse(onErrorNotification.equals(onErrorNotification2));
+        assertFalse(onErrorNotification.equals(onErrorNotification2));
     }
 
     @Test
     public void createWithClass() {
         Notification<Integer> n = Notification.createOnCompleted(Integer.class);
-        Assert.assertTrue(n.isOnCompleted());
-        Assert.assertFalse(n.hasThrowable());
-        Assert.assertFalse(n.hasValue());
+        assertTrue(n.isOnCompleted());
+        assertFalse(n.hasThrowable());
+        assertFalse(n.hasValue());
     }
 
     @Test
@@ -121,9 +122,9 @@ public class NotificationTest {
 
     @Test
     public void toStringVariants() {
-        Assert.assertEquals("[rx.Notification OnNext 1]", stripAt(Notification.createOnNext(1).toString()));
-        Assert.assertEquals("[rx.Notification OnError Forced failure]", stripAt(Notification.createOnError(new TestException("Forced failure")).toString()));
-        Assert.assertEquals("[rx.Notification OnCompleted]", stripAt(Notification.createOnCompleted().toString()));
+        assertEquals("[rx.Notification OnNext 1]", stripAt(Notification.createOnNext(1).toString()));
+        assertEquals("[rx.Notification OnError Forced failure]", stripAt(Notification.createOnError(new TestException("Forced failure")).toString()));
+        assertEquals("[rx.Notification OnCompleted]", stripAt(Notification.createOnCompleted().toString()));
     }
 
     @Test
@@ -134,7 +135,7 @@ public class NotificationTest {
         Notification<Integer> e1 = Notification.createOnError(new TestException());
         Notification<Integer> c1 = Notification.createOnCompleted();
 
-        Assert.assertEquals(n1.hashCode(), n1a.hashCode());
+        assertEquals(n1.hashCode(), n1a.hashCode());
 
         Set<Notification<Integer>> set = new HashSet<Notification<Integer>>();
 
@@ -143,11 +144,11 @@ public class NotificationTest {
         set.add(e1);
         set.add(c1);
 
-        Assert.assertTrue(set.contains(n1));
-        Assert.assertTrue(set.contains(n1a));
-        Assert.assertTrue(set.contains(n2));
-        Assert.assertTrue(set.contains(e1));
-        Assert.assertTrue(set.contains(c1));
+        assertTrue(set.contains(n1));
+        assertTrue(set.contains(n1a));
+        assertTrue(set.contains(n2));
+        assertTrue(set.contains(e1));
+        assertTrue(set.contains(c1));
     }
 
     @Test
@@ -164,27 +165,27 @@ public class NotificationTest {
         Notification<Integer> c1 = Notification.createOnCompleted();
         Notification<Integer> c2 = Notification.createOnCompleted();
 
-        Assert.assertEquals(n1, n1a);
-        Assert.assertNotEquals(n1, n2);
-        Assert.assertNotEquals(n2, n1);
+        assertEquals(n1, n1a);
+        assertNotEquals(n1, n2);
+        assertNotEquals(n2, n1);
 
-        Assert.assertNotEquals(n1, e1);
-        Assert.assertNotEquals(e1, n1);
-        Assert.assertNotEquals(e1, c1);
-        Assert.assertNotEquals(n1, c1);
-        Assert.assertNotEquals(c1, n1);
-        Assert.assertNotEquals(c1, e1);
+        assertNotEquals(n1, e1);
+        assertNotEquals(e1, n1);
+        assertNotEquals(e1, c1);
+        assertNotEquals(n1, c1);
+        assertNotEquals(c1, n1);
+        assertNotEquals(c1, e1);
 
-        Assert.assertEquals(e1, e1);
-        Assert.assertEquals(e1, e2);
+        assertEquals(e1, e1);
+        assertNotEquals(e1, e2);
 
-        Assert.assertEquals(c1, c2);
+        assertEquals(c1, c2);
 
-        Assert.assertFalse(n1.equals(null));
-        Assert.assertFalse(n1.equals(1));
+        assertFalse(n1.equals(null));
+        assertFalse(n1.equals(1));
         
-        Assert.assertEquals(z1a, z1);
-        Assert.assertEquals(z1, z1a);
+        assertEquals(z1a, z1);
+        assertEquals(z1, z1a);
     }
     
     @Test
@@ -195,25 +196,64 @@ public class NotificationTest {
         Notification<Integer> e2 = Notification.createOnError(null);
         Notification<Integer> c1 = Notification.createOnCompleted();
 
-        Assert.assertFalse(z1.hasValue());
-        Assert.assertFalse(z1.hasThrowable());
-        Assert.assertFalse(z1.isOnCompleted());
+        assertFalse(z1.hasValue());
+        assertFalse(z1.hasThrowable());
+        assertFalse(z1.isOnCompleted());
         
-        Assert.assertTrue(n1.hasValue());
-        Assert.assertFalse(n1.hasThrowable());
-        Assert.assertFalse(n1.isOnCompleted());
+        assertTrue(n1.hasValue());
+        assertFalse(n1.hasThrowable());
+        assertFalse(n1.isOnCompleted());
         
-        Assert.assertFalse(e1.hasValue());
-        Assert.assertTrue(e1.hasThrowable());
-        Assert.assertFalse(e1.isOnCompleted());
+        assertFalse(e1.hasValue());
+        assertTrue(e1.hasThrowable());
+        assertFalse(e1.isOnCompleted());
 
-        Assert.assertFalse(e2.hasValue());
-        Assert.assertFalse(e2.hasThrowable());
-        Assert.assertFalse(e2.isOnCompleted());
+        assertFalse(e2.hasValue());
+        assertFalse(e2.hasThrowable());
+        assertFalse(e2.isOnCompleted());
 
-        Assert.assertFalse(c1.hasValue());
-        Assert.assertFalse(c1.hasThrowable());
-        Assert.assertTrue(c1.isOnCompleted());
+        assertFalse(c1.hasValue());
+        assertFalse(c1.hasThrowable());
+        assertTrue(c1.isOnCompleted());
 
+    }
+    
+    @Test
+    public void exceptionEquality() {
+        EqualException ex1 = new EqualException("1");
+        EqualException ex2 = new EqualException("1");
+        EqualException ex3 = new EqualException("3");
+        
+        Notification<Integer> e1 = Notification.createOnError(ex1);
+        Notification<Integer> e2 = Notification.createOnError(ex2);
+        Notification<Integer> e3 = Notification.createOnError(ex3);
+
+        assertEquals(e1, e1);
+        assertEquals(e1, e2);
+        assertEquals(e2, e1);
+        assertEquals(e2, e2);
+        
+        assertNotEquals(e1, e3);
+        assertNotEquals(e2, e3);
+        assertNotEquals(e3, e1);
+        assertNotEquals(e3, e2);
+    }
+    
+    static final class EqualException extends RuntimeException {
+        
+        /** */
+        private static final long serialVersionUID = 446310455393317050L;
+
+        public EqualException(String message) {
+            super(message);
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof EqualException) {
+                return getMessage().equals(((EqualException)o).getMessage());
+            }
+            return false;
+        }
     }
 }

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1255,9 +1255,7 @@ public class ObservableTests {
             }
         });
 
-        if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
-            fail("subscriptions did not receive values");
-        }
+        assertTrue("subscriptions did not receive values", latch.await(1000, TimeUnit.MILLISECONDS));
         assertEquals(1, counter.get());
     }
     
@@ -1387,7 +1385,7 @@ public class ObservableTests {
         Subscriber<Object> ts = new SafeSubscriber<Object>(new TestSubscriber<Object>()) {
             @Override
             public void onError(Throwable e) {
-                throw new TestException();
+                throw new TestException("Forced failure");
             }
         };
         
@@ -1396,6 +1394,8 @@ public class ObservableTests {
             fail("Should have thrown OnErrorFailedException");
         } catch (OnErrorFailedException ex) {
             // expected
+            assertTrue(ex.getCause().toString(), ex.getCause() instanceof TestException);
+            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
     
@@ -1404,7 +1404,7 @@ public class ObservableTests {
         Subscriber<Object> ts = new TestSubscriber<Object>() {
             @Override
             public void onError(Throwable e) {
-                throw new TestException();
+                throw new TestException("Forced failure");
             }
         };
         
@@ -1413,6 +1413,8 @@ public class ObservableTests {
             fail("Should have thrown OnErrorFailedException");
         } catch (OnErrorFailedException ex) {
             // expected
+            assertTrue(ex.getCause().toString(), ex.getCause() instanceof TestException);
+            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
     

--- a/src/test/java/rx/ThrottleWithTimeoutTests.java
+++ b/src/test/java/rx/ThrottleWithTimeoutTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import rx.observers.TestSubscriber;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
@@ -58,5 +59,18 @@ public class ThrottleWithTimeoutTests {
         inOrder.verify(observer).onNext(7);
         inOrder.verify(observer).onCompleted();
         inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void timed() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 2).throttleWithTimeout(1, TimeUnit.SECONDS).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(2);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+
     }
 }

--- a/src/test/java/rx/exceptions/TestException.java
+++ b/src/test/java/rx/exceptions/TestException.java
@@ -33,14 +33,4 @@ public final class TestException extends RuntimeException {
     public TestException(String message) {
         super(message);
     }
-    
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        String thisMessage = getMessage();
-        String otherMessage = ((TestException)o).getMessage();
-        return thisMessage == otherMessage || (thisMessage != null && thisMessage.equals(otherMessage));
-    }
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -1058,4 +1058,23 @@ public class OnSubscribeCombineLatestTest {
         ts.assertNotCompleted();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void combineLatestIterable() {
+        Observable<Integer> source = Observable.just(1);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.combineLatest((Iterable<Observable<Integer>>)Arrays.asList(source, source), new FuncN<Integer>() {
+            @Override
+            public Integer call(Object... args) {
+                return (Integer)args[0] + (Integer)args[1];
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(2);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeDelaySubscriptionOtherTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeDelaySubscriptionOtherTest.java
@@ -308,4 +308,8 @@ public class OnSubscribeDelaySubscriptionOtherTest {
         Assert.assertFalse(subscribed.get());
     }
 
+    @Test(expected = NullPointerException.class)
+    public void otherNull() {
+        Observable.just(1).delaySubscription((Observable<Integer>)null);
+    }
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeFromArrayTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromArrayTest.java
@@ -16,9 +16,10 @@
 
 package rx.internal.operators;
 
-import org.junit.Test;
+import org.junit.*;
 
 import rx.Observable;
+import rx.internal.util.ScalarSynchronousObservable;
 import rx.observers.TestSubscriber;
 
 public class OnSubscribeFromArrayTest {
@@ -62,6 +63,17 @@ public class OnSubscribeFromArrayTest {
         ts.assertNoErrors();
         ts.assertValueCount(1000);
         ts.assertCompleted();
+    }
+
+    @Test
+    public void empty() {
+        Assert.assertSame(Observable.empty(), Observable.from(new Object[0]));
+    }
+
+    @Test
+    public void just() {
+        Observable<Integer> source = Observable.from(new Integer[] { 1 });
+        Assert.assertTrue(source.getClass().toString(), source instanceof ScalarSynchronousObservable);
     }
 
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -15,22 +15,13 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.*;
+import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import rx.Observable;
 import rx.Observer;
@@ -267,5 +258,15 @@ public class OnSubscribeRangeTest {
         ts.assertCompleted();
         ts.assertNoErrors();
         ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
+    }
+    
+    @Test
+    public void negativeCount() {
+        try {
+            Observable.range(1, -1);
+            Assert.fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Count can not be negative", ex.getMessage());
+        }
     }
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
@@ -156,4 +156,63 @@ public class OnSubscribeToObservableFutureTest {
         ts.assertNoErrors();
         ts.assertCompleted();
     }
+    
+    @Test
+    public void withTimeoutNoTimeout() {
+        FutureTask<Integer> task = new FutureTask<Integer>(new Runnable() {
+            @Override
+            public void run() {
+                
+            }
+        }, 1);
+        
+        task.run();
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.from(task, 1, TimeUnit.SECONDS).subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void withTimeoutTimeout() {
+        FutureTask<Integer> task = new FutureTask<Integer>(new Runnable() {
+            @Override
+            public void run() {
+                
+            }
+        }, 1);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.from(task, 10, TimeUnit.MILLISECONDS).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TimeoutException.class);
+        ts.assertNotCompleted();
+    }
+    
+    @Test
+    public void withTimeoutNoTimeoutScheduler() {
+        FutureTask<Integer> task = new FutureTask<Integer>(new Runnable() {
+            @Override
+            public void run() {
+                
+            }
+        }, 1);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.from(task, Schedulers.computation()).subscribe(ts);
+
+        task.run();
+
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -976,5 +976,30 @@ public class OperatorConcatTest {
         ts.assertNoErrors();
         ts.assertCompleted();
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void startWith() throws Exception {
+        for (int i = 2; i < 10; i++) {
+            Class<?>[] clazz = new Class[i];
+            Arrays.fill(clazz, Object.class);
+            
+            Object[] obs = new Object[i];
+            Arrays.fill(obs, 1);
+            
+            Integer[] expected = new Integer[i];
+            Arrays.fill(expected, 1);
+            
+            Method m = Observable.class.getMethod("startWith", clazz);
+            
+            TestSubscriber<Integer> ts = TestSubscriber.create();
+            
+            ((Observable<Integer>)m.invoke(Observable.empty(), obs)).subscribe(ts);
+            
+            ts.assertValues(expected);
+            ts.assertNoErrors();
+            ts.assertCompleted();
+        }
+    }
 
 }

--- a/src/test/java/rx/internal/operators/OperatorDebounceTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDebounceTest.java
@@ -305,4 +305,17 @@ public class OperatorDebounceTest {
         subscriber.assertTerminalEvent();
         subscriber.assertNoErrors();
     }
+    
+    @Test
+    public void debounceDefaultScheduler() throws Exception {
+        
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Observable.range(1, 1000).debounce(1, TimeUnit.SECONDS).subscribe(ts);
+
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(1000);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorDoAfterTerminateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoAfterTerminateTest.java
@@ -94,4 +94,12 @@ public class OperatorDoAfterTerminateTest {
         // Not only IllegalStateException was swallowed
         // But finallyAction was called twice!
     }
+    
+    @SuppressWarnings("deprecation")
+    @Test
+    public void finallyDo() {
+        Observable.empty().finallyDo(aAction0).subscribe();
+        
+        verify(aAction0).call();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
@@ -264,4 +264,14 @@ public class OperatorOnBackpressureBufferTest {
          assertFalse(errorOccurred.get());
     }
 
+    @Test
+    public void maxSize() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.range(1, 10).onBackpressureBuffer(1).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(MissingBackpressureException.class);
+        ts.assertNotCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorRepeatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRepeatTest.java
@@ -15,8 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -198,5 +197,53 @@ public class OperatorRepeatTest {
         ts.assertReceivedOnNext(Collections.<Integer>emptyList());
         
         assertEquals(Arrays.asList(1, 2, 1, 2, 1, 2, 1, 2, 1, 2), concatBase);
+    }
+    
+    @Test
+    public void repeatScheduled() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).repeat(5, Schedulers.computation()).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValues(1, 1, 1, 1, 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void repeatWhenDefaultScheduler() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).repeatWhen((Func1)new Func1<Observable, Observable>() {
+            @Override
+            public Observable call(Observable o) {
+                return o.take(2);
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(1, 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void repeatWhenTrampolineScheduler() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).repeatWhen((Func1)new Func1<Observable, Observable>() {
+            @Override
+            public Observable call(Observable o) {
+                return o.take(2);
+            }
+        }, Schedulers.trampoline()).subscribe(ts);
+        
+        ts.assertValues(1, 1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -1418,4 +1418,81 @@ public class OperatorReplayTest {
             assertEquals("bufferSize < 0", ex.getMessage());
         }
     }
+    
+    @Test
+    public void selectorSizeTimeDefaultScheduler() {
+        Observable<Integer> co = Observable.range(1, 5)
+                .replay(new Func1<Observable<Integer>, Observable<Integer>>() { 
+                    @Override
+                    public Observable<Integer> call(Observable<Integer> t) {
+                        return t;
+                    }
+                }, 2, 2, TimeUnit.SECONDS);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        co.subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void selectorSizeScheduler() {
+        Observable<Integer> co = Observable.range(1, 5)
+                .replay(new Func1<Observable<Integer>, Observable<Integer>>() { 
+                    @Override
+                    public Observable<Integer> call(Observable<Integer> t) {
+                        return t;
+                    }
+                }, 2, Schedulers.computation());
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        co.subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void selectorScheduler() {
+        Observable<Integer> co = Observable.range(1, 5)
+                .replay(new Func1<Observable<Integer>, Observable<Integer>>() { 
+                    @Override
+                    public Observable<Integer> call(Observable<Integer> t) {
+                        return t;
+                    }
+                }, Schedulers.computation());
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        co.subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void timeSizeDefaultScheduler() {
+        ConnectableObservable<Integer> co = Observable.range(1, 5)
+                .replay(2, 2, TimeUnit.SECONDS);
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        co.subscribe(ts);
+        
+        co.connect();
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
@@ -391,4 +391,63 @@ public class OperatorTakeLastTest {
         ts.assertNoErrors();
     }
 
+    @Test
+    public void takeLastBuffer() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        
+        Observable.range(1, 5).takeLastBuffer(1).subscribe(ts);
+        
+        ts.assertValue(Arrays.asList(5));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void takeLastBufferTimed() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        
+        Observable.range(1, 5).takeLastBuffer(5, TimeUnit.SECONDS).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void takeLastBufferTimedSized() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        
+        Observable.range(1, 5).takeLastBuffer(1, 5, TimeUnit.SECONDS).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(Arrays.asList(5));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void takeLastBufferTimedIO() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        
+        Observable.range(1, 5).takeLastBuffer(5, TimeUnit.SECONDS, Schedulers.io()).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void takeLastBufferTimedSizedIO() {
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        
+        Observable.range(1, 5).takeLastBuffer(1, 5, TimeUnit.SECONDS, Schedulers.io()).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(Arrays.asList(5));
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
 }

--- a/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
+++ b/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
@@ -33,6 +33,7 @@ import rx.Scheduler;
 import rx.Subscriber;
 import rx.exceptions.TestException;
 import rx.functions.Action0;
+import rx.observers.TestSubscriber;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
@@ -157,5 +158,18 @@ public class OperatorThrottleFirstTest {
         inOrder.verify(observer).onNext(7);
         inOrder.verify(observer).onCompleted();
         inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void timed() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 2).throttleFirst(1, TimeUnit.SECONDS).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorTimeIntervalTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeIntervalTest.java
@@ -26,8 +26,9 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import rx.Observable;
-import rx.Observer;
+import rx.*;
+import rx.functions.Func1;
+import rx.plugins.RxJavaHooks;
 import rx.schedulers.TestScheduler;
 import rx.schedulers.TimeInterval;
 import rx.subjects.PublishSubject;
@@ -72,5 +73,42 @@ public class OperatorTimeIntervalTest {
                 new TimeInterval<Integer>(3000, 3));
         inOrder.verify(observer, times(1)).onCompleted();
         inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void withDefaultScheduler() {
+        
+        final TestScheduler scheduler = new TestScheduler();
+
+        RxJavaHooks.setOnComputationScheduler(new Func1<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler call(Scheduler t) {
+                return scheduler;
+            }
+        });
+        
+        try {
+            InOrder inOrder = inOrder(observer);
+            subject.timeInterval().subscribe(observer);
+    
+            scheduler.advanceTimeBy(1000, TIME_UNIT);
+            subject.onNext(1);
+            scheduler.advanceTimeBy(2000, TIME_UNIT);
+            subject.onNext(2);
+            scheduler.advanceTimeBy(3000, TIME_UNIT);
+            subject.onNext(3);
+            subject.onCompleted();
+    
+            inOrder.verify(observer, times(1)).onNext(
+                    new TimeInterval<Integer>(1000, 1));
+            inOrder.verify(observer, times(1)).onNext(
+                    new TimeInterval<Integer>(2000, 2));
+            inOrder.verify(observer, times(1)).onNext(
+                    new TimeInterval<Integer>(3000, 3));
+            inOrder.verify(observer, times(1)).onCompleted();
+            inOrder.verifyNoMoreInteractions();
+        } finally {
+            RxJavaHooks.reset();
+        }
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
@@ -15,29 +15,19 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.MockitoAnnotations;
+import org.junit.*;
+import org.mockito.*;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Observer;
-import rx.Subscriber;
-import rx.Subscription;
+import rx.functions.Func1;
+import rx.observers.TestSubscriber;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
@@ -359,5 +349,82 @@ public class OperatorTimeoutTests {
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).unsubscribe();
+    }
+    
+    @Test
+    public void withDefaultScheduler() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).timeout(5, TimeUnit.SECONDS).subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void withSelector() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).timeout(new Func1<Integer, Observable<Object>>() {
+            @Override
+            public Observable<Object> call(Integer t) {
+                return Observable.never();
+            }
+        }).subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void withSelectorAndDefault() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).timeout(new Func1<Integer, Observable<Object>>() {
+            @Override
+            public Observable<Object> call(Integer t) {
+                return Observable.never();
+            }
+        }, Observable.just(2)).subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void withSelectorAndDefault2() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).concatWith(
+        Observable.<Integer>never())
+        .timeout(new Func1<Integer, Observable<Object>>() {
+            @Override
+            public Observable<Object> call(Integer t) {
+                return Observable.just((Object)1);
+            }
+        }, Observable.just(2)).subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void withDefaultSchedulerAndOther() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.just(1).timeout(5, TimeUnit.SECONDS, Observable.just(2)).subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
@@ -15,19 +15,12 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
@@ -35,13 +28,10 @@ import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Observer;
-import rx.Subscriber;
 import rx.exceptions.TestException;
-import rx.functions.Func0;
-import rx.functions.Func1;
+import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
@@ -434,5 +424,19 @@ public class OperatorTimeoutWithSelectorTest {
         inOrder.verify(o, never()).onNext(3);
         inOrder.verify(o).onCompleted();
         inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void selectorNull() {
+        try {
+            Observable.never().timeout(new Func0<Observable<Object>>() {
+                @Override
+                public Observable<Object> call() {
+                    return Observable.never();
+                }
+            }, null, Observable.empty());
+        } catch (NullPointerException ex) {
+            assertEquals("timeoutSelector is null", ex.getMessage());
+        }
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
+++ b/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
@@ -148,4 +148,53 @@ public class OperatorToObservableSortedListTest {
             ex.printStackTrace();
         }
     }
+    
+    @Test
+    public void testSortedListCapacity() {
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.toSortedList(4);
+
+        @SuppressWarnings("unchecked")
+        Observer<List<Integer>> observer = mock(Observer.class);
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onCompleted();
+    }
+    
+    @Test
+    public void testSortedCustomComparer() {
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.toSortedList(new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return t2.compareTo(t1);
+            }
+        });
+
+        @SuppressWarnings("unchecked")
+        Observer<List<Integer>> observer = mock(Observer.class);
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onCompleted();
+    }
+    
+    @Test
+    public void testSortedCustomComparerHinted() {
+        Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
+        Observable<List<Integer>> observable = w.toSortedList(new Func2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer t1, Integer t2) {
+                return t2.compareTo(t1);
+            }
+        }, 4);
+
+        @SuppressWarnings("unchecked")
+        Observer<List<Integer>> observer = mock(Observer.class);
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorWindowWithTimeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithTimeTest.java
@@ -192,5 +192,42 @@ public class OperatorWindowWithTimeTest {
         ts.assertCompleted();
         Assert.assertFalse(ts.getOnNextEvents().isEmpty());
     }
+
+    @Test
+    public void timeCountDefaultScheduler() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 10).window(5, TimeUnit.SECONDS, 5)
+        .flatMap(new Func1<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Observable<Integer> w) {
+                return w;
+            }
+        }).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValueCount(10);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
     
+    @Test
+    public void spanSkipDefaultScheduler() {
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 10).window(5, 5, TimeUnit.SECONDS)
+        .flatMap(new Func1<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Observable<Integer> w) {
+                return w;
+            }
+        }).subscribe(ts);
+        
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+        ts.assertValueCount(10);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
 }

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -15,44 +15,22 @@
  */
 package rx.internal.operators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
-import rx.Notification;
+import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.functions.Action1;
-import rx.functions.Func2;
-import rx.functions.Func3;
-import rx.functions.FuncN;
-import rx.functions.Functions;
+import rx.functions.*;
 import rx.internal.util.RxRingBuffer;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -1400,5 +1378,120 @@ public class OperatorZipTest {
         sub1.assertValueCount(10);
         sub1.assertNoErrors();
         sub1.assertCompleted();
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void zip4() {
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable<Integer> source = Observable.just(1);
+        
+        Observable.zip(source, source, source, source, new Func4() {
+            @Override
+            public Object call(Object t1, Object t2, Object t3, Object t4) {
+                return "" + t1 + t2 + t3 + t4;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue("1111");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void zip5() {
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable<Integer> source = Observable.just(1);
+        
+        Observable.zip(source, source, source, source, source, new Func5() {
+            @Override
+            public Object call(Object t1, Object t2, Object t3, Object t4, Object t5) {
+                return "" + t1 + t2 + t3 + t4 + t5;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue("11111");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void zip6() {
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable<Integer> source = Observable.just(1);
+        
+        Observable.zip(source, source, source, source, source, source, new Func6() {
+            @Override
+            public Object call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6) {
+                return "" + t1 + t2 + t3 + t4 + t5 + t6;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue("111111");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void zip7() {
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable<Integer> source = Observable.just(1);
+        
+        Observable.zip(source, source, source, source, source, source, source, new Func7() {
+            @Override
+            public Object call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6, Object t7) {
+                return "" + t1 + t2 + t3 + t4 + t5 + t6 + t7;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue("1111111");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void zip8() {
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable<Integer> source = Observable.just(1);
+        
+        Observable.zip(source, source, source, source, source, source, source, source, new Func8() {
+            @Override
+            public Object call(Object t1, Object t2, Object t3, Object t4, Object t5, Object t6, Object t7, Object t8) {
+                return "" + t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue("11111111");
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void zip9() {
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable<Integer> source = Observable.just(1);
+        
+        Observable.zip(source, source, source, source, source, source, source, source, source, new Func9() {
+            @Override
+            public Object call(Object t1, Object t2, Object t3, Object t4, Object t5, 
+                    Object t6, Object t7, Object t8, Object t9) {
+                return "" + t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8 + t9;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue("111111111");
+        ts.assertNoErrors();
+        ts.assertCompleted();
     }
 }

--- a/src/test/java/rx/observables/AsyncOnSubscribeTest.java
+++ b/src/test/java/rx/observables/AsyncOnSubscribeTest.java
@@ -60,7 +60,7 @@ public class AsyncOnSubscribeTest {
     @Test
     public void testSerializesConcurrentObservables() throws InterruptedException {
         final TestScheduler scheduler = new TestScheduler();
-        OnSubscribe<Integer> os = AsyncOnSubscribe.createStateful(new Func0<Integer>(){
+        AsyncOnSubscribe<Integer, Integer> os = AsyncOnSubscribe.createStateful(new Func0<Integer>(){
             @Override
             public Integer call() {
                 return 1;

--- a/src/test/java/rx/schedulers/SchedulerTests.java
+++ b/src/test/java/rx/schedulers/SchedulerTests.java
@@ -117,12 +117,12 @@ public final class SchedulerTests {
 
     public static void testCancelledRetention(Scheduler.Worker w, boolean periodic) throws InterruptedException {
         System.out.println("Wait before GC");
-        Thread.sleep(1000);
+        Thread.sleep(500);
 
         System.out.println("GC");
         System.gc();
 
-        Thread.sleep(1000);
+        Thread.sleep(500);
 
 
         MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
@@ -131,7 +131,7 @@ public final class SchedulerTests {
 
         System.out.printf("Starting: %.3f MB%n", initial / 1024.0 / 1024.0);
 
-        int n = 500 * 1000;
+        int n = 100 * 1000;
         if (periodic) {
             final CountDownLatch cdl = new CountDownLatch(n);
             final Action0 action = new Action0() {
@@ -165,12 +165,12 @@ public final class SchedulerTests {
         w.unsubscribe();
 
         System.out.println("Wait before second GC");
-        Thread.sleep(NewThreadWorker.PURGE_FREQUENCY + 2000);
+        Thread.sleep(NewThreadWorker.PURGE_FREQUENCY + 1000);
 
         System.out.println("Second GC");
         System.gc();
 
-        Thread.sleep(1000);
+        Thread.sleep(500);
 
         memHeap = memoryMXBean.getHeapMemoryUsage();
         long finish = memHeap.getUsed();


### PR DESCRIPTION
This PR improves the coverage of `rx.Observable` methods plus 
- fixes a javadoc issue 
- fixes an enum-coverage anomaly in Notification (now it is simply biased towards onNext signals)
- removes `equals()` from `TestException` as it caused anomalies with deduplication inside `CompositeException`
- fixes 3 PMD rule violations (2 suppressed, 1 corrected)
- `timestamp` and `timeInterval` now use the `Schedulers.computation()` as the source for the current time instead of `Schedulers.immediate()` which can't be properly hooked. By default, they both return `System.currentTimeMillis()`.
