### PR TITLE
1.x: change test heap size to avoid 137

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ if (project.hasProperty('release.useLastTag')) {
 }
 
 test{
-     maxHeapSize = "3g"
+     maxHeapSize = "1500m"
 }
 
 license {

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ if (project.hasProperty('release.useLastTag')) {
 }
 
 test{
-     maxHeapSize = "2g"
+     maxHeapSize = "3g"
 }
 
 license {

--- a/src/test/java/rx/internal/operators/DeferredScalarSubscriberTest.java
+++ b/src/test/java/rx/internal/operators/DeferredScalarSubscriberTest.java
@@ -341,8 +341,8 @@ public class DeferredScalarSubscriberTest {
     
     @Test
     public void emissionRequestRace2() {
-        Worker w = Schedulers.computation().createWorker();
-        Worker w2 = Schedulers.computation().createWorker();
+        Worker w = Schedulers.io().createWorker();
+        Worker w2 = Schedulers.io().createWorker();
         try {
             for (int i = 0; i < 10000; i++) {
     

--- a/src/test/java/rx/internal/util/JCToolsQueueTests.java
+++ b/src/test/java/rx/internal/util/JCToolsQueueTests.java
@@ -132,7 +132,7 @@ public class JCToolsQueueTests {
         testOfferPoll(q);
     }
     
-    @Test(timeout = 2000)
+    @Test(timeout = 20000)
     public void testMpscLinkedAtomicQueuePipelined() throws InterruptedException {
         final MpscLinkedAtomicQueue<Integer> q = new MpscLinkedAtomicQueue<Integer>();
         
@@ -202,7 +202,7 @@ public class JCToolsQueueTests {
         
         testOfferPoll(q);
     }
-    @Test(timeout = 2000)
+    @Test(timeout = 20000)
     public void testMpscLinkedQueuePipelined() throws InterruptedException {
         if (!UnsafeAccess.isUnsafeAvailable()) {
             return;
@@ -356,7 +356,7 @@ public class JCToolsQueueTests {
         testOfferPoll(q);
     }
     
-    @Test(timeout = 2000)
+    @Test(timeout = 20000)
     public void testSpscLinkedAtomicQueuePipelined() throws InterruptedException {
         final SpscLinkedAtomicQueue<Integer> q = new SpscLinkedAtomicQueue<Integer>();
         final AtomicInteger count = new AtomicInteger();
@@ -411,7 +411,7 @@ public class JCToolsQueueTests {
         testOfferPoll(q);
     }
     
-    @Test(timeout = 2000)
+    @Test(timeout = 20000)
     public void testSpscLinkedQueuePipelined() throws InterruptedException {
         if (!UnsafeAccess.isUnsafeAvailable()) {
             return;


### PR DESCRIPTION
It appears that since we added jacoco to the build, it fails sometimes with error 137 which is the code for the system killing the JVM for running out of memory. It is likely the coverage data plus some test's excessive memory use (I don't know which ones) try to go above the current 2GB limit.

This is an experiment.
