### PR TITLE
1.x: add missing RxJavaHooks options, fix bugs

### DIFF
--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -91,6 +91,7 @@ public class RxJavaPlugins {
         INSTANCE.errorHandler.set(null);
         INSTANCE.observableExecutionHook.set(null);
         INSTANCE.singleExecutionHook.set(null);
+        INSTANCE.completableExecutionHook.set(null);
         INSTANCE.schedulersHook.set(null);
     }
 


### PR DESCRIPTION
These PR adds the remaining hooks which weren't even tested with the original RxJavaPlugins plus a full coverage of the RxJavaHooks itself.

This is a mandatory addition and 1.1.7 can't be released without it (i.e., with an incomplete RxJavaHooks that is).
