### PR TITLE
1.x: no need to run gradle assembe by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
 sudo: false
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 
+# prevent travis running gradle assemble; let the build script do it anyway
+install: true
+
 # script for build and release via Travis to Bintray
 script: gradle/buildViaTravis.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
 sudo: false
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 
+git:
+  depth: 10
+
 # prevent travis running gradle assemble; let the build script do it anyway
 install: true
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'
 
 apply plugin: 'java'
-apply plugin: 'pmd'
+//apply plugin: 'pmd'
 apply plugin: 'findbugs'
 apply plugin: 'jacoco'
 apply plugin: 'ru.vyarus.animalsniffer'
@@ -81,40 +81,40 @@ jacocoTestReport {
 
 build.dependsOn jacocoTestReport
 
-pmd {
-    toolVersion = '5.4.2'
-    ignoreFailures = true
-    sourceSets = [sourceSets.main]
-    ruleSets = []
-    ruleSetFiles = files('pmd.xml')
 
-}
+//pmd {
+//    toolVersion = '5.4.2'
+//    ignoreFailures = true
+//    sourceSets = [sourceSets.main]
+//    ruleSets = []
+//    ruleSetFiles = files('pmd.xml')
+//}
 
-pmdMain {
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
+//pmdMain {
+//    reports {
+//        html.enabled = true
+//        xml.enabled = true
+//    }
+//}
 
-task pmdPrint(dependsOn: 'pmdMain') << {
-    File file = new File('build/reports/pmd/main.xml')
-    if (file.exists()) {
+//task pmdPrint(dependsOn: 'pmdMain') << {
+//    File file = new File('build/reports/pmd/main.xml')
+//    if (file.exists()) {
+//
+//        println("Listing first 100 PMD violations")
+//
+//        file.eachLine { line, count ->
+//            if (count <= 100) {
+//               println(line)
+//            }
+//        }
+//
+//    } else {
+//        println("PMD file not found.")
+//    }
+//}
 
-        println("Listing first 100 PMD violations")
-
-        file.eachLine { line, count ->
-            if (count <= 100) {
-               println(line)
-            }
-        }
-
-    } else {
-        println("PMD file not found.")
-    }
-}
-
-build.dependsOn pmdPrint
+//build.dependsOn pmdPrint
 
 animalsniffer {
     annotation = 'rx.internal.util.SuppressAnimalSniffer'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ if (project.hasProperty('release.useLastTag')) {
 }
 
 test{
-     maxHeapSize = "1500m"
+     maxHeapSize = "1200m"
 }
 
 license {

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This script will build the project.
 
+git fsck
+
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew -Prelease.useLastTag=true build --stacktrace

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script will build the project.
 
-git fsck
+git fsck --full
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -3,7 +3,7 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew -Prelease.useLastTag=true build
+  ./gradlew -Prelease.useLastTag=true build --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot --stacktrace
@@ -12,5 +12,5 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final --stacktrace
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-  ./gradlew -Prelease.useLastTag=true build
+  ./gradlew -Prelease.useLastTag=true build --stacktrace
 fi


### PR DESCRIPTION
By default, Travis runs `gradle assemble` and if it fails, there seems to be no way to specify `--stacktrace` for it other than disabling it entirely. The `buildViaTravis.sh` does a full build anyway.

I'm posting this as Nebula fails in the assembly phase for some reason but by default, nothing else is printed.
