### PR TITLE
2.x: implement concat(Map)Eager(DelayError) and expose concat(Map)DelayError overload

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -127,13 +127,13 @@ public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
             
             InnerQueuedSubscriber<R> inner = new InnerQueuedSubscriber<R>(this, prefetch);
             
-            if (!cancelled) {
+            if (cancelled) {
                 return;
             }
 
             subscribers.offer(inner);
             
-            if (!cancelled) {
+            if (cancelled) {
                 return;
             }
             
@@ -141,7 +141,6 @@ public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
             
             if (cancelled) {
                 inner.cancel();
-            } else {
                 drainAndCancel();
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -70,7 +70,7 @@ public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
         final int maxConcurrency;
         
         final int prefetch;
-
+        
         final ErrorMode errorMode;
 
         final AtomicReference<Throwable> error;
@@ -296,6 +296,7 @@ public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
                             inner = null;
                             subscribers.poll();
                             current = null;
+                            s.request(1);
                             continue outer;
                         }
                         
@@ -334,6 +335,7 @@ public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
                             inner = null;
                             subscribers.poll();
                             current = null;
+                            s.request(1);
                             continue outer;
                         }
                     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.flowable.FlowableConcatMap.ErrorMode;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscribers.flowable.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+    
+    final int maxConcurrency;
+    
+    final int prefetch;
+    
+    final ErrorMode errorMode;
+    
+    public FlowableConcatMapEager(Publisher<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+            int maxConcurrency,
+            int prefetch,
+            ErrorMode errorMode
+                    ) {
+        super(source);
+        this.mapper = mapper;
+        this.maxConcurrency = maxConcurrency;
+        this.prefetch = prefetch;
+        this.errorMode = errorMode;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        source.subscribe(new ConcatMapEagerDelayErrorSubscriber<T, R>(
+                s, mapper, maxConcurrency, prefetch, errorMode));
+    }
+
+    static final class ConcatMapEagerDelayErrorSubscriber<T, R>
+    extends AtomicInteger
+    implements Subscriber<T>, Subscription, InnerQueuedSubscriberSupport<R> {
+        /** */
+        private static final long serialVersionUID = -4255299542215038287L;
+
+        final Subscriber<? super R> actual;
+        
+        final Function<? super T, ? extends Publisher<? extends R>> mapper;
+        
+        final int maxConcurrency;
+        
+        final int prefetch;
+
+        final ErrorMode errorMode;
+
+        final AtomicReference<Throwable> error;
+        
+        final AtomicLong requested;
+        
+        Subscription s;
+        
+        Queue<InnerQueuedSubscriber<R>> subscribers;
+        
+        volatile boolean cancelled;
+        
+        volatile boolean done;
+        
+        volatile InnerQueuedSubscriber<R> current;
+        
+        public ConcatMapEagerDelayErrorSubscriber(Subscriber<? super R> actual,
+                Function<? super T, ? extends Publisher<? extends R>> mapper, int maxConcurrency, int prefetch,
+                ErrorMode errorMode) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.maxConcurrency = maxConcurrency;
+            this.prefetch = prefetch;
+            this.errorMode = errorMode;
+            this.subscribers = new SpscLinkedArrayQueue<InnerQueuedSubscriber<R>>(Math.min(prefetch, maxConcurrency));
+            this.error = new AtomicReference<Throwable>();
+            this.requested = new AtomicLong();
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+                
+                s.request(maxConcurrency == Integer.MAX_VALUE ? Long.MAX_VALUE : maxConcurrency);
+            }
+            
+        }
+        
+        @Override
+        public void onNext(T t) {
+            Publisher<? extends R> p;
+            
+            try {
+                p = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                s.cancel();
+                onError(ex);
+                return;
+            }
+            
+            InnerQueuedSubscriber<R> inner = new InnerQueuedSubscriber<R>(this, prefetch);
+            
+            if (!cancelled) {
+                subscribers.offer(inner);
+                if (!cancelled) {
+                    p.subscribe(inner);
+                } else {
+                    drainAndCancel();
+                }
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (Exceptions.addThrowable(error, t)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+        
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void cancel() {
+            if (cancelled) {
+                return;
+            }
+            cancelled = true;
+            s.cancel();
+            
+            drainAndCancel();
+        }
+        
+        void drainAndCancel() {
+            if (getAndIncrement() == 0) {
+                do {
+                    cancelAll();
+                } while (decrementAndGet() != 0);
+            }
+        }
+        
+        void cancelAll() {
+            InnerQueuedSubscriber<R> inner;
+            
+            while ((inner = subscribers.poll()) != null) {
+                inner.cancel();
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                drain();
+            }
+        }
+        
+        @Override
+        public void innerNext(InnerQueuedSubscriber<R> inner, R value) {
+            if (!inner.queue().offer(value)) {
+                inner.cancel();
+                innerError(inner, new MissingBackpressureException());
+            } else {
+                drain();
+            }
+        }
+        
+        @Override
+        public void innerError(InnerQueuedSubscriber<R> inner, Throwable e) {
+            if (Exceptions.addThrowable(this.error, e)) {
+                inner.setDone();
+                if (errorMode != ErrorMode.END) {
+                    s.cancel();
+                }
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+        
+        @Override
+        public void innerComplete(InnerQueuedSubscriber<R> inner) {
+            inner.setDone();
+            drain();
+        }
+        
+        @Override
+        public void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            InnerQueuedSubscriber<R> inner = current;
+            Subscriber<? super R> a = actual;
+            long r = requested.get();
+            long e = 0L;
+            ErrorMode em = errorMode;
+            
+            outer:
+            for (;;) {
+                
+                if (inner == null) {
+
+                    if (em != ErrorMode.END) {
+                        Throwable ex = error.get();
+                        if (ex != null) {
+                            cancelAll();
+                            
+                            a.onError(ex);
+                            return;
+                        }
+                    }
+
+                    boolean outerDone = done;
+                    
+                    inner = subscribers.peek();
+                    
+                    if (outerDone && inner == null) {
+                        Throwable ex = error.get();
+                        if (ex != null) {
+                            a.onError(ex);
+                        } else {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (inner != null) {
+                        current = inner;
+                    }
+                }
+                
+                if (inner != null) {
+                    Queue<R> q = inner.queue();
+                    
+                    while (e != r) {
+                        if (cancelled) {
+                            cancelAll();
+                            return;
+                        }
+                        
+                        if (em == ErrorMode.IMMEDIATE) {
+                            Throwable ex = error.get();
+                            if (ex != null) {
+                                cancelAll();
+                                
+                                a.onError(ex);
+                                return;
+                            }
+                        }
+                        
+                        boolean d = inner.isDone();
+                        
+                        R v = q.poll();
+                        
+                        boolean empty = v == null;
+                        
+                        if (d && empty) {
+                            inner = null;
+                            subscribers.poll();
+                            current = null;
+                            continue outer;
+                        }
+                        
+                        if (empty) {
+                            break;
+                        }
+                        
+                        a.onNext(v);
+                        
+                        e++;
+                        
+                        inner.requestOne();
+                    }
+
+                    if (e == r) {
+                        if (cancelled) {
+                            cancelAll();
+                            return;
+                        }
+                        
+                        if (em == ErrorMode.IMMEDIATE) {
+                            Throwable ex = error.get();
+                            if (ex != null) {
+                                cancelAll();
+                                
+                                a.onError(ex);
+                                return;
+                            }
+                        }
+                        
+                        boolean d = inner.isDone();
+                        
+                        boolean empty = inner.queue().isEmpty();
+                        
+                        if (d && empty) {
+                            inner = null;
+                            subscribers.poll();
+                            current = null;
+                            continue outer;
+                        }
+                    }
+                }
+                
+                if (e != 0L && r != Long.MAX_VALUE) {
+                    r = requested.addAndGet(-e);
+                    e = 0L;
+                }
+                
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -131,6 +131,9 @@ public class FlowableConcatMapEager<T, R> extends FlowableSource<T, R> {
                 subscribers.offer(inner);
                 if (!cancelled) {
                     p.subscribe(inner);
+                    if (cancelled) {
+                        inner.cancel();
+                    }
                 } else {
                     drainAndCancel();
                 }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriber.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.QueueDrainHelper;
+
+/**
+ * Subscriber that can fuse with the upstream and calls a support interface
+ * whenever an event is available.
+ *
+ * @param <T> the value type
+ */
+public final class InnerQueuedSubscriber<T> 
+extends AtomicReference<Subscription>
+implements Subscriber<T>, Subscription {
+
+    /** */
+    private static final long serialVersionUID = 22876611072430776L;
+
+    final InnerQueuedSubscriberSupport<T> parent;
+    
+    final int prefetch;
+    
+    final int limit;
+
+    Queue<T> queue;
+    
+    volatile boolean done;
+    
+    long produced;
+    
+    int fusionMode;
+    
+    public InnerQueuedSubscriber(InnerQueuedSubscriberSupport<T> parent, int prefetch) {
+        this.parent = parent;
+        this.prefetch = prefetch;
+        this.limit = prefetch - (prefetch >> 2);
+    }
+    
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.setOnce(this, s)) {
+            if (s instanceof QueueSubscription) {
+                @SuppressWarnings("unchecked")
+                QueueSubscription<T> qs = (QueueSubscription<T>) s;
+                
+                int m = qs.requestFusion(QueueSubscription.ANY);
+                if (m == QueueSubscription.SYNC) {
+                    fusionMode = m;
+                    queue = qs;
+                    done = true;
+                    parent.innerComplete(this);
+                    return;
+                }
+                if (m == QueueSubscription.ASYNC) {
+                    fusionMode = m;
+                    queue = qs;
+                    QueueDrainHelper.request(get(), prefetch);
+                    return;
+                }
+            }
+            
+            queue = QueueDrainHelper.createQueue(prefetch);
+            
+            QueueDrainHelper.request(get(), prefetch);
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (fusionMode == QueueSubscription.SYNC) {
+            parent.drain();
+            return;
+        }
+        parent.innerNext(this, t);
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        parent.innerError(this, t);
+    }
+    
+    @Override
+    public void onComplete() {
+        parent.innerComplete(this);
+    }
+    
+    @Override
+    public void request(long n) {
+        long p = produced + n;
+        if (p >= limit) {
+            produced = 0L;
+            get().request(p);
+        } else {
+            produced = p;
+        }
+    }
+    
+    public void requestOne() {
+        long p = produced + 1;
+        if (p == limit) {
+            produced = 0L;
+            get().request(p);
+        } else {
+            produced = p;
+        }
+    }
+    
+    @Override
+    public void cancel() {
+        SubscriptionHelper.dispose(this);
+    }
+    
+    public boolean isDone() {
+        return done;
+    }
+    
+    public void setDone() {
+        this.done = true;
+    }
+    
+    public Queue<T> queue() {
+        return queue;
+    }
+    
+    public int fusionMode() {
+        return fusionMode;
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriberSupport.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriberSupport.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+/**
+ * Interface to allow the InnerQueuedSubscriber to call back a parent
+ * with signals.
+ *
+ * @param <T> the value type
+ */
+public interface InnerQueuedSubscriberSupport<T> {
+
+    void innerNext(InnerQueuedSubscriber<T> inner, T value);
+    
+    void innerError(InnerQueuedSubscriber<T> inner, Throwable e);
+    
+    void innerComplete(InnerQueuedSubscriber<T> inner);
+    
+    void drain();
+}

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -820,7 +820,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * Assert that the upstream is a fuseable source.
      * @return this
      */
-    public TestSubscriber<T> assertFuseable() {
+    public final TestSubscriber<T> assertFuseable() {
         if (qs == null) {
             throw new AssertionError("Upstream is not fuseable.");
         }
@@ -831,11 +831,55 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * Assert that the upstream is not a fuseable source.
      * @return this
      */
-    public TestSubscriber<T> assertNotFuseable() {
+    public final TestSubscriber<T> assertNotFuseable() {
         if (qs != null) {
             throw new AssertionError("Upstream is fuseable.");
         }
         return this;
+    }
+
+    /**
+     * Assert that the upstream signalled the specified values in order and
+     * completed normally.
+     * @param values the expected values, asserted in order
+     * @return this
+     * @see #assertFailure(Class, Object...)
+     * @see #assertFailureAndMessage(Class, String, Object...)
+     */
+    public final TestSubscriber<T> assertResult(T... values) {
+        return assertValues(values)
+                .assertNoErrors()
+                .assertComplete();
+    }
+
+    /**
+     * Assert that the upstream signalled the specified values in order
+     * and then failed with a specific class or subclass of Throwable.
+     * @param error the expected exception (parent) class
+     * @param values the expected values, asserted in order
+     * @return this
+     */
+    public final TestSubscriber<T> assertFailure(Class<Throwable> error, T... values) {
+        return assertValues(values)
+                .assertError(error)
+                .assertNotComplete();
+    }
+
+    /**
+     * Assert that the upstream signalled the specified values in order,
+     * then failed with a specific class or subclass of Throwable
+     * and with the given exact error message.
+     * @param error the expected exception (parent) class
+     * @param message the expected failure message
+     * @param values the expected values, asserted in order
+     * @return this
+     */
+    public final TestSubscriber<T> assertFailureAndMessage(Class<? extends Throwable> error, 
+            String message, T... values) {
+        return assertValues(values)
+                .assertError(error)
+                .assertErrorMessage(message)
+                .assertNotComplete();
     }
 
     /**

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import static org.junit.Assert.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableConcatMapEagerTest {
+
+    @Test
+    public void normal() {
+        Flowable.range(1, 5)
+        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer t) {
+                return Flowable.range(t, 2);
+            }
+        })
+        .test()
+        .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalBackpressured() {
+        TestSubscriber<Integer> ts = Flowable.range(1, 5)
+        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer t) {
+                return Flowable.range(t, 2);
+            }
+        })
+        .test(3);
+        
+        ts.assertValues(1, 2, 2);
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2, 2, 3);
+        
+        ts.request(1);
+
+        ts.assertValues(1, 2, 2, 3, 3);
+
+        ts.request(5);
+
+        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalDelayBoundary() {
+        Flowable.range(1, 5)
+        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer t) {
+                return Flowable.range(t, 2);
+            }
+        }, false)
+        .test()
+        .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalDelayBoundaryBackpressured() {
+        TestSubscriber<Integer> ts = Flowable.range(1, 5)
+        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer t) {
+                return Flowable.range(t, 2);
+            }
+        }, false)
+        .test(3);
+        
+        ts.assertValues(1, 2, 2);
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2, 2, 3);
+        
+        ts.request(1);
+
+        ts.assertValues(1, 2, 2, 3, 3);
+
+        ts.request(5);
+
+        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalDelayEnd() {
+        Flowable.range(1, 5)
+        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer t) {
+                return Flowable.range(t, 2);
+            }
+        }, true)
+        .test()
+        .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalDelayEndBackpressured() {
+        TestSubscriber<Integer> ts = Flowable.range(1, 5)
+        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer t) {
+                return Flowable.range(t, 2);
+            }
+        }, true)
+        .test(3);
+        
+        ts.assertValues(1, 2, 2);
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2, 2, 3);
+        
+        ts.request(1);
+
+        ts.assertValues(1, 2, 2, 3, 3);
+
+        ts.request(5);
+
+        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void mainErrorsDelayBoundary() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        final PublishProcessor<Integer> inner = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = main.concatMapEagerDelayError(
+                new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer t) {
+                        return inner;
+                    }
+                }, false).test();
+        
+        main.onNext(1);
+        
+        inner.onNext(2);
+        
+        ts.assertValue(2);
+        
+        main.onError(new TestException("Forced failure"));
+        
+        ts.assertNoErrors();
+        
+        inner.onNext(3);
+        inner.onComplete();
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3);
+    }
+
+    @Test
+    public void mainErrorsDelayEnd() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        final PublishProcessor<Integer> inner = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = main.concatMapEagerDelayError(
+                new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer t) {
+                        return inner;
+                    }
+                }, true).test();
+        
+        main.onNext(1);
+        main.onNext(2);
+        
+        inner.onNext(2);
+        
+        ts.assertValue(2);
+        
+        main.onError(new TestException("Forced failure"));
+        
+        ts.assertNoErrors();
+        
+        inner.onNext(3);
+        inner.onComplete();
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3, 2, 3);
+    }
+    
+    @Test
+    public void mainErrorsImmediate() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        final PublishProcessor<Integer> inner = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = main.concatMapEager(
+                new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer t) {
+                        return inner;
+                    }
+                }).test();
+        
+        main.onNext(1);
+        main.onNext(2);
+        
+        inner.onNext(2);
+        
+        ts.assertValue(2);
+        
+        main.onError(new TestException("Forced failure"));
+
+        assertFalse("inner has subscribers?", inner.hasSubscribers());
+        
+        inner.onNext(3);
+        inner.onComplete();
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.reactivestreams.Publisher;
 import static org.junit.Assert.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
@@ -229,5 +229,21 @@ public class FlowableConcatMapEagerTest {
         inner.onComplete();
         
         ts.assertFailureAndMessage(TestException.class, "Forced failure", 2);
+    }
+    
+    @Test
+    public void longEager() {
+        
+        Flowable.range(1, 2 * Flowable.bufferSize())
+        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v) {
+                return Flowable.just(1);
+            }
+        })
+        .test()
+        .assertValueCount(2 * Flowable.bufferSize())
+        .assertNoErrors()
+        .assertComplete();
     }
 }


### PR DESCRIPTION
Started a syncing process between 1.x and 2.x operators (based on [this diff](https://gist.github.com/akarnokd/4a391527e099412cad87d3dffbfef762)). The first set is the addition of the eager version of `concat` and `concatMap`. In addition, all of them get a `XDelayError` overloads as well.
