### PR TITLE
2.x: +fromAsync, distinctUC, skip, take overloads, fix TestSubscriber API

### DIFF
--- a/src/main/java/io/reactivex/AsyncEmitter.java
+++ b/src/main/java/io/reactivex/AsyncEmitter.java
@@ -1,0 +1,88 @@
+package io.reactivex;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * Abstraction over a RxJava Subscriber that allows associating
+ * a resource with it and exposes the current number of downstream
+ * requested amount.
+ * <p>
+ * The onNext, onError and onCompleted methods should be called 
+ * in a sequential manner, just like the Observer's methods. The
+ * other methods are threadsafe.
+ *
+ * @param <T> the value type to emit
+ */
+public interface AsyncEmitter<T> {
+
+    /**
+     * Signal a value.
+     * @param t the value, not null
+     */
+    void onNext(T t);
+    
+    /**
+     * Signal an exception.
+     * @param t the exception, not null
+     */
+    void onError(Throwable t);
+    
+    /**
+     * Signal the completion.
+     */
+    void onComplete();
+    
+    /**
+     * Sets a Disposable on this emitter; any previous Disposable
+     * or Cancellation will be unsubscribed/cancelled.
+     * @param s the disposable, null is allowed
+     */
+    void setDisposable(Disposable s);
+    
+    /**
+     * Sets a Cancellable on this emitter; any previous Disposable
+     * or Cancellation will be unsubscribed/cancelled.
+     * @param c the cancellable resource, null is allowed
+     */
+    void setCancellation(Cancellable c);
+    /**
+     * The current outstanding request amount.
+     * <p>This method it threadsafe.
+     * @return the current outstanding request amount
+     */
+    long requested();
+    
+    /**
+     * Returns true if the downstream cancelled the sequence.
+     * @return true if the downstream cancelled the sequence
+     */
+    boolean isCancelled();
+    
+    /**
+     * A functional interface that has a single close method
+     * that can throw.
+     */
+    interface Cancellable {
+        
+        /**
+         * Cancel the action or free a resource.
+         * @throws Exception on error
+         */
+        void cancel() throws Exception;
+    }
+    
+    /**
+     * Options to handle backpressure in the emitter.
+     */
+    enum BackpressureMode {
+        NONE,
+        
+        ERROR,
+        
+        BUFFER,
+        
+        DROP,
+        
+        LATEST
+    }
+}

--- a/src/main/java/io/reactivex/AsyncEmitter.java
+++ b/src/main/java/io/reactivex/AsyncEmitter.java
@@ -7,8 +7,8 @@ import io.reactivex.disposables.Disposable;
  * a resource with it and exposes the current number of downstream
  * requested amount.
  * <p>
- * The onNext, onError and onCompleted methods should be called 
- * in a sequential manner, just like the Observer's methods. The
+ * The onNext, onError and onComplete methods should be called 
+ * in a sequential manner, just like the Subscriber's methods. The
  * other methods are threadsafe.
  *
  * @param <T> the value type to emit

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -491,6 +491,12 @@ public abstract class Flowable<T> implements Publisher<T> {
             }
         return new FlowableFromArray<T>(values);
     }
+    
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> fromAsync(Consumer<AsyncEmitter<T>> asyncEmitter, AsyncEmitter.BackpressureMode mode) {
+        return new FlowableFromAsync<T>(asyncEmitter, mode);
+    }
 
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -785,6 +791,24 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(v9, "The ninth is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8, v9);
+    }
+
+    @SuppressWarnings("unchecked")
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10) {
+        Objects.requireNonNull(v1, "The first value is null");
+        Objects.requireNonNull(v2, "The second value is null");
+        Objects.requireNonNull(v3, "The third value is null");
+        Objects.requireNonNull(v4, "The fourth value is null");
+        Objects.requireNonNull(v5, "The fifth value is null");
+        Objects.requireNonNull(v6, "The sixth value is null");
+        Objects.requireNonNull(v7, "The seventh value is null");
+        Objects.requireNonNull(v8, "The eigth value is null");
+        Objects.requireNonNull(v9, "The ninth is null");
+        Objects.requireNonNull(v10, "The tenth is null");
+        
+        return fromArray(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -1807,6 +1831,14 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(keySelector, "keySelector is null");
         return FlowableDistinct.untilChanged(this, keySelector);
     }
+    
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <K> Flowable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
+        Objects.requireNonNull(comparer, "comparer is null");
+        return new FlowableDistinctUntilChanged<T>(this, comparer);
+    }
+    
     
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2869,7 +2901,14 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         return new FlowableSkip<T>(this, n);
     }
-    
+
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Flowable<T> skip(long time, TimeUnit unit) {
+        // TODO consider inlining this behavior
+        return skipUntil(timer(time, unit));
+    }
+
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> skip(long time, TimeUnit unit, Scheduler scheduler) {
@@ -3120,7 +3159,14 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    @SchedulerSupport(SchedulerSupport.NONE)
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Flowable<T> take(long time, TimeUnit unit) {
+        // TODO consider inlining this behavior
+        return takeUntil(timer(time, unit));
+    }
+
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> take(long time, TimeUnit unit, Scheduler scheduler) {
         // TODO consider inlining this behavior
         return takeUntil(timer(time, unit, scheduler));
@@ -3429,6 +3475,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final BlockingFlowable<T> toBlocking() {
         return BlockingFlowable.from(this);
+    }
+    
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Completable toCompletable() {
+        return Completable.fromFlowable(this);
     }
     
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.functions.BiPredicate;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.subscribers.flowable.*;
+
+public final class FlowableDistinctUntilChanged<T> extends FlowableSource<T, T> {
+
+    final BiPredicate<? super T, ? super T> comparer;
+
+    public FlowableDistinctUntilChanged(Publisher<T> source, BiPredicate<? super T, ? super T> comparer) {
+        super(source);
+        this.comparer = comparer;
+    }
+    
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        if (s instanceof ConditionalSubscriber) {
+            ConditionalSubscriber<? super T> cs = (ConditionalSubscriber<? super T>) s;
+            source.subscribe(new DistinctUntilChangedConditionalSubscriber<T>(cs, comparer));
+        } else {
+            source.subscribe(new DistinctUntilChangedSubscriber<T>(s, comparer));
+        }
+    }
+
+    static final class DistinctUntilChangedSubscriber<T> extends BasicFuseableSubscriber<T, T>
+    implements ConditionalSubscriber<T> {
+
+        final BiPredicate<? super T, ? super T> comparer;
+        
+        T last;
+        
+        boolean hasValue;
+        
+        public DistinctUntilChangedSubscriber(Subscriber<? super T> actual, 
+                BiPredicate<? super T, ? super T> comparer) {
+            super(actual);
+            this.comparer = comparer;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t)) {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            if (sourceMode != NONE) {
+                actual.onNext(t);
+                return true;
+            }
+            
+            if (hasValue) {
+                boolean equal;
+                try {
+                    equal = comparer.test(last, t);
+                } catch (Throwable ex) {
+                    fail(ex);
+                    return false;
+                }
+                last = t;
+                if (equal) {
+                    return false;
+                }
+                actual.onNext(t);
+                return true;
+            }
+            hasValue = true;
+            last = t;
+            actual.onNext(t);
+            return true;
+        }
+        
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public T poll() {
+            for (;;) {
+                T v = qs.poll();
+                if (v == null) {
+                    return null;
+                }
+                if (!hasValue) {
+                    hasValue = true;
+                    last = v;
+                    return v;
+                }
+                if (!comparer.test(last, v)) {
+                    last = v;
+                    return v;
+                }
+                last = v;
+                if (sourceMode != SYNC) {
+                    s.request(1);
+                }
+            }
+        }
+        
+    }
+    
+    static final class DistinctUntilChangedConditionalSubscriber<T> extends BasicFuseableConditionalSubscriber<T, T> {
+
+        final BiPredicate<? super T, ? super T> comparer;
+        
+        T last;
+        
+        boolean hasValue;
+        
+        public DistinctUntilChangedConditionalSubscriber(ConditionalSubscriber<? super T> actual, 
+                BiPredicate<? super T, ? super T> comparer) {
+            super(actual);
+            this.comparer = comparer;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t)) {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            if (sourceMode != NONE) {
+                return actual.tryOnNext(t);
+            }
+            
+            if (hasValue) {
+                boolean equal;
+                try {
+                    equal = comparer.test(last, t);
+                } catch (Throwable ex) {
+                    fail(ex);
+                    return false;
+                }
+                last = t;
+                if (equal) {
+                    return false;
+                }
+                return actual.tryOnNext(t);
+            }
+            hasValue = true;
+            last = t;
+            return actual.tryOnNext(t);
+        }
+        
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public T poll() {
+            for (;;) {
+                T v = qs.poll();
+                if (v == null) {
+                    return null;
+                }
+                if (!hasValue) {
+                    hasValue = true;
+                    last = v;
+                    return v;
+                }
+                if (!comparer.test(last, v)) {
+                    last = v;
+                    return v;
+                }
+                last = v;
+                if (sourceMode != SYNC) {
+                    s.request(1);
+                }
+            }
+        }
+        
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromAsync.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromAsync.java
@@ -1,0 +1,512 @@
+package io.reactivex.internal.operators.flowable;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+
+public final class FlowableFromAsync<T> extends Flowable<T> {
+
+    final Consumer<AsyncEmitter<T>> asyncEmitter;
+    
+    final AsyncEmitter.BackpressureMode backpressure;
+    
+    public FlowableFromAsync(Consumer<AsyncEmitter<T>> asyncEmitter, AsyncEmitter.BackpressureMode backpressure) {
+        this.asyncEmitter = asyncEmitter;
+        this.backpressure = backpressure;
+    }
+    
+    @Override
+    public void subscribeActual(Subscriber<? super T> t) {
+        BaseAsyncEmitter<T> emitter;
+        
+        switch (backpressure) {
+        case NONE: {
+            emitter = new NoneAsyncEmitter<T>(t);
+            break;
+        }
+        case ERROR: {
+            emitter = new ErrorAsyncEmitter<T>(t);
+            break;
+        }
+        case DROP: {
+            emitter = new DropAsyncEmitter<T>(t);
+            break;
+        }
+        case LATEST: {
+            emitter = new LatestAsyncEmitter<T>(t);
+            break;
+        }
+        default: {
+            emitter = new BufferAsyncEmitter<T>(t, bufferSize());
+            break;
+        }
+        }
+
+        t.onSubscribe(emitter);
+        asyncEmitter.accept(emitter);
+        
+    }
+    
+    static final class CancellableSubscription 
+    extends AtomicReference<AsyncEmitter.Cancellable>
+    implements Disposable {
+        
+        /** */
+        private static final long serialVersionUID = 5718521705281392066L;
+
+        public CancellableSubscription(AsyncEmitter.Cancellable cancellable) {
+            super(cancellable);
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return get() == null;
+        }
+        
+        @Override
+        public void dispose() {
+            if (get() != null) {
+                AsyncEmitter.Cancellable c = getAndSet(null);
+                if (c != null) {
+                    try {
+                        c.cancel();
+                    } catch (Exception ex) {
+                        Exceptions.throwIfFatal(ex);
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+        }
+    }
+    
+    static abstract class BaseAsyncEmitter<T> 
+    extends AtomicLong
+    implements AsyncEmitter<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = 7326289992464377023L;
+
+        final Subscriber<? super T> actual;
+        
+        final SerialDisposable serial;
+
+        public BaseAsyncEmitter(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.serial = new SerialDisposable();
+        }
+
+        @Override
+        public void onComplete() {
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                actual.onComplete();
+            } finally {
+                serial.dispose();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                actual.onError(e);
+            } finally {
+                serial.dispose();
+            }
+        }
+
+        @Override
+        public final void cancel() {
+            serial.dispose();
+            onUnsubscribed();
+        }
+        
+        void onUnsubscribed() {
+            // default is no-op
+        }
+
+        @Override
+        public final boolean isCancelled() {
+            return serial.isDisposed();
+        }
+
+        @Override
+        public final void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(this, n);
+                onRequested();
+            }
+        }
+
+        void onRequested() {
+            // default is no-op
+        }
+        
+        @Override
+        public final void setDisposable(Disposable s) {
+            serial.set(s);
+        }
+
+        @Override
+        public final void setCancellation(AsyncEmitter.Cancellable c) {
+            setDisposable(new CancellableSubscription(c));
+        }
+
+        @Override
+        public final long requested() {
+            return get();
+        }
+    }
+    
+    static final class NoneAsyncEmitter<T> extends BaseAsyncEmitter<T> {
+
+        /** */
+        private static final long serialVersionUID = 3776720187248809713L;
+
+        public NoneAsyncEmitter(Subscriber<? super T> actual) {
+            super(actual);
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (isCancelled()) {
+                return;
+            }
+
+            actual.onNext(t);
+            
+            for (;;) {
+                long r = get();
+                if (r == 0L || compareAndSet(r, r - 1)) {
+                    return;
+                }
+            }
+        }
+
+    }
+    
+    static abstract class NoOverflowBaseAsyncEmitter<T> extends BaseAsyncEmitter<T> {
+
+        /** */
+        private static final long serialVersionUID = 4127754106204442833L;
+
+        public NoOverflowBaseAsyncEmitter(Subscriber<? super T> actual) {
+            super(actual);
+        }
+
+        @Override
+        public final void onNext(T t) {
+            if (isCancelled()) {
+                return;
+            }
+
+            if (get() != 0) {
+                actual.onNext(t);
+                BackpressureHelper.produced(this, 1);
+            } else {
+                onOverflow();
+            }
+        }
+        
+        abstract void onOverflow();
+    }
+    
+    static final class DropAsyncEmitter<T> extends NoOverflowBaseAsyncEmitter<T> {
+
+        /** */
+        private static final long serialVersionUID = 8360058422307496563L;
+
+        public DropAsyncEmitter(Subscriber<? super T> actual) {
+            super(actual);
+        }
+
+        @Override
+        void onOverflow() {
+            // nothing to do
+        }
+        
+    }
+
+    static final class ErrorAsyncEmitter<T> extends NoOverflowBaseAsyncEmitter<T> {
+
+        /** */
+        private static final long serialVersionUID = 338953216916120960L;
+
+        public ErrorAsyncEmitter(Subscriber<? super T> actual) {
+            super(actual);
+        }
+
+        @Override
+        void onOverflow() {
+            onError(new MissingBackpressureException("fromAsync: could not emit value due to lack of requests"));
+        }
+        
+    }
+    
+    static final class BufferAsyncEmitter<T> extends BaseAsyncEmitter<T> {
+
+        /** */
+        private static final long serialVersionUID = 2427151001689639875L;
+
+        final Queue<T> queue;
+        
+        Throwable error;
+        volatile boolean done;
+        
+        final AtomicInteger wip;
+        
+        public BufferAsyncEmitter(Subscriber<? super T> actual, int capacityHint) {
+            super(actual);
+            this.queue = new SpscLinkedArrayQueue<T>(capacityHint);
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        public void onNext(T t) {
+            queue.offer(t);
+            drain();
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            error = e;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+        
+        @Override
+        void onRequested() {
+            drain();
+        }
+
+        @Override
+        void onUnsubscribed() {
+            if (wip.getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+        
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            final Subscriber<? super T> a = actual;
+            final Queue<T> q = queue;
+            
+            for (;;) {
+                long r = get();
+                long e = 0L;
+                
+                while (e != r) {
+                    if (isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+                    
+                    boolean d = done;
+                    
+                    T o = q.poll();
+                    
+                    boolean empty = o == null;
+                    
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            super.onError(ex);
+                        } else {
+                            super.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(o);
+                    
+                    e++;
+                }
+                
+                if (e == r) {
+                    if (isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+                    
+                    boolean d = done;
+                    
+                    boolean empty = q.isEmpty();
+                    
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            super.onError(ex);
+                        } else {
+                            super.onComplete();
+                        }
+                        return;
+                    }
+                }
+                
+                if (e != 0) {
+                    BackpressureHelper.produced(this, e);
+                }
+                
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    static final class LatestAsyncEmitter<T> extends BaseAsyncEmitter<T> {
+
+        /** */
+        private static final long serialVersionUID = 4023437720691792495L;
+
+        final AtomicReference<T> queue;
+
+        Throwable error;
+        volatile boolean done;
+        
+        final AtomicInteger wip;
+        
+        public LatestAsyncEmitter(Subscriber<? super T> actual) {
+            super(actual);
+            this.queue = new AtomicReference<T>();
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        public void onNext(T t) {
+            queue.set(t);
+            drain();
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            error = e;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+        
+        @Override
+        void onRequested() {
+            drain();
+        }
+
+        @Override
+        void onUnsubscribed() {
+            if (wip.getAndIncrement() == 0) {
+                queue.lazySet(null);
+            }
+        }
+        
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            final Subscriber<? super T> a = actual;
+            final AtomicReference<T> q = queue;
+            
+            for (;;) {
+                long r = get();
+                long e = 0L;
+                
+                while (e != r) {
+                    if (isCancelled()) {
+                        q.lazySet(null);
+                        return;
+                    }
+                    
+                    boolean d = done;
+                    
+                    T o = q.getAndSet(null);
+                    
+                    boolean empty = o == null;
+                    
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            super.onError(ex);
+                        } else {
+                            super.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    a.onNext(o);
+                    
+                    e++;
+                }
+                
+                if (e == r) {
+                    if (isCancelled()) {
+                        q.lazySet(null);
+                        return;
+                    }
+                    
+                    boolean d = done;
+                    
+                    boolean empty = q.get() == null;
+                    
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            super.onError(ex);
+                        } else {
+                            super.onComplete();
+                        }
+                        return;
+                    }
+                }
+                
+                if (e != 0) {
+                    BackpressureHelper.produced(this, e);
+                }
+                
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/util/BackpressureHelper.java
+++ b/src/main/java/io/reactivex/internal/util/BackpressureHelper.java
@@ -72,24 +72,24 @@ public enum BackpressureHelper {
     }
     
     /**
-     * Atomically subtract the given number (positive, not validated) form the target field.
+     * Atomically subtract the given number (positive, not validated) from the target field.
      * @param requested the target field holding the current requested amount
      * @param n the produced element count, positive (not validated)
      * @return the new amount
      */
     public static long produced(AtomicLong requested, long n) {
         for (;;) {
-            long r = requested.get();
-            if (r == Long.MAX_VALUE) {
+            long current = requested.get();
+            if (current == Long.MAX_VALUE) {
                 return Long.MAX_VALUE;
             }
-            long u = r - n;
-            if (u < 0L) {
-                RxJavaPlugins.onError(new IllegalStateException("More produced than requested: " + u));
-                u = 0L;
+            long update = current - n;
+            if (update < 0L) {
+                RxJavaPlugins.onError(new IllegalStateException("More produced than requested: " + update));
+                update = 0L;
             }
-            if (requested.compareAndSet(r, u)) {
-                return r;
+            if (requested.compareAndSet(current, update)) {
+                return update;
             }
         }
     }

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -43,7 +43,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
     /** The actual subscriber to forward events to. */
     private final Subscriber<? super T> actual;
     /** The initial request amount if not null. */
-    private final Long initialRequest;
+    private final long initialRequest;
     /** The latch that indicates an onError or onCompleted has been called. */
     private final CountDownLatch done;
     /** The list of values received. */
@@ -82,9 +82,9 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * Constructs a non-forwarding TestSubscriber with the specified initial request value.
      * <p>The TestSubscriber doesn't validate the initialRequest value so one can
      * test sources with invalid values as well.
-     * @param initialRequest the initial request value if not null
+     * @param initialRequest the initial request value
      */
-    public TestSubscriber(Long initialRequest) {
+    public TestSubscriber(long initialRequest) {
         this(EmptySubscriber.INSTANCE, initialRequest);
     }
 
@@ -93,7 +93,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * @param actual the actual Subscriber to forward events to
      */
     public TestSubscriber(Subscriber<? super T> actual) {
-        this(actual, null);
+        this(actual, Long.MAX_VALUE);
     }
 
     /**
@@ -101,9 +101,9 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * <p>The TestSubscriber doesn't validate the initialRequest value so one can
      * test sources with invalid values as well.
      * @param actual the actual Subscriber to forward events to
-     * @param initialRequest the initial request value if not null
+     * @param initialRequest the initial request value
      */
-    public TestSubscriber(Subscriber<? super T> actual, Long initialRequest) {
+    public TestSubscriber(Subscriber<? super T> actual, long initialRequest) {
         this.actual = actual;
         this.initialRequest = initialRequest;
         this.values = new ArrayList<T>();
@@ -163,7 +163,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
             return;
         }
         
-        if (initialRequest != null) {
+        if (initialRequest != 0L) {
             s.request(initialRequest);
         }
         

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1167,9 +1167,14 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void distinctUntilChangedFunctionNull() {
-        just1.distinctUntilChanged(null);
+        just1.distinctUntilChanged((Function<Integer, Integer>)null);
     }
-    
+
+    @Test(expected = NullPointerException.class)
+    public void distinctUntilChangedBiPredicateNull() {
+        just1.distinctUntilChanged((BiPredicate<Integer, Integer>)null);
+    }
+
     @Test(expected = NullPointerException.class)
     public void distinctUntilChangedFunctionReturnsNull() {
         just1.distinctUntilChanged(new Function<Integer, Object>() {

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -35,7 +35,7 @@ public class FlowableSubscriberTest {
      */
     @Test
     public void testRequestFromFinalSubscribeWithRequestValue() {
-        TestSubscriber<String> s = new TestSubscriber<String>((Long)null);
+        TestSubscriber<String> s = new TestSubscriber<String>(0L);
         s.request(10);
         final AtomicLong r = new AtomicLong();
         s.onSubscribe(new Subscription() {
@@ -132,7 +132,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestFromDecoupledOperator() {
-        TestSubscriber<String> s = new TestSubscriber<String>((Long)null);
+        TestSubscriber<String> s = new TestSubscriber<String>(0L);
         Operator<String, String> o = new Operator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
@@ -283,7 +283,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestThroughMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>create(new Publisher<Integer>() {
@@ -308,7 +308,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestThroughTakeThatReducesRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>create(new Publisher<Integer>() {
@@ -336,7 +336,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestThroughTakeWhereRequestIsSmallerThanTake() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>create(new Publisher<Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -141,7 +141,7 @@ public class FlowableAllTest {
     
     @Test
     public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>((Long)null);
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0L);
         Flowable.empty().all(new Predicate<Object>() {
             @Override
             public boolean test(Object t1) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -171,7 +171,7 @@ public class FlowableAmbTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testProducerRequestThroughAmb() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested1 = new AtomicLong();
         final AtomicLong requested2 = new AtomicLong();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -240,7 +240,7 @@ public class FlowableAnyTest {
     
     @Test
     public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>((Long)null);
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0L);
         
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -341,7 +341,7 @@ public class FlowableBufferTest {
         Flowable<Integer> source = Flowable.never();
 
         Subscriber<List<Integer>> o = TestHelper.mockSubscriber();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(o, (Long)null);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(o, 0L);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
         .doOnNext(new Consumer<List<Integer>>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -59,7 +59,7 @@ public class FlowableCacheTest {
         
         assertFalse("Source is connected!", source.isConnected());
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(10);
         
         source.subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -402,7 +402,7 @@ public class FlowableConcatTest {
         final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, null);
+        TestSubscriber<String> ts = new TestSubscriber<String>(observer, 0L);
 
         final Flowable<String> concat = Flowable.concat(Flowable.create(w1), Flowable.create(w2));
 
@@ -444,7 +444,7 @@ public class FlowableConcatTest {
         final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, null);
+        TestSubscriber<String> ts = new TestSubscriber<String>(observer, 0L);
         
         @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.create(w1), Flowable.create(w2));

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
@@ -85,7 +85,7 @@ public class FlowableDefaultIfEmptyTest {
     
     @Test
     public void testBackpressureEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         Flowable.<Integer>empty().defaultIfEmpty(1).subscribe(ts);
         ts.assertNoValues();
         ts.assertNotTerminated();
@@ -97,7 +97,7 @@ public class FlowableDefaultIfEmptyTest {
     
     @Test
     public void testBackpressureNonEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         Flowable.just(1,2,3).defaultIfEmpty(1).subscribe(ts);
         ts.assertNoValues();
         ts.assertNotTerminated();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -195,7 +195,7 @@ public class FlowableDelaySubscriptionOtherTest {
         
         PublishProcessor<Object> other = PublishProcessor.create();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         final AtomicInteger subscribed = new AtomicInteger();
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromAsyncTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromAsyncTest.java
@@ -1,0 +1,729 @@
+package io.reactivex.internal.operators.flowable;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Consumer;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.*;
+
+public class FlowableFromAsyncTest {
+
+    PublishAsyncEmitter source;
+
+    PublishAsyncEmitterNoCancel sourceNoCancel;
+
+    TestSubscriber<Integer> ts;
+    
+    @Before
+    public void before() {
+        source = new PublishAsyncEmitter();
+        sourceNoCancel = new PublishAsyncEmitterNoCancel();
+        ts = new TestSubscriber<Integer>(0L);
+    }
+    
+    @Test
+    public void normalBuffered() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.request(1);
+        
+        ts.assertValue(1);
+        
+        Assert.assertEquals(0, source.requested());
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void normalDrop() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        
+        source.onNext(1);
+
+        ts.request(1);
+
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.assertValues(2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void normalLatest() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        
+        source.onNext(1);
+
+        source.onNext(2);
+        source.onComplete();
+
+        ts.request(1);
+
+        ts.assertValues(2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void normalNone() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void normalNoneRequested() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        ts.request(2);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+
+    @Test
+    public void normalError() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+
+        ts.assertNoValues();
+        ts.assertError(MissingBackpressureException.class);
+        ts.assertNotComplete();
+        
+        Assert.assertEquals("fromAsync: could not emit value due to lack of requests", ts.errors().get(0).getMessage());
+    }
+
+    @Test
+    public void errorBuffered() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertValue(1);
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void errorLatest() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertValues(2);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void errorNone() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedBuffer() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        ts.cancel();
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedLatest() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        ts.cancel();
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedError() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        ts.cancel();
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedDrop() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        ts.cancel();
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedNone() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        ts.cancel();
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedNoCancelBuffer() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        ts.cancel();
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedNoCancelLatest() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        ts.cancel();
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedNoCancelError() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        ts.cancel();
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedNoCancelDrop() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        ts.cancel();
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribedNoCancelNone() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        ts.cancel();
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(1);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void deferredRequest() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.request(2);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void take() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.request(2);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void takeOne() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        ts.request(2);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void requestExact() {
+        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        ts.request(2);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void takeNoCancel() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onComplete();
+        
+        ts.request(2);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void takeOneNoCancel() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        ts.request(2);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        sourceNoCancel.onComplete();
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void unsubscribeNoCancel() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        ts.request(2);
+        
+        sourceNoCancel.onNext(1);
+
+        ts.cancel();
+        
+        sourceNoCancel.onNext(2);
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+
+    @Test
+    public void unsubscribeInline() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cancel();
+            }
+        };
+        
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
+        
+        sourceNoCancel.onNext(1);
+        
+        ts1.assertValues(1);
+        ts1.assertNoErrors();
+        ts1.assertNotComplete();
+    }
+
+    @Test
+    public void completeInline() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onComplete();
+        
+        ts.request(2);
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void errorInline() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(2);
+        
+        ts.assertValues(1);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void requestInline() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                request(1);
+            }
+        };
+        
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        
+        ts1.assertValues(1, 2);
+        ts1.assertNoErrors();
+        ts1.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribeInlineLatest() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cancel();
+            }
+        };
+        
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        
+        sourceNoCancel.onNext(1);
+        
+        ts1.assertValues(1);
+        ts1.assertNoErrors();
+        ts1.assertNotComplete();
+    }
+
+    @Test
+    public void unsubscribeInlineExactLatest() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cancel();
+            }
+        };
+        
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        
+        sourceNoCancel.onNext(1);
+        
+        ts1.assertValues(1);
+        ts1.assertNoErrors();
+        ts1.assertNotComplete();
+    }
+
+    @Test
+    public void completeInlineLatest() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onComplete();
+        
+        ts.request(2);
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void completeInlineExactLatest() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onComplete();
+        
+        ts.request(1);
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void errorInlineLatest() {
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onError(new TestException());
+        
+        ts.request(2);
+        
+        ts.assertValues(1);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void requestInlineLatest() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                request(1);
+            }
+        };
+        
+        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        
+        sourceNoCancel.onNext(1);
+        sourceNoCancel.onNext(2);
+        
+        ts1.assertValues(1, 2);
+        ts1.assertNoErrors();
+        ts1.assertNotComplete();
+    }
+    
+    static final class PublishAsyncEmitter implements Consumer<AsyncEmitter<Integer>>, Subscriber<Integer> {
+        
+        final PublishProcessor<Integer> subject;
+        
+        AsyncEmitter<Integer> current;
+        
+        public PublishAsyncEmitter() {
+            this.subject = PublishProcessor.create();
+        }
+        
+        long requested() {
+            return current.requested();
+        }
+        
+        @Override
+        public void accept(final AsyncEmitter<Integer> t) {
+
+            this.current = t;
+            
+            final AsyncSubscriber<Integer> as = new AsyncSubscriber<Integer>() {
+
+                @Override
+                public void onComplete() {
+                    t.onComplete();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
+
+                @Override
+                public void onNext(Integer v) {
+                    t.onNext(v);
+                }
+                
+            };
+            
+            subject.subscribe(as);
+            
+            t.setCancellation(new AsyncEmitter.Cancellable() {
+                @Override
+                public void cancel() throws Exception {
+                    as.dispose();
+                }
+            });;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(Integer t) {
+            subject.onNext(t);
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            subject.onError(e);
+        }
+        
+        @Override
+        public void onComplete() {
+            subject.onComplete();
+        }
+    }
+    
+    static final class PublishAsyncEmitterNoCancel implements Consumer<AsyncEmitter<Integer>>, Subscriber<Integer> {
+        
+        final PublishProcessor<Integer> subject;
+        
+        public PublishAsyncEmitterNoCancel() {
+            this.subject = PublishProcessor.create();
+        }
+        
+        @Override
+        public void accept(final AsyncEmitter<Integer> t) {
+
+            subject.subscribe(new Subscriber<Integer>() {
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+                
+                @Override
+                public void onComplete() {
+                    t.onComplete();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
+
+                @Override
+                public void onNext(Integer v) {
+                    t.onNext(v);
+                }
+                
+            });
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(Integer t) {
+            subject.onNext(t);
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            subject.onError(e);
+        }
+        
+        @Override
+        public void onComplete() {
+            subject.onComplete();
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromAsyncTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromAsyncTest.java
@@ -52,6 +52,8 @@ public class FlowableFromAsyncTest {
         source.onNext(1);
 
         ts.request(1);
+        
+        ts.assertNoValues();
 
         source.onNext(2);
         source.onComplete();
@@ -69,6 +71,8 @@ public class FlowableFromAsyncTest {
 
         source.onNext(2);
         source.onComplete();
+
+        ts.assertNoValues();
 
         ts.request(1);
 
@@ -146,7 +150,9 @@ public class FlowableFromAsyncTest {
         source.onNext(1);
         source.onNext(2);
         source.onError(new TestException());
-        
+
+        ts.assertNoValues();
+
         ts.request(1);
         
         ts.assertValues(2);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -119,7 +119,7 @@ public class FlowableFromIterableTest {
         }
         Flowable<Integer> o = Flowable.fromIterable(list);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         ts.assertNoValues();
         ts.request(1);
@@ -139,7 +139,7 @@ public class FlowableFromIterableTest {
     public void testNoBackpressure() {
         Flowable<Integer> o = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5));
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1527,7 +1527,7 @@ public class FlowableGroupByTest {
      */
     @Test
     public void testBackpressureInnerDoesntOverflowOuter() {
-        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<GroupedFlowable<Integer, Integer>>((Long)null);
+        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<GroupedFlowable<Integer, Integer>>(0L);
         
         Flowable.fromArray(1, 2)
                 .groupBy(new Function<Integer, Integer>() {
@@ -1553,8 +1553,8 @@ public class FlowableGroupByTest {
     
     @Test
     public void testOneGroupInnerRequestsTwiceBuffer() {
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>((Long)null);
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>((Long)null);
+        TestSubscriber<Object> ts1 = new TestSubscriber<Object>(0L);
+        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>(0L);
         
         Flowable.range(1, Flowable.bufferSize() * 2)
         .groupBy(new Function<Integer, Object>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -96,7 +96,7 @@ public class FlowableMaterializeTest {
 
     @Test
     public void testBackpressureOnEmptyStream() {
-        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>((Long)null);
+        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>(0L);
         Flowable.<Integer> empty().materialize().subscribe(ts);
         ts.assertNoValues();
         ts.request(1);
@@ -107,7 +107,7 @@ public class FlowableMaterializeTest {
 
     @Test
     public void testBackpressureNoError() {
-        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>((Long)null);
+        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>(0L);
         Flowable.just(1, 2, 3).materialize().subscribe(ts);
         ts.assertNoValues();
         ts.request(1);
@@ -121,7 +121,7 @@ public class FlowableMaterializeTest {
     
     @Test
     public void testBackpressureNoErrorAsync() throws InterruptedException {
-        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>((Long)null);
+        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>(0L);
         Flowable.just(1, 2, 3)
             .materialize()
             .subscribeOn(Schedulers.computation())
@@ -142,7 +142,7 @@ public class FlowableMaterializeTest {
 
     @Test
     public void testBackpressureWithError() {
-        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>((Long)null);
+        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>(0L);
         Flowable.<Integer> error(new IllegalArgumentException()).materialize().subscribe(ts);
         ts.assertNoValues();
         ts.request(1);
@@ -152,7 +152,7 @@ public class FlowableMaterializeTest {
 
     @Test
     public void testBackpressureWithEmissionThenError() {
-        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>((Long)null);
+        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>(0L);
         IllegalArgumentException ex = new IllegalArgumentException();
         Flowable.fromIterable(Arrays.asList(1)).concatWith(Flowable.<Integer> error(ex)).materialize()
                 .subscribe(ts);
@@ -184,7 +184,7 @@ public class FlowableMaterializeTest {
     
     @Test
     public void testUnsubscribeJustBeforeCompletionNotificationShouldPreventThatNotificationArriving() {
-        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>((Long)null);
+        TestSubscriber<Try<Optional<Integer>>> ts = new TestSubscriber<Try<Optional<Integer>>>(0L);
 
         Flowable.<Integer>empty().materialize()
                 .subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -260,7 +260,7 @@ public class FlowableMergeMaxConcurrentTest {
         
         final CountDownLatch cdl = new CountDownLatch(5);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L) {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -1099,7 +1099,7 @@ public class FlowableMergeTest {
     @Test
     public void shouldCompleteAfterApplyingBackpressure_NormalPath() {
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(Flowable.range(1, 2)));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(0L);
         source.subscribe(subscriber);
         subscriber.request(3); // 1, 2, <complete> - with request(2) we get the 1 and 2 but not the <complete>
         subscriber.assertValues(1, 2);
@@ -1109,7 +1109,7 @@ public class FlowableMergeTest {
     @Test
     public void shouldCompleteAfterApplyingBackpressure_FastPath() {
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(Flowable.just(1)));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(0L);
         source.subscribe(subscriber);
         subscriber.request(2); // 1, <complete> - should work as per .._NormalPath above
         subscriber.assertValue(1);
@@ -1120,7 +1120,7 @@ public class FlowableMergeTest {
     public void shouldNotCompleteIfThereArePendingScalarSynchronousEmissionsWhenTheLastInnerSubscriberCompletes() {
         TestScheduler scheduler = Schedulers.test();
         Flowable<Long> source = Flowable.mergeDelayError(Flowable.just(1L), Flowable.timer(1, TimeUnit.SECONDS, scheduler).skip(1));
-        TestSubscriber<Long> subscriber = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> subscriber = new TestSubscriber<Long>(0L);
         source.subscribe(subscriber);
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
         subscriber.assertNoValues();
@@ -1137,7 +1137,7 @@ public class FlowableMergeTest {
     public void delayedErrorsShouldBeEmittedWhenCompleteAfterApplyingBackpressure_NormalPath() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.range(1, 2), Flowable.<Integer>error(exception));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(0L);
         source.subscribe(subscriber);
         subscriber.request(3); // 1, 2, <error>
         subscriber.assertValues(1, 2);
@@ -1149,7 +1149,7 @@ public class FlowableMergeTest {
     public void delayedErrorsShouldBeEmittedWhenCompleteAfterApplyingBackpressure_FastPath() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(1), Flowable.<Integer>error(exception));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(0L);
         source.subscribe(subscriber);
         subscriber.request(2); // 1, <error>
         subscriber.assertValue(1);
@@ -1171,7 +1171,7 @@ public class FlowableMergeTest {
     public void shouldNotReceivedDelayedErrorWhileThereAreStillScalarSynchronousEmissionsInTheQueue() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(1), Flowable.just(2), Flowable.<Integer>error(exception));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(0L);
         subscriber.request(1);
         source.subscribe(subscriber);
         subscriber.assertValue(1);
@@ -1185,7 +1185,7 @@ public class FlowableMergeTest {
     public void shouldNotReceivedDelayedErrorWhileThereAreStillNormalEmissionsInTheQueue() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.range(1, 2), Flowable.range(3, 2), Flowable.<Integer>error(exception));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(0L);
         subscriber.request(3);
         source.subscribe(subscriber);
         subscriber.assertValues(1, 2, 3);
@@ -1355,7 +1355,7 @@ public class FlowableMergeTest {
     @Test
     public void testSlowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>((long)req) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(req) {
                 int remaining = req;
 
                 @Override
@@ -1373,7 +1373,7 @@ public class FlowableMergeTest {
     @Test
     public void testSlowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>((long)req) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(req) {
                 int remaining = req;
                 @Override
                 public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -30,7 +30,7 @@ public class FlowableOnBackpressureBufferTest {
 
     @Test
     public void testNoBackpressureSupport() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         // this will be ignored
         ts.request(100);
         // we take 500 so it unsubscribes
@@ -64,7 +64,7 @@ public class FlowableOnBackpressureBufferTest {
                 l2.countDown();
             }
 
-        }, null);
+        }, 0L);
         // this will be ignored
         ts.request(100);
         // we take 500 so it unsubscribes
@@ -118,7 +118,7 @@ public class FlowableOnBackpressureBufferTest {
                 l1.countDown();
             }
 
-        }, null);
+        }, 0L);
 
         ts.request(100);
         infinite.subscribeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -30,7 +30,7 @@ public class FlowableOnBackpressureDropTest {
 
     @Test
     public void testNoBackpressureSupport() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         // this will be ignored
         ts.request(100);
         // we take 500 so it unsubscribes
@@ -71,7 +71,7 @@ public class FlowableOnBackpressureDropTest {
                 l2.countDown();
             }
 
-        }, null);
+        }, 0L);
         // this will be ignored
         ts.request(100);
         // we take 500 so it unsubscribes

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
@@ -60,7 +60,7 @@ public class FlowableOnBackpressureLatestTest {
     @Test
     public void testSynchronousDrop() {
         PublishProcessor<Integer> source = PublishProcessor.create();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         source.onBackpressureLatest().subscribe(ts);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -344,7 +344,7 @@ public class FlowablePublishTest {
     public void testZeroRequested() {
         ConnectableFlowable<Integer> source = Flowable.just(1).publish();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         source.subscribe(ts);
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -95,7 +95,7 @@ public class FlowableRangeTest {
     public void testBackpressureViaRequest() {
         Flowable<Integer> o = Flowable.range(1, Flowable.bufferSize());
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         ts.assertNoValues();
         ts.request(1);
@@ -123,7 +123,7 @@ public class FlowableRangeTest {
 
         Flowable<Integer> o = Flowable.range(1, list.size());
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
@@ -136,7 +136,7 @@ public class FlowableRangeTest {
     void testWithBackpressureOneByOne(int start) {
         Flowable<Integer> source = Flowable.range(start, 100);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(1);
         source.subscribe(ts);
         
@@ -151,7 +151,7 @@ public class FlowableRangeTest {
     void testWithBackpressureAllAtOnce(int start) {
         Flowable<Integer> source = Flowable.range(start, 100);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(100);
         source.subscribe(ts);
         
@@ -178,7 +178,7 @@ public class FlowableRangeTest {
     public void testWithBackpressureRequestWayMore() {
         Flowable<Integer> source = Flowable.range(50, 100);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(150);
         source.subscribe(ts);
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -878,7 +878,7 @@ public class FlowableReplayTest {
     public void testColdReplayBackpressure() {
         Flowable<Integer> source = Flowable.range(0, 1000).replay().autoConnect();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(10);
         
         source.subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
@@ -142,7 +142,7 @@ public class FlowableSkipTest {
     @Test
     public void testBackpressureMultipleSmallAsyncRequests() throws InterruptedException {
         final AtomicLong requests = new AtomicLong(0);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.interval(100, TimeUnit.MILLISECONDS)
                 .doOnRequest(new LongConsumer() {
                     @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -157,7 +157,7 @@ public class FlowableSwitchIfEmptyTest {
     }
     @Test
     public void testBackpressureNoRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         Flowable.<Integer>empty().switchIfEmpty(Flowable.just(1, 2, 3)).subscribe(ts);
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -165,7 +165,7 @@ public class FlowableSwitchIfEmptyTest {
     
     @Test
     public void testBackpressureOnFirstObservable() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         Flowable.just(1,2,3).switchIfEmpty(Flowable.just(4, 5, 6)).subscribe(ts);
         ts.assertNotComplete();
         ts.assertNoErrors();
@@ -174,7 +174,7 @@ public class FlowableSwitchIfEmptyTest {
     
     @Test(timeout = 10000)
     public void testRequestsNotLost() throws InterruptedException {
-        final TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        final TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.create(new Publisher<Long>() {
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -547,7 +547,7 @@ public class FlowableSwitchTest {
     
     @Test(timeout = 10000)
     public void testInitialRequestsAreAdditive() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                           .map(
@@ -566,7 +566,7 @@ public class FlowableSwitchTest {
     
     @Test(timeout = 10000)
     public void testInitialRequestsDontOverflow() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                         .map(new Function<Long, Flowable<Long>>() {
@@ -584,7 +584,7 @@ public class FlowableSwitchTest {
     
     @Test(timeout = 10000)
     public void testSecondaryRequestsDontOverflow() throws InterruptedException {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                         .map(new Function<Long, Flowable<Long>>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -206,7 +206,7 @@ public class FlowableTakeLastTimedTest {
     public void testContinuousDelivery() {
         TestScheduler scheduler = Schedulers.test();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         PublishProcessor<Integer> ps = PublishProcessor.create();
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -380,7 +380,7 @@ public class FlowableTakeTest {
     @Test
     public void testDoesntRequestMoreThanNeededFromUpstream() throws InterruptedException {
         final AtomicLong requests = new AtomicLong();
-        TestSubscriber<Long> ts = new TestSubscriber<Long>((Long)null);
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.interval(100, TimeUnit.MILLISECONDS)
             //
             .doOnRequest(new LongConsumer() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -255,7 +255,7 @@ public class FlowableTakeUntilTest {
     public void testBackpressure() {
         PublishProcessor<Integer> until = PublishProcessor.create();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         Flowable.range(1, 10).takeUntil(until).unsafeSubscribe(ts);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToObservableListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToObservableListTest.java
@@ -98,7 +98,7 @@ public class FlowableToObservableListTest {
     @Test
     public void testBackpressureHonored() {
         Flowable<List<Integer>> w = Flowable.just(1, 2, 3, 4, 5).toList();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>((Long)null);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
         
         w.subscribe(ts);
         
@@ -131,7 +131,7 @@ public class FlowableToObservableListTest {
                 Flowable<List<Integer>> sorted = source.toList();
 
                 final CyclicBarrier cb = new CyclicBarrier(2);
-                final TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>((Long)null);
+                final TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
                 sorted.subscribe(ts);
                 
                 w.schedule(new Runnable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToObservableSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToObservableSortedListTest.java
@@ -70,7 +70,7 @@ public class FlowableToObservableSortedListTest {
     @Test
     public void testBackpressureHonored() {
         Flowable<List<Integer>> w = Flowable.just(1, 3, 2, 5, 4).toSortedList();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>((Long)null);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
         
         w.subscribe(ts);
         
@@ -103,7 +103,7 @@ public class FlowableToObservableSortedListTest {
                 Flowable<List<Integer>> sorted = source.toSortedList();
 
                 final CyclicBarrier cb = new CyclicBarrier(2);
-                final TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>((Long)null);
+                final TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
                 sorted.subscribe(ts);
                 w.schedule(new Runnable() {
                     @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -292,7 +292,7 @@ public class FlowableWindowWithSizeTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testBackpressureOuterInexact() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>((Long)null);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
         
         Flowable.range(1, 5)
         .window(2, 1)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -260,7 +260,7 @@ public class FlowableWithLatestFromTest {
         
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         result.subscribe(ts);
 

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -829,7 +829,7 @@ public class ReplayProcessorTest {
         rs.onNext(3);
         rs.onComplete();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         rs.subscribe(ts);
         
@@ -858,7 +858,7 @@ public class ReplayProcessorTest {
         rs.onNext(3);
         rs.onComplete();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         rs.subscribe(ts);
         
@@ -887,7 +887,7 @@ public class ReplayProcessorTest {
         rs.onNext(3);
         rs.onComplete();
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Long)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         
         rs.subscribe(ts);
         

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -433,7 +433,7 @@ public class SingleTest {
             }
         });
 
-        TestSubscriber<String> ts = new TestSubscriber<String>((Long)null);
+        TestSubscriber<String> ts = new TestSubscriber<String>(0L);
 
         s.subscribe(ts);
 

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -161,19 +161,19 @@ public class TestSubscriberTest {
 
     @Test(expected = NullPointerException.class)
     public void testNullDelegate1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((DefaultObserver<Integer>)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(null);
         ts.onComplete();
     }
     
     @Test(expected = NullPointerException.class)
     public void testNullDelegate2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Subscriber<Integer>)null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(null);
         ts.onComplete();
     }
     
     @Test(expected = NullPointerException.class)
     public void testNullDelegate3() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>((Subscriber<Integer>)null, null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(null, 0L);
         ts.onComplete();
     }
     
@@ -200,7 +200,7 @@ public class TestSubscriberTest {
     @Test
     public void testDelegate3() {
         TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(ts1, null);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(ts1, 0L);
         ts2.onComplete();
         ts1.assertComplete();
     }


### PR DESCRIPTION
This PR adds a few operators and overloads from 1.x
- `fromAsync`
- `just` - 10 arguments
- `distinctUntilChanged(BiPredicate<? super T, ? super T> comparer)`
- `skip` timed - default scheduler
- `take` timed - default scheduler
- `toCompletable`

In addition, this PR fixes the API of TestSubscriber by making the initial value primitive `long` and having 0 as no initial request instead of the trickery with `null`.
