### PR TITLE
2.x: test sync + cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk7
 
 # force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+#addons:
+#  apt:
+#    packages:
+#      - oracle-java8-installer
+
+# prevent travis running gradle assemble; let the build script do it anyway
+install: true
       
 sudo: false
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ group = 'io.reactivex.rxjava2'
 description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'
 
 apply plugin: 'java'
-apply plugin: 'pmd'
+// apply plugin: 'pmd'
 apply plugin: 'findbugs'
 apply plugin: 'jacoco'
 apply plugin: 'ru.vyarus.animalsniffer'
@@ -84,42 +84,41 @@ jacocoTestReport {
 
 build.dependsOn jacocoTestReport
 
-pmd {
-    toolVersion = '5.4.2'
-    ignoreFailures = true
-    sourceSets = [sourceSets.main]
-    ruleSets = []
-    ruleSetFiles = files('pmd.xml')
+// pmd {
+//     toolVersion = '5.4.2'
+//     ignoreFailures = true
+//     sourceSets = [sourceSets.main]
+//     ruleSets = []
+//     ruleSetFiles = files('pmd.xml')
+// }
 
-}
+// pmdMain {
+//     reports {
+//         html.enabled = true
+//         xml.enabled = true
+//     }
+// }
 
-pmdMain {
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
+// build.dependsOn pmdMain
 
-build.dependsOn pmdMain
+// task pmdPrint(dependsOn: 'pmdMain') << {
+//     File file = new File('build/reports/pmd/main.xml')
+//     if (file.exists()) {
 
-task pmdPrint(dependsOn: 'pmdMain') << {
-    File file = new File('build/reports/pmd/main.xml')
-    if (file.exists()) {
+//         println("Listing first 100 PMD violations")
 
-        println("Listing first 100 PMD violations")
+//         file.eachLine { line, count ->
+//             if (count <= 100) {
+//                println(line)
+//             }
+//         }
 
-        file.eachLine { line, count ->
-            if (count <= 100) {
-               println(line)
-            }
-        }
+//     } else {
+//         println("PMD file not found.")
+//     }
+// }
 
-    } else {
-        println("PMD file not found.")
-    }
-}
-
-build.dependsOn pmdPrint
+// build.dependsOn pmdPrint
 
 findbugs {
     ignoreFailures true

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
   repositories { jcenter() }
-  dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:4.0.0' }
+  dependencies { 
+    classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:4.0.0' 
+    classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.1.0'
+  }
 }
 
 group = 'io.reactivex.rxjava2'
@@ -11,23 +14,43 @@ apply plugin: 'java'
 apply plugin: 'pmd'
 apply plugin: 'findbugs'
 apply plugin: 'jacoco'
+apply plugin: 'ru.vyarus.animalsniffer'
 apply plugin: 'nebula.rxjava-project'
 
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
+
     compile 'org.reactivestreams:reactive-streams:1.0.0'
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
 
     perfCompile 'org.openjdk.jmh:jmh-core:1.11.3'
     perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.11.3'
-    // perfCompile 'org.reactivex:rxjava:1.0.14'
 }
 
 javadoc {
-    exclude "**/io/reactivex/internal/**"
+    exclude "**/rx/internal/**"
+    exclude "**/test/**"
+    exclude "**/perf/**"
+    options {
+        windowTitle = "RxJava Javadoc ${project.version}"
+    }
+    // Clear the following options to make the docs consistent with the old format
+    options.addStringOption('top').value = ''
+    options.addStringOption('doctitle').value = ''
+    options.addStringOption('header').value = ''
+    if (JavaVersion.current().isJava7()) {
+        // "./gradle/stylesheet.css" only supports Java 7
+        options.addStringOption('stylesheetfile', rootProject.file('./gradle/stylesheet.css').toString())
+    }
+}
+
+animalsniffer {
+    annotation = 'io.reactivex.internal.util.SuppressAnimalSniffer'
 }
 
 // support for snapshot/final releases with the various branches RxJava uses
@@ -41,7 +64,7 @@ if (project.hasProperty('release.useLastTag')) {
 }
 
 test {
-    maxHeapSize = "2g"
+    maxHeapSize = "1200m"
 
     if (System.getenv('CI') == null) {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
@@ -112,3 +135,4 @@ findbugsMain {
         xml.enabled = true
     }
 }
+

--- a/src/main/java/io/reactivex/AsyncEmitter.java
+++ b/src/main/java/io/reactivex/AsyncEmitter.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex;
 
 import io.reactivex.disposables.Disposable;

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -93,59 +93,82 @@ public abstract class Flowable<T> implements Publisher<T> {
         return BUFFER_SIZE;
     }
 
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize, Publisher<? extends T>... sources) {
-        return combineLatest(sources, combiner, delayError, bufferSize);
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<Object[], ? extends R> combiner) {
+        return combineLatest(sources, combiner, bufferSize());
     }
 
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> combiner) {
-        return combineLatest(sources, combiner, false, bufferSize());
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatest(Function<Object[], ? extends R> combiner, Publisher<? extends T>... sources) {
+        return combineLatest(sources, combiner, bufferSize());
     }
 
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
-        return combineLatest(sources, combiner, delayError, bufferSize());
-    }
-
     @BackpressureSupport(BackpressureKind.FULL)
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         validateBufferSize(bufferSize);
-        
-        // the queue holds a pair of values so we need to double the capacity
-        int s = bufferSize << 1;
-        return new FlowableCombineLatest<T, R>(null, sources, combiner, s, delayError);
-    }
-
-    @BackpressureSupport(BackpressureKind.FULL)
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
-        return combineLatest(sources, combiner, false, bufferSize());
-    }
-
-    @BackpressureSupport(BackpressureKind.FULL)
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
-        return combineLatest(sources, combiner, delayError, bufferSize());
-    }
-
-    @BackpressureSupport(BackpressureKind.FULL)
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
-        validateBufferSize(bufferSize);
-        Objects.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
             return empty();
         }
-        // the queue holds a pair of values so we need to double the capacity
-        int s = bufferSize << 1;
-        return new FlowableCombineLatest<T, R>(sources, null, combiner, s, delayError);
+        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false);
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources, Function<Object[], ? extends R> combiner) {
+        return combineLatest(sources, combiner, bufferSize());
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources, Function<Object[], ? extends R> combiner, int bufferSize) {
+        Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        validateBufferSize(bufferSize);
+        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false);
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatestDelayError(Publisher<? extends T>[] sources, Function<Object[], ? extends R> combiner) {
+        return combineLatestDelayError(sources, combiner, bufferSize());
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatestDelayError(Function<Object[], ? extends R> combiner, Publisher<? extends T>... sources) {
+        return combineLatestDelayError(sources, combiner, bufferSize());
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatestDelayError(Publisher<? extends T>[] sources, Function<Object[], ? extends R> combiner, int bufferSize) {
+        Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        validateBufferSize(bufferSize);
+        if (sources.length == 0) {
+            return empty();
+        }
+        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true);
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatestDelayError(Iterable<? extends Publisher<? extends T>> sources, Function<Object[], ? extends R> combiner) {
+        return combineLatestDelayError(sources, combiner, bufferSize());
+    }
+
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public static <T, R> Flowable<R> combineLatestDelayError(Iterable<? extends Publisher<? extends T>> sources, Function<Object[], ? extends R> combiner, int bufferSize) {
+        Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        validateBufferSize(bufferSize);
+        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true);
     }
 
     @SuppressWarnings("unchecked")
@@ -155,7 +178,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T1> p1, Publisher<? extends T2> p2, 
             BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return combineLatest(f, false, bufferSize(), p1, p2);
+        return combineLatest(f, p1, p2);
     }
 
     @SuppressWarnings("unchecked")
@@ -165,7 +188,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T1> p1, Publisher<? extends T2> p2, 
             Publisher<? extends T3> p3, 
             Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3);
     }
 
     @SuppressWarnings("unchecked")
@@ -175,7 +198,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T1> p1, Publisher<? extends T2> p2, 
             Publisher<? extends T3> p3, Publisher<? extends T4> p4,
             Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3, p4);
     }
 
     @SuppressWarnings("unchecked")
@@ -186,7 +209,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T3> p3, Publisher<? extends T4> p4,
             Publisher<? extends T5> p5,
             Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3, p4, p5);
     }
 
     @SuppressWarnings("unchecked")
@@ -197,7 +220,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T3> p3, Publisher<? extends T4> p4,
             Publisher<? extends T5> p5, Publisher<? extends T6> p6,
             Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3, p4, p5, p6);
     }
 
     @SuppressWarnings("unchecked")
@@ -209,7 +232,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T5> p5, Publisher<? extends T6> p6,
             Publisher<? extends T7> p7,
             Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3, p4, p5, p6, p7);
     }
 
     @SuppressWarnings("unchecked")
@@ -221,7 +244,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T5> p5, Publisher<? extends T6> p6,
             Publisher<? extends T7> p7, Publisher<? extends T8> p8,
             Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @SuppressWarnings("unchecked")
@@ -234,7 +257,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<? extends T7> p7, Publisher<? extends T8> p8,
             Publisher<? extends T9> p9,
             Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
-        return combineLatest(Functions.toFunction(combiner), false, bufferSize(), p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        return combineLatest(Functions.toFunction(combiner), p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2637,7 +2637,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     public final void subscribe(Observer<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
         
-        // TODO plugin wrappings
+        observer = RxJavaPlugins.onSubscribe(this, observer);
         
         subscribeActual(observer);
     }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -824,6 +824,10 @@ public abstract class Single<T> implements SingleConsumable<T> {
         toFlowable().subscribe(s);
     }
     
+    public final void subscribe(Observer<? super T> s) {
+        toObservable().subscribe(s);
+    }
+    
     public final Single<T> subscribeOn(final Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return new SingleSubscribeOn<T>(this, scheduler);
@@ -859,6 +863,10 @@ public abstract class Single<T> implements SingleConsumable<T> {
     
     public final Flowable<T> toFlowable() {
         return new SingleToFlowable<T>(this);
+    }
+    
+    public final Observable<T> toObservable() {
+        return new SingleToObservable<T>(this);
     }
     
     public final void unsafeSubscribe(Subscriber<? super T> s) {

--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -47,10 +47,11 @@ public final class CompositeException extends RuntimeException {
 
     public CompositeException(Throwable... exceptions) {
         this.exceptions = new ArrayList<Throwable>();
-        this.message = null;
         if (exceptions == null) {
+            this.message = "1 exception occurred. ";
             this.exceptions.add(new NullPointerException("exceptions is null"));
         } else {
+            this.message = exceptions.length + " exceptions occurred. ";
             for (Throwable t : exceptions) {
                 this.exceptions.add(t != null ? t : new NullPointerException("One of the exceptions is null"));
             }
@@ -135,12 +136,12 @@ public final class CompositeException extends RuntimeException {
                 // we now have 'e' as the last in the chain
                 try {
                     chain.initCause(e);
-                } catch (Throwable t) {
+                } catch (Throwable t) { // NOPMD 
                     // ignore
                     // the javadocs say that some Throwables (depending on how they're made) will never
                     // let me call initCause without blowing up even if it returns null
                 }
-                chain = chain.getCause();
+                chain = getRootCause(chain);
             }
             cause = localCause;
         }
@@ -292,5 +293,26 @@ public final class CompositeException extends RuntimeException {
      */
     public boolean isEmpty() {
         return exceptions.isEmpty() && getCause() == null;
+    }
+    
+    /**
+     * Returns the root cause of {@code e}. If {@code e.getCause()} returns {@null} or {@code e}, just return {@code e} itself.
+     *
+     * @param e the {@link Throwable} {@code e}.
+     * @return The root cause of {@code e}. If {@code e.getCause()} returns {@null} or {@code e}, just return {@code e} itself.
+     */
+    private Throwable getRootCause(Throwable e) {
+        Throwable root = e.getCause();
+        if (root == null || root == e) {
+            return e;
+        } else {
+            while(true) {
+                Throwable cause = root.getCause();
+                if (cause == null || cause == root) {
+                    return root;
+                }
+                root = root.getCause();
+            }
+        }
     }
 }

--- a/src/main/java/io/reactivex/exceptions/OnCompleteFailedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnCompleteFailedException.java
@@ -18,7 +18,11 @@ public final class OnCompleteFailedException extends RuntimeException {
     private static final long serialVersionUID = -6179993283427447098L;
 
     public OnCompleteFailedException(Throwable cause) {
-        super(cause);
+        super(cause != null ? cause : new NullPointerException());
     }
-    
+
+    public OnCompleteFailedException(String message, Throwable cause) {
+        super(message, cause != null ? cause : new NullPointerException());
+    }
+
 }

--- a/src/main/java/io/reactivex/exceptions/OnErrorFailedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorFailedException.java
@@ -18,6 +18,10 @@ public final class OnErrorFailedException extends RuntimeException {
     private static final long serialVersionUID = 2656125445290831911L;
 
     public OnErrorFailedException(Throwable cause) {
-        super(cause);
+        super(cause != null ? cause : new NullPointerException());
+    }
+
+    public OnErrorFailedException(String message, Throwable cause) {
+        super(message, cause != null ? cause : new NullPointerException());
     }
 }

--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -17,20 +17,12 @@ public final class OnErrorNotImplementedException extends RuntimeException {
     /** */
     private static final long serialVersionUID = -3698670655303683299L;
 
-    public OnErrorNotImplementedException() {
-        super();
-    }
-
     public OnErrorNotImplementedException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public OnErrorNotImplementedException(String message) {
-        super(message);
+        super(message, cause != null ? cause : new NullPointerException());
     }
 
     public OnErrorNotImplementedException(Throwable cause) {
-        super(cause);
+        super(cause != null ? cause : new NullPointerException());
     }
     
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterator.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterator.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.Exceptions;
+
+public final class BlockingFlowableIterator<T> 
+extends AtomicReference<Subscription>
+implements Subscriber<T>, Iterator<T>, Runnable, Disposable {
+
+    /** */
+    private static final long serialVersionUID = 6695226475494099826L;
+
+    final Queue<T> queue;
+    
+    final long batchSize;
+    
+    final long limit;
+    
+    final Lock lock;
+    
+    final Condition condition;
+    
+    long produced;
+    
+    volatile boolean done;
+    Throwable error;
+
+    volatile boolean cancelled;
+    
+    public BlockingFlowableIterator(int batchSize) {
+        this.queue = new SpscLinkedArrayQueue<T>(batchSize);
+        this.batchSize = batchSize;
+        this.limit = batchSize - (batchSize >> 2);
+        this.lock = new ReentrantLock();
+        this.condition = lock.newCondition();
+    }
+
+    @Override
+    public boolean hasNext() {
+        for (;;) {
+            if (cancelled) {
+                return false;
+            }
+            boolean d = done;
+            boolean empty = queue.isEmpty();
+            if (d) {
+                Throwable e = error;
+                if (e != null) {
+                    Exceptions.propagate(e);
+                    return false;
+                } else
+                if (empty) {
+                    return false;
+                }
+            }
+            if (empty) {
+                lock.lock();
+                try {
+                    while (!cancelled && !done && queue.isEmpty()) {
+                        condition.await();
+                    }
+                } catch (InterruptedException ex) {
+                    run();
+                    Exceptions.propagate(ex);
+                    return false;
+                } finally {
+                    lock.unlock();
+                }
+            } else {
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public T next() {
+        if (hasNext()) {
+            T v = queue.poll();
+            
+            if (v == null) {
+                run();
+                
+                throw new IllegalStateException("Queue empty?!");
+            }
+            
+            long p = produced + 1;
+            if (p == limit) {
+                produced = 0;
+                get().request(p);
+            } else {
+                produced = p;
+            }
+            
+            return v;
+        }
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.setOnce(this, s)) {
+            s.request(batchSize);
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (!queue.offer(t)) {
+            SubscriptionHelper.dispose(this);
+            
+            onError(new IllegalStateException("Queue full?!"));
+        } else {
+            signalConsumer();
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        error = t;
+        done = true;
+        signalConsumer();
+    }
+
+    @Override
+    public void onComplete() {
+        done = true;
+        signalConsumer();
+    }
+    
+    void signalConsumer() {
+        lock.lock();
+        try {
+            condition.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void run() {
+        SubscriptionHelper.dispose(this);
+        signalConsumer();
+    }
+    
+    @Override // otherwise default method which isn't available in Java 7
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+    
+    @Override
+    public void dispose() {
+        SubscriptionHelper.dispose(this);
+    }
+    
+    @Override
+    public boolean isDisposed() {
+        return SubscriptionHelper.isCancelled(get());
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromAsync.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromAsync.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Queue;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -22,6 +22,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Objects;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.single;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Wraps a Single and exposes it as a Flowable.
+ *
+ * @param <T> the value type
+ */
+public final class SingleToObservable<T> extends Observable<T> {
+    
+    final SingleConsumable<? extends T> source;
+    
+    public SingleToObservable(SingleConsumable<? extends T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    public void subscribeActual(final Observer<? super T> s) {
+        source.subscribe(new SingleToObservableObserver<T>(s));
+    }
+    
+    static final class SingleToObservableObserver<T> 
+    implements SingleSubscriber<T>, Disposable {
+
+        final Observer<? super T> actual;
+        
+        Disposable d;
+        
+        public SingleToObservableObserver(Observer<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onNext(value);
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -86,8 +86,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
     }
 
     private boolean writeToQueue(final AtomicReferenceArray<Object> buffer, final T e, final long index, final int offset) {
-        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
         soElement(buffer, offset, e);// StoreStore
+        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
         return true;
     }
 
@@ -97,11 +97,11 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
         producerBuffer = newBuffer;
         producerLookAhead = currIndex + mask - 1;
-        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
         soElement(newBuffer, offset, e);// StoreStore
         soNext(oldBuffer, newBuffer);
         soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is
                                                                  // inserted
+        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
     }
 
     private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
@@ -127,8 +127,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         final Object e = lvElement(buffer, offset);// LoadLoad
         boolean isNextBuffer = e == HAS_NEXT;
         if (null != e && !isNextBuffer) {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             soElement(buffer, offset, null);// StoreStore
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             return (T) e;
         } else if (isNextBuffer) {
             return newBufferPoll(lvNext(buffer), index, mask);
@@ -145,8 +145,8 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
         if (null == n) {
             return null;
         } else {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             soElement(nextBuffer, offsetInNew, null);// StoreStore
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
             return n;
         }
     }
@@ -338,9 +338,9 @@ public final class SpscLinkedArrayQueue<T> implements Queue<T> {
             soElement(newBuffer, pi, first);
             soNext(buffer, newBuffer);
             
-            soProducerIndex(p + 2);// this ensures correctness on 32bit platforms
-            
             soElement(buffer, pi, HAS_NEXT); // new buffer is visible after element is
+
+            soProducerIndex(p + 2);// this ensures correctness on 32bit platforms
         }
 
         return true;

--- a/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
@@ -22,7 +22,7 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     
     final String prefix;
     
-    static volatile boolean CREATE_TRACE = true;
+    static volatile boolean CREATE_TRACE = false;
     
     public RxThreadFactory(String prefix) {
         this.prefix = prefix;
@@ -32,12 +32,26 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     public Thread newThread(Runnable r) {
         StringBuilder nameBuilder = new StringBuilder();
         nameBuilder.append(prefix)
+        .append('-')
         .append(incrementAndGet());
         
         if (CREATE_TRACE) {
             nameBuilder.append("\r\n");
             for (StackTraceElement se :Thread.currentThread().getStackTrace()) {
-                nameBuilder.append(se.toString()).append("\r\n");
+                String s = se.toString();
+                if (s.contains("sun.reflect.")) {
+                    continue;
+                }
+                if (s.contains("junit.runners.")) {
+                    continue;
+                }
+                if (s.contains("org.gradle.internal.")) {
+                    continue;
+                }
+                if (s.contains("java.util.concurrent.ThreadPoolExecutor")) {
+                    continue;
+                }
+                nameBuilder.append(s).append("\r\n");
             }
         }
         Thread t = new Thread(r, nameBuilder.toString());

--- a/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
@@ -22,13 +22,25 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     
     final String prefix;
     
+    static volatile boolean CREATE_TRACE = true;
+    
     public RxThreadFactory(String prefix) {
         this.prefix = prefix;
     }
     
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = new Thread(r, prefix + incrementAndGet());
+        StringBuilder nameBuilder = new StringBuilder();
+        nameBuilder.append(prefix)
+        .append(incrementAndGet());
+        
+        if (CREATE_TRACE) {
+            nameBuilder.append("\r\n");
+            for (StackTraceElement se :Thread.currentThread().getStackTrace()) {
+                nameBuilder.append(se.toString()).append("\r\n");
+            }
+        }
+        Thread t = new Thread(r, nameBuilder.toString());
         t.setDaemon(true);
         return t;
     }

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.internal.util.SuppressAnimalSniffer;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -62,9 +63,10 @@ public enum SchedulerPoolFactory {
                 
                 next.scheduleAtFixedRate(new Runnable() {
                     @Override
+                    @SuppressAnimalSniffer
                     public void run() {
                         try {
-                            for (ScheduledThreadPoolExecutor e : new ArrayList<ScheduledThreadPoolExecutor>(POOLS.keySet())) {
+                            for (ScheduledThreadPoolExecutor e : new ArrayList<ScheduledThreadPoolExecutor>(POOLS.keySet())) {  // CHM.keySet returns KeySetView in Java 8+; false positive here
                                 if (e.isShutdown()) {
                                     POOLS.remove(e);
                                 } else {

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/DeferredScalarSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/DeferredScalarSubscriber.java
@@ -67,4 +67,10 @@ implements Subscriber<T> {
             actual.onComplete();
         }
     }
+    
+    @Override
+    public void cancel() {
+        super.cancel();
+        s.cancel();
+    }
 }

--- a/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
@@ -107,6 +107,7 @@ public class DeferredScalarSubscription<T> extends BasicQueueSubscription<T> {
                 if (get() != CANCELLED) {
                     actual.onComplete();
                 }
+                lazySet(HAS_REQUEST_HAS_VALUE);
                 return;
             }
             this.value = v;

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -156,7 +156,7 @@ public enum SubscriptionHelper {
     
     /**
      * Atomically swaps in the common cancelled subscription instance
-     * and disposes the previous subscription if any.
+     * and cancels the previous subscription if any.
      * @param field the target field to dispose the contents of
      * @return true if the swap from the non-cancelled instance to the
      * common cancelled instance happened in the caller's thread (allows

--- a/src/main/java/io/reactivex/internal/util/Exceptions.java
+++ b/src/main/java/io/reactivex/internal/util/Exceptions.java
@@ -103,9 +103,7 @@ public enum Exceptions {
             if (current == null) {
                 update = exception;
             } else {
-                update = new Throwable("Multiple exceptions");
-                update.addSuppressed(current);
-                update.addSuppressed(exception);
+                update = new CompositeException(current, exception);
             }
             
             if (field.compareAndSet(current, update)) {

--- a/src/main/java/io/reactivex/internal/util/SuppressAnimalSniffer.java
+++ b/src/main/java/io/reactivex/internal/util/SuppressAnimalSniffer.java
@@ -11,14 +11,16 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.exceptions;
+package io.reactivex.internal.util;
 
-public final class UnsubscribeFailedException extends RuntimeException {
-    /** */
-    private static final long serialVersionUID = 8947024194181365640L;
+import java.lang.annotation.*;
 
-    public UnsubscribeFailedException(Throwable cause) {
-        super(cause != null ? cause : new NullPointerException());
-    }
-    
+/**
+ * Suppress errors by the AnimalSniffer plugin.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Documented
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface SuppressAnimalSniffer {
+
 }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -439,12 +439,12 @@ public final class RxJavaPlugins {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Observer<? super T> onSubscribe(Observable<T> source, Observer<? super T> subscriber) {
+    public static <T> Observer<? super T> onSubscribe(Observable<T> source, Observer<? super T> observer) {
         BiFunction<Observable, Observer, Observer> f = onObservableSubscribe;
         if (f != null) {
-            return f.apply(source, subscriber);
+            return f.apply(source, observer);
         }
-        return subscriber;
+        return observer;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.exceptions;
+
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.exceptions.CompositeException.CompositeExceptionCausalChain;
+
+public class CompositeExceptionTest {
+
+    private final Throwable ex1 = new Throwable("Ex1");
+    private final Throwable ex2 = new Throwable("Ex2", ex1);
+    private final Throwable ex3 = new Throwable("Ex3", ex2);
+
+    private CompositeException getNewCompositeExceptionWithEx123() {
+        List<Throwable> throwables = new ArrayList<Throwable>();
+        throwables.add(ex1);
+        throwables.add(ex2);
+        throwables.add(ex3);
+        return new CompositeException(throwables);
+    }
+
+    @Test(timeout = 1000)
+    public void testMultipleWithSameCause() {
+        Throwable rootCause = new Throwable("RootCause");
+        Throwable e1 = new Throwable("1", rootCause);
+        Throwable e2 = new Throwable("2", rootCause);
+        Throwable e3 = new Throwable("3", rootCause);
+        CompositeException ce = new CompositeException(Arrays.asList(e1, e2, e3));
+
+        System.err.println("----------------------------- print composite stacktrace");
+        ce.printStackTrace();
+        assertEquals(3, ce.getExceptions().size());
+        
+        assertNoCircularReferences(ce);
+        assertNotNull(getRootCause(ce));
+        System.err.println("----------------------------- print cause stacktrace");
+        ce.getCause().printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionFromParentThenChild() {
+        CompositeException cex = new CompositeException(Arrays.asList(ex1, ex2));
+        
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(2, cex.getExceptions().size());
+        
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+        
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionFromChildThenParent() {
+        CompositeException cex = new CompositeException(Arrays.asList(ex2, ex1));
+        
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(2, cex.getExceptions().size());
+        
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+        
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionFromChildAndComposite() {
+        CompositeException cex = new CompositeException(Arrays.asList(ex1, getNewCompositeExceptionWithEx123()));
+        
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(3, cex.getExceptions().size());
+        
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionFromCompositeAndChild() {
+        CompositeException cex = new CompositeException(Arrays.asList(getNewCompositeExceptionWithEx123(), ex1));
+        
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(3, cex.getExceptions().size());
+        
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionFromTwoDuplicateComposites() {
+        List<Throwable> exs = new ArrayList<Throwable>();
+        exs.add(getNewCompositeExceptionWithEx123());
+        exs.add(getNewCompositeExceptionWithEx123());
+        CompositeException cex = new CompositeException(exs);
+        
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(3, cex.getExceptions().size());
+        
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    /**
+     * This hijacks the Throwable.printStackTrace() output and puts it in a string, where we can look for
+     * "CIRCULAR REFERENCE" (a String added by Throwable.printEnclosedStackTrace)
+     */
+    private static void assertNoCircularReferences(Throwable ex) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(baos);
+        ex.printStackTrace(printStream);
+        assertFalse(baos.toString().contains("CIRCULAR REFERENCE"));
+    }
+
+    private static Throwable getRootCause(Throwable ex) {
+        Throwable root = ex.getCause();
+        if (root == null) {
+            return null;
+        } else {
+            while(true) {
+                if (root.getCause() == null) {
+                    return root;
+                } else {
+                    root = root.getCause();
+                }
+            }
+        }
+    }
+    
+    @Test
+    public void testNullCollection() {
+        CompositeException composite = new CompositeException((List<Throwable>)null);
+        composite.getCause();
+        composite.printStackTrace();
+    }
+    @Test
+    public void testNullElement() {
+        CompositeException composite = new CompositeException(Collections.singletonList((Throwable) null));
+        composite.getCause();
+        composite.printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionWithUnsupportedInitCause() {
+        Throwable t = new Throwable() {
+            /** */
+            private static final long serialVersionUID = -3282577447436848385L;
+
+            @Override
+            public synchronized Throwable initCause(Throwable cause) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        CompositeException cex = new CompositeException(Arrays.asList(t, ex1));
+
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(2, cex.getExceptions().size());
+
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    @Test(timeout = 1000)
+    public void testCompositeExceptionWithNullInitCause() {
+        Throwable t = new Throwable("ThrowableWithNullInitCause") {
+            /** */
+            private static final long serialVersionUID = -7984762607894527888L;
+
+            @Override
+            public synchronized Throwable initCause(Throwable cause) {
+                return null;
+            }
+        };
+        CompositeException cex = new CompositeException(Arrays.asList(t, ex1));
+
+        System.err.println("----------------------------- print composite stacktrace");
+        cex.printStackTrace();
+        assertEquals(2, cex.getExceptions().size());
+
+        assertNoCircularReferences(cex);
+        assertNotNull(getRootCause(cex));
+
+        System.err.println("----------------------------- print cause stacktrace");
+        cex.getCause().printStackTrace();
+    }
+
+    @Test
+    public void messageCollection() {
+        CompositeException compositeException = new CompositeException(Arrays.asList(ex1, ex3));
+        assertEquals("2 exceptions occurred. ", compositeException.getMessage());
+    }
+
+    @Test
+    public void messageVarargs() {
+        CompositeException compositeException = new CompositeException(ex1, ex2, ex3);
+        assertEquals("3 exceptions occurred. ", compositeException.getMessage());
+    }
+
+    @Test
+    public void complexCauses() {
+        Throwable e1 = new Throwable("1");
+        Throwable e2 = new Throwable("2");
+        e1.initCause(e2);
+
+        Throwable e3 = new Throwable("3");
+        Throwable e4 = new Throwable("4");
+        e3.initCause(e4);
+
+        Throwable e5 = new Throwable("5");
+        Throwable e6 = new Throwable("6");
+        e5.initCause(e6);
+
+        CompositeException compositeException = new CompositeException(e1, e3, e5);
+        assert(compositeException.getCause() instanceof CompositeExceptionCausalChain);
+
+        List<Throwable> causeChain = new ArrayList<Throwable>();
+        Throwable cause = compositeException.getCause().getCause();
+        while (cause != null) {
+            causeChain.add(cause);
+            cause = cause.getCause();
+        }
+        // The original relations
+        //
+        // e1 -> e2
+        // e3 -> e4
+        // e5 -> e6
+        //
+        // will be set to
+        //
+        // e1 -> e2 -> e3 -> e4 -> e5 -> e6
+        assertEquals(Arrays.asList(e1, e2, e3, e4, e5, e6), causeChain);
+    }
+}

--- a/src/test/java/io/reactivex/exceptions/ExceptionsNullTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsNullTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.exceptions;
+
+import org.junit.*;
+
+/**
+ * Checks the Exception classes to verify they don't crash with null argument
+ */
+public class ExceptionsNullTest {
+
+    @Test
+    public void testOnCompleteFailedExceptionNull() {
+        Throwable t = new OnCompleteFailedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnCompleteFailedExceptionMessageAndNull() {
+        Throwable t = new OnCompleteFailedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+
+    @Test
+    public void testOnErrorFailedExceptionNull() {
+        Throwable t = new OnErrorFailedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnErrorFailedExceptionMessageAndNull() {
+        Throwable t = new OnErrorFailedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testUnsubscribeFailedExceptionNull() {
+        Throwable t = new UnsubscribeFailedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Ignore("UnsubscribeFailedException will likely not be ported")
+    @Test
+    public void testUnsubscribeFailedExceptionMessageAndNull() {
+//        Throwable t = new UnsubscribeFailedException("Message", null);
+//        
+//        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+
+    @Test
+    public void testOnErrorNotImplementedExceptionNull() {
+        Throwable t = new OnErrorNotImplementedException(null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Test
+    public void testOnErrorNotImplementedExceptionMessageAndNull() {
+        Throwable t = new OnErrorNotImplementedException("Message", null);
+        
+        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Ignore("OnErrorThrowable may be ported later")
+    @Test
+    public void testOnErrorThrowableFrom() {
+//        Throwable t = OnErrorThrowable.from(null);
+//        Assert.assertTrue(t.getCause() instanceof NullPointerException);
+    }
+    
+    @Ignore("OnErrorThrowable may be ported later")
+    @Test
+    public void testOnErrorThrowableAddValueAsLastCause() {
+//        Throwable t = OnErrorThrowable.addValueAsLastCause(null, "value");
+//        Assert.assertTrue(t instanceof NullPointerException);
+    }
+
+}

--- a/src/test/java/io/reactivex/exceptions/ExceptionsNullTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsNullTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.exceptions;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.*;
+import io.reactivex.internal.util.Exceptions;
+import io.reactivex.observables.GroupedObservable;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+public class ExceptionsTest {
+    
+    @Ignore("Exceptions is not an enum")
+    @Test
+    public void constructorShouldBePrivate() {
+        TestHelper.checkUtilityClass(Exceptions.class);
+    }
+
+    @Test
+    public void testOnErrorNotImplementedIsThrown() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        
+        Observable.just(1, 2, 3).subscribe(new Consumer<Integer>() {
+
+            @Override
+            public void accept(Integer t1) {
+                throw new RuntimeException("hello");
+            }
+
+        });
+        
+        TestHelper.assertError(errors, 0, RuntimeException.class, "hello");
+        RxJavaPlugins.reset();
+    }
+
+    /**
+     * https://github.com/ReactiveX/RxJava/issues/3885
+     */
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnCompleteFailedException.class)
+    public void testOnCompletedExceptionIsThrown() {
+        Observable.empty()
+            .subscribe(new Observer<Object>() {
+                @Override
+                public void onComplete() {
+                    throw new RuntimeException();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Object o) {
+                }
+                
+                @Override
+                public void onSubscribe(Disposable d) {
+                    
+                }
+            });
+    }
+
+    @Test
+    public void testStackOverflowWouldOccur() {
+        final PublishSubject<Integer> a = PublishSubject.create();
+        final PublishSubject<Integer> b = PublishSubject.create();
+        final int MAX_STACK_DEPTH = 800;
+        final AtomicInteger depth = new AtomicInteger();
+        
+        a.subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                
+            }
+            
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                e.printStackTrace();
+            }
+
+            @Override
+            public void onNext(Integer n) {
+                b.onNext(n + 1);
+            }
+        });
+        b.subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                // TODO Auto-generated method stub
+                
+            }
+            
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                e.printStackTrace();
+            }
+
+            @Override
+            public void onNext(Integer n) {
+                if (depth.get() < MAX_STACK_DEPTH) { 
+                    depth.set(Thread.currentThread().getStackTrace().length);
+                    a.onNext(n + 1);
+                }
+            }
+        });
+        a.onNext(1);
+        assertTrue(depth.get() > MAX_STACK_DEPTH);
+    }
+    
+    @Test(expected = StackOverflowError.class)
+    public void testStackOverflowErrorIsThrown() {
+        Observable.just(1).subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                
+            }
+            
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                e.printStackTrace();
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                throw new StackOverflowError();
+            }
+
+        });
+    }
+
+    @Test(expected = ThreadDeath.class)
+    public void testThreadDeathIsThrown() {
+        Observable.just(1).subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                
+            }
+            
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                e.printStackTrace();
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                throw new ThreadDeath();
+            }
+
+        });
+    }
+
+    /**
+     * https://github.com/ReactiveX/RxJava/issues/969
+     */
+    @Ignore("v2 components should not throw")
+    @Test
+    public void testOnErrorExceptionIsThrown() {
+        try {
+            Observable.error(new IllegalArgumentException("original exception")).subscribe(new Observer<Object>() {
+
+                @Override
+                public void onSubscribe(Disposable d) {
+                    
+                }
+                
+                @Override
+                public void onComplete() {
+
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    throw new IllegalStateException("This should be thrown");
+                }
+
+                @Override
+                public void onNext(Object o) {
+
+                }
+            });
+            fail("expecting an exception to be thrown");
+        } catch (OnErrorFailedException t) {
+            CompositeException cause = (CompositeException) t.getCause();
+            assertTrue(cause.getExceptions().get(0) instanceof IllegalArgumentException);
+            assertTrue(cause.getExceptions().get(1) instanceof IllegalStateException);
+        }
+    }
+
+    /**
+     * https://github.com/ReactiveX/RxJava/issues/2998
+     * @throws Exception on arbitrary errors
+     */
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromGroupBy() throws Exception {
+        Observable
+            .just(1)
+            .groupBy(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer integer) {
+                    throw new RuntimeException();
+                }
+            })
+            .subscribe(new Observer<GroupedObservable<Integer, Integer>>() {
+                
+                @Override
+                public void onSubscribe(Disposable d) {
+                    
+                }
+                
+                @Override
+                public void onComplete() {
+
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    throw new RuntimeException();
+                }
+
+                @Override
+                public void onNext(GroupedObservable<Integer, Integer> integerIntegerGroupedObservable) {
+
+                }
+            });
+    }
+
+    /**
+     * https://github.com/ReactiveX/RxJava/issues/2998
+     * @throws Exception on arbitrary errors
+     */
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromOnNext() throws Exception {
+        Observable
+            .just(1)
+            .doOnNext(new Consumer<Integer>() {
+                @Override
+                public void accept(Integer integer) {
+                    throw new RuntimeException();
+                }
+            })
+            .subscribe(new Observer<Integer>() {
+                
+                @Override
+                public void onSubscribe(Disposable d) {
+                    
+                }
+                
+                @Override
+                public void onComplete() {
+
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    throw new RuntimeException();
+                }
+
+                @Override
+                public void onNext(Integer integer) {
+
+                }
+            });
+    }
+
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromSubscribe() {
+        Observable.create(new ObservableConsumable<Integer>() {
+                              @Override
+                              public void subscribe(Observer<? super Integer> s1) {
+                                  Observable.create(new ObservableConsumable<Integer>() {
+                                      @Override
+                                      public void subscribe(Observer<? super Integer> s2) {
+                                          throw new IllegalArgumentException("original exception");
+                                      }
+                                  }).subscribe(s1);
+                              }
+                          }
+        ).subscribe(new OnErrorFailedSubscriber());
+    }
+
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromUnsafeSubscribe() {
+        Observable.create(new ObservableConsumable<Integer>() {
+                              @Override
+                              public void subscribe(Observer<? super Integer> s1) {
+                                  Observable.create(new ObservableConsumable<Integer>() {
+                                      @Override
+                                      public void subscribe(Observer<? super Integer> s2) {
+                                          throw new IllegalArgumentException("original exception");
+                                      }
+                                  }).subscribe(s1);
+                              }
+                          }
+        ).subscribe(new OnErrorFailedSubscriber());
+    }
+
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromSingleDoOnSuccess() throws Exception {
+        Single.just(1)
+                .doOnSuccess(new Consumer<Integer>() {
+                    @Override
+                    public void accept(Integer integer) {
+                        throw new RuntimeException();
+                    }
+                })
+                .subscribe(new OnErrorFailedSubscriber());
+    }
+
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromSingleSubscribe() {
+        Single.create(new SingleConsumable<Integer>() {
+                          @Override
+                          public void subscribe(SingleSubscriber<? super Integer> s1) {
+                              Single.create(new SingleConsumable<Integer>() {
+                                  @Override
+                                  public void subscribe(SingleSubscriber<? super Integer> s2) {
+                                      throw new IllegalArgumentException("original exception");
+                                  }
+                              }).subscribe(s1);
+                          }
+                      }
+        ).subscribe(new OnErrorFailedSubscriber());
+    }
+
+    @Ignore("v2 components should not throw")
+    @Test(expected = OnErrorFailedException.class)
+    public void testOnErrorExceptionIsThrownFromSingleUnsafeSubscribe() {
+        Single.create(new SingleConsumable<Integer>() {
+                          @Override
+                          public void subscribe(final SingleSubscriber<? super Integer> s1) {
+                              Single.create(new SingleConsumable<Integer>() {
+                                  @Override
+                                  public void subscribe(SingleSubscriber<? super Integer> s2) {
+                                      throw new IllegalArgumentException("original exception");
+                                  }
+                              }).subscribe(new Subscriber<Integer>() {
+
+                                  @Override
+                                  public void onSubscribe(Subscription s) {
+                                      s.request(Long.MAX_VALUE);
+                                  }
+                                  
+                                  @Override
+                                  public void onComplete() {
+                                  }
+
+                                  @Override
+                                  public void onError(Throwable e) {
+                                      s1.onError(e);
+                                  }
+
+                                  @Override
+                                  public void onNext(Integer v) {
+                                      s1.onSuccess(v);
+                                  }
+
+                              });
+                          }
+                      }
+        ).subscribe(new OnErrorFailedSubscriber());
+    }
+
+    private class OnErrorFailedSubscriber implements Observer<Integer> {
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            
+        }
+        
+        @Override
+        public void onComplete() {
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void onNext(Integer value) {
+        }
+    }
+}

--- a/src/test/java/io/reactivex/exceptions/OnNextValueTest.java
+++ b/src/test/java/io/reactivex/exceptions/OnNextValueTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.exceptions;
+
+import static org.junit.Assert.*;
+
+import java.io.*;
+
+import org.junit.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Function;
+
+/**
+ * ```java
+ * public OnNextValue(Object value) {
+ *    super("OnError while emitting onNext value: " + value);
+ *    this.value = value;
+ * }
+ * ```
+ * I know this is probably a helpful error message in some cases but this can be a really costly operation when an objects toString is an expensive call or contains a lot of output. I don't think we should be printing this in any case but if so it should be on demand (overload of getMessage()) rather than eagerly.
+ * <p/>
+ * In my case it is causing a toString of a large context object that is normally only used for debugging purposes which makes the exception logs hard to use and they are rolling over the log files very quickly.
+ * <p/>
+ * There is an added danger that if there is a bug in the toString method it will cause inconsistent exception creation. If the object throws an exception while rendering a string it will actually end up not seeing the real exception.
+ */
+public final class OnNextValueTest {
+    private static final class BadToString {
+
+        private final boolean throwDuringToString;
+
+        private BadToString(boolean throwDuringToString) {
+            this.throwDuringToString = throwDuringToString;
+        }
+
+        @Override
+        public String toString() {
+            if (throwDuringToString) {
+                throw new IllegalArgumentException("Error Making toString");
+            } else {
+                return "BadToString";
+            }
+        }
+    }
+
+    private static class BadToStringObserver implements Observer<BadToString> {
+        @Override
+        public void onComplete() {
+            System.out.println("On Complete");
+            fail("OnComplete shouldn't be reached");
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            String trace = stackTraceAsString(e);
+            System.out.println("On Error: " + trace);
+
+            assertTrue(trace, trace.contains("OnNextValue"));
+
+            assertTrue("No Cause on throwable" + e, e.getCause() != null);
+//            assertTrue(e.getCause().getClass().getSimpleName() + " no OnNextValue",
+//                    e.getCause() instanceof OnErrorThrowable.OnNextValue);
+        }
+
+        @Override
+        public void onNext(BadToString badToString) {
+            System.out.println("On Next");
+            fail("OnNext shouldn't be reached");
+
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            
+        }
+    }
+
+    public static String stackTraceAsString(Throwable e) {
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    @Ignore("Not sure what this does")
+    @Test
+    public void addOnNextValueExceptionAdded() throws Exception {
+        Observer<BadToString> observer = new BadToStringObserver();
+
+        Observable.just(new BadToString(false))
+                .map(new Function<BadToString, BadToString>() {
+                    @Override
+                    public BadToString apply(BadToString badToString) {
+                        throw new IllegalArgumentException("Failure while handling");
+                    }
+                }).subscribe(observer);
+
+    }
+
+    @Ignore("Not sure what this does")
+    @Test
+    public void addOnNextValueExceptionNotAddedWithBadString() throws Exception {
+        Observer<BadToString> observer = new BadToStringObserver();
+
+        Observable.just(new BadToString(true))
+                .map(new Function<BadToString, BadToString>() {
+                    @Override
+                    public BadToString apply(BadToString badToString) {
+                        throw new IllegalArgumentException("Failure while handling");
+                    }
+                }).subscribe(observer);
+
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderInteger() {
+//        assertEquals("123", OnNextValue.renderValue(123));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderByte() {
+//        assertEquals("10", OnNextValue.renderValue((byte) 10));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderBoolean() {
+//        assertEquals("true", OnNextValue.renderValue(true));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderShort() {
+//        assertEquals("10", OnNextValue.renderValue((short) 10));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderLong() {
+//        assertEquals("10", OnNextValue.renderValue(10L));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderCharacter() {
+//        assertEquals("10", OnNextValue.renderValue(10L));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderFloat() {
+//        assertEquals("10.0", OnNextValue.renderValue(10.0f));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderDouble() {
+//        assertEquals("10.0", OnNextValue.renderValue(10.0));
+    }
+    
+    @Ignore("OnNextValue not ported")
+    @Test
+    public void testRenderVoid() {
+//        assertEquals("null", OnNextValue.renderValue((Void) null));
+    }
+}

--- a/src/test/java/io/reactivex/exceptions/OnNextValueTest.java
+++ b/src/test/java/io/reactivex/exceptions/OnNextValueTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/reactivex/flowable/FlowableEventStreamTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableEventStreamTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.flowable;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+
+public class FlowableEventStreamTest {
+    @Test
+    public void constructorShouldBePrivate() {
+        TestHelper.checkUtilityClass(FlowableEventStream.class);
+    }
+}

--- a/src/test/java/io/reactivex/flowable/FlowableGroupByTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableGroupByTests.java
@@ -20,6 +20,7 @@ import io.reactivex.Flowable;
 import io.reactivex.flowable.FlowableEventStream.Event;
 import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableGroupByTests {
 
@@ -83,5 +84,28 @@ public class FlowableGroupByTests {
         });
 
         System.out.println("**** finished");
+    }
+    
+    @Test
+    public void groupsCompleteAsSoonAsMainCompletes() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Flowable.range(0, 20)
+        .groupBy(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer i) {
+                return i % 5;
+            }
+        })
+        .concatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> v) {
+                return v;
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(0, 5, 10, 15, 1, 6, 11, 16, 2, 7, 12, 17, 3, 8, 13, 18, 4, 9, 14, 19);
+        ts.assertComplete();
+        ts.assertNoErrors();
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -75,38 +75,38 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void combineLatestVarargsNull() {
-        Flowable.combineLatest(new Function<Object[], Object>() {
+        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return 1;
             }
-        }, true, 128, (Publisher<Object>[])null);
+        }, (Publisher<Object>[])null);
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestVarargsOneIsNull() {
-        Flowable.combineLatest(new Function<Object[], Object>() {
+        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return 1;
             }
-        }, true, 128, Flowable.never(), null).toBlocking().lastOption();
+        }, Flowable.never(), null).toBlocking().lastOption();
     }
 
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableNull() {
-        Flowable.combineLatest((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
+        Flowable.combineLatestDelayError((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return 1;
             }
-        }, true, 128);
+        });
     }
     
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableIteratorNull() {
-        Flowable.combineLatest(new Iterable<Publisher<Object>>() {
+        Flowable.combineLatestDelayError(new Iterable<Publisher<Object>>() {
             @Override
             public Iterator<Publisher<Object>> iterator() {
                 return null;
@@ -116,52 +116,52 @@ public class FlowableNullTests {
             public Object apply(Object[] v) {
                 return 1;
             }
-        }, true, 128).toBlocking().lastOption();
+        }).toBlocking().lastOption();
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableOneIsNull() {
-        Flowable.combineLatest(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {
+        Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return 1;
             }
-        }, true, 128).toBlocking().lastOption();
+        }).toBlocking().lastOption();
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestVarargsFunctionNull() {
-        Flowable.combineLatest(null, true, 128, Flowable.never());
+        Flowable.combineLatestDelayError(null, Flowable.never());
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestVarargsFunctionReturnsNull() {
-        Flowable.combineLatest(new Function<Object[], Object>() {
+        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return null;
             }
-        }, true, 128, just1).toBlocking().lastOption();
+        }, just1).toBlocking().lastOption();
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionNull() {
-        Flowable.combineLatest(Arrays.asList(just1), null, true, 128);
+        Flowable.combineLatestDelayError(Arrays.asList(just1), null);
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionReturnsNull() {
-        Flowable.combineLatest(Arrays.asList(just1), new Function<Object[], Object>() {
+        Flowable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return null;
             }
-        }, true, 128).toBlocking().lastOption();
+        }).toBlocking().lastOption();
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
@@ -18,12 +18,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.flowables.BlockingFlowable;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 
-public class BlockingOperatorLatestTest {
+public class BlockingFlowableLatestTest {
     @Test(timeout = 1000)
     public void testSimple() {
         TestScheduler scheduler = new TestScheduler();
@@ -162,5 +162,11 @@ public class BlockingOperatorLatestTest {
         source.onComplete();
 
         Assert.assertEquals(false, it.hasNext());
+    }
+    
+    @Ignore("THe target is an enum")
+    @Test
+    public void constructorshouldbeprivate() {
+        TestHelper.checkUtilityClass(BlockingFlowableLatest.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
@@ -21,13 +21,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.BlockingFlowable;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.TestScheduler;
 
-public class BlockingOperatorMostRecentTest {
+public class BlockingFlowableMostRecentTest {
     @Test
     public void testMostRecentNull() {
         assertEquals(null, Flowable.<Void>never().toBlocking().mostRecent(null).iterator().next());
@@ -98,4 +98,11 @@ public class BlockingOperatorMostRecentTest {
         }
 
     }
+
+    @Ignore("THe target is an enum")
+    @Test
+    public void constructorshouldbeprivate() {
+        TestHelper.checkUtilityClass(BlockingFlowableMostRecent.class);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -23,14 +23,14 @@ import java.util.concurrent.atomic.*;
 import org.junit.*;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.BlockingFlowable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.Schedulers;
 
-public class BlockingOperatorNextTest {
+public class BlockingFlowableNextTest {
 
     private void fireOnNextInNewThread(final FlowProcessor<String> o, final String value) {
         new Thread() {
@@ -316,4 +316,11 @@ public class BlockingOperatorNextTest {
         assertEquals(2, BehaviorProcessor.createDefault(2).toBlocking().iterator().next().intValue());
         assertEquals(3, BehaviorProcessor.createDefault(3).toBlocking().next().iterator().next().intValue());
     }
+    
+    @Ignore("THe target is an enum")
+    @Test
+    public void constructorshouldbeprivate() {
+        TestHelper.checkUtilityClass(BlockingFlowableNext.class);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+
+public class BlockingFlowableToFutureTest {
+    @Ignore("No separate file")
+    @Test
+    public void constructorShouldBePrivate() {
+//        TestHelper.checkUtilityClass(BlockingFlowableToFuture.class);
+    }
+
+    static <T> Future<T> toFuture(Flowable<T> f) {
+        return f.toBlocking().toFuture();
+    }
+    
+    @Test
+    public void testToFuture() throws InterruptedException, ExecutionException {
+        Flowable<String> obs = Flowable.just("one");
+        Future<String> f = toFuture(obs);
+        assertEquals("one", f.get());
+    }
+
+    @Test
+    public void testToFutureList() throws InterruptedException, ExecutionException {
+        Flowable<String> obs = Flowable.just("one", "two", "three");
+        Future<List<String>> f = toFuture(obs.toList());
+        assertEquals("one", f.get().get(0));
+        assertEquals("two", f.get().get(1));
+        assertEquals("three", f.get().get(2));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testExceptionWithMoreThanOneElement() throws Throwable {
+        Flowable<String> obs = Flowable.just("one", "two");
+        Future<String> f = toFuture(obs);
+        try {
+            // we expect an exception since there are more than 1 element
+            f.get();
+        }
+        catch(ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    public void testToFutureWithException() {
+        Flowable<String> obs = Flowable.create(new Publisher<String>() {
+
+            @Override
+            public void subscribe(Subscriber<? super String> observer) {
+                observer.onSubscribe(new BooleanSubscription());
+                observer.onNext("one");
+                observer.onError(new TestException());
+            }
+        });
+
+        Future<String> f = toFuture(obs);
+        try {
+            f.get();
+            fail("expected exception");
+        } catch (Throwable e) {
+            assertEquals(TestException.class, e.getCause().getClass());
+        }
+    }
+
+    @Test(expected=CancellationException.class)
+    public void testGetAfterCancel() throws Exception {
+        Flowable<String> obs = Flowable.never();
+        Future<String> f = toFuture(obs);
+        boolean cancelled = f.cancel(true);
+        assertTrue(cancelled);  // because OperationNeverComplete never does
+        f.get();                // Future.get() docs require this to throw
+    }
+
+    @Test(expected=CancellationException.class)
+    public void testGetWithTimeoutAfterCancel() throws Exception {
+        Flowable<String> obs = Flowable.never();
+        Future<String> f = toFuture(obs);
+        boolean cancelled = f.cancel(true);
+        assertTrue(cancelled);  // because OperationNeverComplete never does
+        f.get(Long.MAX_VALUE, TimeUnit.NANOSECONDS);    // Future.get() docs require this to throw
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetWithEmptyFlowable() throws Throwable {
+        Flowable<String> obs = Flowable.empty();
+        Future<String> f = obs.toBlocking().toFuture();
+        try {
+            f.get();
+        }
+        catch(ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Ignore("null value is not allowed")
+    @Test
+    public void testGetWithASingleNullItem() throws Exception {
+        Flowable<String> obs = Flowable.just((String)null);
+        Future<String> f = obs.toBlocking().toFuture();
+        assertEquals(null, f.get());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromAsyncTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromAsyncTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators.flowable;
 
 import org.junit.*;

--- a/src/test/java/io/reactivex/internal/subscribers/flowable/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/flowable/DeferredScalarSubscriberTest.java
@@ -1,0 +1,427 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class DeferredScalarSubscriberTest {
+
+    @Test
+    public void completeFirst() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ds.onNext(1);
+
+        ts.assertNoValues();
+
+        ds.onComplete();
+        
+        ts.assertNoValues();
+        
+        ts.request(1);
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void requestFirst() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(1);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ds.onNext(1);
+
+        ts.assertNoValues();
+        
+        ds.onComplete();
+        
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void empty() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ts.assertNoValues();
+
+        ds.onComplete();
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ts.assertNoValues();
+
+        ds.onError(new TestException());
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void unsubscribeComposes() {
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        
+        ps.subscribe(ds);
+        
+        assertTrue("No subscribers?", ps.hasSubscribers());
+        
+        ts.cancel();
+        
+        ds.onNext(1);
+        ds.onComplete();
+        
+        ts.request(1);
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        assertFalse("Subscribers?", ps.hasSubscribers());
+        assertTrue("Deferred not unsubscribed?", ds.isCancelled());
+    }
+    
+    @Test
+    public void emptySource() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        Flowable.just(1).ignoreElements().subscribe(ds); // we need a producer from upstream
+        
+        ts.assertNoValues();
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void justSource() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.subscribeTo(Flowable.just(1));
+        
+        ts.assertNoValues();
+
+        ts.request(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void rangeSource() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.subscribeTo(Flowable.range(1, 10));
+        
+        ts.assertNoValues();
+
+        ts.request(1);
+        
+        ts.assertValue(10);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void completeAfterNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cancel();
+            }
+        };
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        ds.onNext(1);
+        
+        ts.assertNoValues();
+
+        ds.onComplete();
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void completeAfterNextViaRequest() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cancel();
+            }
+        };
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        ds.onNext(1);
+        ds.onComplete();
+        
+        ts.assertNoValues();
+
+        ts.request(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void doubleComplete() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ds.onNext(1);
+        
+        ts.request(1);
+        
+        ds.onComplete();
+        ds.onComplete();
+        
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void doubleComplete2() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ds.onNext(1);
+        
+        ds.onComplete();
+        ds.onComplete();
+        
+        ts.request(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void doubleRequest() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ds.onNext(1);
+        
+        ts.request(1);
+        ts.request(1);
+        
+        ds.onComplete();
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void negativeRequest() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+
+        ds.downstreamRequest(-99);
+
+        RxJavaPlugins.reset();
+        TestHelper.assertError(list, 0, IllegalArgumentException.class, "n > 0 required but it was -99");
+    }
+
+    @Test
+    public void callsAfterUnsubscribe() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+        ds.setupDownstream();
+        
+        ts.cancel();
+        
+        ds.downstreamRequest(1);
+        ds.onNext(1);
+        ds.onComplete();
+        ds.onComplete();
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+    @Test
+    public void emissionRequestRace() {
+        Worker w = Schedulers.computation().createWorker();
+        try {
+            for (int i = 0; i < 10000; i++) {
+    
+                final TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+                TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+                ds.setupDownstream();
+                ds.onNext(1);
+    
+                final AtomicInteger ready = new AtomicInteger(2);
+                
+                w.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        ready.decrementAndGet();
+                        while (ready.get() != 0) ;
+
+                        ts.request(1);
+                    }
+                });
+                
+                ready.decrementAndGet();
+                while (ready.get() != 0) ;
+                
+                ds.onComplete();
+                
+                ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+                ts.assertValues(1);
+                ts.assertNoErrors();
+                ts.assertComplete();
+    
+            }
+        } finally {
+            w.dispose();
+        }
+    }
+    
+    @Test
+    public void emissionRequestRace2() {
+        Worker w = Schedulers.io().createWorker();
+        Worker w2 = Schedulers.io().createWorker();
+        int m = 10000;
+        if (Runtime.getRuntime().availableProcessors() < 3) {
+            m = 1000;
+        }
+        try {
+            for (int i = 0; i < m; i++) {
+    
+                final TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+                TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
+                ds.setupDownstream();
+                ds.onNext(1);
+    
+                final AtomicInteger ready = new AtomicInteger(3);
+                
+                w.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        ready.decrementAndGet();
+                        while (ready.get() != 0) ;
+
+                        ts.request(1);
+                    }
+                });
+
+                w2.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        ready.decrementAndGet();
+                        while (ready.get() != 0) ;
+
+                        ts.request(1);
+                    }
+                });
+
+                ready.decrementAndGet();
+                while (ready.get() != 0) ;
+                
+                ds.onComplete();
+                
+                ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+                ts.assertValues(1);
+                ts.assertNoErrors();
+                ts.assertComplete();
+    
+            }
+        } finally {
+            w.dispose();
+            w2.dispose();
+        }
+    }
+    
+    static final class TestingDeferredScalarSubscriber extends DeferredScalarSubscriber<Integer, Integer> {
+
+        /** */
+        private static final long serialVersionUID = 6285096158319517837L;
+
+        public TestingDeferredScalarSubscriber(Subscriber<? super Integer> actual) {
+            super(actual);
+        }
+
+        @Override
+        public void onNext(Integer t) {
+            value = t;
+            hasValue = true;
+        }
+        
+        public void setupDownstream() {
+            onSubscribe(new BooleanSubscription());
+        }
+        
+        public void subscribeTo(Publisher<Integer> p) {
+            p.subscribe(this);
+        }
+        
+        public void downstreamRequest(long n) {
+            request(n);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
@@ -1,25 +1,33 @@
 /**
- * Copyright 2016 Netflix, Inc.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * 
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License is
- * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
- * the License for the specific language governing permissions and limitations under the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
-package io.reactivex.internal.operators.flowable;
+package io.reactivex.internal.util;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import org.junit.*;
 
-import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.TestHelper;
 
 public class BackpressureHelperTest {
+    @Ignore("BackpressureHelper is an enum")
+    @Test
+    public void constructorShouldBePrivate() {
+        TestHelper.checkUtilityClass(BackpressureHelper.class);
+    }
+
     @Test
     public void testAddCap() {
         assertEquals(2L, BackpressureHelper.addCap(1, 1));

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -335,7 +335,11 @@ public abstract class AbstractSchedulerTests {
                     @Override
                     public void run() {
                         if (i > 42) {
-                            observer.onComplete();
+                            try {
+                                observer.onComplete();
+                            } finally {
+                                inner.dispose();
+                            }
                             return;
                         }
 


### PR DESCRIPTION
- More unit tests ported;
- `TestObserver` cleanup and sync with `TestSubscriber`;
- fix travis to run with Java 7 instead of 8;
- added AnimalSniffer;
- cleaned up `combineLatest`, introduced `combineLatestDelayError`;
- test names are as in 1.x, please don't complain about the `test` prefix in the method names!
