### PR TITLE
1.x: merge/flatMap to keep scalar/inner element relative order

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -352,7 +352,8 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 }
             }
             if (success) {
-                if (subscriber.queue == null || subscriber.queue.isEmpty()) {
+                RxRingBuffer subscriberQueue = subscriber.queue;
+                if (subscriberQueue == null || subscriberQueue.isEmpty()) {
                     emitScalar(subscriber, value, r);
                 } else {
                     queueScalar(subscriber, value);
@@ -465,7 +466,8 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 }
             }
             if (success) {
-                if (queue == null || queue.isEmpty()) {
+                Queue<Object> mainQueue = queue;
+                if (mainQueue == null || mainQueue.isEmpty()) {
                     emitScalar(value, r);
                 } else {
                     queueScalar(value);

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -352,9 +352,15 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 }
             }
             if (success) {
-                emitScalar(subscriber, value, r);
+                if (subscriber.queue == null || subscriber.queue.isEmpty()) {
+                    emitScalar(subscriber, value, r);
+                } else {
+                    queueScalar(subscriber, value);
+                    emitLoop();
+                }
             } else {
                 queueScalar(subscriber, value);
+                emit();
             }
         }
 
@@ -383,7 +389,6 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 }
                 return;
             }
-            emit();
         }
 
         protected void emitScalar(InnerSubscriber<T> subscriber, T value, long r) {
@@ -460,9 +465,15 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 }
             }
             if (success) {
-                emitScalar(value, r);
+                if (queue == null || queue.isEmpty()) {
+                    emitScalar(value, r);
+                } else {
+                    queueScalar(value);
+                    emitLoop();
+                }
             } else {
                 queueScalar(value);
+                emit();
             }
         }
 
@@ -495,7 +506,6 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 onError(OnErrorThrowable.addValueAsLastCause(new MissingBackpressureException(), value));
                 return;
             }
-            emit();
         }
 
         protected void emitScalar(T value, long r) {


### PR DESCRIPTION
This PR changes flatmap to make sure there is no element reordering happening on the fast-paths.

Related: #4206.
