### PR TITLE
2.x: use generic type instead of Object in combineLatest and zip

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -93,22 +93,22 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize, ObservableConsumable<? extends T>... sources) {
+    public static <T, R> Observable<R> combineLatest(Function<? super T[], ? extends R> combiner, boolean delayError, int bufferSize, ObservableConsumable<? extends T>... sources) {
         return combineLatest(sources, combiner, delayError, bufferSize);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> combiner) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super T[], ? extends R> combiner) {
         return combineLatest(sources, combiner, false, bufferSize());
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super T[], ? extends R> combiner, boolean delayError) {
         return combineLatest(sources, combiner, delayError, bufferSize());
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super T[], ? extends R> combiner, boolean delayError, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         validateBufferSize(bufferSize);
@@ -119,17 +119,17 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
+    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super T[], ? extends R> combiner) {
         return combineLatest(sources, combiner, false, bufferSize());
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError) {
+    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super T[], ? extends R> combiner, boolean delayError) {
         return combineLatest(sources, combiner, delayError, bufferSize());
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, boolean delayError, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(ObservableConsumable<? extends T>[] sources, Function<? super T[], ? extends R> combiner, boolean delayError, int bufferSize) {
         validateBufferSize(bufferSize);
         Objects.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
@@ -962,7 +962,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zip(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Observable<R> zip(Iterable<? extends ObservableConsumable<? extends T>> sources, Function<? super T[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return new ObservableZip<T, R>(null, sources, zipper, bufferSize(), false);
@@ -970,7 +970,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zip(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources, final Function<Object[], R> zipper) {
+    public static <T, R> Observable<R> zip(ObservableConsumable<? extends ObservableConsumable<? extends T>> sources, final Function<T[], R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         // FIXME don't want to fiddle with manual type inference, this will be inlined later anyway
@@ -1073,7 +1073,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zipArray(Function<? super Object[], ? extends R> zipper, 
+    public static <T, R> Observable<R> zipArray(Function<? super T[], ? extends R> zipper,
             boolean delayError, int bufferSize, ObservableConsumable<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
@@ -1084,7 +1084,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zipIterable(Function<? super Object[], ? extends R> zipper,
+    public static <T, R> Observable<R> zipIterable(Function<? super T[], ? extends R> zipper,
             boolean delayError, int bufferSize, 
             Iterable<? extends ObservableConsumable<? extends T>> sources) {
         Objects.requireNonNull(zipper, "zipper is null");

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -29,13 +29,13 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class ObservableCombineLatest<T, R> extends Observable<R> {
     final ObservableConsumable<? extends T>[] sources;
     final Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable;
-    final Function<? super Object[], ? extends R> combiner;
+    final Function<? super T[], ? extends R> combiner;
     final int bufferSize;
     final boolean delayError;
     
     public ObservableCombineLatest(ObservableConsumable<? extends T>[] sources,
             Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable,
-            Function<? super Object[], ? extends R> combiner, int bufferSize,
+            Function<? super T[], ? extends R> combiner, int bufferSize,
             boolean delayError) {
         this.sources = sources;
         this.sourcesIterable = sourcesIterable;
@@ -77,11 +77,11 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         /** */
         private static final long serialVersionUID = 8567835998786448817L;
         final Observer<? super R> actual;
-        final Function<? super Object[], ? extends R> combiner;
+        final Function<? super T[], ? extends R> combiner;
         final int count;
         final CombinerSubscriber<T, R>[] subscribers;
         final int bufferSize;
-        final Object[] latest;
+        final T[] latest;
         final SpscLinkedArrayQueue<Object> queue;
         final boolean delayError;
         
@@ -96,14 +96,14 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         
         @SuppressWarnings("unchecked")
         public LatestCoordinator(Observer<? super R> actual, 
-                Function<? super Object[], ? extends R> combiner, 
+                Function<? super T[], ? extends R> combiner,
                 int count, int bufferSize, boolean delayError) {
             this.actual = actual;
             this.combiner = combiner;
             this.count = count;
             this.bufferSize = bufferSize;
             this.delayError = delayError;
-            this.latest = new Object[count];
+            this.latest = (T[])new Object[count];
             this.subscribers = new CombinerSubscriber[count];
             this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
         }
@@ -167,7 +167,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
                     return;
                 }
                 len = latest.length;
-                Object o = latest[index];
+                T o = latest[index];
                 a = active;
                 if (o == null) {
                     active = ++a;
@@ -230,7 +230,9 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
                     }
 
                     q.poll();
-                    Object[] array = (Object[])q.poll();
+
+                    @SuppressWarnings("unchecked")
+                    T[] array = (T[])q.poll();
                     
                     if (array == null) {
                         cancelled = true;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
@@ -26,13 +26,13 @@ public final class ObservableZip<T, R> extends Observable<R> {
     
     final ObservableConsumable<? extends T>[] sources;
     final Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable;
-    final Function<? super Object[], ? extends R> zipper;
+    final Function<? super T[], ? extends R> zipper;
     final int bufferSize;
     final boolean delayError;
     
     public ObservableZip(ObservableConsumable<? extends T>[] sources,
             Iterable<? extends ObservableConsumable<? extends T>> sourcesIterable,
-            Function<? super Object[], ? extends R> zipper,
+            Function<? super T[], ? extends R> zipper,
             int bufferSize,
             boolean delayError) {
         this.sources = sources;
@@ -74,21 +74,21 @@ public final class ObservableZip<T, R> extends Observable<R> {
         /** */
         private static final long serialVersionUID = 2983708048395377667L;
         final Observer<? super R> actual;
-        final Function<? super Object[], ? extends R> zipper;
+        final Function<? super T[], ? extends R> zipper;
         final ZipSubscriber<T, R>[] subscribers;
-        final Object[] row;
+        final T[] row;
         final boolean delayError;
         
         volatile boolean cancelled;
         
         @SuppressWarnings("unchecked")
         public ZipCoordinator(Observer<? super R> actual, 
-                Function<? super Object[], ? extends R> zipper, 
+                Function<? super T[], ? extends R> zipper,
                 int count, boolean delayError) {
             this.actual = actual;
             this.zipper = zipper;
             this.subscribers = new ZipSubscriber[count];
-            this.row = new Object[count];
+            this.row = (T[])new Object[count];
             this.delayError = delayError;
         }
         
@@ -140,7 +140,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
             
             final ZipSubscriber<T, R>[] zs = subscribers;
             final Observer<? super R> a = actual;
-            final Object[] os = row;
+            final T[] os = row;
             final boolean delayError = this.delayError;
             
             for (;;) {


### PR DESCRIPTION
As discussed in https://github.com/ReactiveX/RxJava/issues/1277#issuecomment-233357354

This PR gives a stricter type signature for `combineLatest`, `zip`, `zipArray` and `zipIterable`. It replaces occurrences of `Object` with its generic type `T`. In practice users will not need to type-cast arrays in the combine function anymore.
