### PR TITLE
2.x: Test sync, +groupJoin, +join, +onTerminateDetach

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -25,6 +25,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.subscribers.observable.*;
 import io.reactivex.internal.util.Exceptions;
@@ -1995,6 +1996,18 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         return new ObservableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError);
     }
 
+    @BackpressureSupport(BackpressureKind.ERROR)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <TRight, TLeftEnd, TRightEnd, R> Observable<R> groupJoin(
+            Publisher<? extends TRight> other,
+            Function<? super T, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
+            Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
+            BiFunction<? super T, ? super Observable<TRight>, ? extends R> resultSelector
+                    ) {
+        return new ObservableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+                this, other, leftEnd, rightEnd, resultSelector);
+    }
+    
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> ignoreElements() {
         return new ObservableIgnoreElements<T>(this);
@@ -2010,6 +2023,18 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
         });
     }
 
+    @BackpressureSupport(BackpressureKind.ERROR)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <TRight, TLeftEnd, TRightEnd, R> Observable<R> join(
+            Publisher<? extends TRight> other,
+            Function<? super T, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
+            Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
+            BiFunction<? super T, ? super TRight, ? extends R> resultSelector
+                    ) {
+        return new ObservableJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+                this, other, leftEnd, rightEnd, resultSelector);
+    }
+    
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> last() {
         return takeLast(1).single();

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -25,7 +25,6 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.functions.Objects;
-import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.subscribers.observable.*;
 import io.reactivex.internal.util.Exceptions;
@@ -1999,7 +1998,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <TRight, TLeftEnd, TRightEnd, R> Observable<R> groupJoin(
-            Publisher<? extends TRight> other,
+            ObservableConsumable<? extends TRight> other,
             Function<? super T, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super Observable<TRight>, ? extends R> resultSelector
@@ -2026,7 +2025,7 @@ public abstract class Observable<T> implements ObservableConsumable<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <TRight, TLeftEnd, TRightEnd, R> Observable<R> join(
-            Publisher<? extends TRight> other,
+            ObservableConsumable<? extends TRight> other,
             Function<? super T, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super TRight, ? extends R> resultSelector

--- a/src/main/java/io/reactivex/internal/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableContainer.java
@@ -20,9 +20,27 @@ import io.reactivex.disposables.Disposable;
  */
 public interface DisposableContainer {
     
+    /**
+     * Adds a disposable to this container or disposes it if the
+     * container has been disposed.
+     * @param d the disposable to add, not null
+     * @return true if successful, false if this container has been disposed
+     */
     boolean add(Disposable d);
     
+    /**
+     * Removes and disposes the given disposable if it is part of this
+     * container.
+     * @param d the disposable to remove and dispose, not null
+     * @return true if the operation was successful
+     */
     boolean remove(Disposable d);
     
+    /**
+     * Removes (but does not dispose) the given disposable if it is part of this
+     * container.
+     * @param d the disposable to remove, not null
+     * @return true if the operation was successful
+     */
     boolean delete(Disposable d);
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.subscribers.flowable.EmptyComponent;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+public final class FlowableDetach<T> extends FlowableSource<T, T> {
+
+    public FlowableDetach(Publisher<T> source) {
+        super(source);
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new DetachSubscriber<T>(s));
+    }
+    
+    static final class DetachSubscriber<T> implements Subscriber<T>, Subscription {
+        
+        Subscriber<? super T> actual;
+        
+        Subscription s;
+        
+        public DetachSubscriber(Subscriber<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            Subscription s = this.s;
+            this.s = EmptyComponent.INSTANCE;
+            this.actual = EmptyComponent.asSubscriber();
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            Subscriber<? super T> a = actual;
+            this.s = EmptyComponent.INSTANCE;
+            this.actual = EmptyComponent.asSubscriber();
+            a.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            Subscriber<? super T> a = actual;
+            this.s = EmptyComponent.INSTANCE;
+            this.actual = EmptyComponent.asSubscriber();
+            a.onComplete();
+        }
+    }
+}
+

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -202,6 +202,8 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
             if (!cancelled) {
                 cancelled = true;
 
+                s.cancel();
+                
                 if (getAndIncrement() == 0) {
                     queue.clear();
                 }
@@ -250,6 +252,7 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
                             b = it.hasNext();
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
+                            s.cancel();
                             onError(ex);
                             it = null;
                             continue;
@@ -280,6 +283,7 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
                             v = it.next();
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
+                            s.cancel();
                             onError(ex);
                             continue;
                         }
@@ -298,6 +302,7 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
                             b = it.hasNext();
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
+                            s.cancel();
                             onError(ex);
                             continue;
                         }
@@ -318,6 +323,7 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
                             empty = q.isEmpty() && it == null;
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
+                            s.cancel();
                             onError(ex);
                             empty = true;
                         }
@@ -373,11 +379,10 @@ public final class FlowableFlattenIterable<T, R> extends FlowableSource<T, R> {
 
                     a.onError(ex);
                     return true;
-                } else
-                    if (empty) {
-                        a.onComplete();
-                        return true;
-                    }
+                } else if (empty) {
+                    a.onComplete();
+                    return true;
+                }
             }
             return false;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -155,7 +155,15 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                     return;
                 }
                 
-                T t = it.next();
+                T t;
+                
+                try {
+                    t = it.next();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    a.onError(ex);
+                    return;
+                }
 
                 if (cancelled) {
                     return;
@@ -172,7 +180,18 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                     return;
                 }
 
-                if (!it.hasNext()) {
+                boolean b;
+                
+                try {
+                    b = it.hasNext();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    a.onError(ex);
+                    return;
+                }
+                
+                
+                if (!b) {
                     if (!cancelled) {
                         a.onComplete();
                     }
@@ -195,7 +214,15 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                         return;
                     }
                     
-                    T t = it.next();
+                    T t;
+                    
+                    try {
+                        t = it.next();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        a.onError(ex);
+                        return;
+                    }
 
                     if (cancelled) {
                         return;
@@ -212,7 +239,17 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                         return;
                     }
 
-                    if (!it.hasNext()) {
+                    boolean b;
+                    
+                    try {
+                        b = it.hasNext();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        a.onError(ex);
+                        return;
+                    }
+                    
+                    if (!b) {
                         if (!cancelled) {
                             a.onComplete();
                         }
@@ -229,7 +266,17 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                         return;
                     }
 
-                    if (!it.hasNext()) {
+                    boolean b;
+                    
+                    try {
+                        b = it.hasNext();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        a.onError(ex);
+                        return;
+                    }
+                    
+                    if (!b) {
                         if (!cancelled) {
                             a.onComplete();
                         }
@@ -268,7 +315,15 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                     return;
                 }
                 
-                T t = it.next();
+                T t;
+                
+                try {
+                    t = it.next();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    a.onError(ex);
+                    return;
+                }
 
                 if (cancelled) {
                     return;
@@ -285,7 +340,17 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                     return;
                 }
 
-                if (!it.hasNext()) {
+                boolean b;
+                
+                try {
+                    b = it.hasNext();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    a.onError(ex);
+                    return;
+                }
+                
+                if (!b) {
                     if (!cancelled) {
                         a.onComplete();
                     }
@@ -308,7 +373,15 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                         return;
                     }
                     
-                    T t = it.next();
+                    T t;
+                    
+                    try {
+                        t = it.next();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        a.onError(ex);
+                        return;
+                    }
 
                     if (cancelled) {
                         return;
@@ -326,7 +399,17 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                         return;
                     }
 
-                    if (!it.hasNext()) {
+                    boolean hasNext;
+                    
+                    try {
+                        hasNext = it.hasNext();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        a.onError(ex);
+                        return;
+                    }
+                    
+                    if (!hasNext) {
                         if (!cancelled) {
                             a.onComplete();
                         }
@@ -345,7 +428,17 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                         return;
                     }
 
-                    if (!it.hasNext()) {
+                    boolean hasNext;
+                    
+                    try {
+                        hasNext = it.hasNext();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        a.onError(ex);
+                        return;
+                    }
+                    
+                    if (!hasNext) {
                         if (!cancelled) {
                             a.onComplete();
                         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -1,0 +1,496 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.UnicastProcessor;
+
+public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends FlowableSource<TLeft, R> {
+
+    final Publisher<? extends TRight> other;
+    
+    final Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd;
+    
+    final Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd;
+    
+    final BiFunction<? super TLeft, ? super Flowable<TRight>, ? extends R> resultSelector;
+    
+    public FlowableGroupJoin(
+            Publisher<TLeft> source, 
+            Publisher<? extends TRight> other,
+            Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+            Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+            BiFunction<? super TLeft, ? super Flowable<TRight>, ? extends R> resultSelector) {
+        super(source);
+        this.other = other;
+        this.leftEnd = leftEnd;
+        this.rightEnd = rightEnd;
+        this.resultSelector = resultSelector;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+
+        GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent = 
+                new GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+        
+        s.onSubscribe(parent);
+        
+        LeftRightSubscriber left = new LeftRightSubscriber(parent, true);
+        parent.disposables.add(left);
+        LeftRightSubscriber right = new LeftRightSubscriber(parent, false);
+        parent.disposables.add(right);
+        
+        source.subscribe(left);
+        other.subscribe(right);
+    }
+    
+    interface JoinSupport {
+        
+        void innerError(Throwable ex);
+        
+        void innerComplete(LeftRightSubscriber sender);
+        
+        void innerValue(boolean isLeft, Object o);
+        
+        void innerClose(boolean isLeft, LeftRightEndSubscriber index);
+        
+        void innerCloseError(Throwable ex);
+    }
+    
+    static final class GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> 
+    extends AtomicInteger implements Subscription, JoinSupport {
+
+        /** */
+        private static final long serialVersionUID = -6071216598687999801L;
+
+        final Subscriber<? super R> actual;
+        
+        final AtomicLong requested;
+        
+        final SpscLinkedArrayQueue<Object> queue;
+        
+        final CompositeDisposable disposables;
+        
+        final Map<Integer, UnicastProcessor<TRight>> lefts;
+        
+        final Map<Integer, TRight> rights;
+
+        final AtomicReference<Throwable> error;
+        
+        final Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd;
+        
+        final Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd;
+        
+        final BiFunction<? super TLeft, ? super Flowable<TRight>, ? extends R> resultSelector;
+        
+        final AtomicInteger active;
+        
+        int leftIndex;
+        
+        int rightIndex;
+
+        volatile boolean cancelled;
+        
+        static final Integer LEFT_VALUE = 1;
+        
+        static final Integer RIGHT_VALUE = 2;
+        
+        static final Integer LEFT_CLOSE = 3;
+        
+        static final Integer RIGHT_CLOSE = 4;
+        
+        public GroupJoinSubscription(Subscriber<? super R> actual, Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+                Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+                        BiFunction<? super TLeft, ? super Flowable<TRight>, ? extends R> resultSelector) {
+            this.actual = actual;
+            this.requested = new AtomicLong();
+            this.disposables = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
+            this.lefts = new LinkedHashMap<Integer, UnicastProcessor<TRight>>();
+            this.rights = new LinkedHashMap<Integer, TRight>();
+            this.error = new AtomicReference<Throwable>();
+            this.leftEnd = leftEnd;
+            this.rightEnd = rightEnd;
+            this.resultSelector = resultSelector;
+            this.active = new AtomicInteger(2);
+        }
+        
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (cancelled) {
+                return;
+            }
+            cancelled = true;
+            cancelAll();
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+        
+        void cancelAll() {
+            disposables.dispose();
+        }
+        
+        void errorAll(Subscriber<?> a) {
+            Throwable ex = Exceptions.terminate(error);
+            
+            for (UnicastProcessor<TRight> up : lefts.values()) {
+                up.onError(ex);
+            }
+            
+            lefts.clear();
+            rights.clear();
+            
+            a.onError(ex);
+        }
+        
+        void fail(Throwable exc, Subscriber<?> a, Queue<?> q) {
+            Exceptions.throwIfFatal(exc);
+            Exceptions.addThrowable(error, exc);
+            q.clear();
+            cancelAll();
+            errorAll(a);
+        }
+        
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            SpscLinkedArrayQueue<Object> q = queue;
+            Subscriber<? super R> a = actual;
+            
+            for (;;) {
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+                    
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        q.clear();
+                        cancelAll();
+                        errorAll(a);
+                        return;
+                    }
+                    
+                    boolean d = active.get() == 0;
+                    
+                    Integer mode = (Integer)q.poll();
+                    
+                    boolean empty = mode == null;
+                    
+                    if (d && empty) {
+                        for (UnicastProcessor<?> up : lefts.values()) {
+                            up.onComplete();
+                        }
+
+                        lefts.clear();
+                        rights.clear();
+                        disposables.dispose();
+                        
+                        a.onComplete();
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    Object val = q.poll();
+                    
+                    if (mode == LEFT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TLeft left = (TLeft)val;
+                        
+                        UnicastProcessor<TRight> up = new UnicastProcessor<TRight>();
+                        int idx = leftIndex++;
+                        lefts.put(idx, up);
+                        
+                        Publisher<TLeftEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, true, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        R w;
+                        
+                        try {
+                            w = Objects.requireNonNull(resultSelector.apply(left, up), "The resultSelector returned a null value");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        // TODO since only left emission calls the actual, it is possible to link downstream backpressure with left's source and not error out
+                        if (requested.get() != 0L) {
+                            a.onNext(w);
+                            BackpressureHelper.produced(requested, 1);
+                        } else {
+                            fail(new MissingBackpressureException("Could not emit value due to lack of requests"), a, q);
+                            return;
+                        }
+                        
+                        for (TRight right : rights.values()) {
+                            up.onNext(right);
+                        }
+                    } 
+                    else if (mode == RIGHT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TRight right = (TRight)val;
+                        
+                        int idx = rightIndex++;
+                        
+                        rights.put(idx, right);
+                        
+                        Publisher<TRightEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, false, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        for (UnicastProcessor<TRight> up : lefts.values()) {
+                            up.onNext(right);
+                        }
+                    }
+                    else if (mode == LEFT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        UnicastProcessor<TRight> up = lefts.remove(end.index);
+                        disposables.remove(end);
+                        if (up != null) {
+                            up.onComplete();
+                        }
+                    }
+                    else if (mode == RIGHT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        rights.remove(end.index);
+                        disposables.remove(end);
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        @Override
+        public void innerError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                active.decrementAndGet();
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+        
+        @Override
+        public void innerComplete(LeftRightSubscriber sender) {
+            disposables.delete(sender);
+            active.decrementAndGet();
+            drain();
+        }
+        
+        @Override
+        public void innerValue(boolean isLeft, Object o) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_VALUE : RIGHT_VALUE, o);
+            }
+            drain();
+        }
+        
+        @Override
+        public void innerClose(boolean isLeft, LeftRightEndSubscriber index) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_CLOSE : RIGHT_CLOSE, index);
+            }
+            drain();
+        }
+        
+        @Override
+        public void innerCloseError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+    }
+    
+    static final class LeftRightSubscriber 
+    extends AtomicReference<Subscription>
+    implements Subscriber<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1883890389173668373L;
+
+        final JoinSupport parent;
+
+        final boolean isLeft;
+        
+        public LeftRightSubscriber(JoinSupport parent, boolean isLeft) {
+            this.parent = parent;
+            this.isLeft = isLeft;
+        }
+        
+        @Override
+        public void dispose() {
+            SubscriptionHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return SubscriptionHelper.isCancelled(get());
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object t) {
+            parent.innerValue(isLeft, t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.innerComplete(this);
+        }
+        
+    }
+    
+    static final class LeftRightEndSubscriber 
+    extends AtomicReference<Subscription>
+    implements Subscriber<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1883890389173668373L;
+
+        final JoinSupport parent;
+
+        final boolean isLeft;
+        
+        final int index;
+        
+        public LeftRightEndSubscriber(JoinSupport parent, 
+                boolean isLeft, int index) {
+            this.parent = parent;
+            this.isLeft = isLeft;
+            this.index = index;
+        }
+        
+        @Override
+        public void dispose() {
+            SubscriptionHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return SubscriptionHelper.isCancelled(get());
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object t) {
+            if (SubscriptionHelper.dispose(this)) {
+                parent.innerClose(isLeft, this);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.innerClose(isLeft, this);
+        }
+        
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
@@ -1,0 +1,386 @@
+package io.reactivex.internal.operators.flowable;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.flowable.FlowableGroupJoin.*;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends FlowableSource<TLeft, R> {
+
+    final Publisher<? extends TRight> other;
+    
+    final Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd;
+    
+    final Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd;
+    
+    final BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector;
+    
+    public FlowableJoin(
+            Publisher<TLeft> source, 
+            Publisher<? extends TRight> other,
+            Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+            Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+            BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
+        super(source);
+        this.other = other;
+        this.leftEnd = leftEnd;
+        this.rightEnd = rightEnd;
+        this.resultSelector = resultSelector;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+
+        GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent = 
+                new GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+        
+        s.onSubscribe(parent);
+        
+        LeftRightSubscriber left = new LeftRightSubscriber(parent, true);
+        parent.disposables.add(left);
+        LeftRightSubscriber right = new LeftRightSubscriber(parent, false);
+        parent.disposables.add(right);
+        
+        source.subscribe(left);
+        other.subscribe(right);
+    }
+    
+    static final class GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> 
+    extends AtomicInteger implements Subscription, JoinSupport {
+
+        /** */
+        private static final long serialVersionUID = -6071216598687999801L;
+
+        final Subscriber<? super R> actual;
+        
+        final AtomicLong requested;
+        
+        final SpscLinkedArrayQueue<Object> queue;
+        
+        final CompositeDisposable disposables;
+        
+        final Map<Integer, TLeft> lefts;
+        
+        final Map<Integer, TRight> rights;
+
+        final AtomicReference<Throwable> error;
+        
+        final Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd;
+        
+        final Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd;
+        
+        final BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector;
+        
+        final AtomicInteger active;
+        
+        int leftIndex;
+        
+        int rightIndex;
+
+        volatile boolean cancelled;
+        
+        static final Integer LEFT_VALUE = 1;
+        
+        static final Integer RIGHT_VALUE = 2;
+        
+        static final Integer LEFT_CLOSE = 3;
+        
+        static final Integer RIGHT_CLOSE = 4;
+        
+        public GroupJoinSubscription(Subscriber<? super R> actual, Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+                Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+                        BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
+            this.actual = actual;
+            this.requested = new AtomicLong();
+            this.disposables = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
+            this.lefts = new LinkedHashMap<Integer, TLeft>();
+            this.rights = new LinkedHashMap<Integer, TRight>();
+            this.error = new AtomicReference<Throwable>();
+            this.leftEnd = leftEnd;
+            this.rightEnd = rightEnd;
+            this.resultSelector = resultSelector;
+            this.active = new AtomicInteger(2);
+        }
+        
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (cancelled) {
+                return;
+            }
+            cancelled = true;
+            cancelAll();
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+        
+        void cancelAll() {
+            disposables.dispose();
+        }
+        
+        void errorAll(Subscriber<?> a) {
+            Throwable ex = Exceptions.terminate(error);
+            
+            lefts.clear();
+            rights.clear();
+            
+            a.onError(ex);
+        }
+        
+        void fail(Throwable exc, Subscriber<?> a, Queue<?> q) {
+            Exceptions.throwIfFatal(exc);
+            Exceptions.addThrowable(error, exc);
+            q.clear();
+            cancelAll();
+            errorAll(a);
+        }
+        
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            SpscLinkedArrayQueue<Object> q = queue;
+            Subscriber<? super R> a = actual;
+            
+            for (;;) {
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+                    
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        q.clear();
+                        cancelAll();
+                        errorAll(a);
+                        return;
+                    }
+                    
+                    boolean d = active.get() == 0;
+                    
+                    Integer mode = (Integer)q.poll();
+                    
+                    boolean empty = mode == null;
+                    
+                    if (d && empty) {
+
+                        lefts.clear();
+                        rights.clear();
+                        disposables.dispose();
+                        
+                        a.onComplete();
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    Object val = q.poll();
+                    
+                    if (mode == LEFT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TLeft left = (TLeft)val;
+                        
+                        int idx = leftIndex++;
+                        lefts.put(idx, left);
+                        
+                        Publisher<TLeftEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, true, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        long r = requested.get();
+                        long e = 0L;
+                        
+                        for (TRight right : rights.values()) {
+                            
+                            R w;
+                            
+                            try {
+                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                            } catch (Throwable exc) {
+                                fail(exc, a, q);
+                                return;
+                            }
+                            
+                            if (e != r) {
+                                a.onNext(w);
+                                
+                                e++;
+                            } else {
+                                Exceptions.addThrowable(error, new MissingBackpressureException("Could not emit value due to lack of requests"));
+                                q.clear();
+                                cancelAll();
+                                errorAll(a);
+                                return;
+                            }
+                        }
+                        
+                        if (e != 0L) {
+                            BackpressureHelper.produced(requested, e);
+                        }
+                    } 
+                    else if (mode == RIGHT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TRight right = (TRight)val;
+                        
+                        int idx = rightIndex++;
+                        
+                        rights.put(idx, right);
+                        
+                        Publisher<TRightEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, false, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        long r = requested.get();
+                        long e = 0L;
+                        
+                        for (TLeft left : lefts.values()) {
+                            
+                            R w;
+                            
+                            try {
+                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                            } catch (Throwable exc) {
+                                fail(exc, a, q);
+                                return;
+                            }
+                            
+                            if (e != r) {
+                                a.onNext(w);
+                                
+                                e++;
+                            } else {
+                                Exceptions.addThrowable(error, new MissingBackpressureException("Could not emit value due to lack of requests"));
+                                q.clear();
+                                cancelAll();
+                                errorAll(a);
+                                return;
+                            }
+                        }
+                        
+                        if (e != 0L) {
+                            BackpressureHelper.produced(requested, e);
+                        }
+                    }
+                    else if (mode == LEFT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        lefts.remove(end.index);
+                        disposables.remove(end);
+                    }
+                    else if (mode == RIGHT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        rights.remove(end.index);
+                        disposables.remove(end);
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        @Override
+        public void innerError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                active.decrementAndGet();
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+        
+        @Override
+        public void innerComplete(LeftRightSubscriber sender) {
+            disposables.delete(sender);
+            active.decrementAndGet();
+            drain();
+        }
+        
+        @Override
+        public void innerValue(boolean isLeft, Object o) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_VALUE : RIGHT_VALUE, o);
+            }
+            drain();
+        }
+        
+        @Override
+        public void innerClose(boolean isLeft, LeftRightEndSubscriber index) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_CLOSE : RIGHT_CLOSE, index);
+            }
+            drain();
+        }
+        
+        @Override
+        public void innerCloseError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -21,8 +21,6 @@ import static io.reactivex.Flowable.bufferSize;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
-import org.reactivestreams.*;
-
 import io.reactivex.Observable;
 import io.reactivex.ObservableConsumable;
 import io.reactivex.Observer;
@@ -30,9 +28,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.Objects;
-import io.reactivex.internal.operators.flowable.FlowableGroupJoin.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
@@ -96,7 +92,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
         /** */
         private static final long serialVersionUID = -6071216598687999801L;
 
-        final Subscriber<? super R> actual;
+        final Observer<? super R> actual;
         
         final SpscLinkedArrayQueue<Object> queue;
         
@@ -131,7 +127,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
         static final Integer RIGHT_CLOSE = 4;
         
         public GroupJoinSubscription(
-                Subscriber<? super R> actual, 
+                Observer<? super R> actual, 
                 Function<? super TLeft, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
                 Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
                 BiFunction<? super TLeft, ? super Observable<TRight>, ? extends R> resultSelector) {
@@ -168,7 +164,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
             disposables.dispose();
         }
         
-        void errorAll(Subscriber<?> a) {
+        void errorAll(Observer<?> a) {
             Throwable ex = Exceptions.terminate(error);
             
             for (UnicastSubject<TRight> up : lefts.values()) {
@@ -181,7 +177,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
             a.onError(ex);
         }
         
-        void fail(Throwable exc, Subscriber<?> a, Queue<?> q) {
+        void fail(Throwable exc, Observer<?> a, Queue<?> q) {
             Exceptions.throwIfFatal(exc);
             Exceptions.addThrowable(error, exc);
             q.clear();
@@ -196,7 +192,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
             
             int missed = 1;
             SpscLinkedArrayQueue<Object> q = queue;
-            Subscriber<? super R> a = actual;
+            Observer<? super R> a = actual;
             
             for (;;) {
                 for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -1,0 +1,487 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static io.reactivex.Flowable.bufferSize;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableConsumable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.flowable.FlowableGroupJoin.*;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.UnicastSubject;
+
+public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends ObservableSource<TLeft, R> {
+
+    final ObservableConsumable<? extends TRight> other;
+    
+    final Function<? super TLeft, ? extends ObservableConsumable<TLeftEnd>> leftEnd;
+    
+    final Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd;
+    
+    final BiFunction<? super TLeft, ? super Observable<TRight>, ? extends R> resultSelector;
+    
+    public ObservableGroupJoin(
+            ObservableConsumable<TLeft> source, 
+            ObservableConsumable<? extends TRight> other,
+            Function<? super TLeft, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
+            Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
+            BiFunction<? super TLeft, ? super Observable<TRight>, ? extends R> resultSelector) {
+        super(source);
+        this.other = other;
+        this.leftEnd = leftEnd;
+        this.rightEnd = rightEnd;
+        this.resultSelector = resultSelector;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> s) {
+
+        GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent = 
+                new GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+        
+        s.onSubscribe(parent);
+        
+        LeftRightSubscriber left = new LeftRightSubscriber(parent, true);
+        parent.disposables.add(left);
+        LeftRightSubscriber right = new LeftRightSubscriber(parent, false);
+        parent.disposables.add(right);
+        
+        source.subscribe(left);
+        other.subscribe(right);
+    }
+
+    interface JoinSupport {
+        
+        void innerError(Throwable ex);
+        
+        void innerComplete(LeftRightSubscriber sender);
+        
+        void innerValue(boolean isLeft, Object o);
+        
+        void innerClose(boolean isLeft, LeftRightEndSubscriber index);
+        
+        void innerCloseError(Throwable ex);
+    }
+
+    static final class GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> 
+    extends AtomicInteger implements Disposable, JoinSupport {
+
+        /** */
+        private static final long serialVersionUID = -6071216598687999801L;
+
+        final Subscriber<? super R> actual;
+        
+        final SpscLinkedArrayQueue<Object> queue;
+        
+        final CompositeDisposable disposables;
+        
+        final Map<Integer, UnicastSubject<TRight>> lefts;
+        
+        final Map<Integer, TRight> rights;
+
+        final AtomicReference<Throwable> error;
+        
+        final Function<? super TLeft, ? extends ObservableConsumable<TLeftEnd>> leftEnd;
+        
+        final Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd;
+        
+        final BiFunction<? super TLeft, ? super Observable<TRight>, ? extends R> resultSelector;
+        
+        final AtomicInteger active;
+        
+        int leftIndex;
+        
+        int rightIndex;
+
+        volatile boolean cancelled;
+        
+        static final Integer LEFT_VALUE = 1;
+        
+        static final Integer RIGHT_VALUE = 2;
+        
+        static final Integer LEFT_CLOSE = 3;
+        
+        static final Integer RIGHT_CLOSE = 4;
+        
+        public GroupJoinSubscription(
+                Subscriber<? super R> actual, 
+                Function<? super TLeft, ? extends ObservableConsumable<TLeftEnd>> leftEnd,
+                Function<? super TRight, ? extends ObservableConsumable<TRightEnd>> rightEnd,
+                BiFunction<? super TLeft, ? super Observable<TRight>, ? extends R> resultSelector) {
+            this.actual = actual;
+            this.disposables = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
+            this.lefts = new LinkedHashMap<Integer, UnicastSubject<TRight>>();
+            this.rights = new LinkedHashMap<Integer, TRight>();
+            this.error = new AtomicReference<Throwable>();
+            this.leftEnd = leftEnd;
+            this.rightEnd = rightEnd;
+            this.resultSelector = resultSelector;
+            this.active = new AtomicInteger(2);
+        }
+        
+        @Override
+        public void dispose() {
+            if (cancelled) {
+                return;
+            }
+            cancelled = true;
+            cancelAll();
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return cancelled;
+        }
+        
+        void cancelAll() {
+            disposables.dispose();
+        }
+        
+        void errorAll(Subscriber<?> a) {
+            Throwable ex = Exceptions.terminate(error);
+            
+            for (UnicastSubject<TRight> up : lefts.values()) {
+                up.onError(ex);
+            }
+            
+            lefts.clear();
+            rights.clear();
+            
+            a.onError(ex);
+        }
+        
+        void fail(Throwable exc, Subscriber<?> a, Queue<?> q) {
+            Exceptions.throwIfFatal(exc);
+            Exceptions.addThrowable(error, exc);
+            q.clear();
+            cancelAll();
+            errorAll(a);
+        }
+        
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            SpscLinkedArrayQueue<Object> q = queue;
+            Subscriber<? super R> a = actual;
+            
+            for (;;) {
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+                    
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        q.clear();
+                        cancelAll();
+                        errorAll(a);
+                        return;
+                    }
+                    
+                    boolean d = active.get() == 0;
+                    
+                    Integer mode = (Integer)q.poll();
+                    
+                    boolean empty = mode == null;
+                    
+                    if (d && empty) {
+                        for (UnicastSubject<?> up : lefts.values()) {
+                            up.onComplete();
+                        }
+
+                        lefts.clear();
+                        rights.clear();
+                        disposables.dispose();
+                        
+                        a.onComplete();
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    Object val = q.poll();
+                    
+                    if (mode == LEFT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TLeft left = (TLeft)val;
+                        
+                        UnicastSubject<TRight> up = UnicastSubject.create();
+                        int idx = leftIndex++;
+                        lefts.put(idx, up);
+                        
+                        ObservableConsumable<TLeftEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, true, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        R w;
+                        
+                        try {
+                            w = Objects.requireNonNull(resultSelector.apply(left, up), "The resultSelector returned a null value");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        a.onNext(w);
+                        
+                        for (TRight right : rights.values()) {
+                            up.onNext(right);
+                        }
+                    } 
+                    else if (mode == RIGHT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TRight right = (TRight)val;
+                        
+                        int idx = rightIndex++;
+                        
+                        rights.put(idx, right);
+                        
+                        ObservableConsumable<TRightEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, false, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        for (UnicastSubject<TRight> up : lefts.values()) {
+                            up.onNext(right);
+                        }
+                    }
+                    else if (mode == LEFT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        UnicastSubject<TRight> up = lefts.remove(end.index);
+                        disposables.remove(end);
+                        if (up != null) {
+                            up.onComplete();
+                        }
+                    }
+                    else if (mode == RIGHT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        rights.remove(end.index);
+                        disposables.remove(end);
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        @Override
+        public void innerError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                active.decrementAndGet();
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+        
+        @Override
+        public void innerComplete(LeftRightSubscriber sender) {
+            disposables.delete(sender);
+            active.decrementAndGet();
+            drain();
+        }
+        
+        @Override
+        public void innerValue(boolean isLeft, Object o) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_VALUE : RIGHT_VALUE, o);
+            }
+            drain();
+        }
+        
+        @Override
+        public void innerClose(boolean isLeft, LeftRightEndSubscriber index) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_CLOSE : RIGHT_CLOSE, index);
+            }
+            drain();
+        }
+        
+        @Override
+        public void innerCloseError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+    }
+    
+    static final class LeftRightSubscriber 
+    extends AtomicReference<Disposable>
+    implements Observer<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1883890389173668373L;
+
+        final JoinSupport parent;
+
+        final boolean isLeft;
+        
+        public LeftRightSubscriber(JoinSupport parent, boolean isLeft) {
+            this.parent = parent;
+            this.isLeft = isLeft;
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            DisposableHelper.setOnce(this, s);
+        }
+
+        @Override
+        public void onNext(Object t) {
+            parent.innerValue(isLeft, t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.innerComplete(this);
+        }
+        
+    }
+    
+    static final class LeftRightEndSubscriber 
+    extends AtomicReference<Disposable>
+    implements Observer<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1883890389173668373L;
+
+        final JoinSupport parent;
+
+        final boolean isLeft;
+        
+        final int index;
+        
+        public LeftRightEndSubscriber(JoinSupport parent, 
+                boolean isLeft, int index) {
+            this.parent = parent;
+            this.isLeft = isLeft;
+            this.index = index;
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            DisposableHelper.setOnce(this, s);
+        }
+
+        @Override
+        public void onNext(Object t) {
+            if (DisposableHelper.dispose(this)) {
+                parent.innerClose(isLeft, this);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.innerClose(isLeft, this);
+        }
+        
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
@@ -1,0 +1,502 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.flowable.FlowableSource;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends FlowableSource<TLeft, R> {
+
+    final Publisher<? extends TRight> other;
+    
+    final Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd;
+    
+    final Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd;
+    
+    final BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector;
+    
+    public ObservableJoin(
+            Publisher<TLeft> source, 
+            Publisher<? extends TRight> other,
+            Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+            Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+            BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
+        super(source);
+        this.other = other;
+        this.leftEnd = leftEnd;
+        this.rightEnd = rightEnd;
+        this.resultSelector = resultSelector;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+
+        GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent = 
+                new GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+        
+        s.onSubscribe(parent);
+        
+        LeftRightSubscriber left = new LeftRightSubscriber(parent, true);
+        parent.disposables.add(left);
+        LeftRightSubscriber right = new LeftRightSubscriber(parent, false);
+        parent.disposables.add(right);
+        
+        source.subscribe(left);
+        other.subscribe(right);
+    }
+    
+    static final class GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> 
+    extends AtomicInteger implements Subscription {
+
+        /** */
+        private static final long serialVersionUID = -6071216598687999801L;
+
+        final Subscriber<? super R> actual;
+        
+        final AtomicLong requested;
+        
+        final SpscLinkedArrayQueue<Object> queue;
+        
+        final CompositeDisposable disposables;
+        
+        final Map<Integer, TLeft> lefts;
+        
+        final Map<Integer, TRight> rights;
+
+        final AtomicReference<Throwable> error;
+        
+        final Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd;
+        
+        final Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd;
+        
+        final BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector;
+        
+        final AtomicInteger active;
+        
+        int leftIndex;
+        
+        int rightIndex;
+
+        volatile boolean cancelled;
+        
+        static final Integer LEFT_VALUE = 1;
+        
+        static final Integer RIGHT_VALUE = 2;
+        
+        static final Integer LEFT_CLOSE = 3;
+        
+        static final Integer RIGHT_CLOSE = 4;
+        
+        public GroupJoinSubscription(Subscriber<? super R> actual, Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+                Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+                        BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
+            this.actual = actual;
+            this.requested = new AtomicLong();
+            this.disposables = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
+            this.lefts = new LinkedHashMap<Integer, TLeft>();
+            this.rights = new LinkedHashMap<Integer, TRight>();
+            this.error = new AtomicReference<Throwable>();
+            this.leftEnd = leftEnd;
+            this.rightEnd = rightEnd;
+            this.resultSelector = resultSelector;
+            this.active = new AtomicInteger(2);
+        }
+        
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (cancelled) {
+                return;
+            }
+            cancelled = true;
+            cancelAll();
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+        
+        void cancelAll() {
+            disposables.dispose();
+        }
+        
+        void errorAll(Subscriber<?> a) {
+            Throwable ex = Exceptions.terminate(error);
+            
+            lefts.clear();
+            rights.clear();
+            
+            a.onError(ex);
+        }
+        
+        void fail(Throwable exc, Subscriber<?> a, Queue<?> q) {
+            Exceptions.throwIfFatal(exc);
+            Exceptions.addThrowable(error, exc);
+            q.clear();
+            cancelAll();
+            errorAll(a);
+        }
+        
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            SpscLinkedArrayQueue<Object> q = queue;
+            Subscriber<? super R> a = actual;
+            
+            for (;;) {
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+                    
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        q.clear();
+                        cancelAll();
+                        errorAll(a);
+                        return;
+                    }
+                    
+                    boolean d = active.get() == 0;
+                    
+                    Integer mode = (Integer)q.poll();
+                    
+                    boolean empty = mode == null;
+                    
+                    if (d && empty) {
+
+                        lefts.clear();
+                        rights.clear();
+                        disposables.dispose();
+                        
+                        a.onComplete();
+                        return;
+                    }
+                    
+                    if (empty) {
+                        break;
+                    }
+                    
+                    Object val = q.poll();
+                    
+                    if (mode == LEFT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TLeft left = (TLeft)val;
+                        
+                        int idx = leftIndex++;
+                        lefts.put(idx, left);
+                        
+                        Publisher<TLeftEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, true, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        long r = requested.get();
+                        long e = 0L;
+                        
+                        for (TRight right : rights.values()) {
+                            
+                            R w;
+                            
+                            try {
+                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                            } catch (Throwable exc) {
+                                fail(exc, a, q);
+                                return;
+                            }
+                            
+                            if (e != r) {
+                                a.onNext(w);
+                                
+                                e++;
+                            } else {
+                                Exceptions.addThrowable(error, new MissingBackpressureException("Could not emit value due to lack of requests"));
+                                q.clear();
+                                cancelAll();
+                                errorAll(a);
+                                return;
+                            }
+                        }
+                        
+                        if (e != 0L) {
+                            BackpressureHelper.produced(requested, e);
+                        }
+                    } 
+                    else if (mode == RIGHT_VALUE) {
+                        @SuppressWarnings("unchecked")
+                        TRight right = (TRight)val;
+                        
+                        int idx = rightIndex++;
+                        
+                        rights.put(idx, right);
+                        
+                        Publisher<TRightEnd> p;
+                        
+                        try {
+                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                        } catch (Throwable exc) {
+                            fail(exc, a, q);
+                            return;
+                        }
+                        
+                        LeftRightEndSubscriber end = new LeftRightEndSubscriber(this, false, idx);
+                        disposables.add(end);
+                        
+                        p.subscribe(end);
+                        
+                        ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            cancelAll();
+                            errorAll(a);
+                            return;
+                        }
+                        
+                        long r = requested.get();
+                        long e = 0L;
+                        
+                        for (TLeft left : lefts.values()) {
+                            
+                            R w;
+                            
+                            try {
+                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                            } catch (Throwable exc) {
+                                fail(exc, a, q);
+                                return;
+                            }
+                            
+                            if (e != r) {
+                                a.onNext(w);
+                                
+                                e++;
+                            } else {
+                                Exceptions.addThrowable(error, new MissingBackpressureException("Could not emit value due to lack of requests"));
+                                q.clear();
+                                cancelAll();
+                                errorAll(a);
+                                return;
+                            }
+                        }
+                        
+                        if (e != 0L) {
+                            BackpressureHelper.produced(requested, e);
+                        }
+                    }
+                    else if (mode == LEFT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        lefts.remove(end.index);
+                        disposables.remove(end);
+                    }
+                    else if (mode == RIGHT_CLOSE) {
+                        LeftRightEndSubscriber end = (LeftRightEndSubscriber)val;
+                        
+                        rights.remove(end.index);
+                        disposables.remove(end);
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+        
+        void innerError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                active.decrementAndGet();
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+        
+        void innerComplete(LeftRightSubscriber sender) {
+            disposables.delete(sender);
+            active.decrementAndGet();
+            drain();
+        }
+        
+        void innerValue(boolean isLeft, Object o) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_VALUE : RIGHT_VALUE, o);
+            }
+            drain();
+        }
+        
+        void innerClose(boolean isLeft, LeftRightEndSubscriber index) {
+            synchronized (this) {
+                queue.offer(isLeft ? LEFT_CLOSE : RIGHT_CLOSE, index);
+            }
+            drain();
+        }
+        
+        void innerCloseError(Throwable ex) {
+            if (Exceptions.addThrowable(error, ex)) {
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+    }
+    
+    static final class LeftRightSubscriber 
+    extends AtomicReference<Subscription>
+    implements Subscriber<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1883890389173668373L;
+
+        final GroupJoinSubscription<?, ?, ?, ?, ?> parent;
+
+        final boolean isLeft;
+        
+        public LeftRightSubscriber(GroupJoinSubscription<?, ?, ?, ?, ?> parent, boolean isLeft) {
+            this.parent = parent;
+            this.isLeft = isLeft;
+        }
+        
+        @Override
+        public void dispose() {
+            SubscriptionHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return SubscriptionHelper.isCancelled(get());
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object t) {
+            parent.innerValue(isLeft, t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.innerComplete(this);
+        }
+        
+    }
+    
+    static final class LeftRightEndSubscriber 
+    extends AtomicReference<Subscription>
+    implements Subscriber<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1883890389173668373L;
+
+        final GroupJoinSubscription<?, ?, ?, ?, ?> parent;
+
+        final boolean isLeft;
+        
+        final int index;
+        
+        public LeftRightEndSubscriber(GroupJoinSubscription<?, ?, ?, ?, ?> parent, 
+                boolean isLeft, int index) {
+            this.parent = parent;
+            this.isLeft = isLeft;
+            this.index = index;
+        }
+        
+        @Override
+        public void dispose() {
+            SubscriptionHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return SubscriptionHelper.isCancelled(get());
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object t) {
+            if (SubscriptionHelper.dispose(this)) {
+                parent.innerClose(isLeft, this);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.innerClose(isLeft, this);
+        }
+        
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/EmptyComponent.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/EmptyComponent.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Singleton implementing many interfaces as empty.
+ */
+public enum EmptyComponent implements Subscriber<Object>, Observer<Object>, Subscription, Disposable {
+    INSTANCE;
+
+    @SuppressWarnings("unchecked")
+    public static <T> Subscriber<T> asSubscriber() {
+        return (Subscriber<T>)INSTANCE;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Observer<T> asObserver() {
+        return (Observer<T>)INSTANCE;
+    }
+    
+    @Override
+    public void dispose() {
+        // deliberately no-op
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return true;
+    }
+
+    @Override
+    public void request(long n) {
+        // deliberately no-op
+    }
+
+    @Override
+    public void cancel() {
+        // deliberately no-op
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+        d.dispose();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.cancel();
+    }
+
+    @Override
+    public void onNext(Object t) {
+        // deliberately no-op
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        RxJavaPlugins.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+        // deliberately no-op
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -1,0 +1,277 @@
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableConcatDelayErrorTest {
+
+    @Test
+    public void mainCompletes() {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        source.concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.range(v, 2);
+            }
+        }).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+        
+        ts.assertValues(1, 2, 2, 3);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void mainErrors() {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        source.concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.range(v, 2);
+            }
+        }).subscribe(ts);
+        
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+        
+        ts.assertValues(1, 2, 2, 3);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void innerErrors() {
+        final Flowable<Integer> inner = Flowable.range(1, 2)
+                .concatWith(Flowable.<Integer>error(new TestException()));
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return inner;
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(1, 2, 1, 2, 1, 2);
+        ts.assertError(CompositeException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void singleInnerErrors() {
+        final Flowable<Integer> inner = Flowable.range(1, 2).concatWith(Flowable.<Integer>error(new TestException()));
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return inner;
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerNull() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return null;
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(NullPointerException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerThrows() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                throw new TestException();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerWithEmpty() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.range(1, 3)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2);
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(1, 2, 1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void innerWithScalar() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.range(1, 3)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return v == 2 ? Flowable.just(3) : Flowable.range(1, 2);
+            }
+        }).subscribe(ts);
+        
+        ts.assertValues(1, 2, 3, 1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void backpressure() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.range(v, 2);
+            }
+        }).subscribe(ts);
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(1);
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        ts.request(3);
+        ts.assertValues(1, 2, 2, 3);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        ts.request(2);
+        
+        ts.assertValues(1, 2, 2, 3, 3, 4);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    static <T> Flowable<T> withError(Flowable<T> source) {
+        return source.concatWith(Flowable.<T>error(new TestException()));
+    }
+    
+
+    @Test
+    public void concatDelayErrorFlowable() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Flowable.concatDelayError(
+                Flowable.just(Flowable.just(1), Flowable.just(2)))
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void concatDelayErrorFlowableError() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Flowable.concatDelayError(
+                withError(Flowable.just(withError(Flowable.just(1)), withError(Flowable.just(2)))))
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertError(CompositeException.class);
+        ts.assertNotComplete();
+        
+        CompositeException ce = (CompositeException)ts.errors().get(0);
+        List<Throwable> cex = ce.getExceptions();
+        
+        assertEquals(2, cex.size());
+        
+        assertTrue(cex.get(0).toString(), cex.get(0) instanceof CompositeException);
+        assertTrue(cex.get(1).toString(), cex.get(1) instanceof TestException);
+        
+        ce = (CompositeException)cex.get(0);
+        cex = ce.getExceptions();
+        
+        assertTrue(cex.get(0).toString(), cex.get(0) instanceof TestException);
+        assertTrue(cex.get(1).toString(), cex.get(1) instanceof TestException);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayErrorIterable() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Flowable.concatDelayError(
+                Arrays.asList(Flowable.just(1), Flowable.just(2)))
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayErrorIterableError() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Flowable.concatDelayError(
+                Arrays.asList(withError(Flowable.just(1)), withError(Flowable.just(2))))
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertError(CompositeException.class);
+        ts.assertNotComplete();
+        
+        assertEquals(2, ((CompositeException)ts.errors().get(0)).getExceptions().size());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subscribers.TestSubscriber;
+
+
+public class FlowableDetachTest {
+
+    Object o;
+    
+    @Test
+    public void just() throws Exception {
+        o = new Object();
+        
+        WeakReference<Object> wr = new WeakReference<Object>(o);
+        
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        
+        Flowable.just(o).count().onTerminateDetach().subscribe(ts);
+        
+        ts.assertValue(1L);
+        ts.assertComplete();
+        ts.assertNoErrors();
+        
+        o = null;
+        
+        System.gc();
+        Thread.sleep(200);
+        
+        Assert.assertNull("Object retained!", wr.get());
+        
+    }
+    
+    @Test
+    public void error() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        
+        Flowable.error(new TestException()).onTerminateDetach().subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void empty() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        
+        Flowable.empty().onTerminateDetach().subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void range() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        
+        Flowable.range(1, 1000).onTerminateDetach().subscribe(ts);
+        
+        ts.assertValueCount(1000);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    
+    @Test
+    public void backpressured() throws Exception {
+        o = new Object();
+        
+        WeakReference<Object> wr = new WeakReference<Object>(o);
+        
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+        
+        Flowable.just(o).count().onTerminateDetach().subscribe(ts);
+
+        ts.assertNoValues();
+
+        ts.request(1);
+        
+        ts.assertValue(1L);
+        ts.assertComplete();
+        ts.assertNoErrors();
+        
+        o = null;
+        
+        System.gc();
+        Thread.sleep(200);
+        
+        Assert.assertNull("Object retained!", wr.get());
+    }
+
+    @Test
+    public void justUnsubscribed() throws Exception {
+        o = new Object();
+        
+        WeakReference<Object> wr = new WeakReference<Object>(o);
+        
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
+        
+        Flowable.just(o).count().onTerminateDetach().subscribe(ts);
+        
+        ts.cancel();
+        o = null;
+        
+        System.gc();
+        Thread.sleep(200);
+        
+        Assert.assertNull("Object retained!", wr.get());
+        
+    }
+
+    @Test
+    public void deferredUpstreamProducer() {
+        final AtomicReference<Subscriber<? super Object>> subscriber = new AtomicReference<Subscriber<? super Object>>();
+        
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
+        
+        Flowable.create(new Publisher<Object>() {
+            @Override
+            public void subscribe(Subscriber<? super Object> t) {
+                subscriber.set(t);
+            }
+        }).onTerminateDetach().subscribe(ts);
+        
+        ts.request(2);
+        
+        new FlowableRange(1, 3).subscribe(subscriber.get());
+        
+        ts.assertValues(1, 2);
+        
+        ts.request(1);
+        
+        ts.assertValues(1, 2, 3);
+        ts.assertComplete();
+        ts.assertNoErrors();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -13,18 +13,21 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.Arrays;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableFlattenIterableTest {
 
     @Test
-    public void normal() {
+    public void normal0() {
         
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         
@@ -46,5 +49,499 @@ public class FlowableFlattenIterableTest {
         ts.assertValues(2, 3)
         .assertNoErrors()
         .assertComplete();
+    }
+    
+    final Function<Integer, Iterable<Integer>> mapper = new Function<Integer, Iterable<Integer>>() {
+        @Override
+        public Iterable<Integer> apply(Integer v) {
+            return Arrays.asList(v, v + 1);
+        }
+    };
+    
+    @Test
+    public void normal() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.range(1, 5).concatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void normalViaFlatMap() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.range(1, 5).flatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void normalBackpressured() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        
+        Flowable.range(1, 5).concatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(2);
+        
+        ts.assertValues(1, 2, 2);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        
+        ts.request(7);
+        
+        ts.assertValues(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void longRunning() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        int n = 1000 * 1000;
+        
+        Flowable.range(1, n).concatMapIterable(mapper)
+        .subscribe(ts);
+
+        ts.assertValueCount(n * 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void asIntermediate() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        int n = 1000 * 1000;
+        
+        Flowable.range(1, n).concatMapIterable(mapper).concatMap(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.just(v);
+            }
+        })
+        .subscribe(ts);
+
+        ts.assertValueCount(n * 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void just() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.just(1).concatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void justHidden() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.just(1).hide().concatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void empty() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.<Integer>empty().concatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void error() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.<Integer>just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .concatMapIterable(mapper)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void iteratorHasNextThrowsImmediately() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        throw new TestException();
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+        
+        Flowable.range(1, 2)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return it;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void iteratorHasNextThrowsImmediatelyJust() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        throw new TestException();
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+        
+        Flowable.just(1)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return it;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void iteratorHasNextThrowsSecondCall() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    int count;
+                    @Override
+                    public boolean hasNext() {
+                        if (++count >= 2) {
+                            throw new TestException();
+                        }
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+        
+        Flowable.range(1, 2)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return it;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void iteratorNextThrows() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        throw new TestException();
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+        
+        Flowable.range(1, 2)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return it;
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void iteratorNextThrowsAndUnsubscribes() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        throw new TestException();
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+        
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+        
+        ps
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return it;
+            }
+        })
+        .unsafeSubscribe(ts);
+        
+        ps.onNext(1);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+        
+        Assert.assertFalse("PublishProcessor has Subscribers?!", ps.hasSubscribers());
+    }
+
+    @Test
+    public void mixture() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.range(0, 1000)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return (v % 2) == 0 ? Collections.singleton(1) : Collections.<Integer>emptySet();
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValueCount(500);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void emptyInnerThenSingleBackpressured() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        
+        Flowable.range(1, 2)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return v == 2 ? Collections.singleton(1) : Collections.<Integer>emptySet();
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void manyEmptyInnerThenSingleBackpressured() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        
+        Flowable.range(1, 1000)
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return v == 1000 ? Collections.singleton(1) : Collections.<Integer>emptySet();
+            }
+        })
+        .subscribe(ts);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void hasNextIsNotCalledAfterChildUnsubscribedOnNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        final AtomicInteger counter = new AtomicInteger();
+        
+        final Iterable<Integer> it = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        counter.getAndIncrement();
+                        return true;
+                    }
+                    
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+                    
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+        
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+        
+        ps
+        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return it;
+            }
+        })
+        .take(1)
+        .unsafeSubscribe(ts);
+        
+        ps.onNext(1);
+        
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+        
+        Assert.assertFalse("PublishProcessor has Subscribers?!", ps.hasSubscribers());
+        Assert.assertEquals(1, counter.get());
+    }
+    
+    @Test
+    public void normalPrefetchViaFlatMap() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        Flowable.range(1, 5).flatMapIterable(mapper, 2)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void withResultSelectorMaxConcurrent() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Flowable.range(1, 5)
+        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) {
+                return Collections.singletonList(1);
+            }
+        }, new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) {
+                return a * 10 + b;
+            }
+        }, 2)
+        .subscribe(ts)
+        ;
+        
+        ts.assertValues(11, 21, 31, 41, 51);
+        ts.assertNoErrors();
+        ts.assertComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.junit.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableFromArrayTest {
+    
+    Flowable<Integer> create(int n) {
+        Integer[] array = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            array[i] = i;
+        }
+        return Flowable.fromArray(array);
+    }
+    @Test
+    public void simple() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        create(1000).subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(1000);
+        ts.assertComplete();
+    }
+
+    @Test
+    public void backpressure() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        create(1000).subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        
+        ts.request(10);
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(10);
+        ts.assertNotComplete();
+        
+        ts.request(1000);
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(1000);
+        ts.assertComplete();
+    }
+
+    @Test
+    public void empty() {
+        Assert.assertSame(Flowable.empty(), Flowable.fromArray(new Object[0]));
+    }
+
+    @Test
+    public void just() {
+        Flowable<Integer> source = Flowable.fromArray(new Integer[] { 1 });
+        Assert.assertTrue(source.getClass().toString(), source instanceof ScalarCallable);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromCallableTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableFromCallableTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotInvokeFuncUntilSubscription() throws Exception {
+        Callable<Object> func = mock(Callable.class);
+
+        when(func.call()).thenReturn(new Object());
+
+        Flowable<Object> fromCallableFlowable = Flowable.fromCallable(func);
+
+        verifyZeroInteractions(func);
+
+        fromCallableFlowable.subscribe();
+
+        verify(func).call();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldCallOnNextAndOnCompleted() throws Exception {
+        Callable<String> func = mock(Callable.class);
+
+        when(func.call()).thenReturn("test_value");
+
+        Flowable<String> fromCallableFlowable = Flowable.fromCallable(func);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+
+        fromCallableFlowable.subscribe(observer);
+
+        verify(observer).onNext("test_value");
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldCallOnError() throws Exception {
+        Callable<Object> func = mock(Callable.class);
+
+        Throwable throwable = new IllegalStateException("Test exception");
+        when(func.call()).thenThrow(throwable);
+
+        Flowable<Object> fromCallableFlowable = Flowable.fromCallable(func);
+
+        Subscriber<Object> observer = TestHelper.mockSubscriber();
+
+        fromCallableFlowable.subscribe(observer);
+
+        verify(observer, never()).onNext(anyObject());
+        verify(observer, never()).onComplete();
+        verify(observer).onError(throwable);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotDeliverResultIfSubscriberUnsubscribedBeforeEmission() throws Exception {
+        Callable<String> func = mock(Callable.class);
+
+        final CountDownLatch funcLatch = new CountDownLatch(1);
+        final CountDownLatch observerLatch = new CountDownLatch(1);
+
+        when(func.call()).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                observerLatch.countDown();
+
+                try {
+                    funcLatch.await();
+                } catch (InterruptedException e) {
+                    // It's okay, unsubscription causes Thread interruption
+
+                    // Restoring interruption status of the Thread
+                    Thread.currentThread().interrupt();
+                }
+
+                return "should_not_be_delivered";
+            }
+        });
+
+        Flowable<String> fromCallableFlowable = Flowable.fromCallable(func);
+
+        Subscriber<String> observer = TestHelper.mockSubscriber();
+        
+        TestSubscriber<String> outer = new TestSubscriber<String>(observer);
+
+        fromCallableFlowable
+                .subscribeOn(Schedulers.computation())
+                .subscribe(outer);
+
+        // Wait until func will be invoked
+        observerLatch.await();
+
+        // Unsubscribing before emission
+        outer.cancel();
+
+        // Emitting result
+        funcLatch.countDown();
+
+        // func must be invoked
+        verify(func).call();
+
+        // Observer must not be notified at all
+        verify(observer).onSubscribe(any(Subscription.class));
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void shouldAllowToThrowCheckedException() {
+        final Exception checkedException = new Exception("test exception");
+
+        Flowable<Object> fromCallableFlowable = Flowable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw checkedException;
+            }
+        });
+
+        Subscriber<Object> observer = TestHelper.mockSubscriber();
+
+        fromCallableFlowable.subscribe(observer);
+
+        verify(observer).onSubscribe(any(Subscription.class));
+        verify(observer).onError(checkedException);
+        verifyNoMoreInteractions(observer);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -1,0 +1,360 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+
+import org.junit.*;
+import org.mockito.MockitoAnnotations;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+import io.reactivex.processors.PublishProcessor;
+
+public class FlowableGroupJoinTest {
+
+    Subscriber<Object> observer = TestHelper.mockSubscriber();
+
+    BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer t1, Integer t2) {
+            return t1 + t2;
+        }
+    };
+
+    <T> Function<Integer, Flowable<T>> just(final Flowable<T> observable) {
+        return new Function<Integer, Flowable<T>>() {
+            @Override
+            public Flowable<T> apply(Integer t1) {
+                return observable;
+            }
+        };
+    }
+
+    <T, R> Function<T, Flowable<R>> just2(final Flowable<R> observable) {
+        return new Function<T, Flowable<R>>() {
+            @Override
+            public Flowable<R> apply(T t1) {
+                return observable;
+            }
+        };
+    }
+
+    BiFunction<Integer, Flowable<Integer>, Flowable<Integer>> add2 = new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
+        @Override
+        public Flowable<Integer> apply(final Integer leftValue, Flowable<Integer> rightValues) {
+            return rightValues.map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer rightValue) {
+                    return add.apply(leftValue, rightValue);
+                }
+            });
+        }
+
+    };
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void behaveAsJoin() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> m = Flowable.merge(source1.groupJoin(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add2));
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source1.onNext(4);
+
+        source2.onNext(16);
+        source2.onNext(32);
+        source2.onNext(64);
+
+        source1.onComplete();
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(20);
+        verify(observer, times(1)).onNext(33);
+        verify(observer, times(1)).onNext(34);
+        verify(observer, times(1)).onNext(36);
+        verify(observer, times(1)).onNext(65);
+        verify(observer, times(1)).onNext(66);
+        verify(observer, times(1)).onNext(68);
+
+        verify(observer, times(1)).onComplete(); //Never emitted?
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    class Person {
+        final int id;
+        final String name;
+
+        public Person(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    class PersonFruit {
+        final int personId;
+        final String fruit;
+
+        public PersonFruit(int personId, String fruit) {
+            this.personId = personId;
+            this.fruit = fruit;
+        }
+    }
+
+    class PPF {
+        final Person person;
+        final Flowable<PersonFruit> fruits;
+
+        public PPF(Person person, Flowable<PersonFruit> fruits) {
+            this.person = person;
+            this.fruits = fruits;
+        }
+    }
+
+    @Test
+    public void normal1() {
+        Flowable<Person> source1 = Flowable.fromIterable(Arrays.asList(
+                new Person(1, "Joe"),
+                new Person(2, "Mike"),
+                new Person(3, "Charlie")
+                ));
+
+        Flowable<PersonFruit> source2 = Flowable.fromIterable(Arrays.asList(
+                new PersonFruit(1, "Strawberry"),
+                new PersonFruit(1, "Apple"),
+                new PersonFruit(3, "Peach")
+                ));
+
+        Flowable<PPF> q = source1.groupJoin(
+                source2,
+                just2(Flowable.<Object> never()),
+                just2(Flowable.<Object> never()),
+                new BiFunction<Person, Flowable<PersonFruit>, PPF>() {
+                    @Override
+                    public PPF apply(Person t1, Flowable<PersonFruit> t2) {
+                        return new PPF(t1, t2);
+                    }
+                });
+
+        q.subscribe(
+                new Subscriber<PPF>() {
+                    @Override
+                    public void onNext(final PPF ppf) {
+                        ppf.fruits.filter(new Predicate<PersonFruit>() {
+                            @Override
+                            public boolean test(PersonFruit t1) {
+                                return ppf.person.id == t1.personId;
+                            }
+                        }).subscribe(new Consumer<PersonFruit>() {
+                            @Override
+                            public void accept(PersonFruit t1) {
+                                observer.onNext(Arrays.asList(ppf.person.name, t1.fruit));
+                            }
+                        });
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        observer.onError(e);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        observer.onComplete();
+                    }
+                    
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        s.request(Long.MAX_VALUE);
+                    }
+
+                }
+                );
+
+        verify(observer, times(1)).onNext(Arrays.asList("Joe", "Strawberry"));
+        verify(observer, times(1)).onNext(Arrays.asList("Joe", "Apple"));
+        verify(observer, times(1)).onNext(Arrays.asList("Charlie", "Peach"));
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void leftThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add2);
+
+        m.subscribe(observer);
+
+        source2.onNext(1);
+        source1.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add2);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source2.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onNext(any(Flowable.class));
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void leftDurationThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> duration1 = Flowable.<Integer> error(new RuntimeException("Forced failure"));
+
+        Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
+                just(duration1),
+                just(Flowable.never()), add2);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightDurationThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> duration1 = Flowable.<Integer> error(new RuntimeException("Forced failure"));
+
+        Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
+                just(Flowable.never()),
+                just(duration1), add2);
+        m.subscribe(observer);
+
+        source2.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void leftDurationSelectorThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
+                fail,
+                just(Flowable.never()), add2);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightDurationSelectorThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
+                just(Flowable.never()),
+                fail, add2);
+        m.subscribe(observer);
+
+        source2.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void resultSelectorThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        BiFunction<Integer, Flowable<Integer>, Integer> fail = new BiFunction<Integer, Flowable<Integer>, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Flowable<Integer> t2) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Integer> m = source1.groupJoin(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), fail);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source2.onNext(2);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
@@ -26,7 +26,7 @@ import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
 
-public class OnSubscribeJoinTest {
+public class FlowableJoinTest {
     Subscriber<Object> observer = TestHelper.mockSubscriber();
 
     BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableToCompletableTest {
+
+    @Test
+    public void testJustSingleItemObservable() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        Completable cmp = Flowable.just("Hello World!").toCompletable();
+        cmp.subscribe(subscriber);
+
+        subscriber.assertNoValues();
+        subscriber.assertComplete();
+        subscriber.assertNoErrors();
+    }
+
+    @Test
+    public void testErrorObservable() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        IllegalArgumentException error = new IllegalArgumentException("Error");
+        Completable cmp = Flowable.<String>error(error).toCompletable();
+        cmp.subscribe(subscriber);
+
+        subscriber.assertError(error);
+        subscriber.assertNoValues();
+    }
+
+    @Test
+    public void testJustTwoEmissionsObservableThrowsError() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        Completable cmp = Flowable.just("First", "Second").toCompletable();
+        cmp.subscribe(subscriber);
+
+        subscriber.assertNoErrors();
+        subscriber.assertNoValues();
+    }
+
+    @Test
+    public void testEmptyObservable() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        Completable cmp = Flowable.<String>empty().toCompletable();
+        cmp.subscribe(subscriber);
+
+        subscriber.assertNoErrors();
+        subscriber.assertNoValues();
+        subscriber.assertComplete();
+    }
+
+    @Test
+    public void testNeverObservable() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        Completable cmp = Flowable.<String>never().toCompletable();
+        cmp.subscribe(subscriber);
+
+        subscriber.assertNotTerminated();
+        subscriber.assertNoValues();
+    }
+
+    @Test
+    public void testShouldUseUnsafeSubscribeInternallyNotSubscribe() {
+        TestSubscriber<String> subscriber = TestSubscriber.create();
+        final AtomicBoolean unsubscribed = new AtomicBoolean(false);
+        Completable cmp = Flowable.just("Hello World!").doOnCancel(new Runnable() {
+
+            @Override
+            public void run() {
+                unsubscribed.set(true);
+            }}).toCompletable();
+        
+        cmp.subscribe(subscriber);
+        
+        subscriber.assertComplete();
+        
+        assertFalse(unsubscribed.get());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/OnSubscribeJoinTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.*;
+import org.mockito.MockitoAnnotations;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+import io.reactivex.processors.PublishProcessor;
+
+public class OnSubscribeJoinTest {
+    Subscriber<Object> observer = TestHelper.mockSubscriber();
+
+    BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer t1, Integer t2) {
+            return t1 + t2;
+        }
+    };
+
+    <T> Function<Integer, Flowable<T>> just(final Flowable<T> observable) {
+        return new Function<Integer, Flowable<T>>() {
+            @Override
+            public Flowable<T> apply(Integer t1) {
+                return observable;
+            }
+        };
+    }
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void normal1() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source1.onNext(4);
+
+        source2.onNext(16);
+        source2.onNext(32);
+        source2.onNext(64);
+
+        source1.onComplete();
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(20);
+        verify(observer, times(1)).onNext(33);
+        verify(observer, times(1)).onNext(34);
+        verify(observer, times(1)).onNext(36);
+        verify(observer, times(1)).onNext(65);
+        verify(observer, times(1)).onNext(66);
+        verify(observer, times(1)).onNext(68);
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void normal1WithDuration() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        PublishProcessor<Integer> duration1 = PublishProcessor.create();
+
+        Flowable<Integer> m = source1.join(source2,
+                just(duration1),
+                just(Flowable.never()), add);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source2.onNext(16);
+
+        duration1.onNext(1);
+
+        source1.onNext(4);
+        source1.onNext(8);
+
+        source1.onComplete();
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(20);
+        verify(observer, times(1)).onNext(24);
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void normal2() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source1.onComplete();
+
+        source2.onNext(16);
+        source2.onNext(32);
+        source2.onNext(64);
+
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(33);
+        verify(observer, times(1)).onNext(34);
+        verify(observer, times(1)).onNext(65);
+        verify(observer, times(1)).onNext(66);
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void leftThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add);
+
+        m.subscribe(observer);
+
+        source2.onNext(1);
+        source1.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), add);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source2.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void leftDurationThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> duration1 = Flowable.<Integer> error(new RuntimeException("Forced failure"));
+
+        Flowable<Integer> m = source1.join(source2,
+                just(duration1),
+                just(Flowable.never()), add);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightDurationThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Flowable<Integer> duration1 = Flowable.<Integer> error(new RuntimeException("Forced failure"));
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                just(duration1), add);
+        m.subscribe(observer);
+
+        source2.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void leftDurationSelectorThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Integer> m = source1.join(source2,
+                fail,
+                just(Flowable.never()), add);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightDurationSelectorThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                fail, add);
+        m.subscribe(observer);
+
+        source2.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void resultSelectorThrows() {
+        PublishProcessor<Integer> source1 = PublishProcessor.create();
+        PublishProcessor<Integer> source2 = PublishProcessor.create();
+
+        BiFunction<Integer, Integer, Integer> fail = new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Integer> m = source1.join(source2,
+                just(Flowable.never()),
+                just(Flowable.never()), fail);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source2.onNext(2);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableJoinTest.java
@@ -1,0 +1,302 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.*;
+import org.mockito.MockitoAnnotations;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+import io.reactivex.subjects.PublishSubject;
+
+public class ObservableJoinTest {
+    Observer<Object> observer = TestHelper.mockObserver();
+
+    BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer t1, Integer t2) {
+            return t1 + t2;
+        }
+    };
+
+    <T> Function<Integer, Observable<T>> just(final Observable<T> observable) {
+        return new Function<Integer, Observable<T>>() {
+            @Override
+            public Observable<T> apply(Integer t1) {
+                return observable;
+            }
+        };
+    }
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void normal1() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                just(Observable.never()), add);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source1.onNext(4);
+
+        source2.onNext(16);
+        source2.onNext(32);
+        source2.onNext(64);
+
+        source1.onComplete();
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(20);
+        verify(observer, times(1)).onNext(33);
+        verify(observer, times(1)).onNext(34);
+        verify(observer, times(1)).onNext(36);
+        verify(observer, times(1)).onNext(65);
+        verify(observer, times(1)).onNext(66);
+        verify(observer, times(1)).onNext(68);
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void normal1WithDuration() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        PublishSubject<Integer> duration1 = PublishSubject.create();
+
+        Observable<Integer> m = source1.join(source2,
+                just(duration1),
+                just(Observable.never()), add);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source2.onNext(16);
+
+        duration1.onNext(1);
+
+        source1.onNext(4);
+        source1.onNext(8);
+
+        source1.onComplete();
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(20);
+        verify(observer, times(1)).onNext(24);
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void normal2() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                just(Observable.never()), add);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source1.onNext(2);
+        source1.onComplete();
+
+        source2.onNext(16);
+        source2.onNext(32);
+        source2.onNext(64);
+
+        source2.onComplete();
+
+        verify(observer, times(1)).onNext(17);
+        verify(observer, times(1)).onNext(18);
+        verify(observer, times(1)).onNext(33);
+        verify(observer, times(1)).onNext(34);
+        verify(observer, times(1)).onNext(65);
+        verify(observer, times(1)).onNext(66);
+
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void leftThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                just(Observable.never()), add);
+
+        m.subscribe(observer);
+
+        source2.onNext(1);
+        source1.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                just(Observable.never()), add);
+
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source2.onError(new RuntimeException("Forced failure"));
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void leftDurationThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Observable<Integer> duration1 = Observable.<Integer> error(new RuntimeException("Forced failure"));
+
+        Observable<Integer> m = source1.join(source2,
+                just(duration1),
+                just(Observable.never()), add);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightDurationThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Observable<Integer> duration1 = Observable.<Integer> error(new RuntimeException("Forced failure"));
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                just(duration1), add);
+        m.subscribe(observer);
+
+        source2.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void leftDurationSelectorThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Function<Integer, Observable<Integer>> fail = new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Observable<Integer> m = source1.join(source2,
+                fail,
+                just(Observable.never()), add);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void rightDurationSelectorThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        Function<Integer, Observable<Integer>> fail = new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t1) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                fail, add);
+        m.subscribe(observer);
+
+        source2.onNext(1);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void resultSelectorThrows() {
+        PublishSubject<Integer> source1 = PublishSubject.create();
+        PublishSubject<Integer> source2 = PublishSubject.create();
+
+        BiFunction<Integer, Integer, Integer> fail = new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Observable<Integer> m = source1.join(source2,
+                just(Observable.never()),
+                just(Observable.never()), fail);
+        m.subscribe(observer);
+
+        source1.onNext(1);
+        source2.onNext(2);
+
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any());
+    }
+}


### PR DESCRIPTION
- add `groupJoin`, `join`, `onTerminateDetach`
- fix missing cancellation in `FlowableFlattenIterable`
- fix `fromIterable` error handling
- added several unit test methods and classes from 1.x
