### PR TITLE
2.x: subscribeOn allow cancelling before the actual subscription happens (just like 1.x)

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -3127,14 +3127,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> subscribeOn(Scheduler scheduler) {
-        return subscribeOn(scheduler, true);
-    }
-
-    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> subscribeOn(Scheduler scheduler, boolean requestOn) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableSubscribeOn<T>(this, scheduler, requestOn);
+        return new FlowableSubscribeOn<T>(this, scheduler);
     }
 
     @BackpressureSupport(BackpressureKind.FULL)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -24,8 +24,8 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Flowable.Operator;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.subscriptions.*;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableSubscribeOnTest {
@@ -264,6 +264,21 @@ public class FlowableSubscribeOnTest {
         }).subscribeOn(Schedulers.newThread()).subscribe(ts);
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
+    }
+    
+    @Test
+    public void cancelBeforeActualSubscribe() {
+        TestScheduler test = Schedulers.test();
+        
+        TestSubscriber<Integer> ts = Flowable.just(1).hide()
+                .subscribeOn(test).test(Long.MAX_VALUE, 0, true);
+        
+        test.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        ts
+        .assertSubscribed()
+        .assertNoValues()
+        .assertNotTerminated();
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.schedulers.*;
 
 public class ObservableSubscribeOnTest {
 
@@ -181,4 +181,24 @@ public class ObservableSubscribeOnTest {
         ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertEquals(10, count.get());
     }
+    
+    @Test
+    public void cancelBeforeActualSubscribe() {
+        TestScheduler test = Schedulers.test();
+        
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        Observable.just(1).asObservable()
+                .subscribeOn(test).subscribe(to);
+        
+        to.dispose();
+        
+        test.advanceTimeBy(1, TimeUnit.SECONDS);
+        
+        to
+        .assertSubscribed()
+        .assertNoValues()
+        .assertNotTerminated();
+    }
+    
 }


### PR DESCRIPTION
This PR fixes the `subscribeOn` operator to allow cancellation before the actual subscription to the source takes place - just like how 1.x works.
