### PR TITLE
Fix retryWhen/repeatWhen potential concurrent reentry when resubscribing

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -41,7 +41,7 @@ import rx.functions.*;
 import rx.internal.producers.ProducerArbiter;
 import rx.observers.Subscribers;
 import rx.schedulers.Schedulers;
-import rx.subjects.BehaviorSubject;
+import rx.subjects.*;
 import rx.subscriptions.SerialSubscription;
 
 public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
@@ -202,7 +202,7 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
         // the source observable. We use a BehaviorSubject because subscribeToSource 
         // may emit a terminal before the restarts observable (transformed terminals) 
         // is subscribed
-        final BehaviorSubject<Notification<?>> terminals = BehaviorSubject.create();
+        final Subject<Notification<?>, Notification<?>> terminals = BehaviorSubject.<Notification<?>>create().toSerialized();
         final Subscriber<Notification<?>> dummySubscriber = Subscribers.empty();
         // subscribe immediately so the last emission will be replayed to the next 
         // subscriber (which is the one we care about)


### PR DESCRIPTION
When the function's returned Observable signals the resubscription in the operator `redo` (which is the base for `repeatWhen` and `retryWhen`). It is possible an asyncronous source triggers the function (and thus the same `Observable`) from another thread while the first is still coming back from the resubscription itself.

This PR serializes the dispatching `BehaviorSubject` to prevent such concurrent execution of the when chain.

This may or may not be the source of the failure of #4175 but I can't reproduce the failure with the 1.x branch. /cc @davidmoten.
