### PR TITLE
collect, DeferredScalarSubscriber - prevent multiple terminal emissions

### DIFF
--- a/src/main/java/rx/internal/operators/DeferredScalarSubscriberSafe.java
+++ b/src/main/java/rx/internal/operators/DeferredScalarSubscriberSafe.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package rx.internal.operators;
+
+import rx.Subscriber;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Supplements {@code DeferredScalarSubscriber} with defensive behaviour that ensures no emissions
+ * occur after a terminal event. If {@code onError} is called more than once then errors after the first
+ * are reported to {@code RxJavaHooks.onError}.
+ * 
+ * @param <T> source value type
+ * @param <R> result value type
+ */
+public abstract class DeferredScalarSubscriberSafe<T, R> extends DeferredScalarSubscriber<T,R> {
+
+    protected boolean done;
+    
+    public DeferredScalarSubscriberSafe(Subscriber<? super R> actual) {
+        super(actual);
+    }
+
+    @Override
+    public void onError(Throwable ex) {
+        if (!done) {
+            done = true;
+            super.onError(ex);
+        } else {
+            RxJavaHooks.onError(ex);
+        }
+    }
+
+    @Override
+    public void onCompleted() {
+        if (done) {
+            return;
+        }
+        done = true;
+        super.onCompleted();
+    }
+    
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeCollect.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCollect.java
@@ -50,7 +50,7 @@ public final class OnSubscribeCollect<T, R> implements OnSubscribe<R> {
         new CollectSubscriber<T, R>(t, initialValue, collector).subscribeTo(source);
     }
     
-    static final class CollectSubscriber<T, R> extends DeferredScalarSubscriber<T, R> {
+    static final class CollectSubscriber<T, R> extends DeferredScalarSubscriberSafe<T, R> {
 
         final Action2<R, ? super T> collector;
 
@@ -63,12 +63,15 @@ public final class OnSubscribeCollect<T, R> implements OnSubscribe<R> {
 
         @Override
         public void onNext(T t) {
+            if (done) {
+                return;
+            }
             try {
                 collector.call(value, t);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 unsubscribe();
-                actual.onError(ex);
+                onError(ex);
             }
         }
         

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -939,62 +939,7 @@ public class ObservableTests {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @Test
-    public void testCollectToList() {
-        Observable<List<Integer>> o = Observable.just(1, 2, 3).collect(new Func0<List<Integer>>() {
-
-            @Override
-            public List<Integer> call() {
-                return new ArrayList<Integer>();
-            }
-            
-        }, new Action2<List<Integer>, Integer>() {
-
-            @Override
-            public void call(List<Integer> list, Integer v) {
-                list.add(v);
-            }
-        });
         
-        List<Integer> list =  o.toBlocking().last();
-
-        assertEquals(3, list.size());
-        assertEquals(1, list.get(0).intValue());
-        assertEquals(2, list.get(1).intValue());
-        assertEquals(3, list.get(2).intValue());
-        
-        // test multiple subscribe
-        List<Integer> list2 =  o.toBlocking().last();
-
-        assertEquals(3, list2.size());
-        assertEquals(1, list2.get(0).intValue());
-        assertEquals(2, list2.get(1).intValue());
-        assertEquals(3, list2.get(2).intValue());
-    }
-
-    @Test
-    public void testCollectToString() {
-        String value = Observable.just(1, 2, 3).collect(new Func0<StringBuilder>() {
-
-            @Override
-            public StringBuilder call() {
-                return new StringBuilder();
-            }
-            
-        }, new Action2<StringBuilder, Integer>() {
-
-            @Override
-            public void call(StringBuilder sb, Integer v) {
-                if (sb.length() > 0) {
-                    sb.append("-");
-                }
-                sb.append(v);
-            }
-        }).toBlocking().last().toString();
-
-        assertEquals("1-2-3", value);
-    }
-    
     @Test
     public void testMergeWith() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/rx/internal/operators/OnSubscribeCollectTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCollectTest.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import rx.Observable;
+import rx.Producer;
+import rx.Subscriber;
+import rx.Observable.OnSubscribe;
+import rx.functions.Action1;
+import rx.functions.Action2;
+import rx.functions.Func0;
+import rx.observers.TestSubscriber;
+import rx.plugins.RxJavaHooks;
+
+public class OnSubscribeCollectTest {
+
+    @Test
+    public void testCollectToList() {
+        Observable<List<Integer>> o = Observable.just(1, 2, 3).collect(new Func0<List<Integer>>() {
+
+            @Override
+            public List<Integer> call() {
+                return new ArrayList<Integer>();
+            }
+            
+        }, new Action2<List<Integer>, Integer>() {
+
+            @Override
+            public void call(List<Integer> list, Integer v) {
+                list.add(v);
+            }
+        });
+        
+        List<Integer> list =  o.toBlocking().last();
+
+        assertEquals(3, list.size());
+        assertEquals(1, list.get(0).intValue());
+        assertEquals(2, list.get(1).intValue());
+        assertEquals(3, list.get(2).intValue());
+        
+        // test multiple subscribe
+        List<Integer> list2 =  o.toBlocking().last();
+
+        assertEquals(3, list2.size());
+        assertEquals(1, list2.get(0).intValue());
+        assertEquals(2, list2.get(1).intValue());
+        assertEquals(3, list2.get(2).intValue());
+    }
+
+    @Test
+    public void testCollectToString() {
+        String value = Observable.just(1, 2, 3).collect(new Func0<StringBuilder>() {
+
+            @Override
+            public StringBuilder call() {
+                return new StringBuilder();
+            }
+            
+        }, new Action2<StringBuilder, Integer>() {
+
+            @Override
+            public void call(StringBuilder sb, Integer v) {
+                if (sb.length() > 0) {
+                    sb.append("-");
+                }
+                sb.append(v);
+            }
+        }).toBlocking().last().toString();
+
+        assertEquals("1-2-3", value);
+    }
+    
+    @Test
+    public void testFactoryFailureResultsInErrorEmission() {
+        TestSubscriber<Object> ts = TestSubscriber.create();
+        final RuntimeException e = new RuntimeException();
+        Observable.just(1).collect(new Func0<List<Integer>>() {
+
+            @Override
+            public List<Integer> call() {
+                throw e;
+            }
+        }, new Action2<List<Integer>, Integer>() {
+
+            @Override
+            public void call(List<Integer> list, Integer t) {
+                list.add(t);
+            }
+        }).subscribe(ts);
+        ts.assertNoValues();
+        ts.assertError(e);
+        ts.assertNotCompleted();
+    }
+    
+    @Test
+    public void testCollectorFailureDoesNotResultInTwoErrorEmissions() {
+        try {
+            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            RxJavaHooks.setOnError(new Action1<Throwable>() {
+
+                @Override
+                public void call(Throwable t) {
+                    list.add(t);
+                }
+            });
+            final RuntimeException e1 = new RuntimeException();
+            final RuntimeException e2 = new RuntimeException();
+            TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+            Observable.create(new OnSubscribe<Integer>() {
+
+                @Override
+                public void call(final Subscriber<? super Integer> sub) {
+                    sub.setProducer(new Producer() {
+
+                        @Override
+                        public void request(long n) {
+                            if (n > 0) {
+                                sub.onNext(1);
+                                sub.onError(e2);
+                            }
+                        }
+                    });
+                }
+            }).collect(new Func0<List<Integer>>() {
+
+                @Override
+                public List<Integer> call() {
+                    return new ArrayList<Integer>();
+                }
+            }, //
+                    new Action2<List<Integer>, Integer>() {
+
+                        @Override
+                        public void call(List<Integer> t1, Integer t2) {
+                            throw e1;
+                        }
+                    }).unsafeSubscribe(ts);
+            assertEquals(Arrays.asList(e1), ts.getOnErrorEvents());
+            ts.assertNotCompleted();
+            assertEquals(Arrays.asList(e2), list);
+        } finally {
+            RxJavaHooks.reset();
+        }
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissions() {
+        final RuntimeException e1 = new RuntimeException();
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        Observable.create(new OnSubscribe<Integer>() {
+
+            @Override
+            public void call(final Subscriber<? super Integer> sub) {
+                sub.setProducer(new Producer() {
+
+                    @Override
+                    public void request(long n) {
+                        if (n > 0) {
+                            sub.onNext(1);
+                            sub.onCompleted();
+                        }
+                    }
+                });
+            }
+        }).collect(new Func0<List<Integer>>() {
+
+            @Override
+            public List<Integer> call() {
+                return new ArrayList<Integer>();
+            }
+        }, //
+                new Action2<List<Integer>, Integer>() {
+
+                    @Override
+                    public void call(List<Integer> t1, Integer t2) {
+                        throw e1;
+                    }
+                }).unsafeSubscribe(ts);
+        assertEquals(Arrays.asList(e1), ts.getOnErrorEvents());
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInErrorAndOnNextEmissions() {
+        final RuntimeException e1 = new RuntimeException();
+        TestSubscriber<List<Integer>> ts = TestSubscriber.create();
+        final AtomicBoolean added = new AtomicBoolean();
+        Observable.create(new OnSubscribe<Integer>() {
+
+            @Override
+            public void call(final Subscriber<? super Integer> sub) {
+                sub.setProducer(new Producer() {
+
+                    @Override
+                    public void request(long n) {
+                        if (n > 0) {
+                            sub.onNext(1);
+                            sub.onNext(2);
+                        }
+                    }
+                });
+            }
+        }).collect(new Func0<List<Integer>>() {
+
+            @Override
+            public List<Integer> call() {
+                return new ArrayList<Integer>();
+            }
+        }, //
+                new Action2<List<Integer>, Integer>() {
+                    boolean once = true;
+                    @Override
+                    public void call(List<Integer> list, Integer t) {
+                        if (once) {
+                            once = false;
+                            throw e1;
+                        } else {
+                            added.set(true);
+                        }
+                    }
+                }).unsafeSubscribe(ts);
+        assertEquals(Arrays.asList(e1), ts.getOnErrorEvents());
+        ts.assertNoValues();
+        ts.assertNotCompleted();
+        assertFalse(added.get());
+    }
+    
+}

--- a/src/test/java/rx/internal/operators/OnSubscribeReduceTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeReduceTest.java
@@ -255,7 +255,7 @@ public class OnSubscribeReduceTest {
             assertEquals(Arrays.asList(e1), ts.getOnErrorEvents());
             assertEquals(Arrays.asList(e2), list);
         } finally {
-            RxJavaHooks.setOnError(null);
+            RxJavaHooks.reset();
         }
     }
 

--- a/src/test/java/rx/internal/operators/OperatorAllTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAllTest.java
@@ -289,7 +289,7 @@ public class OperatorAllTest {
             assertEquals(Arrays.asList(e1), ts.getOnErrorEvents());
             assertEquals(Arrays.asList(e2), list);
         } finally {
-            RxJavaHooks.setOnError(null);
+            RxJavaHooks.reset();
         }
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorAnyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAnyTest.java
@@ -382,7 +382,7 @@ public class OperatorAnyTest {
             assertEquals(Arrays.asList(e1), ts.getOnErrorEvents());
             assertEquals(Arrays.asList(e2), list);
         } finally {
-            RxJavaHooks.setOnError(null);
+            RxJavaHooks.reset();
         }
     }
 }


### PR DESCRIPTION
As per discussion in #4242, if an operator maps an `onNext` emission to an `onError` emission downstream then it needs be defensive about another event being sent from upstream even if upstream has been unsubscribed.
- `DeferredScalarSubscriber` has been updated with a `done` flag
- moved tests from `ObservableTests` to new class `OnSubscribeCollectTest`
- added three tests of post error emissions
- added factory failure test  
