### PR TITLE
1.x: concatDelayError multiple arguments

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -1453,15 +1453,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates two Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by two Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1471,7 +1471,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t2
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2) {
@@ -1479,15 +1479,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates three Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by three Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1499,7 +1499,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t3
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2,Observable<? extends T> t3 ) {
@@ -1507,15 +1507,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates four Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by four Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1529,7 +1529,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t4
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4) {
@@ -1537,15 +1537,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates five Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by five Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1561,7 +1561,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t5
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5) {
@@ -1569,15 +1569,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates six Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by six Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1595,7 +1595,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t6
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6) {
@@ -1603,15 +1603,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates seven Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by seven Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1631,7 +1631,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t7
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7) {
@@ -1639,15 +1639,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates eight Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by eight Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1669,7 +1669,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t8
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8) {
@@ -1677,15 +1677,15 @@ public class Observable<T> {
     }
 
     /**
-     * Concatenates nine Observables into a single sequence by subscribing to each Observable,
-     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     * Returns an Observable that emits the items emitted by nine Observables, one after the other, without
+     * interleaving them, and delays any errors till all Observables terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
-     *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream. The {@code Observable}
+     *  sources are expected to honor backpressure as well.
+     *  If any of the source {@code Observable}s violate this, it <em>may</em> throw an
+     *  {@code IllegalStateException} when the source {@code Observable} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1709,7 +1709,7 @@ public class Observable<T> {
      *            an Observable to be concatenated
      * @param t9
      *            an Observable to be concatenated
-     * @return the new Observable with the concatenating behavior
+     * @return an Observable with the concatenating behavior
      */
     @Experimental
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8, Observable<? extends T> t9) {

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -1453,6 +1453,270 @@ public class Observable<T> {
     }
 
     /**
+     * Concatenates two Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2) {
+        return concatDelayError(just(t1, t2));
+    }
+
+    /**
+     * Concatenates three Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2,Observable<? extends T> t3 ) {
+        return concatDelayError(just(t1, t2, t3));
+    }
+
+    /**
+     * Concatenates four Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @param t4
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4) {
+        return concatDelayError(just(t1, t2, t3, t4));
+    }
+
+    /**
+     * Concatenates five Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @param t4
+     *            an Observable to be concatenated
+     * @param t5
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5) {
+        return concatDelayError(just(t1, t2, t3, t4, t5));
+    }
+
+    /**
+     * Concatenates six Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @param t4
+     *            an Observable to be concatenated
+     * @param t5
+     *            an Observable to be concatenated
+     * @param t6
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6) {
+        return concatDelayError(just(t1, t2, t3, t4, t5, t6));
+    }
+
+    /**
+     * Concatenates seven Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @param t4
+     *            an Observable to be concatenated
+     * @param t5
+     *            an Observable to be concatenated
+     * @param t6
+     *            an Observable to be concatenated
+     * @param t7
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7) {
+        return concatDelayError(just(t1, t2, t3, t4, t5, t6, t7));
+    }
+
+    /**
+     * Concatenates eight Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @param t4
+     *            an Observable to be concatenated
+     * @param t5
+     *            an Observable to be concatenated
+     * @param t6
+     *            an Observable to be concatenated
+     * @param t7
+     *            an Observable to be concatenated
+     * @param t8
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8) {
+        return concatDelayError(just(t1, t2, t3, t4, t5, t6, t7, t8));
+    }
+
+    /**
+     * Concatenates nine Observables into a single sequence by subscribing to each Observable,
+     * one after the other, one at a time and delays any errors till all inner Observables terminate.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Observable}
+     *  sources are expected to honor backpressure as well. If the outer violates this, a
+     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Observable}s violates
+     *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Observable} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param t1
+     *            an Observable to be concatenated
+     * @param t2
+     *            an Observable to be concatenated
+     * @param t3
+     *            an Observable to be concatenated
+     * @param t4
+     *            an Observable to be concatenated
+     * @param t5
+     *            an Observable to be concatenated
+     * @param t6
+     *            an Observable to be concatenated
+     * @param t7
+     *            an Observable to be concatenated
+     * @param t8
+     *            an Observable to be concatenated
+     * @param t9
+     *            an Observable to be concatenated
+     * @return the new Observable with the concatenating behavior
+     */
+    @Experimental
+    public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8, Observable<? extends T> t9) {
+        return concatDelayError(just(t1, t2, t3, t4, t5, t6, t7, t8, t9));
+    }
+
+    /**
      * Returns an Observable that calls an Observable factory to create an Observable for each new Observer
      * that subscribes. That is, for each subscriber, the actual Observable that subscriber observes is
      * determined by the factory function.

--- a/src/test/java/rx/internal/operators/OnSubscribeConcatDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeConcatDelayErrorTest.java
@@ -277,4 +277,317 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(2, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError2() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+
+        Observable.concatDelayError(o1, o2)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError2Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+
+        Observable.concatDelayError(withError1, withError2)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(2, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError3() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+
+        Observable.concatDelayError(o1, o2, o3)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError3Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+
+        Observable.concatDelayError(withError1, withError2, withError3)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(3, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError4() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+        Observable<Integer> o4 = Observable.just(4);
+
+        Observable.concatDelayError(o1, o2, o3, o4)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError4Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+        Observable<Integer> withError4 = withError(Observable.just(4));
+
+        Observable.concatDelayError(withError1, withError2, withError3, withError4)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(4, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError5() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+        Observable<Integer> o4 = Observable.just(4);
+        Observable<Integer> o5 = Observable.just(5);
+
+        Observable.concatDelayError(o1, o2, o3, o4, o5)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError5Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+        Observable<Integer> withError4 = withError(Observable.just(4));
+        Observable<Integer> withError5 = withError(Observable.just(5));
+
+        Observable.concatDelayError(withError1, withError2, withError3, withError4, withError5)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(5, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError6() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+        Observable<Integer> o4 = Observable.just(4);
+        Observable<Integer> o5 = Observable.just(5);
+        Observable<Integer> o6 = Observable.just(6);
+
+        Observable.concatDelayError(o1, o2, o3, o4, o5, o6)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError6Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+        Observable<Integer> withError4 = withError(Observable.just(4));
+        Observable<Integer> withError5 = withError(Observable.just(5));
+        Observable<Integer> withError6 = withError(Observable.just(6));
+
+        Observable.concatDelayError(withError1, withError2, withError3, withError4, withError5, withError6)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(6, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError7() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+        Observable<Integer> o4 = Observable.just(4);
+        Observable<Integer> o5 = Observable.just(5);
+        Observable<Integer> o6 = Observable.just(6);
+        Observable<Integer> o7 = Observable.just(7);
+
+        Observable.concatDelayError(o1, o2, o3, o4, o5, o6, o7)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError7Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+        Observable<Integer> withError4 = withError(Observable.just(4));
+        Observable<Integer> withError5 = withError(Observable.just(5));
+        Observable<Integer> withError6 = withError(Observable.just(6));
+        Observable<Integer> withError7 = withError(Observable.just(7));
+
+        Observable.concatDelayError(withError1, withError2, withError3, withError4, withError5, withError6, withError7)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(7, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError8() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+        Observable<Integer> o4 = Observable.just(4);
+        Observable<Integer> o5 = Observable.just(5);
+        Observable<Integer> o6 = Observable.just(6);
+        Observable<Integer> o7 = Observable.just(7);
+        Observable<Integer> o8 = Observable.just(8);
+
+
+        Observable.concatDelayError(o1, o2, o3, o4, o5, o6, o7, o8)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError8Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+        Observable<Integer> withError4 = withError(Observable.just(4));
+        Observable<Integer> withError5 = withError(Observable.just(5));
+        Observable<Integer> withError6 = withError(Observable.just(6));
+        Observable<Integer> withError7 = withError(Observable.just(7));
+        Observable<Integer> withError8 = withError(Observable.just(8));
+
+        Observable.concatDelayError(withError1, withError2, withError3, withError4, withError5, withError6, withError7, withError8)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(8, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError9() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> o1 = Observable.just(1);
+        Observable<Integer> o2 = Observable.just(2);
+        Observable<Integer> o3 = Observable.just(3);
+        Observable<Integer> o4 = Observable.just(4);
+        Observable<Integer> o5 = Observable.just(5);
+        Observable<Integer> o6 = Observable.just(6);
+        Observable<Integer> o7 = Observable.just(7);
+        Observable<Integer> o8 = Observable.just(8);
+        Observable<Integer> o9 = Observable.just(9);
+
+
+        Observable.concatDelayError(o1, o2, o3, o4, o5, o6, o7, o8, o9)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatDelayError9Error() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        Observable<Integer> withError1 = withError(Observable.just(1));
+        Observable<Integer> withError2 = withError(Observable.just(2));
+        Observable<Integer> withError3 = withError(Observable.just(3));
+        Observable<Integer> withError4 = withError(Observable.just(4));
+        Observable<Integer> withError5 = withError(Observable.just(5));
+        Observable<Integer> withError6 = withError(Observable.just(6));
+        Observable<Integer> withError7 = withError(Observable.just(7));
+        Observable<Integer> withError8 = withError(Observable.just(8));
+        Observable<Integer> withError9 = withError(Observable.just(9));
+
+        Observable.concatDelayError(withError1, withError2, withError3, withError4, withError5, withError6, withError7, withError8, withError9)
+                .subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        ts.assertError(CompositeException.class);
+        ts.assertNotCompleted();
+
+        assertEquals(9, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
+    }
 }


### PR DESCRIPTION
This PR adds multiple arguments to concatDelayError operator

Related to: #4152 
