### PR TITLE
2.x: test sync and missing operators (8/02)

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -22,19 +22,19 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? extends R>>{
+public final class FlowableMapNotification<T, R> extends Flowable<R> {
 
     final Publisher<T> source;
     
-    final Function<? super T, ? extends Publisher<? extends R>> onNextMapper;
-    final Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper;
-    final Supplier<? extends Publisher<? extends R>> onCompleteSupplier;
+    final Function<? super T, ? extends R> onNextMapper;
+    final Function<? super Throwable, ? extends R> onErrorMapper;
+    final Supplier<? extends R> onCompleteSupplier;
 
     public FlowableMapNotification(
             Publisher<T> source,
-            Function<? super T, ? extends Publisher<? extends R>> onNextMapper, 
-            Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper, 
-            Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
+            Function<? super T, ? extends R> onNextMapper, 
+            Function<? super Throwable, ? extends R> onErrorMapper, 
+            Supplier<? extends R> onCompleteSupplier) {
         this.source = source;
         this.onNextMapper = onNextMapper;
         this.onErrorMapper = onErrorMapper;
@@ -42,7 +42,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
     }
     
     @Override
-    protected void subscribeActual(Subscriber<? super Publisher<? extends R>> s) {
+    protected void subscribeActual(Subscriber<? super R> s) {
         source.subscribe(new MapNotificationSubscriber<T, R>(s, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
     
@@ -53,14 +53,14 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         /** */
         private static final long serialVersionUID = 2757120512858778108L;
         
-        final Subscriber<? super Publisher<? extends R>> actual;
-        final Function<? super T, ? extends Publisher<? extends R>> onNextMapper;
-        final Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper;
-        final Supplier<? extends Publisher<? extends R>> onCompleteSupplier;
+        final Subscriber<? super R> actual;
+        final Function<? super T, ? extends R> onNextMapper;
+        final Function<? super Throwable, ? extends R> onErrorMapper;
+        final Supplier<? extends R> onCompleteSupplier;
         
         Subscription s;
         
-        Publisher<? extends R> value;
+        R value;
         
         volatile boolean done;
 
@@ -71,10 +71,10 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         static final int HAS_REQUEST_NO_VALUE = 2;
         static final int HAS_REQUEST_HAS_VALUE = 3;
 
-        public MapNotificationSubscriber(Subscriber<? super Publisher<? extends R>> actual,
-                Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
-                Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper,
-                Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
+        public MapNotificationSubscriber(Subscriber<? super R> actual,
+                Function<? super T, ? extends R> onNextMapper,
+                Function<? super Throwable, ? extends R> onErrorMapper,
+                Supplier<? extends R> onCompleteSupplier) {
             this.actual = actual;
             this.onNextMapper = onNextMapper;
             this.onErrorMapper = onErrorMapper;
@@ -91,7 +91,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         
         @Override
         public void onNext(T t) {
-            Publisher<? extends R> p;
+            R p;
             
             try {
                 p = onNextMapper.apply(t);
@@ -115,7 +115,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         
         @Override
         public void onError(Throwable t) {
-            Publisher<? extends R> p;
+            R p;
             
             try {
                 p = onErrorMapper.apply(t);
@@ -134,7 +134,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         
         @Override
         public void onComplete() {
-            Publisher<? extends R> p;
+            R p;
             
             try {
                 p = onCompleteSupplier.get();
@@ -152,7 +152,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
         }
         
         
-        void tryEmit(Publisher<? extends R> p) {
+        void tryEmit(R p) {
             long r = get();
             if (r != 0L) {
                 actual.onNext(p);
@@ -197,7 +197,7 @@ public final class FlowableMapNotification<T, R> extends Flowable<Publisher<? ex
                     } else
                     if (s == NO_REQUEST_HAS_VALUE) {
                         if (state.compareAndSet(NO_REQUEST_HAS_VALUE, HAS_REQUEST_HAS_VALUE)) {
-                            Publisher<? extends R> p = value;
+                            R p = value;
                             value = null;
                             actual.onNext(p);
                             actual.onComplete();

--- a/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Scheduler;
+import io.reactivex.disposables.*;
+
+/**
+ * A Scheduler partially implementing the API by allowing only non-delayed, non-periodic
+ * task execution on the current thread immediately.
+ * <p>
+ * Note that this doesn't support recursive scheduling and disposing the returned Disposable
+ * has no effect (because when the schedule() method returns, the task has been already run).
+ */
+public final class ImmediateThinScheduler extends Scheduler {
+    
+    /**
+     * The singleton instance of the immediate (thin) scheduler.
+     */
+    public static final Scheduler INSTANCE = new ImmediateThinScheduler();
+
+    static final Worker WORKER = new ImmediateThinWorker();
+    
+    static final Disposable DISPOSED;
+    
+    static {
+        DISPOSED = Disposables.empty();
+        DISPOSED.dispose();
+    }
+    
+    private ImmediateThinScheduler() {
+        // singleton class
+    }
+    
+    @Override
+    public Disposable scheduleDirect(Runnable run) {
+        run.run();
+        return DISPOSED;
+    }
+    
+    @Override
+    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
+    }
+    
+    @Override
+    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
+        throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
+    }
+    
+    @Override
+    public Worker createWorker() {
+        return WORKER;
+    }
+    
+    static final class ImmediateThinWorker extends Worker {
+
+        @Override
+        public void dispose() {
+            // This worker is always stateless and won't track tasks
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return false; // dispose() has no effect
+        }
+
+        @Override
+        public Disposable schedule(Runnable run) {
+            run.run();
+            return DISPOSED;
+        }
+        
+        @Override
+        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
+        }
+        
+        @Override
+        public Disposable schedulePeriodically(Runnable run, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
+        }
+    }
+}

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -528,23 +528,23 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableNull() {
-        Flowable.mergeDelayError(128, 128, (Iterable<Publisher<Object>>)null);
+        Flowable.mergeDelayError((Iterable<Publisher<Object>>)null, 128, 128);
     }
     
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableIteratorNull() {
-        Flowable.mergeDelayError(128, 128, new Iterable<Publisher<Object>>() {
+        Flowable.mergeDelayError(new Iterable<Publisher<Object>>() {
             @Override
             public Iterator<Publisher<Object>> iterator() {
                 return null;
             }
-        }).toBlocking().lastOption();
+        }, 128, 128).toBlocking().lastOption();
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableOneIsNull() {
-        Flowable.mergeDelayError(128, 128, Arrays.asList(just1, null)).toBlocking().lastOption();
+        Flowable.mergeDelayError(Arrays.asList(just1, null), 128, 128).toBlocking().lastOption();
     }
     
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
- Add `rebatchRequests` which delegates to `observeOn` with the help of an internal `ImmediateThinScheduler` that only executes tasks immediately. Still not planning to expose an immediate scheduler.
- Fix `FlowableMapNotification`'s type signature, no need to restrict it to return `Publisher<R>` but can go with `R` itself.
- Make sure `flatMap` doesn't reorder scalars and elements of the same inner source.
- Change parameter ordering on `mergeDelayError(Iterator)` overloads.
