### PR TITLE
1.x: distinctUntilChanged change erroneous behavior

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorDistinctUntilChanged.java
+++ b/src/main/java/rx/internal/operators/OperatorDistinctUntilChanged.java
@@ -62,7 +62,7 @@ public final class OperatorDistinctUntilChanged<T, U> implements Operator<T, T>,
     
     @Override
     public Boolean call(U t1, U t2) {
-        return (t1 == t2 || (t1 != null && t1.equals(t2)));
+        return (t1 == t2 || (t2 != null && t2.equals(t1)));
     }
 
     @Override


### PR DESCRIPTION
#### 📘 PR summary

Fix behavior change of `distinctUntilChanged`  introduced in the version `1.1.7` of RxJava

Related to: #4034
