### PR TITLE
1.x: Remove needless static field for initialization in IndexedRingBuffer.

### DIFF
--- a/src/main/java/rx/internal/util/IndexedRingBuffer.java
+++ b/src/main/java/rx/internal/util/IndexedRingBuffer.java
@@ -61,8 +61,6 @@ public final class IndexedRingBuffer<E> implements Subscription {
 
     };
 
-    static int defaultSize = 256;
-
     /* package for unit testing */static final int SIZE;
 
     // default size of ring buffer
@@ -237,6 +235,8 @@ public final class IndexedRingBuffer<E> implements Subscription {
      * } </pre>
      */
     static {
+        int defaultSize = 128;
+
         // lower default for Android (https://github.com/ReactiveX/RxJava/issues/1820)
         if (PlatformDependent.isAndroid()) {
             defaultSize = 8;


### PR DESCRIPTION
Equivalent of #4269 
