### PR TITLE
2.x: Add serialized single subscriber wrapper.

### DIFF
--- a/src/main/java/io/reactivex/subscribers/single/SingleSerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/single/SingleSerializedSubscriber.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers.single;
+
+import io.reactivex.SingleSubscriber;
+import io.reactivex.disposables.Disposable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class SingleSerializedSubscriber implements SingleSubscriber {
+
+    final SingleSubscriber actual;
+
+    final AtomicBoolean once = new AtomicBoolean();
+
+    public SingleSerializedSubscriber(SingleSubscriber actual) {
+        this.actual = actual;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable d) {
+        actual.onSubscribe(d);
+    }
+
+    @Override
+    public void onSuccess(Object value) {
+        if (once.compareAndSet(false, true)) {
+            actual.onSuccess(value);
+        }
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        if (once.compareAndSet(false, true)) {
+            actual.onError(e);
+        }
+    }
+
+}


### PR DESCRIPTION
There's already one for observer, subscriber, and completable subscriber.
