### PR TITLE
2.x: Add missing license headers

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators.flowable;
 
 import java.util.*;

--- a/src/main/java/io/reactivex/internal/util/ArrayListSupplier.java
+++ b/src/main/java/io/reactivex/internal/util/ArrayListSupplier.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.util;
 
 import java.util.*;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
Now every file has a license header.
