### PR TITLE
2.x: fix SubscriptionArbiter reentrancy/cancel bug

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRedo.java
@@ -22,7 +22,7 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscribers.flowable.ToNotificationSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
-import io.reactivex.processors.BehaviorProcessor;
+import io.reactivex.processors.*;
 
 // FIXME split and update to the Rsc version
 public final class FlowableRedo<T> extends Flowable<T> {
@@ -39,7 +39,7 @@ public final class FlowableRedo<T> extends Flowable<T> {
     public void subscribeActual(Subscriber<? super T> s) {
         
         // FIXE use BehaviorSubject? (once available)
-        BehaviorProcessor<Try<Optional<Object>>> subject = BehaviorProcessor.create();
+        FlowProcessor<Try<Optional<Object>>> subject = BehaviorProcessor.<Try<Optional<Object>>>create().toSerialized();
         
         final RedoSubscriber<T> parent = new RedoSubscriber<T>(s, subject, source);
 
@@ -70,13 +70,13 @@ public final class FlowableRedo<T> extends Flowable<T> {
         /** */
         private static final long serialVersionUID = -1151903143112844287L;
         final Subscriber<? super T> actual;
-        final BehaviorProcessor<Try<Optional<Object>>> subject;
+        final FlowProcessor<Try<Optional<Object>>> subject;
         final Publisher<? extends T> source;
         final SubscriptionArbiter arbiter;
         
         final AtomicInteger wip = new AtomicInteger();
         
-        public RedoSubscriber(Subscriber<? super T> actual, BehaviorProcessor<Try<Optional<Object>>> subject, Publisher<? extends T> source) {
+        public RedoSubscriber(Subscriber<? super T> actual, FlowProcessor<Try<Optional<Object>>> subject, Publisher<? extends T> source) {
             this.actual = actual;
             this.subject = subject;
             this.source = source;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -1008,10 +1008,34 @@ public class FlowableConcatTest {
         }
     }
     
-    @Test
+    static final class InfiniteIterator implements Iterator<Integer>, Iterable<Integer> {
+
+        int count;
+        
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public Integer next() {
+            return count++;
+        }
+        
+        @Override
+        public void remove() {
+        }
+        
+        @Override
+        public Iterator<Integer> iterator() {
+            return this;
+        }
+    }
+    
+    @Test(timeout = 5000)
     public void veryLongTake() {
-        Flowable.range(1, 1000000000).concatWith(Flowable.<Integer>empty()).take(10)
+        Flowable.fromIterable(new InfiniteIterator()).concatWith(Flowable.<Integer>empty()).take(10)
         .test()
-        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        .assertResult(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -1007,4 +1007,11 @@ public class FlowableConcatTest {
             ts.assertComplete();
         }
     }
+    
+    @Test
+    public void veryLongTake() {
+        Flowable.range(1, 1000000000).concatWith(Flowable.<Integer>empty()).take(10)
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
 }


### PR DESCRIPTION
This PR fixes the case when a call to request() prevented cancellation of the arbiter if the call never returned, thus locking out the drain loop from the cancellation call.

The PR makes sure `request()` is only called outside the guarded region.

1.x is not affected because unsubscription and requesting go on separate "channels".

The PR also fixes `FlowableRedo` by serializing the repeat signal `Processor`.
