### PR TITLE
2.x: Rename create to unsafeCreate, add "safe" create methods.

### DIFF
--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -26,7 +26,7 @@ import io.reactivex.disposables.Disposable;
  *
  * @param <T> the value type to emit
  */
-public interface AsyncEmitter<T> {
+public interface FlowableEmitter<T> {
 
     /**
      * Signal a value.

--- a/src/main/java/io/reactivex/FlowableSource.java
+++ b/src/main/java/io/reactivex/FlowableSource.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex;
+
+public interface FlowableSource<T> {
+    
+    void subscribe(FlowableEmitter<T> e);
+}
+

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -332,6 +332,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source, "source is null");
         return new ObservableFromSource<T>(source);
     }
+
+    public static <T> Observable<T> unsafeCreate(ObservableSource<T> source) {
+        Objects.requireNonNull(source, "source is null");
+        return new ObservableFromUnsafeSource<T>(source);
+    }
     
     public static <T> Observable<T> wrap(ObservableSource<T> source) {
         Objects.requireNonNull(source, "source is null");
@@ -339,7 +344,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (source instanceof Observable) {
             return (Observable<T>)source;
         }
-        return new ObservableFromSource<T>(source);
+        return new ObservableFromUnsafeSource<T>(source);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1051,7 +1056,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> asObservable() {
-        return new ObservableFromSource<T>(this);
+        return new ObservableFromUnsafeSource<T>(this);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -39,7 +39,7 @@ public abstract class Single<T> implements SingleSource<T> {
         if (source instanceof Single) {
             return (Single<T>)source;
         }
-        return new SingleFromSource<T>(source);
+        return new SingleFromUnsafeSource<T>(source);
     }
     
     public static <T> Single<T> amb(final Iterable<? extends SingleSource<? extends T>> sources) {
@@ -191,11 +191,17 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(s9, "s9 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
     }
-    
+
     public static <T> Single<T> create(SingleSource<T> source) {
         Objects.requireNonNull(source, "source is null");
         // TODO plugin wrapper
         return new SingleFromSource<T>(source);
+    }
+
+    public static <T> Single<T> unsafeCreate(SingleSource<T> source) {
+        Objects.requireNonNull(source, "source is null");
+        // TODO plugin wrapper
+        return new SingleFromUnsafeSource<T>(source);
     }
     
     public static <T> Single<T> defer(final Callable<? extends SingleSource<? extends T>> singleSupplier) {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromUnsafeSource.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromUnsafeSource.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.*;
+
+public final class CompletableFromUnsafeSource extends Completable {
+
+    final CompletableSource source;
+
+    public CompletableFromUnsafeSource(CompletableSource source) {
+        this.source = source;
+    }
+    
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(observer);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
@@ -123,7 +123,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> {
 
     public static <T, R> Flowable<R> create(final Flowable<? extends T> source, 
             final Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize) {
-        return create(new Publisher<R>() {
+        return unsafeCreate(new Publisher<R>() {
             @Override
             public void subscribe(Subscriber<? super R> sr) {
                 ConnectableFlowable<T> op = create(source, bufferSize);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -60,7 +60,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> {
     public static <U, R> Flowable<R> multicastSelector(
             final Callable<? extends ConnectableFlowable<U>> connectableFactory,
             final Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
-        return Flowable.create(new Publisher<R>() {
+        return Flowable.unsafeCreate(new Publisher<R>() {
             @Override
             public void subscribe(Subscriber<? super R> child) {
                 ConnectableFlowable<U> co;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromSource.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromSource.java
@@ -1,29 +1,88 @@
 /**
  * Copyright 2016 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
  */
-
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class ObservableFromSource<T> extends Observable<T> {
-    final ObservableSource<T> source;
+    private final ObservableSource<T> source;
 
     public ObservableFromSource(ObservableSource<T> source) {
         this.source = source;
     }
-    
+
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(observer);
+        source.subscribe(new DisposedAwareObserver<T>(observer));
+    }
+
+    /**
+     * An observer which does not send downstream notifications once disposed. Used to guard against
+     * naive implementations of {@link ObservableSource} which do not check for this.
+     */
+    static final class DisposedAwareObserver<T>
+    extends AtomicBoolean
+    implements Observer<T>, Disposable {
+
+        private final Observer<? super T> o;
+        private Disposable d;
+
+        DisposedAwareObserver(Observer<? super T> o) {
+            this.o = o;
+        }
+
+        @Override
+        public void onNext(T value) {
+            if (!get()) {
+                o.onNext(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (!get()) {
+               o.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!get()) {
+                o.onComplete();
+            }
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            this.d = d;
+            o.onSubscribe(this);
+        }
+
+        @Override
+        public void dispose() {
+            if (compareAndSet(false, true)) {
+                d.dispose();
+                d = null;
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get();
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromUnsafeSource.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromUnsafeSource.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+
+public final class ObservableFromUnsafeSource<T> extends Observable<T> {
+    final ObservableSource<T> source;
+
+    public ObservableFromUnsafeSource(ObservableSource<T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(observer);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromSource.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromSource.java
@@ -1,29 +1,79 @@
 /**
  * Copyright 2016 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
  */
-
 package io.reactivex.internal.operators.single;
 
-import io.reactivex.*;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.disposables.Disposable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class SingleFromSource<T> extends Single<T> {
-    final SingleSource<T> source;
+    private final SingleSource<T> source;
 
     public SingleFromSource(SingleSource<T> source) {
         this.source = source;
     }
-    
-    @Override
-    protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(observer);
+
+    @Override protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new DisposeAwareSingleObserver<T>(observer));
+    }
+
+    /**
+     * An observer which does not send downstream notifications once disposed. Used to guard against
+     * naive implementations of {@link SingleSource} which do not check for this.
+     */
+    static final class DisposeAwareSingleObserver<T>
+    extends AtomicBoolean
+    implements SingleObserver<T>, Disposable {
+        private final SingleObserver<? super T> o;
+        private Disposable d;
+
+        DisposeAwareSingleObserver(SingleObserver<? super T> o) {
+            this.o = o;
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            if (!get()) {
+                o.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (!get()) {
+                o.onError(e);
+            }
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            this.d = d;
+            o.onSubscribe(this);
+        }
+
+        @Override
+        public void dispose() {
+            if (compareAndSet(false, true)) {
+                d.dispose();
+                d = null;
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get();
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromUnsafeSource.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromUnsafeSource.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import io.reactivex.*;
+
+public final class SingleFromUnsafeSource<T> extends Single<T> {
+    final SingleSource<T> source;
+
+    public SingleFromUnsafeSource(SingleSource<T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(observer);
+    }
+}

--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -39,7 +39,7 @@ public abstract class InputWithIncrementingInteger {
         final int size = getSize();
         observable = Flowable.range(0, size);
 
-        firehose = Flowable.create(new Publisher<Integer>() {
+        firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -103,7 +103,7 @@ public class CompletableTest {
         /** */
         private static final long serialVersionUID = 7192337844700923752L;
         
-        public final Completable completable = Completable.create(new CompletableSource() {
+        public final Completable completable = Completable.unsafeCreate(new CompletableSource() {
             @Override
             public void subscribe(CompletableObserver s) {
                 getAndIncrement();
@@ -129,7 +129,7 @@ public class CompletableTest {
         /** */
         private static final long serialVersionUID = 7192337844700923752L;
         
-        public final Completable completable = Completable.create(new CompletableSource() {
+        public final Completable completable = Completable.unsafeCreate(new CompletableSource() {
             @Override
             public void subscribe(CompletableObserver s) {
                 getAndIncrement();
@@ -374,12 +374,12 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void createNull() {
-        Completable.create(null);
+        Completable.unsafeCreate(null);
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void createOnSubscribeThrowsNPE() {
-        Completable c = Completable.create(new CompletableSource() {
+        Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
             public void subscribe(CompletableObserver s) { throw new NullPointerException(); }
         });
@@ -390,7 +390,7 @@ public class CompletableTest {
     @Test(timeout = 1000)
     public void createOnSubscribeThrowsRuntimeException() {
         try {
-            Completable c = Completable.create(new CompletableSource() {
+            Completable c = Completable.unsafeCreate(new CompletableSource() {
                 @Override
                 public void subscribe(CompletableObserver s) {
                     throw new TestException();
@@ -2752,7 +2752,7 @@ public class CompletableTest {
     public void subscribeOnNormal() {
         final AtomicReference<String> name = new  AtomicReference<String>();
         
-        Completable c = Completable.create(new CompletableSource() {
+        Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
             public void subscribe(CompletableObserver s) {
                 name.set(Thread.currentThread().getName());
@@ -2770,7 +2770,7 @@ public class CompletableTest {
     public void subscribeOnError() {
         final AtomicReference<String> name = new  AtomicReference<String>();
         
-        Completable c = Completable.create(new CompletableSource() {
+        Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
             public void subscribe(CompletableObserver s) {
                 name.set(Thread.currentThread().getName());
@@ -3866,7 +3866,7 @@ public class CompletableTest {
         final AtomicBoolean hasRun = new AtomicBoolean(false);
         final Exception e = new Exception();
         Completable.error(e)
-            .andThen(Single.<String>create(new Single<String>() {
+            .andThen(Single.<String>unsafeCreate(new Single<String>() {
                 @Override
                 public void subscribeActual(SingleObserver<? super String> s) {
                     hasRun.set(true);
@@ -3967,7 +3967,7 @@ public class CompletableTest {
     @Test
     public void testHookCreate() throws Exception {
         CompletableSource subscriber = mock(CompletableSource.class);
-        Completable create = Completable.create(subscriber);
+        Completable create = Completable.unsafeCreate(subscriber);
 
         verify(onCreate, times(1)).apply(create);
     }
@@ -4431,7 +4431,7 @@ public class CompletableTest {
     public void testHookSubscribeStart() throws Exception {
         TestSubscriber<String> ts = new TestSubscriber<String>();
 
-        Completable completable = Completable.create(new CompletableSource() {
+        Completable completable = Completable.unsafeCreate(new CompletableSource() {
             @Override public void subscribe(CompletableObserver s) {
                 s.onComplete();
             }
@@ -4666,13 +4666,13 @@ public class CompletableTest {
         TestSubscriber<String> ts = new TestSubscriber<String>(0);
         final AtomicBoolean hasRun = new AtomicBoolean(false);
         final Exception e = new Exception();
-        Completable.create(new CompletableSource() {
+        Completable.unsafeCreate(new CompletableSource() {
                 @Override
                 public void subscribe(CompletableObserver cs) {
                     cs.onError(e);
                 }
             })
-            .andThen(Flowable.<String>create(new Publisher<String>() {
+            .andThen(Flowable.<String>unsafeCreate(new Publisher<String>() {
                 @Override
                 public void subscribe(Subscriber<? super String> s) {
                     hasRun.set(true);

--- a/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
@@ -15,21 +15,29 @@
  */
 package io.reactivex.exceptions;
 
-import static org.junit.Assert.*;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.*;
-import org.reactivestreams.*;
-
-import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.TestHelper;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.*;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observables.GroupedObservable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ExceptionsTest {
     
@@ -315,10 +323,10 @@ public class ExceptionsTest {
     @Ignore("v2 components should not throw")
     @Test(expected = RuntimeException.class)
     public void testOnErrorExceptionIsThrownFromSubscribe() {
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
                               @Override
                               public void subscribe(Observer<? super Integer> s1) {
-                                  Observable.create(new ObservableSource<Integer>() {
+                                  Observable.unsafeCreate(new ObservableSource<Integer>() {
                                       @Override
                                       public void subscribe(Observer<? super Integer> s2) {
                                           throw new IllegalArgumentException("original exception");
@@ -332,10 +340,10 @@ public class ExceptionsTest {
     @Ignore("v2 components should not throw")
     @Test(expected = RuntimeException.class)
     public void testOnErrorExceptionIsThrownFromUnsafeSubscribe() {
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
                               @Override
                               public void subscribe(Observer<? super Integer> s1) {
-                                  Observable.create(new ObservableSource<Integer>() {
+                                  Observable.unsafeCreate(new ObservableSource<Integer>() {
                                       @Override
                                       public void subscribe(Observer<? super Integer> s2) {
                                           throw new IllegalArgumentException("original exception");
@@ -362,10 +370,10 @@ public class ExceptionsTest {
     @Ignore("v2 components should not throw")
     @Test(expected = RuntimeException.class)
     public void testOnErrorExceptionIsThrownFromSingleSubscribe() {
-        Single.create(new SingleSource<Integer>() {
+        Single.unsafeCreate(new SingleSource<Integer>() {
                           @Override
                           public void subscribe(SingleObserver<? super Integer> s1) {
-                              Single.create(new SingleSource<Integer>() {
+                              Single.unsafeCreate(new SingleSource<Integer>() {
                                   @Override
                                   public void subscribe(SingleObserver<? super Integer> s2) {
                                       throw new IllegalArgumentException("original exception");
@@ -379,10 +387,10 @@ public class ExceptionsTest {
     @Ignore("v2 components should not throw")
     @Test(expected = RuntimeException.class)
     public void testOnErrorExceptionIsThrownFromSingleUnsafeSubscribe() {
-        Single.create(new SingleSource<Integer>() {
+        Single.unsafeCreate(new SingleSource<Integer>() {
                           @Override
                           public void subscribe(final SingleObserver<? super Integer> s1) {
-                              Single.create(new SingleSource<Integer>() {
+                              Single.unsafeCreate(new SingleSource<Integer>() {
                                   @Override
                                   public void subscribe(SingleObserver<? super Integer> s2) {
                                       throw new IllegalArgumentException("original exception");

--- a/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
@@ -675,7 +675,7 @@ public class FlowableBackpressureTests {
     }
 
     private static Flowable<Integer> incrementingIntegers(final AtomicInteger counter, final ConcurrentLinkedQueue<Thread> threadsSeen) {
-        return Flowable.create(new Publisher<Integer>() {
+        return Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {
@@ -724,7 +724,7 @@ public class FlowableBackpressureTests {
      * @return
      */
     private static Flowable<Integer> firehose(final AtomicInteger counter) {
-        return Flowable.create(new Publisher<Integer>() {
+        return Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
                 Subscription s2 = new FirehoseNoBackpressure(counter, s);

--- a/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
@@ -144,7 +144,7 @@ public class FlowableConcatTests {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
         
-        Flowable<Movie> o1 = Flowable.create(new Publisher<Movie>() {
+        Flowable<Movie> o1 = Flowable.unsafeCreate(new Publisher<Movie>() {
             @Override
             public void subscribe(Subscriber<? super Movie> o) {
                     o.onNext(horrorMovie1);

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -204,7 +204,7 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void createNull() {
-        Flowable.create(null);
+        Flowable.unsafeCreate(null);
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -260,7 +260,7 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>create(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
                 s.onSubscribe(new Subscription() {
@@ -285,7 +285,7 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>create(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
                 s.onSubscribe(new Subscription() {
@@ -310,7 +310,7 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>create(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
                 s.onSubscribe(new Subscription() {
@@ -338,7 +338,7 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>create(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
                 s.onSubscribe(new Subscription() {

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -269,13 +269,13 @@ public class FlowableTests {
         verify(w).onNext(60);
     }
 
-    @Ignore("Throwing is not allowed from the create?!")
+    @Ignore("Throwing is not allowed from the unsafeCreate?!")
     @Test // FIXME throwing is not allowed from the create?!
     public void testOnSubscribeFails() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
 
         final RuntimeException re = new RuntimeException("bad impl");
-        Flowable<String> o = Flowable.create(new Publisher<String>() {
+        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> s) { throw re; }
         });
@@ -442,7 +442,7 @@ public class FlowableTests {
     @Test
     public void testPublishLast() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
-        ConnectableFlowable<String> connectable = Flowable.<String>create(new Publisher<String>() {
+        ConnectableFlowable<String> connectable = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -480,7 +480,7 @@ public class FlowableTests {
     @Test
     public void testReplay() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableFlowable<String> o = Flowable.<String>create(new Publisher<String>() {
+        ConnectableFlowable<String> o = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
                     observer.onSubscribe(new BooleanSubscription());
@@ -533,7 +533,7 @@ public class FlowableTests {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.<String>create(new Publisher<String>() {
+        Flowable<String> o = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
                     observer.onSubscribe(new BooleanSubscription());
@@ -578,7 +578,7 @@ public class FlowableTests {
     @Test
     public void testCacheWithCapacity() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.<String>create(new Publisher<String>() {
+        Flowable<String> o = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -657,7 +657,7 @@ public class FlowableTests {
     public void testErrorThrownWithoutErrorHandlerAsynchronous() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
-        Flowable.create(new Publisher<Object>() {
+        Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
             public void subscribe(final Subscriber<? super Object> observer) {
                 observer.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -233,7 +233,7 @@ public class BlockingFlowableNextTest {
         final CountDownLatch timeHasPassed = new CountDownLatch(COUNT);
         final AtomicBoolean running = new AtomicBoolean(true);
         final AtomicInteger count = new AtomicInteger(0);
-        final Flowable<Integer> obs = Flowable.create(new Publisher<Integer>() {
+        final Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> o) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -69,7 +69,7 @@ public class BlockingFlowableToFutureTest {
 
     @Test
     public void testToFutureWithException() {
-        Flowable<String> obs = Flowable.create(new Publisher<String>() {
+        Flowable<String> obs = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> observer) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -47,7 +47,7 @@ public class BlockingFlowableToIteratorTest {
 
     @Test(expected = TestException.class)
     public void testToIteratorWithException() {
-        Flowable<String> obs = Flowable.create(new Publisher<String>() {
+        Flowable<String> obs = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> observer) {
@@ -69,7 +69,7 @@ public class BlockingFlowableToIteratorTest {
     @Ignore("subscribe() should not throw")
     @Test(expected = TestException.class)
     public void testExceptionThrownFromOnSubscribe() {
-        Iterable<String> strings = Flowable.create(new Publisher<String>() {
+        Iterable<String> strings = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> subscriber) {
                 throw new TestException("intentional");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -47,7 +47,7 @@ public class FlowableAmbTest {
 
     private Flowable<String> createFlowable(final String[] values,
             final long interval, final Throwable e) {
-        return Flowable.create(new Publisher<String>() {
+        return Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(final Subscriber<? super String> subscriber) {
@@ -178,7 +178,7 @@ public class FlowableAmbTest {
         ts.request(3);
         final AtomicLong requested1 = new AtomicLong();
         final AtomicLong requested2 = new AtomicLong();
-        Flowable<Integer> o1 = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> o1 = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -198,7 +198,7 @@ public class FlowableAmbTest {
             }
 
         });
-        Flowable<Integer> o2 = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> o2 = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -61,7 +61,7 @@ public class FlowableBufferTest {
 
     @Test
     public void testSkipAndCountOverlappingBuffers() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -117,7 +117,7 @@ public class FlowableBufferTest {
 
     @Test
     public void testTimedAndCount() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -149,7 +149,7 @@ public class FlowableBufferTest {
 
     @Test
     public void testTimed() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -183,7 +183,7 @@ public class FlowableBufferTest {
 
     @Test
     public void testObservableBasedOpenerAndCloser() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -196,7 +196,7 @@ public class FlowableBufferTest {
             }
         });
 
-        Flowable<Object> openings = Flowable.create(new Publisher<Object>() {
+        Flowable<Object> openings = Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
             public void subscribe(Subscriber<Object> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -209,7 +209,7 @@ public class FlowableBufferTest {
         Function<Object, Flowable<Object>> closer = new Function<Object, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Object opening) {
-                return Flowable.create(new Publisher<Object>() {
+                return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -234,7 +234,7 @@ public class FlowableBufferTest {
 
     @Test
     public void testObservableBasedCloser() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -250,7 +250,7 @@ public class FlowableBufferTest {
         Callable<Flowable<Object>> closer = new Callable<Flowable<Object>>() {
             @Override
             public Flowable<Object> call() {
-                return Flowable.create(new Publisher<Object>() {
+                return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -764,7 +764,7 @@ public class FlowableBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(3L);
         
         final AtomicLong requested = new AtomicLong();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -795,7 +795,7 @@ public class FlowableBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         final AtomicLong requested = new AtomicLong();
         
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -822,7 +822,7 @@ public class FlowableBufferTest {
     public void testProducerRequestThroughBufferWithSize3() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(3L);
         final AtomicLong requested = new AtomicLong();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -851,7 +851,7 @@ public class FlowableBufferTest {
     public void testProducerRequestThroughBufferWithSize4() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         final AtomicLong requested = new AtomicLong();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -881,7 +881,7 @@ public class FlowableBufferTest {
 
         final AtomicLong requested = new AtomicLong();
         
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -910,7 +910,7 @@ public class FlowableBufferTest {
 
         final AtomicLong requested = new AtomicLong();
         
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -936,7 +936,7 @@ public class FlowableBufferTest {
     @Test
     public void testProducerRequestOverflowThroughBufferWithSize3() {
         final AtomicLong requested = new AtomicLong();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -83,7 +83,7 @@ public class FlowableCacheTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.create(new Publisher<String>() {
+        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
@@ -217,7 +217,7 @@ public class FlowableCacheTest {
     @Test
     public void testNoMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Flowable<Integer> firehose = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t) {
                 t.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -82,7 +82,7 @@ public class FlowableConcatTest {
         final Flowable<String> odds = Flowable.fromArray(o);
         final Flowable<String> even = Flowable.fromArray(e);
 
-        Flowable<Flowable<String>> observableOfObservables = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
@@ -111,7 +111,7 @@ public class FlowableConcatTest {
         TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
         TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
 
-        Flowable.concat(Flowable.create(o1), Flowable.create(o2)).subscribe(observer);
+        Flowable.concat(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2)).subscribe(observer);
 
         try {
             // wait for async observables to complete
@@ -158,7 +158,7 @@ public class FlowableConcatTest {
         final CountDownLatch parentHasFinished = new CountDownLatch(1);
         
         
-        Flowable<Flowable<String>> observableOfObservables = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
             public void subscribe(final Subscriber<? super Flowable<String>> observer) {
@@ -181,12 +181,12 @@ public class FlowableConcatTest {
                             // emit first
                             if (!d.isDisposed()) {
                                 System.out.println("Emit o1");
-                                observer.onNext(Flowable.create(o1));
+                                observer.onNext(Flowable.unsafeCreate(o1));
                             }
                             // emit second
                             if (!d.isDisposed()) {
                                 System.out.println("Emit o2");
-                                observer.onNext(Flowable.create(o2));
+                                observer.onNext(Flowable.unsafeCreate(o2));
                             }
 
                             // wait until sometime later and emit third
@@ -197,7 +197,7 @@ public class FlowableConcatTest {
                             }
                             if (!d.isDisposed()) {
                                 System.out.println("Emit o3");
-                                observer.onNext(Flowable.create(o3));
+                                observer.onNext(Flowable.unsafeCreate(o3));
                             }
 
                         } catch (Throwable e) {
@@ -283,7 +283,7 @@ public class FlowableConcatTest {
         final CountDownLatch okToContinue = new CountDownLatch(1);
         @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(callOnce, okToContinue, odds, even);
-        Flowable<String> concatF = Flowable.concat(Flowable.create(observableOfObservables));
+        Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
         concatF.subscribe(observer);
         try {
             //Block main thread to allow observables to serve up o1.
@@ -321,8 +321,8 @@ public class FlowableConcatTest {
         Subscriber<String> observer = TestHelper.mockSubscriber();
         
         @SuppressWarnings("unchecked")
-        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.create(w1), Flowable.create(w2));
-        Flowable<String> concatF = Flowable.concat(Flowable.create(observableOfObservables));
+        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
+        Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
         concatF.take(50).subscribe(observer);
 
@@ -354,14 +354,14 @@ public class FlowableConcatTest {
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
         
-        Flowable<Flowable<String>> observableOfObservables = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in an observable
-                observer.onNext(Flowable.create(w1));
-                observer.onNext(Flowable.create(w2));
+                observer.onNext(Flowable.unsafeCreate(w1));
+                observer.onNext(Flowable.unsafeCreate(w2));
                 observer.onComplete();
             }
 
@@ -406,7 +406,7 @@ public class FlowableConcatTest {
         Subscriber<String> observer = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(observer, 0L);
 
-        final Flowable<String> concat = Flowable.concat(Flowable.create(w1), Flowable.create(w2));
+        final Flowable<String> concat = Flowable.concat(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
 
         try {
             // Subscribe
@@ -449,8 +449,8 @@ public class FlowableConcatTest {
         TestSubscriber<String> ts = new TestSubscriber<String>(observer, 0L);
         
         @SuppressWarnings("unchecked")
-        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.create(w1), Flowable.create(w2));
-        Flowable<String> concatF = Flowable.concat(Flowable.create(observableOfObservables));
+        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
+        Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
         concatF.subscribe(ts);
 
@@ -702,7 +702,7 @@ public class FlowableConcatTest {
     // https://github.com/ReactiveX/RxJava/issues/1818
     @Test
     public void testConcatWithNonCompliantSourceDoubleOnComplete() {
-        Flowable<String> o = Flowable.create(new Publisher<String>() {
+        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -45,7 +45,7 @@ public class FlowableDebounceTest {
 
     @Test
     public void testDebounceWithCompleted() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -71,7 +71,7 @@ public class FlowableDebounceTest {
 
     @Test
     public void testDebounceNeverEmits() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -101,7 +101,7 @@ public class FlowableDebounceTest {
 
     @Test
     public void testDebounceWithError() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -139,7 +139,7 @@ public class FlowableDetachTest {
         
         TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
         
-        Flowable.create(new Publisher<Object>() {
+        Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
             public void subscribe(Subscriber<? super Object> t) {
                 subscriber.set(t);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
@@ -67,7 +67,7 @@ public class FlowableDoOnSubscribeTest {
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
         final AtomicReference<Subscriber<? super Integer>> sref = new AtomicReference<Subscriber<? super Integer>>();
-        Flowable<Integer> o = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -18,11 +18,10 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Consumer;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 
-public class FlowableFromAsyncTest {
+public class FlowableFromSourceTest {
 
     PublishAsyncEmitter source;
 
@@ -39,7 +38,7 @@ public class FlowableFromAsyncTest {
     
     @Test
     public void normalBuffered() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -60,7 +59,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void normalDrop() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.DROP).subscribe(ts);
         
         source.onNext(1);
 
@@ -78,7 +77,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void normalLatest() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         source.onNext(1);
 
@@ -96,7 +95,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void normalNone() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.NONE).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -109,7 +108,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void normalNoneRequested() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.NONE).subscribe(ts);
         ts.request(2);
         
         source.onNext(1);
@@ -124,7 +123,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void normalError() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.ERROR).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -134,12 +133,12 @@ public class FlowableFromAsyncTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotComplete();
         
-        Assert.assertEquals("fromAsync: could not emit value due to lack of requests", ts.errors().get(0).getMessage());
+        Assert.assertEquals("create: could not emit value due to lack of requests", ts.errors().get(0).getMessage());
     }
 
     @Test
     public void errorBuffered() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -158,7 +157,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void errorLatest() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -175,7 +174,7 @@ public class FlowableFromAsyncTest {
     
     @Test
     public void errorNone() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.NONE).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -190,7 +189,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedBuffer() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.cancel();
         
         source.onNext(1);
@@ -206,7 +205,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedLatest() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         ts.cancel();
         
         source.onNext(1);
@@ -222,7 +221,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedError() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.ERROR).subscribe(ts);
         ts.cancel();
         
         source.onNext(1);
@@ -238,7 +237,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedDrop() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.DROP).subscribe(ts);
         ts.cancel();
         
         source.onNext(1);
@@ -254,7 +253,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedNone() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.NONE).subscribe(ts);
         ts.cancel();
         
         source.onNext(1);
@@ -270,7 +269,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelBuffer() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.cancel();
         
         sourceNoCancel.onNext(1);
@@ -286,7 +285,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelLatest() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         ts.cancel();
         
         sourceNoCancel.onNext(1);
@@ -302,7 +301,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelError() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.ERROR).subscribe(ts);
         ts.cancel();
         
         sourceNoCancel.onNext(1);
@@ -318,7 +317,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelDrop() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.DROP).subscribe(ts);
         ts.cancel();
         
         sourceNoCancel.onNext(1);
@@ -334,7 +333,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelNone() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.NONE).subscribe(ts);
         ts.cancel();
         
         sourceNoCancel.onNext(1);
@@ -350,7 +349,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void deferredRequest() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -365,7 +364,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void take() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -380,7 +379,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void takeOne() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
         ts.request(2);
         
         source.onNext(1);
@@ -394,7 +393,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void requestExact() {
-        Flowable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(source, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.request(2);
         
         source.onNext(1);
@@ -408,7 +407,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void takeNoCancel() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -423,7 +422,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void takeOneNoCancel() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
         ts.request(2);
         
         sourceNoCancel.onNext(1);
@@ -437,7 +436,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void unsubscribeNoCancel() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.request(2);
         
         sourceNoCancel.onNext(1);
@@ -462,7 +461,7 @@ public class FlowableFromAsyncTest {
             }
         };
         
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         
@@ -473,7 +472,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void completeInline() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onComplete();
@@ -487,7 +486,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void errorInline() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onError(new TestException());
@@ -509,7 +508,7 @@ public class FlowableFromAsyncTest {
             }
         };
         
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.BUFFER).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -529,7 +528,7 @@ public class FlowableFromAsyncTest {
             }
         };
         
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         
@@ -548,7 +547,7 @@ public class FlowableFromAsyncTest {
             }
         };
         
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         
@@ -559,7 +558,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void completeInlineLatest() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onComplete();
@@ -573,7 +572,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void completeInlineExactLatest() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onComplete();
@@ -587,7 +586,7 @@ public class FlowableFromAsyncTest {
 
     @Test
     public void errorInlineLatest() {
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onError(new TestException());
@@ -609,7 +608,7 @@ public class FlowableFromAsyncTest {
             }
         };
         
-        Flowable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        Flowable.create(sourceNoCancel, FlowableEmitter.BackpressureMode.LATEST).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -619,11 +618,11 @@ public class FlowableFromAsyncTest {
         ts1.assertNotComplete();
     }
     
-    static final class PublishAsyncEmitter implements Consumer<AsyncEmitter<Integer>>, Subscriber<Integer> {
+    static final class PublishAsyncEmitter implements FlowableSource<Integer>, Subscriber<Integer> {
         
         final PublishProcessor<Integer> subject;
         
-        AsyncEmitter<Integer> current;
+        FlowableEmitter<Integer> current;
         
         public PublishAsyncEmitter() {
             this.subject = PublishProcessor.create();
@@ -634,7 +633,7 @@ public class FlowableFromAsyncTest {
         }
         
         @Override
-        public void accept(final AsyncEmitter<Integer> t) {
+        public void subscribe(final FlowableEmitter<Integer> t) {
 
             this.current = t;
             
@@ -659,7 +658,7 @@ public class FlowableFromAsyncTest {
             
             subject.subscribe(as);
             
-            t.setCancellation(new AsyncEmitter.Cancellable() {
+            t.setCancellation(new FlowableEmitter.Cancellable() {
                 @Override
                 public void cancel() throws Exception {
                     as.dispose();
@@ -688,7 +687,7 @@ public class FlowableFromAsyncTest {
         }
     }
     
-    static final class PublishAsyncEmitterNoCancel implements Consumer<AsyncEmitter<Integer>>, Subscriber<Integer> {
+    static final class PublishAsyncEmitterNoCancel implements FlowableSource<Integer>, Subscriber<Integer> {
         
         final PublishProcessor<Integer> subject;
         
@@ -697,7 +696,7 @@ public class FlowableFromAsyncTest {
         }
         
         @Override
-        public void accept(final AsyncEmitter<Integer> t) {
+        public void subscribe(final FlowableEmitter<Integer> t) {
 
             subject.subscribe(new Subscriber<Integer>() {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -182,7 +182,7 @@ public class FlowableGroupByTest {
         final int count = 100;
         final int groupCount = 2;
 
-        Flowable<Event> es = Flowable.create(new Publisher<Event>() {
+        Flowable<Event> es = Flowable.unsafeCreate(new Publisher<Event>() {
 
             @Override
             public void subscribe(final Subscriber<? super Event> observer) {
@@ -594,7 +594,7 @@ public class FlowableGroupByTest {
     public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsAndThenComplete() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
@@ -673,7 +673,7 @@ public class FlowableGroupByTest {
         System.err.println("----------------------------------------------------------------------------------------------");
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
@@ -765,7 +765,7 @@ public class FlowableGroupByTest {
     public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenObservesOnAndDelaysAndThenCompletes() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
@@ -842,7 +842,7 @@ public class FlowableGroupByTest {
     @Test
     public void testGroupsWithNestedSubscribeOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<String>();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
@@ -899,7 +899,7 @@ public class FlowableGroupByTest {
     @Test
     public void testGroupsWithNestedObserveOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<String>();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {
@@ -960,7 +960,7 @@ public class FlowableGroupByTest {
     };
 
     Flowable<Event> SYNC_INFINITE_OBSERVABLE_OF_EVENT(final int numGroups, final AtomicInteger subscribeCounter, final AtomicInteger sentEventCounter) {
-        return Flowable.create(new Publisher<Event>() {
+        return Flowable.unsafeCreate(new Publisher<Event>() {
 
             @Override
             public void subscribe(final Subscriber<? super Event> op) {
@@ -1380,7 +1380,7 @@ public class FlowableGroupByTest {
     @Test
     public void testGroupByUnsubscribe() {
         final Subscription s = mock(Subscription.class);
-        Flowable<Integer> o = Flowable.create(
+        Flowable<Integer> o = Flowable.unsafeCreate(
                 new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> subscriber) {
@@ -1429,7 +1429,7 @@ public class FlowableGroupByTest {
                 }
             }
         });
-        Flowable.create(
+        Flowable.unsafeCreate(
                 new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> subscriber) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -38,7 +38,7 @@ public class FlowableMaterializeTest {
                 "three");
 
         TestObserver observer = new TestObserver();
-        Flowable<Try<Optional<String>>> m = Flowable.create(o1).materialize();
+        Flowable<Try<Optional<String>>> m = Flowable.unsafeCreate(o1).materialize();
         m.subscribe(observer);
 
         try {
@@ -63,7 +63,7 @@ public class FlowableMaterializeTest {
         final TestAsyncErrorObservable o1 = new TestAsyncErrorObservable("one", "two", "three");
 
         TestObserver Observer = new TestObserver();
-        Flowable<Try<Optional<String>>> m = Flowable.create(o1).materialize();
+        Flowable<Try<Optional<String>>> m = Flowable.unsafeCreate(o1).materialize();
         m.subscribe(Observer);
 
         try {
@@ -88,7 +88,7 @@ public class FlowableMaterializeTest {
     public void testMultipleSubscribes() throws InterruptedException, ExecutionException {
         final TestAsyncErrorObservable o = new TestAsyncErrorObservable("one", "two", null, "three");
 
-        Flowable<Try<Optional<String>>> m = Flowable.create(o).materialize();
+        Flowable<Try<Optional<String>>> m = Flowable.unsafeCreate(o).materialize();
 
         assertEquals(3, m.toList().toBlocking().toFuture().get().size());
         assertEquals(3, m.toList().toBlocking().toFuture().get().size());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -43,8 +43,8 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed1() {
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -64,10 +64,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed2() {
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o3 = Flowable.create(new TestErrorFlowable("seven", "eight", null));
-        final Flowable<String> o4 = Flowable.create(new TestErrorFlowable("nine"));
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
+        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -89,10 +89,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed3() {
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("four", "five", "six"));
-        final Flowable<String> o3 = Flowable.create(new TestErrorFlowable("seven", "eight", null));
-        final Flowable<String> o4 = Flowable.create(new TestErrorFlowable("nine"));
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", "five", "six"));
+        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
+        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -112,10 +112,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed4() {
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("four", "five", "six"));
-        final Flowable<String> o3 = Flowable.create(new TestErrorFlowable("seven", "eight"));
-        final Flowable<String> o4 = Flowable.create(new TestErrorFlowable("nine", null));
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", "five", "six"));
+        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight"));
+        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine", null));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -141,7 +141,7 @@ public class FlowableMergeDelayErrorTest {
         // throw the error at the very end so no onComplete will be called after it
         final TestAsyncErrorFlowable o4 = new TestAsyncErrorFlowable("nine", null);
 
-        Flowable<String> m = Flowable.mergeDelayError(Flowable.create(o1), Flowable.create(o2), Flowable.create(o3), Flowable.create(o4));
+        Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2), Flowable.unsafeCreate(o3), Flowable.unsafeCreate(o4));
         m.subscribe(stringObserver);
 
         try {
@@ -168,8 +168,8 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed1() {
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("one", "two", null));
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -188,8 +188,8 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed2() {
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("one", "two", null));
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
         CaptureObserver w = new CaptureObserver();
@@ -218,10 +218,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeFlowableOfFlowables() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
-        Flowable<Flowable<String>> FlowableOfFlowables = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> FlowableOfFlowables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
@@ -243,8 +243,8 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeArray() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -256,8 +256,8 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeList() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
         listOfFlowables.add(o1);
         listOfFlowables.add(o2);
@@ -275,7 +275,7 @@ public class FlowableMergeDelayErrorTest {
         final TestASynchronousFlowable o1 = new TestASynchronousFlowable();
         final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
 
-        Flowable<String> m = Flowable.mergeDelayError(Flowable.create(o1), Flowable.create(o2));
+        Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
         m.subscribe(stringObserver);
 
         try {
@@ -439,7 +439,7 @@ public class FlowableMergeDelayErrorTest {
     @Test
     @Ignore("Subscribers should not throw")
     public void testMergeSourceWhichDoesntPropagateExceptionBack() {
-        Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
                 t1.onSubscribe(new BooleanSubscription());
@@ -511,12 +511,12 @@ public class FlowableMergeDelayErrorTest {
         for (int i = 0; i < 50; i++) {
             final TestASynchronous1sDelayedFlowable o1 = new TestASynchronous1sDelayedFlowable();
             final TestASynchronous1sDelayedFlowable o2 = new TestASynchronous1sDelayedFlowable();
-            Flowable<Flowable<String>> parentFlowable = Flowable.create(new Publisher<Flowable<String>>() {
+            Flowable<Flowable<String>> parentFlowable = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
                 @Override
                 public void subscribe(Subscriber<? super Flowable<String>> op) {
                     op.onSubscribe(new BooleanSubscription());
-                    op.onNext(Flowable.create(o1));
-                    op.onNext(Flowable.create(o2));
+                    op.onNext(Flowable.unsafeCreate(o1));
+                    op.onNext(Flowable.unsafeCreate(o2));
                     op.onError(new NullPointerException("throwing exception in parent"));
                 }
             });
@@ -585,8 +585,8 @@ public class FlowableMergeDelayErrorTest {
     // This is pretty much a clone of testMergeList but with the overloaded MergeDelayError for Iterables
     @Test     
     public void mergeIterable() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
         listOfFlowables.add(o1);
         listOfFlowables.add(o2);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -68,7 +68,7 @@ public class FlowableMergeMaxConcurrentTest {
             for (int i = 0; i < observableCount; i++) {
                 SubscriptionCheckObservable sco = new SubscriptionCheckObservable(subscriptionCount, maxConcurrent);
                 scos.add(sco);
-                os.add(Flowable.create(sco));
+                os.add(Flowable.unsafeCreate(sco));
             }
 
             Iterator<String> iter = Flowable.merge(os, maxConcurrent).toBlocking().iterator();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -73,10 +73,10 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeFlowableOfFlowables() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
-        Flowable<Flowable<String>> FlowableOfFlowables = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> FlowableOfFlowables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
@@ -98,8 +98,8 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeArray() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<String> m = Flowable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -111,8 +111,8 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeList() {
-        final Flowable<String> o1 = Flowable.create(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.create(new TestSynchronousFlowable());
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
         listOfFlowables.add(o1);
         listOfFlowables.add(o2);
@@ -131,7 +131,7 @@ public class FlowableMergeTest {
         final AtomicBoolean unsubscribed = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        Flowable<Flowable<Long>> source = Flowable.create(new Publisher<Flowable<Long>>() {
+        Flowable<Flowable<Long>> source = Flowable.unsafeCreate(new Publisher<Flowable<Long>>() {
 
             @Override
             public void subscribe(final Subscriber<? super Flowable<Long>> observer) {
@@ -198,7 +198,7 @@ public class FlowableMergeTest {
         final TestASynchronousFlowable o1 = new TestASynchronousFlowable();
         final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
 
-        Flowable<String> m = Flowable.merge(Flowable.create(o1), Flowable.create(o2));
+        Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
         TestSubscriber<String> ts = new TestSubscriber<String>(stringObserver);
         m.subscribe(ts);
 
@@ -229,7 +229,7 @@ public class FlowableMergeTest {
         final AtomicInteger concurrentCounter = new AtomicInteger();
         final AtomicInteger totalCounter = new AtomicInteger();
 
-        Flowable<String> m = Flowable.merge(Flowable.create(o1), Flowable.create(o2));
+        Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
         m.subscribe(new DefaultSubscriber<String>() {
 
             @Override
@@ -303,8 +303,8 @@ public class FlowableMergeTest {
     @Test
     public void testError1() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
 
         Flowable<String> m = Flowable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -325,10 +325,10 @@ public class FlowableMergeTest {
     @Test
     public void testError2() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Flowable<String> o1 = Flowable.create(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.create(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
-        final Flowable<String> o3 = Flowable.create(new TestErrorFlowable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
-        final Flowable<String> o4 = Flowable.create(new TestErrorFlowable("nine"));// we expect to lose all of these since o2 is done first and fails
+        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
+        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
+        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));// we expect to lose all of these since o2 is done first and fails
 
         Flowable<String> m = Flowable.merge(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -350,7 +350,7 @@ public class FlowableMergeTest {
     @Ignore("Subscribe should not throw")
     public void testThrownErrorHandling() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable<String> o1 = Flowable.create(new Publisher<String>() {
+        Flowable<String> o1 = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
@@ -504,7 +504,7 @@ public class FlowableMergeTest {
     }
 
     private Flowable<Long> createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
-        return Flowable.create(new Publisher<Long>() {
+        return Flowable.unsafeCreate(new Publisher<Long>() {
 
             @Override
             public void subscribe(final Subscriber<? super Long> child) {
@@ -571,7 +571,7 @@ public class FlowableMergeTest {
     @Test
     public void testConcurrencyWithSleeping() {
 
-        Flowable<Integer> o = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {
@@ -621,7 +621,7 @@ public class FlowableMergeTest {
 
     @Test
     public void testConcurrencyWithBrokenOnCompleteContract() {
-        Flowable<Integer> o = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {
@@ -890,7 +890,7 @@ public class FlowableMergeTest {
     public void mergeWithTerminalEventAfterUnsubscribe() {
         System.out.println("mergeWithTerminalEventAfterUnsubscribe");
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable<String> bad = Flowable.create(new Publisher<String>() {
+        Flowable<String> bad = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
@@ -1073,7 +1073,7 @@ public class FlowableMergeTest {
 
             @Override
             public Flowable<Integer> apply(final Integer i) {
-                return Flowable.create(new Publisher<Integer>() {
+                return Flowable.unsafeCreate(new Publisher<Integer>() {
 
                     @Override
                     public void subscribe(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -536,7 +536,7 @@ public class FlowableObserveOnTest {
     @Test
     public void testQueueFullEmitsError() {
         final CountDownLatch latch = new CountDownLatch(1);
-        Flowable<Integer> flowable = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> flowable = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> o) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -145,7 +145,7 @@ public class FlowableOnBackpressureBufferTest {
 //        assertTrue(s.isUnsubscribed());
     }
 
-    static final Flowable<Long> infinite = Flowable.create(new Publisher<Long>() {
+    static final Flowable<Long> infinite = Flowable.unsafeCreate(new Publisher<Long>() {
 
         @Override
         public void subscribe(Subscriber<? super Long> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -118,7 +118,7 @@ public class FlowableOnBackpressureDropTest {
         assertEquals(n, count.get());
     }
 
-    static final Flowable<Long> infinite = Flowable.create(new Publisher<Long>() {
+    static final Flowable<Long> infinite = Flowable.unsafeCreate(new Publisher<Long>() {
 
         @Override
         public void subscribe(Subscriber<? super Long> s) {
@@ -133,7 +133,7 @@ public class FlowableOnBackpressureDropTest {
     });
     
     private static final Flowable<Long> range(final long n) {
-        return Flowable.create(new Publisher<Long>() {
+        return Flowable.unsafeCreate(new Publisher<Long>() {
 
             @Override
             public void subscribe(Subscriber<? super Long> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -35,7 +35,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
     @Test
     public void testResumeNextWithSynchronousExecution() {
         final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
-        Flowable<String> w = Flowable.create(new Publisher<String>() {
+        Flowable<String> w = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> observer) {
@@ -86,7 +86,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Flowable<String> observable = Flowable.create(w).onErrorResumeNext(resume);
+        Flowable<String> observable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
 
@@ -123,7 +123,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Flowable<String> observable = Flowable.create(w).onErrorResumeNext(resume);
+        Flowable<String> observable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
         DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaObservableTest.java
@@ -33,7 +33,7 @@ public class FlowableOnErrorResumeNextViaObservableTest {
         Subscription s = mock(Subscription.class);
         // Trigger failure on second element
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onErrorResumeNext(resume);
 
@@ -62,7 +62,7 @@ public class FlowableOnErrorResumeNextViaObservableTest {
         Flowable<String> w = Flowable.just("one", "fail", "two", "three", "fail");
         // Resume Observable is async
         TestObservable f = new TestObservable(sr, "twoResume", "threeResume");
-        Flowable<String> resume = Flowable.create(f);
+        Flowable<String> resume = Flowable.unsafeCreate(f);
 
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
@@ -100,7 +100,7 @@ public class FlowableOnErrorResumeNextViaObservableTest {
     @Test
     @Ignore("Publishers should not throw")
     public void testResumeNextWithFailureOnSubscribe() {
-        Flowable<String> testObservable = Flowable.create(new Publisher<String>() {
+        Flowable<String> testObservable = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> t1) {
@@ -122,7 +122,7 @@ public class FlowableOnErrorResumeNextViaObservableTest {
     @Test
     @Ignore("Publishers should not throw")
     public void testResumeNextWithFailureOnSubscribeAsync() {
-        Flowable<String> testObservable = Flowable.create(new Publisher<String>() {
+        Flowable<String> testObservable = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> t1) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -34,7 +34,7 @@ public class FlowableOnErrorReturnTest {
     @Test
     public void testResumeNext() {
         TestObservable f = new TestObservable("one");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
         Flowable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
@@ -70,7 +70,7 @@ public class FlowableOnErrorReturnTest {
     @Test
     public void testFunctionThrowsError() {
         TestObservable f = new TestObservable("one");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
         Flowable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaObservableTest.java
@@ -33,7 +33,7 @@ public class FlowableOnExceptionResumeNextViaObservableTest {
     public void testResumeNextWithException() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "EXCEPTION", "two", "three");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -61,7 +61,7 @@ public class FlowableOnExceptionResumeNextViaObservableTest {
     public void testResumeNextWithRuntimeException() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "RUNTIMEEXCEPTION", "two", "three");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -89,7 +89,7 @@ public class FlowableOnExceptionResumeNextViaObservableTest {
     public void testThrowablePassesThru() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "THROWABLE", "two", "three");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -117,7 +117,7 @@ public class FlowableOnExceptionResumeNextViaObservableTest {
     public void testErrorPassesThru() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "ERROR", "two", "three");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -147,7 +147,7 @@ public class FlowableOnExceptionResumeNextViaObservableTest {
         Flowable<String> w = Flowable.just("one", "fail", "two", "three", "fail");
         // Resume Observable is async
         TestObservable f = new TestObservable("twoResume", "threeResume");
-        Flowable<String> resume = Flowable.create(f);
+        Flowable<String> resume = Flowable.unsafeCreate(f);
 
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -35,7 +35,7 @@ public class FlowablePublishTest {
     @Test
     public void testPublish() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableFlowable<String> o = Flowable.create(new Publisher<String>() {
+        ConnectableFlowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
@@ -367,7 +367,7 @@ public class FlowablePublishTest {
     @Test
     public void testConnectIsIdempotent() {
         final AtomicInteger calls = new AtomicInteger();
-        Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t) {
                 t.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -289,7 +289,7 @@ public class FlowableRefCountTest {
     }
 
     private Flowable<Long> synchronousInterval() {
-        return Flowable.create(new Publisher<Long>() {
+        return Flowable.unsafeCreate(new Publisher<Long>() {
             @Override
             public void subscribe(Subscriber<? super Long> subscriber) {
                 final AtomicBoolean cancel = new AtomicBoolean();
@@ -323,7 +323,7 @@ public class FlowableRefCountTest {
     public void onlyFirstShouldSubscribeAndLastUnsubscribe() {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         final AtomicInteger unsubscriptionCount = new AtomicInteger();
-        Flowable<Integer> observable = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> observable = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> observer) {
                 subscriptionCount.incrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -37,7 +37,7 @@ public class FlowableRepeatTest {
     public void testRepetition() {
         int NUM = 10;
         final AtomicInteger count = new AtomicInteger();
-        int value = Flowable.create(new Publisher<Integer>() {
+        int value = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> o) {
@@ -66,7 +66,7 @@ public class FlowableRepeatTest {
     public void testRepeatTakeWithSubscribeOn() throws InterruptedException {
 
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<Integer> oi = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> oi = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -898,7 +898,7 @@ public class FlowableReplayTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.create(new Publisher<String>() {
+        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
@@ -1034,7 +1034,7 @@ public class FlowableReplayTest {
     @Test
     public void testNoMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Flowable<Integer> firehose = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t) {
                 t.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -40,7 +40,7 @@ public class FlowableRetryTest {
     public void iterativeBackoff() {
         Subscriber<String> consumer = TestHelper.mockSubscriber();
         
-        Flowable<String> producer = Flowable.create(new Publisher<String>() {
+        Flowable<String> producer = Flowable.unsafeCreate(new Publisher<String>() {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();
@@ -112,7 +112,7 @@ public class FlowableRetryTest {
     public void testRetryIndefinitely() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
         int NUM_RETRIES = 20;
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_RETRIES));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retry().unsafeSubscribe(new TestSubscriber<String>(observer));
 
         InOrder inOrder = inOrder(observer);
@@ -131,7 +131,7 @@ public class FlowableRetryTest {
     public void testSchedulingNotificationHandler() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
         int NUM_RETRIES = 2;
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_RETRIES));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         TestSubscriber<String> subscriber = new TestSubscriber<String>(observer);
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
@@ -169,7 +169,7 @@ public class FlowableRetryTest {
     public void testOnNextFromNotificationHandler() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
         int NUM_RETRIES = 2;
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_RETRIES));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
@@ -198,7 +198,7 @@ public class FlowableRetryTest {
     @Test
     public void testOnCompletedFromNotificationHandler() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(1));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(1));
         TestSubscriber<String> subscriber = new TestSubscriber<String>(observer);
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
@@ -219,7 +219,7 @@ public class FlowableRetryTest {
     @Test
     public void testOnErrorFromNotificationHandler() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(2));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(2));
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
@@ -249,7 +249,7 @@ public class FlowableRetryTest {
             }
         };
 
-        int first = Flowable.create(onSubscribe)
+        int first = Flowable.unsafeCreate(onSubscribe)
                 .retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Flowable<? extends Throwable> attempt) {
@@ -271,7 +271,7 @@ public class FlowableRetryTest {
     @Test
     public void testOriginFails() {
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(1));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(1));
         origin.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -286,7 +286,7 @@ public class FlowableRetryTest {
         int NUM_RETRIES = 1;
         int NUM_FAILURES = 2;
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_FAILURES));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry(NUM_RETRIES).subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -304,7 +304,7 @@ public class FlowableRetryTest {
     public void testRetrySuccess() {
         int NUM_FAILURES = 1;
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_FAILURES));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry(3).subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -323,7 +323,7 @@ public class FlowableRetryTest {
     public void testInfiniteRetry() {
         int NUM_FAILURES = 20;
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_FAILURES));
+        Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry().subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -480,7 +480,7 @@ public class FlowableRetryTest {
                 
             }
         };
-        Flowable<String> stream = Flowable.create(onSubscribe);
+        Flowable<String> stream = Flowable.unsafeCreate(onSubscribe);
         Flowable<String> streamWithRetry = stream.retry();
         Disposable sub = streamWithRetry.subscribe();
         assertEquals(1, subsCount.get());
@@ -517,7 +517,7 @@ public class FlowableRetryTest {
             }
         };
 
-        Flowable.create(onSubscribe).retry(3).subscribe(ts);
+        Flowable.unsafeCreate(onSubscribe).retry(3).subscribe(ts);
         assertEquals(4, subsCount.get()); // 1 + 3 retries
     }
 
@@ -536,7 +536,7 @@ public class FlowableRetryTest {
             }
         };
 
-        Flowable.create(onSubscribe).retry(1).subscribe(ts);
+        Flowable.unsafeCreate(onSubscribe).retry(1).subscribe(ts);
         assertEquals(2, subsCount.get());
     }
 
@@ -555,7 +555,7 @@ public class FlowableRetryTest {
             }
         };
 
-        Flowable.create(onSubscribe).retry(0).subscribe(ts);
+        Flowable.unsafeCreate(onSubscribe).retry(0).subscribe(ts);
         assertEquals(1, subsCount.get());
     }
 
@@ -664,7 +664,7 @@ public class FlowableRetryTest {
 
         // Observable that always fails after 100ms
         SlowObservable so = new SlowObservable(100, 0);
-        Flowable<Long> o = Flowable.create(so).retry(5);
+        Flowable<Long> o = Flowable.unsafeCreate(so).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
 
@@ -689,7 +689,7 @@ public class FlowableRetryTest {
 
         // Observable that sends every 100ms (timeout fails instead)
         SlowObservable so = new SlowObservable(100, 10);
-        Flowable<Long> o = Flowable.create(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
+        Flowable<Long> o = Flowable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
 
@@ -712,7 +712,7 @@ public class FlowableRetryTest {
             final int NUM_RETRIES = Flowable.bufferSize() * 2;
             for (int i = 0; i < 400; i++) {
                 Subscriber<String> observer = TestHelper.mockSubscriber();
-                Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_RETRIES));
+                Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
                 TestSubscriber<String> ts = new TestSubscriber<String>(observer);
                 origin.retry().observeOn(Schedulers.computation()).unsafeSubscribe(ts);
                 ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
@@ -755,7 +755,7 @@ public class FlowableRetryTest {
                         public void run() {
                             final AtomicInteger nexts = new AtomicInteger();
                             try {
-                                Flowable<String> origin = Flowable.create(new FuncWithErrors(NUM_RETRIES));
+                                Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
                                 TestSubscriber<String> ts = new TestSubscriber<String>();
                                 origin.retry()
                                 .observeOn(Schedulers.computation()).unsafeSubscribe(ts);
@@ -876,7 +876,7 @@ public class FlowableRetryTest {
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable<String> origin = Flowable.create(new Publisher<String>() {
+        Flowable<String> origin = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> o) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -70,7 +70,7 @@ public class FlowableRetryWithPredicateTest {
     }
     @Test
     public void testRetryTwice() {
-        Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
@@ -106,7 +106,7 @@ public class FlowableRetryWithPredicateTest {
     }
     @Test
     public void testRetryTwiceAndGiveUp() {
-        Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
                 t1.onSubscribe(new BooleanSubscription());
@@ -134,7 +134,7 @@ public class FlowableRetryWithPredicateTest {
     }
     @Test
     public void testRetryOnSpecificException() {
-        Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
@@ -171,7 +171,7 @@ public class FlowableRetryWithPredicateTest {
     public void testRetryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Flowable<Integer> source = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
@@ -230,7 +230,7 @@ public class FlowableRetryWithPredicateTest {
         // Observable that always fails after 100ms
         FlowableRetryTest.SlowObservable so = new FlowableRetryTest.SlowObservable(100, 0);
         Flowable<Long> o = Flowable
-                .create(so)
+                .unsafeCreate(so)
                 .retry(retry5);
 
         FlowableRetryTest.AsyncObserver<Long> async = new FlowableRetryTest.AsyncObserver<Long>(observer);
@@ -256,7 +256,7 @@ public class FlowableRetryWithPredicateTest {
         // Observable that sends every 100ms (timeout fails instead)
         FlowableRetryTest.SlowObservable so = new FlowableRetryTest.SlowObservable(100, 10);
         Flowable<Long> o = Flowable
-                .create(so)
+                .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -44,7 +44,7 @@ public class FlowableSampleTest {
 
     @Test
     public void testSample() {
-        Flowable<Long> source = Flowable.create(new Publisher<Long>() {
+        Flowable<Long> source = Flowable.unsafeCreate(new Publisher<Long>() {
             @Override
             public void subscribe(final Subscriber<? super Long> observer1) {
                 observer1.onSubscribe(new BooleanSubscription());
@@ -265,7 +265,7 @@ public class FlowableSampleTest {
     @Test
     public void testSampleUnsubscribe() {
         final Subscription s = mock(Subscription.class);
-        Flowable<Integer> o = Flowable.create(
+        Flowable<Integer> o = Flowable.unsafeCreate(
                 new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> subscriber) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -294,7 +294,7 @@ public class FlowableScanTest {
     @Test
     public void testScanShouldNotRequestZero() {
         final AtomicReference<Subscription> producer = new AtomicReference<Subscription>();
-        Flowable<Integer> o = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(final Subscriber<? super Integer> subscriber) {
                 Subscription p = spy(new Subscription() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
@@ -39,7 +39,7 @@ public class FlowableSerializeTest {
     @Test
     public void testSingleThreadedBasic() {
         TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
-        Flowable<String> w = Flowable.create(onSubscribe);
+        Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
         w.serialize().subscribe(observer);
         onSubscribe.waitToFinish();
@@ -57,7 +57,7 @@ public class FlowableSerializeTest {
     @Test
     public void testMultiThreadedBasic() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three");
-        Flowable<String> w = Flowable.create(onSubscribe);
+        Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
         BusyObserver busyobserver = new BusyObserver();
 
@@ -80,7 +80,7 @@ public class FlowableSerializeTest {
     @Test
     public void testMultiThreadedWithNPE() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
-        Flowable<String> w = Flowable.create(onSubscribe);
+        Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
         BusyObserver busyobserver = new BusyObserver();
 
@@ -111,7 +111,7 @@ public class FlowableSerializeTest {
         boolean lessThan9 = false;
         for (int i = 0; i < 3; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, "four", "five", "six", "seven", "eight", "nine");
-            Flowable<String> w = Flowable.create(onSubscribe);
+            Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
     
             BusyObserver busyobserver = new BusyObserver();
     

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -40,7 +40,7 @@ public class FlowableSubscribeOnTest {
         TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
 
         Flowable
-        .create(new Publisher<Integer>() {
+        .unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(
                     final Subscriber<? super Integer> subscriber) {
@@ -77,7 +77,7 @@ public class FlowableSubscribeOnTest {
     @Ignore("Publisher.subscribe can't throw")
     public void testThrownErrorHandling() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.create(new Publisher<String>() {
+        Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
@@ -92,7 +92,7 @@ public class FlowableSubscribeOnTest {
     @Test
     public void testOnError() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.create(new Publisher<String>() {
+        Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
@@ -163,7 +163,7 @@ public class FlowableSubscribeOnTest {
     public void testUnsubscribeInfiniteStream() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         final AtomicInteger count = new AtomicInteger();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> sub) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -59,7 +59,7 @@ public class FlowableSwitchIfEmptyTest {
     @Test
     public void testSwitchWithProducer() throws Exception {
         final AtomicBoolean emitted = new AtomicBoolean(false);
-        Flowable<Long> withProducer = Flowable.create(new Publisher<Long>() {
+        Flowable<Long> withProducer = Flowable.unsafeCreate(new Publisher<Long>() {
             @Override
             public void subscribe(final Subscriber<? super Long> subscriber) {
                 subscriber.onSubscribe(new Subscription() {
@@ -89,7 +89,7 @@ public class FlowableSwitchIfEmptyTest {
 
         final BooleanSubscription bs = new BooleanSubscription();
         
-        Flowable<Long> withProducer = Flowable.create(new Publisher<Long>() {
+        Flowable<Long> withProducer = Flowable.unsafeCreate(new Publisher<Long>() {
             @Override
             public void subscribe(final Subscriber<? super Long> subscriber) {
                 subscriber.onSubscribe(bs);
@@ -132,7 +132,7 @@ public class FlowableSwitchIfEmptyTest {
     public void testSwitchShouldTriggerUnsubscribe() {
         final BooleanSubscription bs = new BooleanSubscription();
         
-        Flowable.create(new Publisher<Long>() {
+        Flowable.unsafeCreate(new Publisher<Long>() {
             @Override
             public void subscribe(final Subscriber<? super Long> subscriber) {
                 subscriber.onSubscribe(bs);
@@ -176,7 +176,7 @@ public class FlowableSwitchIfEmptyTest {
     @Test(timeout = 10000)
     public void testRequestsNotLost() throws InterruptedException {
         final TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
-        Flowable.create(new Publisher<Long>() {
+        Flowable.unsafeCreate(new Publisher<Long>() {
 
             @Override
             public void subscribe(final Subscriber<? super Long> subscriber) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -48,11 +48,11 @@ public class FlowableSwitchTest {
 
     @Test
     public void testSwitchWhenOuterCompleteBeforeInner() {
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -77,11 +77,11 @@ public class FlowableSwitchTest {
 
     @Test
     public void testSwitchWhenInnerCompleteBeforeOuter() {
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 10, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 10, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -91,7 +91,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 100, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 100, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -123,11 +123,11 @@ public class FlowableSwitchTest {
 
     @Test
     public void testSwitchWithComplete() {
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(final Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -136,7 +136,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 200, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 200, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(final Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -182,11 +182,11 @@ public class FlowableSwitchTest {
 
     @Test
     public void testSwitchWithError() {
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(final Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -195,7 +195,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 200, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 200, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -241,11 +241,11 @@ public class FlowableSwitchTest {
 
     @Test
     public void testSwitchWithSubsequenceComplete() {
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -254,7 +254,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 130, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 130, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -262,7 +262,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 150, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 150, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -295,11 +295,11 @@ public class FlowableSwitchTest {
 
     @Test
     public void testSwitchWithSubsequenceError() {
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -308,7 +308,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 130, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 130, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -316,7 +316,7 @@ public class FlowableSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 150, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 150, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -378,11 +378,11 @@ public class FlowableSwitchTest {
     @Test
     public void testSwitchIssue737() {
         // https://github.com/ReactiveX/RxJava/issues/737
-        Flowable<Flowable<String>> source = Flowable.create(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 0, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 0, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -393,7 +393,7 @@ public class FlowableSwitchTest {
                         publishCompleted(observer, 40);
                     }
                 }));
-                publishNext(observer, 25, Flowable.create(new Publisher<String>() {
+                publishNext(observer, 25, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
                     public void subscribe(Subscriber<? super String> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -489,7 +489,7 @@ public class FlowableSwitchTest {
     public void testUnsubscribe() {
         final AtomicBoolean isUnsubscribed = new AtomicBoolean();
         Flowable.switchOnNext(
-                Flowable.create(new Publisher<Flowable<Integer>>() {
+                Flowable.unsafeCreate(new Publisher<Flowable<Integer>>() {
                     @Override
                     public void subscribe(final Subscriber<? super Flowable<Integer>> subscriber) {
                         BooleanSubscription bs = new BooleanSubscription();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -109,7 +109,7 @@ public class FlowableTakeTest {
 
     @Test
     public void testTakeDoesntLeakErrors() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -135,7 +135,7 @@ public class FlowableTakeTest {
     public void testTakeZeroDoesntLeakError() {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
         final BooleanSubscription bs = new BooleanSubscription();
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 subscribed.set(true);
@@ -160,7 +160,7 @@ public class FlowableTakeTest {
     @Test
     public void testUnsubscribeAfterTake() {
         TestObservableFunc f = new TestObservableFunc("one", "two", "three");
-        Flowable<String> w = Flowable.create(f);
+        Flowable<String> w = Flowable.unsafeCreate(f);
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
         
@@ -203,7 +203,7 @@ public class FlowableTakeTest {
     @Test(timeout = 2000)
     public void testMultiTake() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -265,7 +265,7 @@ public class FlowableTakeTest {
         }
     }
 
-    private static Flowable<Long> INFINITE_OBSERVABLE = Flowable.create(new Publisher<Long>() {
+    private static Flowable<Long> INFINITE_OBSERVABLE = Flowable.unsafeCreate(new Publisher<Long>() {
 
         @Override
         public void subscribe(Subscriber<? super Long> op) {
@@ -301,7 +301,7 @@ public class FlowableTakeTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -329,7 +329,7 @@ public class FlowableTakeTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.create(new Publisher<Integer>() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -33,8 +33,8 @@ public class FlowableTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Subscriber<String> result = TestHelper.mockSubscriber();
-        Flowable<String> stringObservable = Flowable.create(source)
-                .takeUntil(Flowable.create(other));
+        Flowable<String> stringObservable = Flowable.unsafeCreate(source)
+                .takeUntil(Flowable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -60,7 +60,7 @@ public class FlowableTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Subscriber<String> result = TestHelper.mockSubscriber();
-        Flowable<String> stringObservable = Flowable.create(source).takeUntil(Flowable.create(other));
+        Flowable<String> stringObservable = Flowable.unsafeCreate(source).takeUntil(Flowable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -82,7 +82,7 @@ public class FlowableTakeUntilTest {
         Throwable error = new Throwable();
 
         Subscriber<String> result = TestHelper.mockSubscriber();
-        Flowable<String> stringObservable = Flowable.create(source).takeUntil(Flowable.create(other));
+        Flowable<String> stringObservable = Flowable.unsafeCreate(source).takeUntil(Flowable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -107,7 +107,7 @@ public class FlowableTakeUntilTest {
         Throwable error = new Throwable();
 
         Subscriber<String> result = TestHelper.mockSubscriber();
-        Flowable<String> stringObservable = Flowable.create(source).takeUntil(Flowable.create(other));
+        Flowable<String> stringObservable = Flowable.unsafeCreate(source).takeUntil(Flowable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -135,7 +135,7 @@ public class FlowableTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Subscriber<String> result = TestHelper.mockSubscriber();
-        Flowable<String> stringObservable = Flowable.create(source).takeUntil(Flowable.create(other));
+        Flowable<String> stringObservable = Flowable.unsafeCreate(source).takeUntil(Flowable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -100,7 +100,7 @@ public class FlowableTakeWhileTest {
 
     @Test
     public void testTakeWhileDoesntLeakErrors() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -123,7 +123,7 @@ public class FlowableTakeWhileTest {
         final RuntimeException testException = new RuntimeException("test exception");
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> take = Flowable.create(source)
+        Flowable<String> take = Flowable.unsafeCreate(source)
                 .takeWhile(new Predicate<String>() {
             @Override
             public boolean test(String s) {
@@ -150,7 +150,7 @@ public class FlowableTakeWhileTest {
         TestObservable w = new TestObservable(s, "one", "two", "three");
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable<String> take = Flowable.create(w)
+        Flowable<String> take = Flowable.unsafeCreate(w)
                 .takeWhile(new Predicate<String>() {
             int index = 0;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -43,7 +43,7 @@ public class FlowableThrottleFirstTest {
 
     @Test
     public void testThrottlingWithCompleted() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -71,7 +71,7 @@ public class FlowableThrottleFirstTest {
 
     @Test
     public void testThrottlingWithError() {
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -238,7 +238,7 @@ public class FlowableTimeoutTests {
 
             @Override
             public void run() {
-                Flowable.create(new Publisher<String>() {
+                Flowable.unsafeCreate(new Publisher<String>() {
 
                     @Override
                     public void subscribe(Subscriber<? super String> subscriber) {
@@ -273,7 +273,7 @@ public class FlowableTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Subscription s = mock(Subscription.class);
 
-        Flowable<String> never = Flowable.create(new Publisher<String>() {
+        Flowable<String> never = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> subscriber) {
                 subscriber.onSubscribe(s);
@@ -302,7 +302,7 @@ public class FlowableTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Subscription s = mock(Subscription.class);
 
-        Flowable<String> immediatelyComplete = Flowable.create(new Publisher<String>() {
+        Flowable<String> immediatelyComplete = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> subscriber) {
                 subscriber.onSubscribe(s);
@@ -333,7 +333,7 @@ public class FlowableTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Subscription s = mock(Subscription.class);
 
-        Flowable<String> immediatelyError = Flowable.create(new Publisher<String>() {
+        Flowable<String> immediatelyError = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> subscriber) {
                 subscriber.onSubscribe(s);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -325,7 +325,7 @@ public class FlowableTimeoutWithSelectorTest {
             public Flowable<Integer> apply(Integer t1) {
                 if (t1 == 1) {
                     // Force "unsubscribe" run on another thread
-                    return Flowable.create(new Publisher<Integer>() {
+                    return Flowable.unsafeCreate(new Publisher<Integer>() {
                         @Override
                         public void subscribe(Subscriber<? super Integer> subscriber) {
                             subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -33,7 +33,7 @@ public class FlowableUnsubscribeOnTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
-            Flowable<Integer> w = Flowable.create(new Publisher<Integer>() {
+            Flowable<Integer> w = Flowable.unsafeCreate(new Publisher<Integer>() {
 
                 @Override
                 public void subscribe(Subscriber<? super Integer> t1) {
@@ -77,7 +77,7 @@ public class FlowableUnsubscribeOnTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
-            Flowable<Integer> w = Flowable.create(new Publisher<Integer>() {
+            Flowable<Integer> w = Flowable.unsafeCreate(new Publisher<Integer>() {
 
                 @Override
                 public void subscribe(Subscriber<? super Integer> t1) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -254,7 +254,7 @@ public class FlowableUsingTest {
         Function<Disposable, Flowable<Integer>> observableFactory = new Function<Disposable, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Disposable subscription) {
-                return Flowable.create(new Publisher<Integer>() {
+                return Flowable.unsafeCreate(new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> t1) {
                         throw new TestException();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -244,7 +244,7 @@ public class FlowableWindowWithSizeTest {
     }
 
     public static Flowable<Integer> hotStream() {
-        return Flowable.create(new Publisher<Integer>() {
+        return Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
                 BooleanSubscription bs = new BooleanSubscription();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndObservableTest.java
@@ -44,7 +44,7 @@ public class FlowableWindowWithStartEndObservableTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -57,7 +57,7 @@ public class FlowableWindowWithStartEndObservableTest {
             }
         });
 
-        Flowable<Object> openings = Flowable.create(new Publisher<Object>() {
+        Flowable<Object> openings = Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
             public void subscribe(Subscriber<? super Object> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -70,7 +70,7 @@ public class FlowableWindowWithStartEndObservableTest {
         Function<Object, Flowable<Object>> closer = new Function<Object, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Object opening) {
-                return Flowable.create(new Publisher<Object>() {
+                return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -95,7 +95,7 @@ public class FlowableWindowWithStartEndObservableTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -112,7 +112,7 @@ public class FlowableWindowWithStartEndObservableTest {
             int calls;
             @Override
             public Flowable<Object> call() {
-                return Flowable.create(new Publisher<Object>() {
+                return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -45,7 +45,7 @@ public class FlowableWindowWithTimeTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -79,7 +79,7 @@ public class FlowableWindowWithTimeTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Flowable<String> source = Flowable.create(new Publisher<String>() {
+        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> observer) {
                 observer.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -90,8 +90,8 @@ public class FlowableZipTest {
         TestObservable w3 = new TestObservable();
 
         Flowable<String> zipW = Flowable.zip(
-                Flowable.create(w1), Flowable.create(w2), 
-                Flowable.create(w3), getConcat3StringsZipr());
+                Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2),
+                Flowable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
 
         /* simulate sending data */
@@ -124,7 +124,7 @@ public class FlowableZipTest {
         TestObservable w2 = new TestObservable();
         TestObservable w3 = new TestObservable();
 
-        Flowable<String> zipW = Flowable.zip(Flowable.create(w1), Flowable.create(w2), Flowable.create(w3), getConcat3StringsZipr());
+        Flowable<String> zipW = Flowable.zip(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2), Flowable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
 
         /* simulate sending data */
@@ -1147,7 +1147,7 @@ public class FlowableZipTest {
     Flowable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());
 
     Flowable<Integer> OBSERVABLE_OF_5_INTEGERS(final AtomicInteger numEmitted) {
-        return Flowable.create(new Publisher<Integer>() {
+        return Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> o) {
@@ -1168,7 +1168,7 @@ public class FlowableZipTest {
     }
 
     Flowable<Integer> ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(final CountDownLatch latch) {
-        return Flowable.create(new Publisher<Integer>() {
+        return Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> o) {

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
@@ -235,7 +235,7 @@ public class BlockingObservableNextTest {
         final CountDownLatch timeHasPassed = new CountDownLatch(COUNT);
         final AtomicBoolean running = new AtomicBoolean(true);
         final AtomicInteger count = new AtomicInteger(0);
-        final Observable<Integer> obs = Observable.create(new ObservableSource<Integer>() {
+        final Observable<Integer> obs = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(final Observer<? super Integer> o) {

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -46,7 +46,7 @@ public class BlockingObservableToIteratorTest {
 
     @Test(expected = TestException.class)
     public void testToIteratorWithException() {
-        Observable<String> obs = Observable.create(new ObservableSource<String>() {
+        Observable<String> obs = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
@@ -68,7 +68,7 @@ public class BlockingObservableToIteratorTest {
     @Ignore("subscribe() should not throw")
     @Test(expected = TestException.class)
     public void testExceptionThrownFromOnSubscribe() {
-        Iterable<String> strings = Observable.create(new ObservableSource<String>() {
+        Iterable<String> strings = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpSubscriber) {
                 throw new TestException("intentional");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -43,7 +43,7 @@ public class ObservableAmbTest {
 
     private Observable<String> createObservable(final String[] values,
             final long interval, final Throwable e) {
-        return Observable.create(new ObservableSource<String>() {
+        return Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(final Observer<? super String> NbpSubscriber) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -60,7 +60,7 @@ public class ObservableBufferTest {
 
     @Test
     public void testSkipAndCountOverlappingBuffers() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -116,7 +116,7 @@ public class ObservableBufferTest {
 
     @Test
     public void testTimedAndCount() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -148,7 +148,7 @@ public class ObservableBufferTest {
 
     @Test
     public void testTimed() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -182,7 +182,7 @@ public class ObservableBufferTest {
 
     @Test
     public void testObservableBasedOpenerAndCloser() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -195,7 +195,7 @@ public class ObservableBufferTest {
             }
         });
 
-        Observable<Object> openings = Observable.create(new ObservableSource<Object>() {
+        Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
             public void subscribe(Observer<Object> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -208,7 +208,7 @@ public class ObservableBufferTest {
         Function<Object, Observable<Object>> closer = new Function<Object, Observable<Object>>() {
             @Override
             public Observable<Object> apply(Object opening) {
-                return Observable.create(new ObservableSource<Object>() {
+                return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -233,7 +233,7 @@ public class ObservableBufferTest {
 
     @Test
     public void testObservableBasedCloser() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -249,7 +249,7 @@ public class ObservableBufferTest {
         Callable<Observable<Object>> closer = new Callable<Observable<Object>>() {
             @Override
             public Observable<Object> call() {
-                return Observable.create(new ObservableSource<Object>() {
+                return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -58,7 +58,7 @@ public class ObservableCacheTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new ObservableSource<String>() {
+        Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(final Observer<? super String> NbpObserver) {
@@ -192,7 +192,7 @@ public class ObservableCacheTest {
     @Test
     public void testNoMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Observable<Integer> firehose = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> firehose = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t) {
                 t.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -80,7 +80,7 @@ public class ObservableConcatTest {
         final Observable<String> odds = Observable.fromArray(o);
         final Observable<String> even = Observable.fromArray(e);
 
-        Observable<Observable<String>> observableOfObservables = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
@@ -109,7 +109,7 @@ public class ObservableConcatTest {
         TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
         TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
 
-        Observable.concat(Observable.create(o1), Observable.create(o2)).subscribe(NbpObserver);
+        Observable.concat(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2)).subscribe(NbpObserver);
 
         try {
             // wait for async observables to complete
@@ -156,7 +156,7 @@ public class ObservableConcatTest {
         final CountDownLatch parentHasFinished = new CountDownLatch(1);
         
         
-        Observable<Observable<String>> observableOfObservables = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
 
             @Override
             public void subscribe(final Observer<? super Observable<String>> NbpObserver) {
@@ -170,12 +170,12 @@ public class ObservableConcatTest {
                             // emit first
                             if (!d.isDisposed()) {
                                 System.out.println("Emit o1");
-                                NbpObserver.onNext(Observable.create(o1));
+                                NbpObserver.onNext(Observable.unsafeCreate(o1));
                             }
                             // emit second
                             if (!d.isDisposed()) {
                                 System.out.println("Emit o2");
-                                NbpObserver.onNext(Observable.create(o2));
+                                NbpObserver.onNext(Observable.unsafeCreate(o2));
                             }
 
                             // wait until sometime later and emit third
@@ -186,7 +186,7 @@ public class ObservableConcatTest {
                             }
                             if (!d.isDisposed()) {
                                 System.out.println("Emit o3");
-                                NbpObserver.onNext(Observable.create(o3));
+                                NbpObserver.onNext(Observable.unsafeCreate(o3));
                             }
 
                         } catch (Throwable e) {
@@ -272,7 +272,7 @@ public class ObservableConcatTest {
         final CountDownLatch okToContinue = new CountDownLatch(1);
         @SuppressWarnings("unchecked")
         TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(callOnce, okToContinue, odds, even);
-        Observable<String> concatF = Observable.concat(Observable.create(observableOfObservables));
+        Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
         concatF.subscribe(NbpObserver);
         try {
             //Block main thread to allow observables to serve up o1.
@@ -310,8 +310,8 @@ public class ObservableConcatTest {
         Observer<String> NbpObserver = TestHelper.mockObserver();
         
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.create(w1), Observable.create(w2));
-        Observable<String> concatF = Observable.concat(Observable.create(observableOfObservables));
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
+        Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
         concatF.take(50).subscribe(NbpObserver);
 
@@ -343,14 +343,14 @@ public class ObservableConcatTest {
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
         
-        Observable<Observable<String>> observableOfObservables = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
                 // simulate what would happen in an NbpObservable
-                NbpObserver.onNext(Observable.create(w1));
-                NbpObserver.onNext(Observable.create(w2));
+                NbpObserver.onNext(Observable.unsafeCreate(w1));
+                NbpObserver.onNext(Observable.unsafeCreate(w2));
                 NbpObserver.onComplete();
             }
 
@@ -395,7 +395,7 @@ public class ObservableConcatTest {
         Observer<String> NbpObserver = TestHelper.mockObserver();
         TestObserver<String> ts = new TestObserver<String>(NbpObserver);
 
-        final Observable<String> concat = Observable.concat(Observable.create(w1), Observable.create(w2));
+        final Observable<String> concat = Observable.concat(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
 
         try {
             // Subscribe
@@ -438,8 +438,8 @@ public class ObservableConcatTest {
         TestObserver<String> ts = new TestObserver<String>(NbpObserver);
         
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.create(w1), Observable.create(w2));
-        Observable<String> concatF = Observable.concat(Observable.create(observableOfObservables));
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
+        Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
         concatF.subscribe(ts);
 
@@ -658,7 +658,7 @@ public class ObservableConcatTest {
     // https://github.com/ReactiveX/RxJava/issues/1818
     @Test
     public void testConcatWithNonCompliantSourceDoubleOnComplete() {
-        Observable<String> o = Observable.create(new ObservableSource<String>() {
+        Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> s) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -44,7 +44,7 @@ public class ObservableDebounceTest {
 
     @Test
     public void testDebounceWithCompleted() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -70,7 +70,7 @@ public class ObservableDebounceTest {
 
     @Test
     public void testDebounceNeverEmits() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -100,7 +100,7 @@ public class ObservableDebounceTest {
 
     @Test
     public void testDebounceWithError() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnSubscribeTest.java
@@ -67,7 +67,7 @@ public class ObservableDoOnSubscribeTest {
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
         final AtomicReference<Observer<? super Integer>> sref = new AtomicReference<Observer<? super Integer>>();
-        Observable<Integer> o = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -183,7 +183,7 @@ public class ObservableGroupByTest {
         final int count = 100;
         final int groupCount = 2;
 
-        Observable<Event> es = Observable.create(new ObservableSource<Event>() {
+        Observable<Event> es = Observable.unsafeCreate(new ObservableSource<Event>() {
 
             @Override
             public void subscribe(final Observer<? super Event> NbpObserver) {
@@ -595,7 +595,7 @@ public class ObservableGroupByTest {
     public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsAndThenComplete() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
@@ -674,7 +674,7 @@ public class ObservableGroupByTest {
         System.err.println("----------------------------------------------------------------------------------------------");
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
@@ -766,7 +766,7 @@ public class ObservableGroupByTest {
     public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenObservesOnAndDelaysAndThenCompletes() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
@@ -843,7 +843,7 @@ public class ObservableGroupByTest {
     @Test
     public void testGroupsWithNestedSubscribeOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
@@ -900,7 +900,7 @@ public class ObservableGroupByTest {
     @Test
     public void testGroupsWithNestedObserveOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
@@ -961,7 +961,7 @@ public class ObservableGroupByTest {
     };
 
     Observable<Event> SYNC_INFINITE_OBSERVABLE_OF_EVENT(final int numGroups, final AtomicInteger subscribeCounter, final AtomicInteger sentEventCounter) {
-        return Observable.create(new ObservableSource<Event>() {
+        return Observable.unsafeCreate(new ObservableSource<Event>() {
 
             @Override
             public void subscribe(final Observer<? super Event> op) {
@@ -1374,7 +1374,7 @@ public class ObservableGroupByTest {
     @Test
     public void testGroupByUnsubscribe() {
         final Disposable s = mock(Disposable.class);
-        Observable<Integer> o = Observable.create(
+        Observable<Integer> o = Observable.unsafeCreate(
                 new ObservableSource<Integer>() {
                     @Override
                     public void subscribe(Observer<? super Integer> NbpSubscriber) {
@@ -1423,7 +1423,7 @@ public class ObservableGroupByTest {
                 }
             }
         });
-        Observable.create(
+        Observable.unsafeCreate(
                 new ObservableSource<Integer>() {
                     @Override
                     public void subscribe(Observer<? super Integer> NbpSubscriber) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
@@ -38,7 +38,7 @@ public class ObservableMaterializeTest {
                 "three");
 
         TestLocalObserver NbpObserver = new TestLocalObserver();
-        Observable<Try<Optional<String>>> m = Observable.create(o1).materialize();
+        Observable<Try<Optional<String>>> m = Observable.unsafeCreate(o1).materialize();
         m.subscribe(NbpObserver);
 
         try {
@@ -63,7 +63,7 @@ public class ObservableMaterializeTest {
         final TestAsyncErrorObservable o1 = new TestAsyncErrorObservable("one", "two", "three");
 
         TestLocalObserver NbpObserver = new TestLocalObserver();
-        Observable<Try<Optional<String>>> m = Observable.create(o1).materialize();
+        Observable<Try<Optional<String>>> m = Observable.unsafeCreate(o1).materialize();
         m.subscribe(NbpObserver);
 
         try {
@@ -88,7 +88,7 @@ public class ObservableMaterializeTest {
     public void testMultipleSubscribes() throws InterruptedException, ExecutionException {
         final TestAsyncErrorObservable o = new TestAsyncErrorObservable("one", "two", null, "three");
 
-        Observable<Try<Optional<String>>> m = Observable.create(o).materialize();
+        Observable<Try<Optional<String>>> m = Observable.unsafeCreate(o).materialize();
 
         assertEquals(3, m.toList().toBlocking().toFuture().get().size());
         assertEquals(3, m.toList().toBlocking().toFuture().get().size());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -41,8 +41,8 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed1() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -62,10 +62,10 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed2() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -87,10 +87,10 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed3() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", "five", "six"));
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", "five", "six"));
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -110,10 +110,10 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed4() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", "five", "six"));
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight"));
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine", null));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", "five", "six"));
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight"));
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -139,7 +139,7 @@ public class ObservableMergeDelayErrorTest {
         // throw the error at the very end so no onComplete will be called after it
         final TestAsyncErrorObservable o4 = new TestAsyncErrorObservable("nine", null);
 
-        Observable<String> m = Observable.mergeDelayError(Observable.create(o1), Observable.create(o2), Observable.create(o3), Observable.create(o4));
+        Observable<String> m = Observable.mergeDelayError(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2), Observable.unsafeCreate(o3), Observable.unsafeCreate(o4));
         m.subscribe(stringObserver);
 
         try {
@@ -166,8 +166,8 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed1() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", null));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -186,8 +186,8 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed2() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", null));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         CaptureObserver w = new CaptureObserver();
@@ -212,10 +212,10 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testMergeObservableOfObservables() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
-        Observable<Observable<String>> observableOfObservables = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
@@ -237,8 +237,8 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testMergeArray() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -250,8 +250,8 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testMergeList() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
         List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
@@ -269,7 +269,7 @@ public class ObservableMergeDelayErrorTest {
         final TestASynchronousObservable o1 = new TestASynchronousObservable();
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
-        Observable<String> m = Observable.mergeDelayError(Observable.create(o1), Observable.create(o2));
+        Observable<String> m = Observable.mergeDelayError(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         m.subscribe(stringObserver);
 
         try {
@@ -433,7 +433,7 @@ public class ObservableMergeDelayErrorTest {
     @Test
     @Ignore("Subscribers should not throw")
     public void testMergeSourceWhichDoesntPropagateExceptionBack() {
-        Observable<Integer> source = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t1) {
                 t1.onSubscribe(EmptyDisposable.INSTANCE);
@@ -505,12 +505,12 @@ public class ObservableMergeDelayErrorTest {
         for (int i = 0; i < 50; i++) {
             final TestASynchronous1sDelayedObservable o1 = new TestASynchronous1sDelayedObservable();
             final TestASynchronous1sDelayedObservable o2 = new TestASynchronous1sDelayedObservable();
-            Observable<Observable<String>> parentObservable = Observable.create(new ObservableSource<Observable<String>>() {
+            Observable<Observable<String>> parentObservable = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
                 @Override
                 public void subscribe(Observer<? super Observable<String>> op) {
                     op.onSubscribe(EmptyDisposable.INSTANCE);
-                    op.onNext(Observable.create(o1));
-                    op.onNext(Observable.create(o2));
+                    op.onNext(Observable.unsafeCreate(o1));
+                    op.onNext(Observable.unsafeCreate(o2));
                     op.onError(new NullPointerException("throwing exception in parent"));
                 }
             });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -69,7 +69,7 @@ public class ObservableMergeMaxConcurrentTest {
             for (int i = 0; i < observableCount; i++) {
                 SubscriptionCheckObservable sco = new SubscriptionCheckObservable(subscriptionCount, maxConcurrent);
                 scos.add(sco);
-                os.add(Observable.create(sco));
+                os.add(Observable.unsafeCreate(sco));
             }
 
             Iterator<String> iter = Observable.merge(os, maxConcurrent).toBlocking().iterator();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -70,10 +70,10 @@ public class ObservableMergeTest {
 
     @Test
     public void testMergeObservableOfObservables() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
-        Observable<Observable<String>> observableOfObservables = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
@@ -95,8 +95,8 @@ public class ObservableMergeTest {
 
     @Test
     public void testMergeArray() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
         Observable<String> m = Observable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -108,8 +108,8 @@ public class ObservableMergeTest {
 
     @Test
     public void testMergeList() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
         List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
@@ -128,7 +128,7 @@ public class ObservableMergeTest {
         final AtomicBoolean unsubscribed = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        Observable<Observable<Long>> source = Observable.create(new ObservableSource<Observable<Long>>() {
+        Observable<Observable<Long>> source = Observable.unsafeCreate(new ObservableSource<Observable<Long>>() {
 
             @Override
             public void subscribe(final Observer<? super Observable<Long>> NbpObserver) {
@@ -188,7 +188,7 @@ public class ObservableMergeTest {
         final TestASynchronousObservable o1 = new TestASynchronousObservable();
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
-        Observable<String> m = Observable.merge(Observable.create(o1), Observable.create(o2));
+        Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         TestObserver<String> ts = new TestObserver<String>(stringObserver);
         m.subscribe(ts);
 
@@ -219,7 +219,7 @@ public class ObservableMergeTest {
         final AtomicInteger concurrentCounter = new AtomicInteger();
         final AtomicInteger totalCounter = new AtomicInteger();
 
-        Observable<String> m = Observable.merge(Observable.create(o1), Observable.create(o2));
+        Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         m.subscribe(new DefaultObserver<String>() {
 
             @Override
@@ -293,8 +293,8 @@ public class ObservableMergeTest {
     @Test
     public void testError1() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
 
         Observable<String> m = Observable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -315,10 +315,10 @@ public class ObservableMergeTest {
     @Test
     public void testError2() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));// we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));// we expect to lose all of these since o2 is done first and fails
 
         Observable<String> m = Observable.merge(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -340,7 +340,7 @@ public class ObservableMergeTest {
     @Ignore("Subscribe should not throw")
     public void testThrownErrorHandling() {
         TestObserver<String> ts = new TestObserver<String>();
-        Observable<String> o1 = Observable.create(new ObservableSource<String>() {
+        Observable<String> o1 = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> s) {
@@ -494,7 +494,7 @@ public class ObservableMergeTest {
     }
 
     private Observable<Long> createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
-        return Observable.create(new ObservableSource<Long>() {
+        return Observable.unsafeCreate(new ObservableSource<Long>() {
 
             @Override
             public void subscribe(final Observer<? super Long> child) {
@@ -556,7 +556,7 @@ public class ObservableMergeTest {
     @Test
     public void testConcurrencyWithSleeping() {
 
-        Observable<Integer> o = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(final Observer<? super Integer> s) {
@@ -606,7 +606,7 @@ public class ObservableMergeTest {
 
     @Test
     public void testConcurrencyWithBrokenOnCompleteContract() {
-        Observable<Integer> o = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(final Observer<? super Integer> s) {
@@ -835,7 +835,7 @@ public class ObservableMergeTest {
     public void mergeWithTerminalEventAfterUnsubscribe() {
         System.out.println("mergeWithTerminalEventAfterUnsubscribe");
         TestObserver<String> ts = new TestObserver<String>();
-        Observable<String> bad = Observable.create(new ObservableSource<String>() {
+        Observable<String> bad = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> s) {
@@ -1018,7 +1018,7 @@ public class ObservableMergeTest {
 
             @Override
             public Observable<Integer> apply(final Integer i) {
-                return Observable.create(new ObservableSource<Integer>() {
+                return Observable.unsafeCreate(new ObservableSource<Integer>() {
 
                     @Override
                     public void subscribe(Observer<? super Integer> s) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
@@ -36,7 +36,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
     @Test
     public void testResumeNextWithSynchronousExecution() {
         final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
-        Observable<String> w = Observable.create(new ObservableSource<String>() {
+        Observable<String> w = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
@@ -87,7 +87,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Observable<String> o = Observable.create(w).onErrorResumeNext(resume);
+        Observable<String> o = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
 
@@ -124,7 +124,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Observable<String> o = Observable.create(w).onErrorResumeNext(resume);
+        Observable<String> o = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
         DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
@@ -33,7 +33,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         Disposable s = mock(Disposable.class);
         // Trigger failure on second element
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> NbpObservable = w.onErrorResumeNext(resume);
 
@@ -62,7 +62,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         // Resume NbpObservable is async
         TestObservable f = new TestObservable(sr, "twoResume", "threeResume");
-        Observable<String> resume = Observable.create(f);
+        Observable<String> resume = Observable.unsafeCreate(f);
 
         // Introduce map function that fails intermittently (Map does not prevent this when the NbpObserver is a
         //  rx.operator incl onErrorResumeNextViaObservable)
@@ -100,7 +100,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
     @Test
     @Ignore("Publishers should not throw")
     public void testResumeNextWithFailureOnSubscribe() {
-        Observable<String> testObservable = Observable.create(new ObservableSource<String>() {
+        Observable<String> testObservable = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> t1) {
@@ -122,7 +122,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
     @Test
     @Ignore("Publishers should not throw")
     public void testResumeNextWithFailureOnSubscribeAsync() {
-        Observable<String> testObservable = Observable.create(new ObservableSource<String>() {
+        Observable<String> testObservable = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> t1) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -33,7 +33,7 @@ public class ObservableOnErrorReturnTest {
     @Test
     public void testResumeNext() {
         TestObservable f = new TestObservable("one");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
         Observable<String> NbpObservable = w.onErrorReturn(new Function<Throwable, String>() {
@@ -69,7 +69,7 @@ public class ObservableOnErrorReturnTest {
     @Test
     public void testFunctionThrowsError() {
         TestObservable f = new TestObservable("one");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
         Observable<String> NbpObservable = w.onErrorReturn(new Function<Throwable, String>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
@@ -33,7 +33,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
     public void testResumeNextWithException() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "EXCEPTION", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
 
@@ -61,7 +61,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
     public void testResumeNextWithRuntimeException() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "RUNTIMEEXCEPTION", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
 
@@ -89,7 +89,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
     public void testThrowablePassesThru() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "THROWABLE", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
 
@@ -117,7 +117,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
     public void testErrorPassesThru() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "ERROR", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
 
@@ -147,7 +147,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         // Resume NbpObservable is async
         TestObservable f = new TestObservable("twoResume", "threeResume");
-        Observable<String> resume = Observable.create(f);
+        Observable<String> resume = Observable.unsafeCreate(f);
 
         // Introduce map function that fails intermittently (Map does not prevent this when the NbpObserver is a
         //  rx.operator incl onErrorResumeNextViaObservable)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -36,7 +36,7 @@ public class ObservablePublishTest {
     @Test
     public void testPublish() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableObservable<String> o = Observable.create(new ObservableSource<String>() {
+        ConnectableObservable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(final Observer<? super String> NbpObserver) {
@@ -344,7 +344,7 @@ public class ObservablePublishTest {
     @Test
     public void testConnectIsIdempotent() {
         final AtomicInteger calls = new AtomicInteger();
-        Observable<Integer> source = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t) {
                 t.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -290,7 +290,7 @@ public class ObservableRefCountTest {
     }
 
     private Observable<Long> synchronousInterval() {
-        return Observable.create(new ObservableSource<Long>() {
+        return Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
             public void subscribe(Observer<? super Long> NbpSubscriber) {
                 final AtomicBoolean cancel = new AtomicBoolean();
@@ -318,7 +318,7 @@ public class ObservableRefCountTest {
     public void onlyFirstShouldSubscribeAndLastUnsubscribe() {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         final AtomicInteger unsubscriptionCount = new AtomicInteger();
-        Observable<Integer> o = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> NbpObserver) {
                 subscriptionCount.incrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
@@ -38,7 +38,7 @@ public class ObservableRepeatTest {
     public void testRepetition() {
         int NUM = 10;
         final AtomicInteger count = new AtomicInteger();
-        int value = Observable.create(new ObservableSource<Integer>() {
+        int value = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(final Observer<? super Integer> o) {
@@ -67,7 +67,7 @@ public class ObservableRepeatTest {
     public void testRepeatTakeWithSubscribeOn() throws InterruptedException {
 
         final AtomicInteger counter = new AtomicInteger();
-        Observable<Integer> oi = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> oi = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -798,7 +798,7 @@ public class ObservableReplayTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new ObservableSource<String>() {
+        Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(final Observer<? super String> NbpObserver) {
@@ -934,7 +934,7 @@ public class ObservableReplayTest {
     @Test
     public void testNoMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Observable<Integer> firehose = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> firehose = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t) {
                 t.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -42,7 +42,7 @@ public class ObservableRetryTest {
     public void iterativeBackoff() {
         Observer<String> consumer = TestHelper.mockObserver();
         
-        Observable<String> producer = Observable.create(new ObservableSource<String>() {
+        Observable<String> producer = Observable.unsafeCreate(new ObservableSource<String>() {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();
@@ -113,7 +113,7 @@ public class ObservableRetryTest {
     public void testRetryIndefinitely() {
         Observer<String> NbpObserver = TestHelper.mockObserver();
         int NUM_RETRIES = 20;
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retry().unsafeSubscribe(new TestObserver<String>(NbpObserver));
 
         InOrder inOrder = inOrder(NbpObserver);
@@ -132,7 +132,7 @@ public class ObservableRetryTest {
     public void testSchedulingNotificationHandler() {
         Observer<String> NbpObserver = TestHelper.mockObserver();
         int NUM_RETRIES = 2;
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         TestObserver<String> NbpSubscriber = new TestObserver<String>(NbpObserver);
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
             @Override
@@ -172,7 +172,7 @@ public class ObservableRetryTest {
     public void testOnNextFromNotificationHandler() {
         Observer<String> NbpObserver = TestHelper.mockObserver();
         int NUM_RETRIES = 2;
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
             @Override
             public Observable<Object> apply(Observable<? extends Throwable> t1) {
@@ -201,7 +201,7 @@ public class ObservableRetryTest {
     @Test
     public void testOnCompletedFromNotificationHandler() {
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> origin = Observable.create(new FuncWithErrors(1));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
         TestObserver<String> NbpSubscriber = new TestObserver<String>(NbpObserver);
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
             @Override
@@ -222,7 +222,7 @@ public class ObservableRetryTest {
     @Test
     public void testOnErrorFromNotificationHandler() {
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> origin = Observable.create(new FuncWithErrors(2));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(2));
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
             @Override
             public Observable<?> apply(Observable<? extends Throwable> t1) {
@@ -252,7 +252,7 @@ public class ObservableRetryTest {
             }
         };
 
-        int first = Observable.create(onSubscribe)
+        int first = Observable.unsafeCreate(onSubscribe)
                 .retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
                     @Override
                     public Observable<?> apply(Observable<? extends Throwable> attempt) {
@@ -274,7 +274,7 @@ public class ObservableRetryTest {
     @Test
     public void testOriginFails() {
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> origin = Observable.create(new FuncWithErrors(1));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
         origin.subscribe(NbpObserver);
 
         InOrder inOrder = inOrder(NbpObserver);
@@ -289,7 +289,7 @@ public class ObservableRetryTest {
         int NUM_RETRIES = 1;
         int NUM_FAILURES = 2;
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry(NUM_RETRIES).subscribe(NbpObserver);
 
         InOrder inOrder = inOrder(NbpObserver);
@@ -307,7 +307,7 @@ public class ObservableRetryTest {
     public void testRetrySuccess() {
         int NUM_FAILURES = 1;
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry(3).subscribe(NbpObserver);
 
         InOrder inOrder = inOrder(NbpObserver);
@@ -326,7 +326,7 @@ public class ObservableRetryTest {
     public void testInfiniteRetry() {
         int NUM_FAILURES = 20;
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry().subscribe(NbpObserver);
 
         InOrder inOrder = inOrder(NbpObserver);
@@ -439,7 +439,7 @@ public class ObservableRetryTest {
                 
             }
         };
-        Observable<String> stream = Observable.create(onSubscribe);
+        Observable<String> stream = Observable.unsafeCreate(onSubscribe);
         Observable<String> streamWithRetry = stream.retry();
         Disposable sub = streamWithRetry.subscribe();
         assertEquals(1, subsCount.get());
@@ -476,7 +476,7 @@ public class ObservableRetryTest {
             }
         };
 
-        Observable.create(onSubscribe).retry(3).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(3).subscribe(ts);
         assertEquals(4, subsCount.get()); // 1 + 3 retries
     }
 
@@ -495,7 +495,7 @@ public class ObservableRetryTest {
             }
         };
 
-        Observable.create(onSubscribe).retry(1).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(1).subscribe(ts);
         assertEquals(2, subsCount.get());
     }
 
@@ -514,7 +514,7 @@ public class ObservableRetryTest {
             }
         };
 
-        Observable.create(onSubscribe).retry(0).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(0).subscribe(ts);
         assertEquals(1, subsCount.get());
     }
 
@@ -616,7 +616,7 @@ public class ObservableRetryTest {
 
         // NbpObservable that always fails after 100ms
         SlowObservable so = new SlowObservable(100, 0);
-        Observable<Long> o = Observable.create(so).retry(5);
+        Observable<Long> o = Observable.unsafeCreate(so).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(NbpObserver);
 
@@ -641,7 +641,7 @@ public class ObservableRetryTest {
 
         // NbpObservable that sends every 100ms (timeout fails instead)
         SlowObservable so = new SlowObservable(100, 10);
-        Observable<Long> o = Observable.create(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
+        Observable<Long> o = Observable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(NbpObserver);
 
@@ -664,7 +664,7 @@ public class ObservableRetryTest {
             final int NUM_RETRIES = Flowable.bufferSize() * 2;
             for (int i = 0; i < 400; i++) {
                 Observer<String> NbpObserver = TestHelper.mockObserver();
-                Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+                Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
                 TestObserver<String> ts = new TestObserver<String>(NbpObserver);
                 origin.retry().observeOn(Schedulers.computation()).unsafeSubscribe(ts);
                 ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
@@ -707,7 +707,7 @@ public class ObservableRetryTest {
                         public void run() {
                             final AtomicInteger nexts = new AtomicInteger();
                             try {
-                                Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+                                Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
                                 TestObserver<String> ts = new TestObserver<String>();
                                 origin.retry()
                                 .observeOn(Schedulers.computation()).unsafeSubscribe(ts);
@@ -828,7 +828,7 @@ public class ObservableRetryTest {
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
-        Observable<String> origin = Observable.create(new ObservableSource<String>() {
+        Observable<String> origin = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> o) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -71,7 +71,7 @@ public class ObservableRetryWithPredicateTest {
     }
     @Test
     public void testRetryTwice() {
-        Observable<Integer> source = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -107,7 +107,7 @@ public class ObservableRetryWithPredicateTest {
     }
     @Test
     public void testRetryTwiceAndGiveUp() {
-        Observable<Integer> source = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t1) {
                 t1.onSubscribe(EmptyDisposable.INSTANCE);
@@ -135,7 +135,7 @@ public class ObservableRetryWithPredicateTest {
     }
     @Test
     public void testRetryOnSpecificException() {
-        Observable<Integer> source = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -172,7 +172,7 @@ public class ObservableRetryWithPredicateTest {
     public void testRetryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Observable<Integer> source = Observable.create(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -231,7 +231,7 @@ public class ObservableRetryWithPredicateTest {
         // NbpObservable that always fails after 100ms
         ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 0);
         Observable<Long> o = Observable
-                .create(so)
+                .unsafeCreate(so)
                 .retry(retry5);
 
         ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(NbpObserver);
@@ -257,7 +257,7 @@ public class ObservableRetryWithPredicateTest {
         // NbpObservable that sends every 100ms (timeout fails instead)
         ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 10);
         Observable<Long> o = Observable
-                .create(so)
+                .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
@@ -44,7 +44,7 @@ public class ObservableSampleTest {
 
     @Test
     public void testSample() {
-        Observable<Long> source = Observable.create(new ObservableSource<Long>() {
+        Observable<Long> source = Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
             public void subscribe(final Observer<? super Long> observer1) {
                 observer1.onSubscribe(EmptyDisposable.INSTANCE);
@@ -265,7 +265,7 @@ public class ObservableSampleTest {
     @Test
     public void testSampleUnsubscribe() {
         final Disposable s = mock(Disposable.class);
-        Observable<Integer> o = Observable.create(
+        Observable<Integer> o = Observable.unsafeCreate(
                 new ObservableSource<Integer>() {
                     @Override
                     public void subscribe(Observer<? super Integer> NbpSubscriber) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSerializeTest.java
@@ -38,7 +38,7 @@ public class ObservableSerializeTest {
     @Test
     public void testSingleThreadedBasic() {
         TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         w.serialize().subscribe(NbpObserver);
         onSubscribe.waitToFinish();
@@ -56,7 +56,7 @@ public class ObservableSerializeTest {
     @Test
     public void testMultiThreadedBasic() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three");
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         BusyObserver busyobserver = new BusyObserver();
 
@@ -79,7 +79,7 @@ public class ObservableSerializeTest {
     @Test
     public void testMultiThreadedWithNPE() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         BusyObserver busyobserver = new BusyObserver();
 
@@ -110,7 +110,7 @@ public class ObservableSerializeTest {
         boolean lessThan9 = false;
         for (int i = 0; i < 3; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, "four", "five", "six", "seven", "eight", "nine");
-            Observable<String> w = Observable.create(onSubscribe);
+            Observable<String> w = Observable.unsafeCreate(onSubscribe);
     
             BusyObserver busyobserver = new BusyObserver();
     

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -38,7 +38,7 @@ public class ObservableSubscribeOnTest {
         TestObserver<Integer> NbpObserver = new TestObserver<Integer>();
 
         Observable
-        .create(new ObservableSource<Integer>() {
+        .unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(
                     final Observer<? super Integer> NbpSubscriber) {
@@ -75,7 +75,7 @@ public class ObservableSubscribeOnTest {
     @Ignore("ObservableConsumable.subscribe can't throw")
     public void testThrownErrorHandling() {
         TestObserver<String> ts = new TestObserver<String>();
-        Observable.create(new ObservableSource<String>() {
+        Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> s) {
@@ -90,7 +90,7 @@ public class ObservableSubscribeOnTest {
     @Test
     public void testOnError() {
         TestObserver<String> ts = new TestObserver<String>();
-        Observable.create(new ObservableSource<String>() {
+        Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
             public void subscribe(Observer<? super String> s) {
@@ -161,7 +161,7 @@ public class ObservableSubscribeOnTest {
     public void testUnsubscribeInfiniteStream() throws InterruptedException {
         TestObserver<Integer> ts = new TestObserver<Integer>();
         final AtomicInteger count = new AtomicInteger();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmptyTest.java
@@ -57,7 +57,7 @@ public class ObservableSwitchIfEmptyTest {
 
         final Disposable d = Disposables.empty();
         
-        Observable<Long> withProducer = Observable.create(new ObservableSource<Long>() {
+        Observable<Long> withProducer = Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
             public void subscribe(final Observer<? super Long> NbpSubscriber) {
                 NbpSubscriber.onSubscribe(d);
@@ -100,7 +100,7 @@ public class ObservableSwitchIfEmptyTest {
     public void testSwitchShouldTriggerUnsubscribe() {
         final Disposable d = Disposables.empty();
         
-        Observable.create(new ObservableSource<Long>() {
+        Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
             public void subscribe(final Observer<? super Long> NbpSubscriber) {
                 NbpSubscriber.onSubscribe(d);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -46,11 +46,11 @@ public class ObservableSwitchTest {
 
     @Test
     public void testSwitchWhenOuterCompleteBeforeInner() {
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 50, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -75,11 +75,11 @@ public class ObservableSwitchTest {
 
     @Test
     public void testSwitchWhenInnerCompleteBeforeOuter() {
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 10, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 10, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -89,7 +89,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 100, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 100, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -121,11 +121,11 @@ public class ObservableSwitchTest {
 
     @Test
     public void testSwitchWithComplete() {
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 50, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(final Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -134,7 +134,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 200, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(final Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -180,11 +180,11 @@ public class ObservableSwitchTest {
 
     @Test
     public void testSwitchWithError() {
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 50, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(final Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -193,7 +193,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 200, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -239,11 +239,11 @@ public class ObservableSwitchTest {
 
     @Test
     public void testSwitchWithSubsequenceComplete() {
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 50, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -252,7 +252,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 130, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 130, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -260,7 +260,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 150, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 150, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -293,11 +293,11 @@ public class ObservableSwitchTest {
 
     @Test
     public void testSwitchWithSubsequenceError() {
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 50, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -306,7 +306,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 130, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 130, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -314,7 +314,7 @@ public class ObservableSwitchTest {
                     }
                 }));
 
-                publishNext(NbpObserver, 150, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 150, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -376,11 +376,11 @@ public class ObservableSwitchTest {
     @Test
     public void testSwitchIssue737() {
         // https://github.com/ReactiveX/RxJava/issues/737
-        Observable<Observable<String>> source = Observable.create(new ObservableSource<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 0, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 0, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -391,7 +391,7 @@ public class ObservableSwitchTest {
                         publishCompleted(NbpObserver, 40);
                     }
                 }));
-                publishNext(NbpObserver, 25, Observable.create(new ObservableSource<String>() {
+                publishNext(NbpObserver, 25, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -424,7 +424,7 @@ public class ObservableSwitchTest {
     public void testUnsubscribe() {
         final AtomicBoolean isUnsubscribed = new AtomicBoolean();
         Observable.switchOnNext(
-                Observable.create(new ObservableSource<Observable<Integer>>() {
+                Observable.unsafeCreate(new ObservableSource<Observable<Integer>>() {
                     @Override
                     public void subscribe(final Observer<? super Observable<Integer>> NbpSubscriber) {
                         Disposable bs = Disposables.empty();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -109,7 +109,7 @@ public class ObservableTakeTest {
 
     @Test
     public void testTakeDoesntLeakErrors() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -135,7 +135,7 @@ public class ObservableTakeTest {
     public void testTakeZeroDoesntLeakError() {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
         final Disposable bs = Disposables.empty();
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 subscribed.set(true);
@@ -160,7 +160,7 @@ public class ObservableTakeTest {
     @Test
     public void testUnsubscribeAfterTake() {
         TestObservableFunc f = new TestObservableFunc("one", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
         
@@ -203,7 +203,7 @@ public class ObservableTakeTest {
     @Test(timeout = 2000)
     public void testMultiTake() {
         final AtomicInteger count = new AtomicInteger();
-        Observable.create(new ObservableSource<Integer>() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(Observer<? super Integer> s) {
@@ -265,7 +265,7 @@ public class ObservableTakeTest {
         }
     }
 
-    private static Observable<Long> INFINITE_OBSERVABLE = Observable.create(new ObservableSource<Long>() {
+    private static Observable<Long> INFINITE_OBSERVABLE = Observable.unsafeCreate(new ObservableSource<Long>() {
 
         @Override
         public void subscribe(Observer<? super Long> op) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
@@ -33,8 +33,8 @@ public class ObservableTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Observer<String> result = TestHelper.mockObserver();
-        Observable<String> stringObservable = Observable.create(source)
-                .takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source)
+                .takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -60,7 +60,7 @@ public class ObservableTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Observer<String> result = TestHelper.mockObserver();
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -82,7 +82,7 @@ public class ObservableTakeUntilTest {
         Throwable error = new Throwable();
 
         Observer<String> result = TestHelper.mockObserver();
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -107,7 +107,7 @@ public class ObservableTakeUntilTest {
         Throwable error = new Throwable();
 
         Observer<String> result = TestHelper.mockObserver();
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -135,7 +135,7 @@ public class ObservableTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Observer<String> result = TestHelper.mockObserver();
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
@@ -100,7 +100,7 @@ public class ObservableTakeWhileTest {
 
     @Test
     public void testTakeWhileDoesntLeakErrors() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -123,7 +123,7 @@ public class ObservableTakeWhileTest {
         final RuntimeException testException = new RuntimeException("test exception");
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> take = Observable.create(source)
+        Observable<String> take = Observable.unsafeCreate(source)
                 .takeWhile(new Predicate<String>() {
             @Override
             public boolean test(String s) {
@@ -150,7 +150,7 @@ public class ObservableTakeWhileTest {
         TestObservable w = new TestObservable(s, "one", "two", "three");
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable<String> take = Observable.create(w)
+        Observable<String> take = Observable.unsafeCreate(w)
                 .takeWhile(new Predicate<String>() {
             int index = 0;
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
@@ -42,7 +42,7 @@ public class ObservableThrottleFirstTest {
 
     @Test
     public void testThrottlingWithCompleted() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -70,7 +70,7 @@ public class ObservableThrottleFirstTest {
 
     @Test
     public void testThrottlingWithError() {
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -238,7 +238,7 @@ public class ObservableTimeoutTests {
 
             @Override
             public void run() {
-                Observable.create(new ObservableSource<String>() {
+                Observable.unsafeCreate(new ObservableSource<String>() {
 
                     @Override
                     public void subscribe(Observer<? super String> NbpSubscriber) {
@@ -273,7 +273,7 @@ public class ObservableTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Disposable s = mock(Disposable.class);
 
-        Observable<String> never = Observable.create(new ObservableSource<String>() {
+        Observable<String> never = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpSubscriber) {
                 NbpSubscriber.onSubscribe(s);
@@ -302,7 +302,7 @@ public class ObservableTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Disposable s = mock(Disposable.class);
 
-        Observable<String> immediatelyComplete = Observable.create(new ObservableSource<String>() {
+        Observable<String> immediatelyComplete = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpSubscriber) {
                 NbpSubscriber.onSubscribe(s);
@@ -333,7 +333,7 @@ public class ObservableTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Disposable s = mock(Disposable.class);
 
-        Observable<String> immediatelyError = Observable.create(new ObservableSource<String>() {
+        Observable<String> immediatelyError = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpSubscriber) {
                 NbpSubscriber.onSubscribe(s);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -325,7 +325,7 @@ public class ObservableTimeoutWithSelectorTest {
             public Observable<Integer> apply(Integer t1) {
                 if (t1 == 1) {
                     // Force "unsubscribe" run on another thread
-                    return Observable.create(new ObservableSource<Integer>() {
+                    return Observable.unsafeCreate(new ObservableSource<Integer>() {
                         @Override
                         public void subscribe(Observer<? super Integer> NbpSubscriber) {
                             NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -33,7 +33,7 @@ public class ObservableUnsubscribeOnTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
-            Observable<Integer> w = Observable.create(new ObservableSource<Integer>() {
+            Observable<Integer> w = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
                 @Override
                 public void subscribe(Observer<? super Integer> t1) {
@@ -77,7 +77,7 @@ public class ObservableUnsubscribeOnTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
-            Observable<Integer> w = Observable.create(new ObservableSource<Integer>() {
+            Observable<Integer> w = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
                 @Override
                 public void subscribe(Observer<? super Integer> t1) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -253,7 +253,7 @@ public class ObservableUsingTest {
         Function<Disposable, Observable<Integer>> observableFactory = new Function<Disposable, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Disposable subscription) {
-                return Observable.create(new ObservableSource<Integer>() {
+                return Observable.unsafeCreate(new ObservableSource<Integer>() {
                     @Override
                     public void subscribe(Observer<? super Integer> t1) {
                         throw new TestException();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -198,7 +198,7 @@ public class ObservableWindowWithSizeTest {
     
 
     public static Observable<Integer> hotStream() {
-        return Observable.create(new ObservableSource<Integer>() {
+        return Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> s) {
                 Disposable d = Disposables.empty();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -45,7 +45,7 @@ public class ObservableWindowWithStartEndObservableTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -58,7 +58,7 @@ public class ObservableWindowWithStartEndObservableTest {
             }
         });
 
-        Observable<Object> openings = Observable.create(new ObservableSource<Object>() {
+        Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
             public void subscribe(Observer<? super Object> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -71,7 +71,7 @@ public class ObservableWindowWithStartEndObservableTest {
         Function<Object, Observable<Object>> closer = new Function<Object, Observable<Object>>() {
             @Override
             public Observable<Object> apply(Object opening) {
-                return Observable.create(new ObservableSource<Object>() {
+                return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -96,7 +96,7 @@ public class ObservableWindowWithStartEndObservableTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -113,7 +113,7 @@ public class ObservableWindowWithStartEndObservableTest {
             int calls;
             @Override
             public Observable<Object> call() {
-                return Observable.create(new ObservableSource<Object>() {
+                return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
                         NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -46,7 +46,7 @@ public class ObservableWindowWithTimeTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
@@ -80,7 +80,7 @@ public class ObservableWindowWithTimeTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new ObservableSource<String>() {
+        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
                 NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -92,8 +92,8 @@ public class ObservableZipTest {
         TestObservable w3 = new TestObservable();
 
         Observable<String> zipW = Observable.zip(
-                Observable.create(w1), Observable.create(w2), 
-                Observable.create(w3), getConcat3StringsZipr());
+                Observable.unsafeCreate(w1), Observable.unsafeCreate(w2),
+                Observable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
 
         /* simulate sending data */
@@ -126,7 +126,7 @@ public class ObservableZipTest {
         TestObservable w2 = new TestObservable();
         TestObservable w3 = new TestObservable();
 
-        Observable<String> zipW = Observable.zip(Observable.create(w1), Observable.create(w2), Observable.create(w3), getConcat3StringsZipr());
+        Observable<String> zipW = Observable.zip(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2), Observable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
 
         /* simulate sending data */
@@ -1051,7 +1051,7 @@ public class ObservableZipTest {
     Observable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());
 
     Observable<Integer> OBSERVABLE_OF_5_INTEGERS(final AtomicInteger numEmitted) {
-        return Observable.create(new ObservableSource<Integer>() {
+        return Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(final Observer<? super Integer> o) {
@@ -1072,7 +1072,7 @@ public class ObservableZipTest {
     }
 
     Observable<Integer> ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(final CountDownLatch latch) {
-        return Observable.create(new ObservableSource<Integer>() {
+        return Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
             public void subscribe(final Observer<? super Integer> o) {

--- a/src/test/java/io/reactivex/observable/ObservableConcatTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableConcatTests.java
@@ -145,7 +145,7 @@ public class ObservableConcatTests {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
         
-        Observable<Movie> o1 = Observable.create(new ObservableSource<Movie>() {
+        Observable<Movie> o1 = Observable.unsafeCreate(new ObservableSource<Movie>() {
             @Override
             public void subscribe(Observer<? super Movie> o) {
                     o.onNext(horrorMovie1);

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -205,7 +205,7 @@ public class ObservableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void createNull() {
-        Observable.create(null);
+        Observable.unsafeCreate(null);
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/observable/ObservableTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableTests.java
@@ -269,13 +269,13 @@ public class ObservableTests {
         verify(w).onNext(60);
     }
 
-    @Ignore("Throwing is not allowed from the create?!")
+    @Ignore("Throwing is not allowed from the unsafeCreate?!")
     @Test // FIXME throwing is not allowed from the create?!
     public void testOnSubscribeFails() {
         Observer<String> observer = TestHelper.mockObserver();
 
         final RuntimeException re = new RuntimeException("bad impl");
-        Observable<String> o = Observable.create(new ObservableSource<String>() {
+        Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> s) { throw re; }
         });
@@ -442,7 +442,7 @@ public class ObservableTests {
     @Test
     public void testPublishLast() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
-        ConnectableObservable<String> connectable = Observable.<String>create(new ObservableSource<String>() {
+        ConnectableObservable<String> connectable = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
                 observer.onSubscribe(EmptyDisposable.INSTANCE);
@@ -480,7 +480,7 @@ public class ObservableTests {
     @Test
     public void testReplay() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableObservable<String> o = Observable.<String>create(new ObservableSource<String>() {
+        ConnectableObservable<String> o = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
                     observer.onSubscribe(EmptyDisposable.INSTANCE);
@@ -533,7 +533,7 @@ public class ObservableTests {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.<String>create(new ObservableSource<String>() {
+        Observable<String> o = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
                     observer.onSubscribe(EmptyDisposable.INSTANCE);
@@ -578,7 +578,7 @@ public class ObservableTests {
     @Test
     public void testCacheWithCapacity() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.<String>create(new ObservableSource<String>() {
+        Observable<String> o = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
                 observer.onSubscribe(EmptyDisposable.INSTANCE);
@@ -657,7 +657,7 @@ public class ObservableTests {
     public void testErrorThrownWithoutErrorHandlerAsynchronous() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
-        Observable.create(new ObservableSource<Object>() {
+        Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
             public void subscribe(final Observer<? super Object> observer) {
                 new Thread(new Runnable() {

--- a/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -36,7 +36,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
 
             @Override
             public void run() {
-                Flowable.create(new Publisher<Long>() {
+                Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
                     public void subscribe(Subscriber<? super Long> o) {
@@ -145,7 +145,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
 
             @Override
             public void run() {
-                Flowable.create(new Publisher<Long>() {
+                Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
                     public void subscribe(Subscriber<? super Long> o) {

--- a/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
@@ -36,7 +36,7 @@ public class ReplayProcessorConcurrencyTest {
 
             @Override
             public void run() {
-                Flowable.create(new Publisher<Long>() {
+                Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
                     public void subscribe(Subscriber<? super Long> o) {
@@ -145,7 +145,7 @@ public class ReplayProcessorConcurrencyTest {
 
             @Override
             public void run() {
-                Flowable.create(new Publisher<Long>() {
+                Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
                     public void subscribe(Subscriber<? super Long> o) {

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -283,7 +283,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch completionLatch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            Flowable<Integer> obs = Flowable.create(new Publisher<Integer>() {
+            Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
                 @Override
                 public void subscribe(final Subscriber<? super Integer> observer) {
                     inner.schedule(new Runnable() {

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -320,7 +320,7 @@ public abstract class AbstractSchedulerTests {
 
     @Test
     public final void testRecursiveSchedulerInObservable() {
-        Flowable<Integer> obs = Flowable.create(new Publisher<Integer>() {
+        Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(final Subscriber<? super Integer> observer) {
                 final Scheduler.Worker inner = getScheduler().createWorker();
@@ -368,7 +368,7 @@ public abstract class AbstractSchedulerTests {
     public final void testConcurrentOnNextFailsValidation() throws InterruptedException {
         final int count = 10;
         final CountDownLatch latch = new CountDownLatch(count);
-        Flowable<String> o = Flowable.create(new Publisher<String>() {
+        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(final Subscriber<? super String> observer) {
@@ -430,7 +430,7 @@ public abstract class AbstractSchedulerTests {
 
                     @Override
                     public Flowable<String> apply(final String v) {
-                        return Flowable.create(new Publisher<String>() {
+                        return Flowable.unsafeCreate(new Publisher<String>() {
 
                             @Override
                             public void subscribe(Subscriber<? super String> observer) {

--- a/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
@@ -189,7 +189,7 @@ public class TestSchedulerTest {
             final Runnable calledOp = mock(Runnable.class);
     
             Flowable<Object> poller;
-            poller = Flowable.create(new Publisher<Object>() {
+            poller = Flowable.unsafeCreate(new Publisher<Object>() {
                 @Override
                 public void subscribe(final Subscriber<? super Object> aSubscriber) {
                     final BooleanSubscription bs = new BooleanSubscription();

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -120,7 +120,7 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void createNull() {
-        Single.create(null);
+        Single.unsafeCreate(null);
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -127,7 +127,7 @@ public class SingleTest {
     public void testCreateSuccess() {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
         
-        Single.create(new SingleSource<Object>() {
+        Single.unsafeCreate(new SingleSource<Object>() {
             @Override
             public void subscribe(SingleObserver<? super Object> s) {
                 s.onSubscribe(EmptyDisposable.INSTANCE);
@@ -141,7 +141,7 @@ public class SingleTest {
     @Test
     public void testCreateError() {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
-        Single.create(new SingleSource<Object>() {
+        Single.unsafeCreate(new SingleSource<Object>() {
             @Override
             public void subscribe(SingleObserver<? super Object> s) {
                 s.onSubscribe(EmptyDisposable.INSTANCE);
@@ -198,7 +198,7 @@ public class SingleTest {
     @Test
     public void testTimeout() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Single<String> s1 = Single.<String>create(new SingleSource<String>() {
+        Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> s) {
                 s.onSubscribe(EmptyDisposable.INSTANCE);
@@ -220,7 +220,7 @@ public class SingleTest {
     @Test
     public void testTimeoutWithFallback() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Single<String> s1 = Single.<String>create(new SingleSource<String>() {
+        Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> s) {
                 s.onSubscribe(EmptyDisposable.INSTANCE);
@@ -247,7 +247,7 @@ public class SingleTest {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
 
-        Single<String> s1 = Single.<String>create(new SingleSource<String>() {
+        Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(final SingleObserver<? super String> s) {
                 SerialDisposable sd = new SerialDisposable();
@@ -321,7 +321,7 @@ public class SingleTest {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
 
-        Single<String> s1 = Single.create(new SingleSource<String>() {
+        Single<String> s1 = Single.unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(final SingleObserver<? super String> s) {
                 SerialDisposable sd = new SerialDisposable();
@@ -377,7 +377,7 @@ public class SingleTest {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
 
-        Single<String> s1 = Single.create(new SingleSource<String>() {
+        Single<String> s1 = Single.unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(final SingleObserver<? super String> s) {
                 SerialDisposable sd = new SerialDisposable();
@@ -425,7 +425,7 @@ public class SingleTest {
     
     @Test
     public void testBackpressureAsObservable() {
-        Single<String> s = Single.create(new SingleSource<String>() {
+        Single<String> s = Single.unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> t) {
                 t.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -38,7 +38,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new ObservableSource<Long>() {
+                Observable.unsafeCreate(new ObservableSource<Long>() {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {
@@ -148,7 +148,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new ObservableSource<Long>() {
+                Observable.unsafeCreate(new ObservableSource<Long>() {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
@@ -38,7 +38,7 @@ public class ReplaySubjectConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new ObservableSource<Long>() {
+                Observable.unsafeCreate(new ObservableSource<Long>() {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {
@@ -148,7 +148,7 @@ public class ReplaySubjectConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new ObservableSource<Long>() {
+                Observable.unsafeCreate(new ObservableSource<Long>() {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -30,7 +30,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnNextAfterOnError() {
         TestObservable t = new TestObservable();
-        Flowable<String> st = Flowable.create(t);
+        Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
         st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));
@@ -50,7 +50,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnCompletedAfterOnError() {
         TestObservable t = new TestObservable();
-        Flowable<String> st = Flowable.create(t);
+        Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
         
@@ -71,7 +71,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnNextAfterOnCompleted() {
         TestObservable t = new TestObservable();
-        Flowable<String> st = Flowable.create(t);
+        Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
         st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));
@@ -92,7 +92,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnErrorAfterOnCompleted() {
         TestObservable t = new TestObservable();
-        Flowable<String> st = Flowable.create(t);
+        Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
         st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));

--- a/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
@@ -45,7 +45,7 @@ public class SerializedObserverTest {
     @Test
     public void testSingleThreadedBasic() {
         TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
-        Flowable<String> w = Flowable.create(onSubscribe);
+        Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
         Subscriber<String> aw = serializedSubscriber(observer);
 
@@ -65,7 +65,7 @@ public class SerializedObserverTest {
     @Test
     public void testMultiThreadedBasic() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three");
-        Flowable<String> w = Flowable.create(onSubscribe);
+        Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
         BusySubscriber busySubscriber = new BusySubscriber();
         Subscriber<String> aw = serializedSubscriber(busySubscriber);
@@ -89,7 +89,7 @@ public class SerializedObserverTest {
     @Test(timeout = 1000)
     public void testMultiThreadedWithNPE() throws InterruptedException {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
-        Flowable<String> w = Flowable.create(onSubscribe);
+        Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
         BusySubscriber busySubscriber = new BusySubscriber();
         Subscriber<String> aw = serializedSubscriber(busySubscriber);
@@ -123,7 +123,7 @@ public class SerializedObserverTest {
         for (int i = 0; i < n; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, 
                     "four", "five", "six", "seven", "eight", "nine");
-            Flowable<String> w = Flowable.create(onSubscribe);
+            Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
             BusySubscriber busySubscriber = new BusySubscriber();
             Subscriber<String> aw = serializedSubscriber(busySubscriber);
@@ -412,7 +412,7 @@ public class SerializedObserverTest {
     }
 
     private static Flowable<String> infinite(final AtomicInteger produced) {
-        return Flowable.create(new Publisher<String>() {
+        return Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {


### PR DESCRIPTION
This is a proposal to solve #4255 but for 2.x and closes #4286 built around one goal: make the `create` methods actually usable by developers!

Currently the advice given to most developers using 1.x is avoid `create` unless you are absolutely 100% sure you understand backpressure and cancellation, and even then avoid it if possible. This method is a trap that most new developers fall into. _The method is named "create", after all, so it must be how I create these things!_ I want to make that statement not only correct, but advisable (at least when the still-convenient "from" methods are not suitable, such as when wrapping callback-based APIs).

Because `Observable`, `Single`, and `Completable` are backpressure-free, this amounts to just suppressing downstream notifications when disposed. This doesn't seem too controversial.

The most controversial part is that I have renamed `Flowable.fromAsync` to `Flowable.create` thus making it the canonical way for users to create `Flowable`s directly. I'm much less opinionated on this change, but it felt wrong to have an `Flowable.unsafeCreate` with no associated `create` and `fromAsync` is the "safest" version we have.
