### PR TITLE
1.x: add TestSubscriber.assertValuesAndClear

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -693,7 +693,7 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * @param expectedFirstValue the expected first value
      * @param expectedRestValues the optional rest values
      */
-    public final void assertAndConsume(T expectedFirstValue, T... expectedRestValues) {
+    public final void assertValuesAndClear(T expectedFirstValue, T... expectedRestValues) {
         int n = 1 + expectedRestValues.length;
         assertValueCount(n);
         assertItem(expectedFirstValue, 0);

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -328,19 +328,22 @@ public class TestSubscriber<T> extends Subscriber<T> {
         }
 
         for (int i = 0; i < items.size(); i++) {
-            T expected = items.get(i);
-            T actual = values.get(i);
-            if (expected == null) {
-                // check for null equality
-                if (actual != null) {
-                    assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]\n");
-                }
-            } else if (!expected.equals(actual)) {
-                assertionError("Value at index: " + i 
-                        + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName() 
-                        + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")\n");
-
+            assertItem(items.get(i), i);
+        }
+    }
+    
+    private void assertItem(T expected, int i) {
+        T actual = values.get(i);
+        if (expected == null) {
+            // check for null equality
+            if (actual != null) {
+                assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]\n");
             }
+        } else if (!expected.equals(actual)) {
+            assertionError("Value at index: " + i 
+                    + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName() 
+                    + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")\n");
+
         }
     }
 
@@ -669,5 +672,34 @@ public class TestSubscriber<T> extends Subscriber<T> {
             }
         }
         throw ae;
+    }
+    
+    /**
+     * Assert that the TestSubscriber contains the given first and optional rest values exactly
+     * and if so, clears the internal list of values.
+     * <p>
+     * <code><pre>
+     * TestSubscriber ts = new TestSubscriber();
+     * 
+     * ts.onNext(1);
+     * 
+     * ts.assertAndConsume(1);
+     * 
+     * ts.onNext(2);
+     * ts.onNext(3);
+     * 
+     * ts.assertAndConsume(2, 3); // no mention of 1
+     * </pre></code>
+     * @param expectedFirstValue the expected first value
+     * @param expectedRestValues the optional rest values
+     */
+    public final void assertAndConsume(T expectedFirstValue, T... expectedRestValues) {
+        int n = 1 + expectedRestValues.length;
+        assertValueCount(n);
+        assertItem(expectedFirstValue, 0);
+        for (int i = 0; i < expectedRestValues.length; i++) {
+            assertItem(expectedRestValues[i], i + 1);
+        }
+        values.clear();
     }
 }

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -683,12 +683,12 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * 
      * ts.onNext(1);
      * 
-     * ts.assertAndConsume(1);
+     * ts.assertValuesAndClear(1);
      * 
      * ts.onNext(2);
      * ts.onNext(3);
      * 
-     * ts.assertAndConsume(2, 3); // no mention of 1
+     * ts.assertValuesAndClear(2, 3); // no mention of 1
      * </pre></code>
      * @param expectedFirstValue the expected first value
      * @param expectedRestValues the optional rest values

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -692,7 +692,9 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * </pre></code>
      * @param expectedFirstValue the expected first value
      * @param expectedRestValues the optional rest values
+     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
+    @Experimental
     public final void assertValuesAndClear(T expectedFirstValue, T... expectedRestValues) {
         int n = 1 + expectedRestValues.length;
         assertValueCount(n);

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -781,7 +781,7 @@ public class TestSubscriberTest {
         
         ts.onNext(1);
         
-        ts.assertAndConsume(1);
+        ts.assertValuesAndClear(1);
         
         ts.assertNoValues();
         
@@ -790,13 +790,13 @@ public class TestSubscriberTest {
         
         ts.assertValueCount(2);
         
-        ts.assertAndConsume(2, 3);
+        ts.assertValuesAndClear(2, 3);
         
         ts.onNext(4);
         ts.onNext(5);
         
         try {
-            ts.assertAndConsume(4);
+            ts.assertValuesAndClear(4);
             Assert.fail("Should have thrown AssertionError");
         } catch (AssertionError ex) {
             // expected
@@ -805,13 +805,13 @@ public class TestSubscriberTest {
         ts.assertValueCount(2);
         
         try {
-            ts.assertAndConsume(4, 5, 6);
+            ts.assertValuesAndClear(4, 5, 6);
             Assert.fail("Should have thrown AssertionError");
         } catch (AssertionError ex) {
             // expected
         }
         
-        ts.assertAndConsume(4, 5);
+        ts.assertValuesAndClear(4, 5);
         
         ts.assertNoValues();
     }

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -772,4 +772,47 @@ public class TestSubscriberTest {
         Assert.assertFalse(ts.awaitValueCount(5, 1, TimeUnit.SECONDS));
         
     }
+    
+    @Test
+    public void assertAndConsume() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        ts.assertNoValues();
+        
+        ts.onNext(1);
+        
+        ts.assertAndConsume(1);
+        
+        ts.assertNoValues();
+        
+        ts.onNext(2);
+        ts.onNext(3);
+        
+        ts.assertValueCount(2);
+        
+        ts.assertAndConsume(2, 3);
+        
+        ts.onNext(4);
+        ts.onNext(5);
+        
+        try {
+            ts.assertAndConsume(4);
+            Assert.fail("Should have thrown AssertionError");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        ts.assertValueCount(2);
+        
+        try {
+            ts.assertAndConsume(4, 5, 6);
+            Assert.fail("Should have thrown AssertionError");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        ts.assertAndConsume(4, 5);
+        
+        ts.assertNoValues();
+    }
 }


### PR DESCRIPTION
This PR adds an ~~`assertAndConsume`~~ `assertValuesAndClear` method to `TestSubscriber` to assert on value content and then clear the internal value list. This helps asserting on received values without the need to list all previously seen values in `assertValues`. 

On a sidenote, `getOnNextEvents()` returns the internal list and one can call `clear()` on it.
