### PR TITLE
2.x: Skip static factories when converting between stream types.

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -250,18 +250,18 @@ public abstract class Completable implements CompletableSource {
     }
     
     /**
-     * Returns a Completable instance that subscribes to the given flowable, ignores all values and
+     * Returns a Completable instance that subscribes to the given publisher, ignores all values and
      * emits only the terminal event.
      * 
-     * @param <T> the type of the flowable
-     * @param flowable the Flowable instance to subscribe to, not null
+     * @param <T> the type of the publisher
+     * @param publisher the Publisher instance to subscribe to, not null
      * @return the new Completable instance
-     * @throws NullPointerException if flowable is null
+     * @throws NullPointerException if publisher is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Completable fromFlowable(final Publisher<T> flowable) {
-        Objects.requireNonNull(flowable, "flowable is null");
-        return new CompletableFromFlowable<T>(flowable);
+    public static <T> Completable fromPublisher(final Publisher<T> publisher) {
+        Objects.requireNonNull(publisher, "publisher is null");
+        return new CompletableFromPublisher<T>(publisher);
     }
     
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -974,7 +974,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable repeat() {
-        return fromFlowable(toFlowable().repeat());
+        return fromPublisher(toFlowable().repeat());
     }
     
     /**
@@ -985,7 +985,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable repeat(long times) {
-        return fromFlowable(toFlowable().repeat(times));
+        return fromPublisher(toFlowable().repeat(times));
     }
     
     /**
@@ -997,7 +997,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable repeatUntil(BooleanSupplier stop) {
-        return fromFlowable(toFlowable().repeatUntil(stop));
+        return fromPublisher(toFlowable().repeatUntil(stop));
     }
     
     /**
@@ -1015,7 +1015,7 @@ public abstract class Completable implements CompletableSource {
      * FIXME add unit test once the type has been fixed
      */ 
     public final Completable repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
-        return fromFlowable(toFlowable().repeatWhen(handler));
+        return fromPublisher(toFlowable().repeatWhen(handler));
     }
     
     /**
@@ -1024,7 +1024,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable retry() {
-        return fromFlowable(toFlowable().retry());
+        return fromPublisher(toFlowable().retry());
     }
     
     /**
@@ -1036,7 +1036,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
-        return fromFlowable(toFlowable().retry(predicate));
+        return fromPublisher(toFlowable().retry(predicate));
     }
 
     /**
@@ -1048,7 +1048,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable retry(long times) {
-        return fromFlowable(toFlowable().retry(times));
+        return fromPublisher(toFlowable().retry(times));
     }
 
     /**
@@ -1061,7 +1061,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable retry(Predicate<? super Throwable> predicate) {
-        return fromFlowable(toFlowable().retry(predicate));
+        return fromPublisher(toFlowable().retry(predicate));
     }
     
     /**
@@ -1075,7 +1075,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
-        return fromFlowable(toFlowable().retryWhen(handler));
+        return fromPublisher(toFlowable().retryWhen(handler));
     }
 
     /**

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -27,8 +27,11 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.functions.Objects;
 import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.operators.completable.CompletableFromPublisher;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.flowable.FlowableConcatMap.ErrorMode;
+import io.reactivex.internal.operators.observable.ObservableFromPublisher;
+import io.reactivex.internal.operators.single.SingleFromPublisher;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.internal.subscribers.flowable.*;
 import io.reactivex.internal.util.ArrayListSupplier;
@@ -3496,7 +3499,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable toCompletable() {
-        return Completable.fromFlowable(this);
+        return new CompletableFromPublisher<T>(this);
     }
     
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
@@ -3631,13 +3634,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> toObservable() {
-        return Observable.fromPublisher(this);
+        return new ObservableFromPublisher<T>(this);
     }
     
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
-        return Single.fromPublisher(this);
+        return new SingleFromPublisher<T>(this);
     }
     
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -25,6 +25,7 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.completable.CompletableFromObservable;
 import io.reactivex.internal.operators.flowable.FlowableFromObservable;
 import io.reactivex.internal.operators.single.SingleFromObservable;
 import io.reactivex.internal.operators.observable.*;
@@ -2867,7 +2868,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable toCompletable() {
-        return Completable.fromObservable(this);
+        return new CompletableFromObservable<T>(this);
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromPublisher.java
@@ -18,11 +18,11 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 
-public final class CompletableFromFlowable<T> extends Completable {
+public final class CompletableFromPublisher<T> extends Completable {
 
     final Publisher<T> flowable;
     
-    public CompletableFromFlowable(Publisher<T> flowable) {
+    public CompletableFromPublisher(Publisher<T> flowable) {
         this.flowable = flowable;
     }
 

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -547,12 +547,12 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void fromFlowableNull() {
-        Completable.fromFlowable(null);
+        Completable.fromPublisher(null);
     }
     
     @Test(timeout = 1000)
     public void fromFlowableEmpty() {
-        Completable c = Completable.fromFlowable(Flowable.empty());
+        Completable c = Completable.fromPublisher(Flowable.empty());
         
         c.await();
     }
@@ -560,7 +560,7 @@ public class CompletableTest {
     @Test(timeout = 5000)
     public void fromFlowableSome() {
         for (int n = 1; n < 10000; n *= 10) {
-            Completable c = Completable.fromFlowable(Flowable.range(1, n));
+            Completable c = Completable.fromPublisher(Flowable.range(1, n));
             
             c.await();
         }
@@ -568,7 +568,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void fromFlowableError() {
-        Completable c = Completable.fromFlowable(Flowable.error(new Callable<Throwable>() {
+        Completable c = Completable.fromPublisher(Flowable.error(new Callable<Throwable>() {
             @Override
             public Throwable call() {
                 return new TestException();
@@ -3007,9 +3007,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = Completable.amb(c1, c2);
         
@@ -3038,9 +3038,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = Completable.amb(c1, c2);
         
@@ -3069,9 +3069,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = Completable.amb(c1, c2);
         
@@ -3100,9 +3100,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = Completable.amb(c1, c2);
         
@@ -3232,9 +3232,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = c1.ambWith(c2);
         
@@ -3263,9 +3263,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = c1.ambWith(c2);
         
@@ -3294,9 +3294,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = c1.ambWith(c2);
         
@@ -3325,9 +3325,9 @@ public class CompletableTest {
         PublishProcessor<Object> ps1 = PublishProcessor.create();
         PublishProcessor<Object> ps2 = PublishProcessor.create();
         
-        Completable c1 = Completable.fromFlowable(ps1);
+        Completable c1 = Completable.fromPublisher(ps1);
 
-        Completable c2 = Completable.fromFlowable(ps2);
+        Completable c2 = Completable.fromPublisher(ps2);
         
         Completable c = c1.ambWith(c2);
         


### PR DESCRIPTION
Also rename Publisher->Completable factory method and operator implementation to match other stream types.
