### PR TITLE
2.x: Extract 'WithUpstream' interfaces.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstream.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstream.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Objects;
+
+/**
+ * Abstract base class for operators that take an upstream
+ * source {@link Publisher}.
+ *
+ * @param <T> the upstream value type
+ * @param <R> the output value type
+ */
+abstract class AbstractFlowableWithUpstream<T, R> extends Flowable<R> implements FlowableWithUpstream<T> {
+    
+    /**
+     * The upstream source Publisher.
+     */
+    protected final Publisher<T> source;
+    
+    /**
+     * Constructs a FlowableSource wrapping the given non-null (verified)
+     * source Publisher.
+     * @param source the source (upstream) Publisher instance, not null (verified)
+     */
+    public AbstractFlowableWithUpstream(Publisher<T> source) {
+        this.source = Objects.requireNonNull(source, "source is null");
+    }
+    
+    @Override
+    public final Publisher<T> source() {
+        return source;
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
@@ -18,7 +18,7 @@ import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableAll<T> extends FlowableWithUpstream<T, Boolean> {
+public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolean> {
     
     final Predicate<? super T> predicate;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableAny<T> extends FlowableWithUpstream<T, Boolean> {
+public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolean> {
     final Predicate<? super T> predicate;
     public FlowableAny(Publisher<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableBuffer<T, C extends Collection<? super T>> extends FlowableWithUpstream<T, C> {
+public final class FlowableBuffer<T, C extends Collection<? super T>> extends AbstractFlowableWithUpstream<T, C> {
     final int size;
 
     final int skip;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -30,7 +30,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.*;
 
 public final class FlowableBufferBoundary<T, U extends Collection<? super T>, Open, Close> 
-extends FlowableWithUpstream<T, U> {
+extends AbstractFlowableWithUpstream<T, U> {
     final Callable<U> bufferSupplier;
     final Publisher<? extends Open> bufferOpen;
     final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.*;
 
 public final class FlowableBufferBoundarySupplier<T, U extends Collection<? super T>, B> 
-extends FlowableWithUpstream<T, U> {
+extends AbstractFlowableWithUpstream<T, U> {
     final Callable<? extends Publisher<B>> boundarySupplier;
     final Callable<U> bufferSupplier;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.subscribers.*;
 
 public final class FlowableBufferExactBoundary<T, U extends Collection<? super T>, B> 
-extends FlowableWithUpstream<T, U> {
+extends AbstractFlowableWithUpstream<T, U> {
     final Publisher<B> boundary;
     final Callable<U> bufferSupplier;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -29,7 +29,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableBufferTimed<T, U extends Collection<? super T>> extends FlowableWithUpstream<T, U> {
+public final class FlowableBufferTimed<T, U extends Collection<? super T>> extends AbstractFlowableWithUpstream<T, U> {
 
     final long timespan;
     final long timeskip;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.util.*;
  *
  * @param <T> the source element type
  */
-public final class FlowableCache<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
     /** The cache and replay state. */
     final CacheState<T> state;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
@@ -20,7 +20,7 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableCollect<T, U> extends FlowableWithUpstream<T, U> {
+public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T, U> {
     
     final Callable<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableConcatMap<T, R> extends FlowableWithUpstream<T, R> {
+public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
     final Function<? super T, ? extends Publisher<? extends R>> mapper;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public class FlowableConcatMapEager<T, R> extends FlowableWithUpstream<T, R> {
+public class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
     final Function<? super T, ? extends Publisher<? extends R>> mapper;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCount.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableCount<T> extends FlowableWithUpstream<T, Long> {
+public final class FlowableCount<T> extends AbstractFlowableWithUpstream<T, Long> {
 
     public FlowableCount(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.*;
 
-public final class FlowableDebounce<T, U> extends FlowableWithUpstream<T, T> {
+public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super T, ? extends Publisher<U>> debounceSelector;
 
     public FlowableDebounce(Publisher<T> source, Function<? super T, ? extends Publisher<U>> debounceSelector) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableDebounceTimed<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -22,7 +22,7 @@ import io.reactivex.Scheduler.Worker;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableDelay<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
     final long delay;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableDematerialize<T> extends FlowableWithUpstream<Try<Optional<T>>, T> {
+public final class FlowableDematerialize<T> extends AbstractFlowableWithUpstream<Try<Optional<T>>, T> {
 
     public FlowableDematerialize(Publisher<Try<Optional<T>>> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscribers.flowable.EmptyComponent;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableDetach<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableDetach<T> extends AbstractFlowableWithUpstream<T, T> {
 
     public FlowableDetach(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableDistinct<T, K> extends FlowableWithUpstream<T, T> {
+public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super T, K> keySelector;
     final Callable<? extends Predicate<? super K>> predicateSupplier;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -19,7 +19,7 @@ import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.flowable.*;
 
-public final class FlowableDistinctUntilChanged<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableDistinctUntilChanged<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final BiPredicate<? super T, ? super T> comparer;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -21,7 +21,7 @@ import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.flowable.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableDoOnEach<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T> {
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;
     final Runnable onComplete;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -19,7 +19,7 @@ import io.reactivex.internal.subscribers.flowable.SubscriptionLambdaSubscriber;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-public final class FlowableDoOnLifecycle<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream<T, T> {
     private final Consumer<? super Subscription> onSubscribe;
     private final LongConsumer onRequest;
     private final Runnable onCancel;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAt.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableElementAt<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, T> {
     final long index;
     final T defaultValue;
     public FlowableElementAt(Publisher<T> source, long index, T defaultValue) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -19,7 +19,7 @@ import io.reactivex.functions.Predicate;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscribers.flowable.*;
 
-public final class FlowableFilter<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public FlowableFilter(Publisher<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.queue.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableFlatMap<T, U> extends FlowableWithUpstream<T, U> {
+public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T, U> {
     final Function<? super T, ? extends Publisher<? extends U>> mapper;
     final boolean delayErrors;
     final int maxConcurrency;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableFlattenIterable<T, R> extends FlowableWithUpstream<T, R> {
+public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
     final Function<? super T, ? extends Iterable<? extends R>> mapper;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableGroupBy<T, K, V> extends FlowableWithUpstream<T, GroupedFlowable<K, V>> {
+public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream<T, GroupedFlowable<K, V>> {
     final Function<? super T, ? extends K> keySelector;
     final Function<? super T, ? extends V> valueSelector;
     final int bufferSize;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -33,7 +33,7 @@ import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 
-public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends FlowableWithUpstream<TLeft, R> {
+public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends AbstractFlowableWithUpstream<TLeft, R> {
 
     final Publisher<? extends TRight> other;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  * 
  * @since 2.0
  */
-public class FlowableHide<T> extends FlowableWithUpstream<T, T> {
+public class FlowableHide<T> extends AbstractFlowableWithUpstream<T, T> {
     
     public FlowableHide(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableIgnoreElements<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableIgnoreElements<T> extends AbstractFlowableWithUpstream<T, T> {
 
     public FlowableIgnoreElements(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
@@ -29,7 +29,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends FlowableWithUpstream<TLeft, R> {
+public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends AbstractFlowableWithUpstream<TLeft, R> {
 
     final Publisher<? extends TRight> other;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <T> the upstream value type
  * @param <R> the downstream parameter type
  */
-public final class FlowableLift<R, T> extends FlowableWithUpstream<T, R> {
+public final class FlowableLift<R, T> extends AbstractFlowableWithUpstream<T, R> {
     /** The actual operator. */
     final FlowableOperator<? extends R, ? super T> operator;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.flowable.*;
 
-public final class FlowableMap<T, U> extends FlowableWithUpstream<T, U> {
+public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> {
     final Function<? super T, ? extends U> mapper;
     public FlowableMap(Publisher<T> source, Function<? super T, ? extends U> mapper) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -22,7 +22,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableMapNotification<T, R> extends FlowableWithUpstream<T, R> {
+public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
     final Function<? super T, ? extends R> onNextMapper;
     final Function<? super Throwable, ? extends R> onErrorMapper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMaterialize.java
@@ -21,7 +21,7 @@ import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableMaterialize<T> extends FlowableWithUpstream<T, Try<Optional<T>>> {
+public final class FlowableMaterialize<T> extends AbstractFlowableWithUpstream<T, Try<Optional<T>>> {
 
     public FlowableMaterialize(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableObserveOn<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableObserveOn<T> extends AbstractFlowableWithUpstream<T, T> {
 final Scheduler scheduler;
     
     final boolean delayError;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.queue.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableOnBackpressureBuffer<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithUpstream<T, T> {
     final int bufferSize;
     final boolean unbounded;
     final boolean delayError;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -21,7 +21,7 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableOnBackpressureDrop<T> extends FlowableWithUpstream<T, T> implements Consumer<T> {
+public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUpstream<T, T> implements Consumer<T> {
 
     final Consumer<? super T> onDrop;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatest.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableOnBackpressureLatest<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithUpstream<T, T> {
 
     public FlowableOnBackpressureLatest(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableOnErrorNext<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super Throwable, ? extends Publisher<? extends T>> nextSupplier;
     final boolean allowFatal;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
@@ -22,7 +22,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableOnErrorReturn<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableOnErrorReturn<T> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super Throwable, ? extends T> valueSupplier;
     public FlowableOnErrorReturn(Publisher<T> source, Function<? super Throwable, ? extends T> valueSupplier) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRedo.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 import io.reactivex.processors.*;
 
 // FIXME split and update to the Rsc version
-public final class FlowableRedo<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableRedo<T> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super Flowable<Try<Optional<Object>>>, ? extends Publisher<?>> manager;
 
     public FlowableRedo(Publisher<T> source,

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -30,7 +30,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  * @param <T>
  *            the value type
  */
-public final class FlowableRefCount<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T> {
     final ConnectableFlowable<? extends T> source;
     volatile CompositeDisposable baseSubscription = new CompositeDisposable();
     final AtomicInteger subscriptionCount = new AtomicInteger(0);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
-public final class FlowableRepeat<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> {
     final long count;
     public FlowableRepeat(Publisher<T> source, long count) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.functions.BooleanSupplier;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
-public final class FlowableRepeatUntil<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T, T> {
     final BooleanSupplier until;
     public FlowableRepeatUntil(Publisher<T> source, BooleanSupplier until) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -21,7 +21,7 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
-public final class FlowableRetryBiPredicate<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final BiPredicate<? super Integer, ? super Throwable> predicate;
     public FlowableRetryBiPredicate(
             Publisher<T> source,

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
@@ -21,7 +21,7 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
-public final class FlowableRetryPredicate<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super Throwable> predicate;
     final long count;
     public FlowableRetryPredicate(Publisher<T> source,

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableSampleTimed<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long period;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableScan<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
     final BiFunction<T, T, T> accumulator;
     public FlowableScan(Publisher<T> source, BiFunction<T, T, T> accumulator) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableScanSeed<T, R> extends FlowableWithUpstream<T, R> {
+public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T, R> {
     final BiFunction<R, ? super T, R> accumulator;
     final Callable<R> seedSupplier;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSerialized.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSerialized.java
@@ -16,7 +16,7 @@ import io.reactivex.Flowable;
 import io.reactivex.subscribers.SerializedSubscriber;
 import org.reactivestreams.Subscriber;
 
-public final class FlowableSerialized<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSerialized<T> extends AbstractFlowableWithUpstream<T, T> {
     public FlowableSerialized(Flowable<T> source) {
         super(source);
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingle.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableSingle<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSingle<T> extends AbstractFlowableWithUpstream<T, T> {
     
     final T defaultValue;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkip.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableSkip<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSkip<T> extends AbstractFlowableWithUpstream<T, T> {
     final long n;
     public FlowableSkip(Publisher<T> source, long n) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLast.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableSkipLast<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSkipLast<T> extends AbstractFlowableWithUpstream<T, T> {
     final int skip;
     
     public FlowableSkipLast(Publisher<T> source, int skip) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimed.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableSkipLastTimed<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSkipLastTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long time;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipUntil.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableSkipUntil<T, U> extends FlowableWithUpstream<T, T> {
+public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<T, T> {
     final Publisher<U> other;
     public FlowableSkipUntil(Publisher<T> source, Publisher<U> other) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableSkipWhile<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSkipWhile<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public FlowableSkipWhile(Publisher<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
@@ -21,7 +21,7 @@ import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableSubscribeOn<T> extends FlowableWithUpstream<T , T> {
+public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T , T> {
     final Scheduler scheduler;
     
     public FlowableSubscribeOn(Publisher<T> source, Scheduler scheduler) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmpty.java
@@ -17,7 +17,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
-public final class FlowableSwitchIfEmpty<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableSwitchIfEmpty<T> extends AbstractFlowableWithUpstream<T, T> {
     final Publisher<? extends T> other;
     public FlowableSwitchIfEmpty(Publisher<T> source, Publisher<? extends T> other) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableSwitchMap<T, R> extends FlowableWithUpstream<T, R> {
+public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<T, R> {
     final Function<? super T, ? extends Publisher<? extends R>> mapper;
     final int bufferSize;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableTake<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
     final long limit;
     public FlowableTake(Publisher<T> source, long limit) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLast.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableTakeLast<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTakeLast<T> extends AbstractFlowableWithUpstream<T, T> {
     final int count;
     
     public FlowableTakeLast(Publisher<T> source, int count) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOne.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOne.java
@@ -16,7 +16,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.*;
 
-public final class FlowableTakeLastOne<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTakeLastOne<T> extends AbstractFlowableWithUpstream<T, T> {
 
     public FlowableTakeLastOne(Publisher<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimed.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
-public final class FlowableTakeLastTimed<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTakeLastTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long count;
     final long time;
     final TimeUnit unit;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntil.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableTakeUntil<T, U> extends FlowableWithUpstream<T, T> {
+public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<T, T> {
     final Publisher<? extends U> other;
     public FlowableTakeUntil(Publisher<T> source, Publisher<? extends U> other) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableTakeUntilPredicate<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public FlowableTakeUntilPredicate(Publisher<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableTakeWhile<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTakeWhile<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public FlowableTakeWhile(Publisher<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableThrottleFirstTimed<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
@@ -21,7 +21,7 @@ import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.schedulers.Timed;
 
-public final class FlowableTimeInterval<T> extends FlowableWithUpstream<T, Timed<T>> {
+public final class FlowableTimeInterval<T> extends AbstractFlowableWithUpstream<T, Timed<T>> {
     final Scheduler scheduler;
     final TimeUnit unit;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.*;
 
-public final class FlowableTimeout<T, U, V> extends FlowableWithUpstream<T, T> {
+public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream<T, T> {
     final Callable<? extends Publisher<U>> firstTimeoutSelector;
     final Function<? super T, ? extends Publisher<V>> timeoutSelector; 
     final Publisher<? extends T> other;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableTimeoutTimed<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.ArrayListSupplier;
 
-public final class FlowableToList<T, U extends Collection<? super T>> extends FlowableWithUpstream<T, U> {
+public final class FlowableToList<T, U extends Collection<? super T>> extends AbstractFlowableWithUpstream<T, U> {
     final Callable<U> collectionSupplier;
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class FlowableUnsubscribeOn<T> extends FlowableWithUpstream<T, T> {
+public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream<T, T> {
     final Scheduler scheduler;
     public FlowableUnsubscribeOn(Publisher<T> source, Scheduler scheduler) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 
-public final class FlowableWindow<T> extends FlowableWithUpstream<T, Flowable<T>> {
+public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
     final long size;
     
     final long skip;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -30,7 +30,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.*;
 
-public final class FlowableWindowBoundary<T, B> extends FlowableWithUpstream<T, Flowable<T>> {
+public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
     final Publisher<B> other;
     final int bufferSize;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.*;
 
-public final class FlowableWindowBoundarySelector<T, B, V> extends FlowableWithUpstream<T, Flowable<T>> {
+public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
     final Publisher<B> open;
     final Function<? super B, ? extends Publisher<V>> close;
     final int bufferSize;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -31,7 +31,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.*;
 
-public final class FlowableWindowBoundarySupplier<T, B> extends FlowableWithUpstream<T, Flowable<T>> {
+public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
     final Callable<? extends Publisher<B>> other;
     final int bufferSize;
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -32,7 +32,7 @@ import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableWindowTimed<T> extends FlowableWithUpstream<T, Flowable<T>> {
+public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
     final long timespan;
     final long timeskip;
     final TimeUnit unit;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.SerializedSubscriber;
 
-public final class FlowableWithLatestFrom<T, U, R> extends FlowableWithUpstream<T, R> {
+public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithUpstream<T, R> {
     final BiFunction<? super T, ? super U, ? extends R> combiner;
     final Publisher<? extends U> other;
     public FlowableWithLatestFrom(Publisher<T> source, BiFunction<? super T, ? super U, ? extends R> combiner, Publisher<? extends U> other) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithUpstream.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithUpstream.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2016 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
@@ -15,32 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.Publisher;
 
-import io.reactivex.Flowable;
-import io.reactivex.internal.functions.Objects;
-
-/**
- * Abstract base class for operators that take an upstream
- * source {@link Publisher}.
- *
- * @param <T> the upstream value type
- * @param <R> the output value type
- */
-public abstract class FlowableWithUpstream<T, R> extends Flowable<R> {
-    
-    /**
-     * The upstream source Publisher.
-     */
-    protected final Publisher<T> source;
-    
-    /**
-     * Constructs a FlowableSource wrapping the given non-null (verified)
-     * source Publisher.
-     * @param source the source (upstream) Publisher instance, not null (verified)
-     */
-    public FlowableWithUpstream(Publisher<T> source) {
-        this.source = Objects.requireNonNull(source, "source is null");
-    }
-    
+public interface FlowableWithUpstream<T> {
     /**
      * Returns the source Publisher.
      * <p>
@@ -48,7 +23,5 @@ public abstract class FlowableWithUpstream<T, R> extends Flowable<R> {
      * graph of sequences.
      * @return the source Publisher
      */
-    public final Publisher<T> source() {
-        return source;
-    }
+    Publisher<T> source();
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/AbstractObservableWithUpstream.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/AbstractObservableWithUpstream.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+
+/**
+ * Base class for operators with a source consumable.
+ *
+ * @param <T> the input source type
+ * @param <U> the output type
+ */
+abstract class AbstractObservableWithUpstream<T, U> extends Observable<U> implements ObservableWithUpstream<T> {
+
+    /** The source consumable Observable. */
+    protected final ObservableSource<T> source;
+    
+    /**
+     * Constructs the ObservableSource with the given consumable.
+     * @param source the consumable Observable
+     */
+    public AbstractObservableWithUpstream(ObservableSource<T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    public final ObservableSource<T> source() {
+        return source;
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAll.java
@@ -18,7 +18,7 @@ import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableAll<T> extends ObservableWithUpstream<T, Boolean> {
+public final class ObservableAll<T> extends AbstractObservableWithUpstream<T, Boolean> {
     final Predicate<? super T> predicate;
     public ObservableAll(ObservableSource<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAny.java
@@ -17,7 +17,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableAny<T> extends ObservableWithUpstream<T, Boolean> {
+public final class ObservableAny<T> extends AbstractObservableWithUpstream<T, Boolean> {
     final Predicate<? super T> predicate;
     public ObservableAny(ObservableSource<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
@@ -22,7 +22,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 
-public final class ObservableBuffer<T, U extends Collection<? super T>> extends ObservableWithUpstream<T, U> {
+public final class ObservableBuffer<T, U extends Collection<? super T>> extends AbstractObservableWithUpstream<T, U> {
     final int count;
     final int skip;
     final Callable<U> bufferSupplier;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
@@ -30,7 +30,7 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableBufferBoundary<T, U extends Collection<? super T>, Open, Close> 
-extends ObservableWithUpstream<T, U> {
+extends AbstractObservableWithUpstream<T, U> {
     final Callable<U> bufferSupplier;
     final ObservableSource<? extends Open> bufferOpen;
     final Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
@@ -27,7 +27,7 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableBufferBoundarySupplier<T, U extends Collection<? super T>, B> 
-extends ObservableWithUpstream<T, U> {
+extends AbstractObservableWithUpstream<T, U> {
     final Callable<? extends ObservableSource<B>> boundarySupplier;
     final Callable<U> bufferSupplier;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class ObservableBufferExactBoundary<T, U extends Collection<? super T>, B> 
-extends ObservableWithUpstream<T, U> {
+extends AbstractObservableWithUpstream<T, U> {
     final ObservableSource<B> boundary;
     final Callable<U> bufferSupplier;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.observers.SerializedObserver;
 
 public final class ObservableBufferTimed<T, U extends Collection<? super T>> 
-extends ObservableWithUpstream<T, U> {
+extends AbstractObservableWithUpstream<T, U> {
 
     final long timespan;
     final long timeskip;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCache.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.util.*;
  *
  * @param <T> the source element type
  */
-public final class ObservableCache<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, T> {
     /** The cache and replay state. */
     final CacheState<T> state;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
@@ -19,7 +19,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.internal.disposables.*;
 
-public final class ObservableCollect<T, U> extends ObservableWithUpstream<T, U> {
+public final class ObservableCollect<T, U> extends AbstractObservableWithUpstream<T, U> {
     final Callable<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableConcatMap<T, U> extends ObservableWithUpstream<T, U> {
+public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstream<T, U> {
     final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
     final int bufferSize;
     public ObservableConcatMap(ObservableSource<T> source, Function<? super T, ? extends ObservableSource<? extends U>> mapper, int bufferSize) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCount.java
@@ -17,7 +17,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableCount<T> extends ObservableWithUpstream<T, Long> {
+public final class ObservableCount<T> extends AbstractObservableWithUpstream<T, Long> {
     public ObservableCount(ObservableSource<T> source) {
         super(source);
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.subscribers.observable.DisposableObserver;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableDebounce<T, U> extends ObservableWithUpstream<T, T> {
+public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstream<T, T> {
     final Function<? super T, ? extends ObservableSource<U>> debounceSelector;
 
     public ObservableDebounce(ObservableSource<T> source, Function<? super T, ? extends ObservableSource<U>> debounceSelector) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableDebounceTimed<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
@@ -21,7 +21,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.observers.SerializedObserver;
 
-public final class ObservableDelay<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, T> {
     final long delay;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDematerialize.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableDematerialize<T> extends ObservableWithUpstream<Try<Optional<T>>, T> {
+public final class ObservableDematerialize<T> extends AbstractObservableWithUpstream<Try<Optional<T>>, T> {
     
     public ObservableDematerialize(ObservableSource<Try<Optional<T>>> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.*;
 
-public final class ObservableDistinct<T, K> extends ObservableWithUpstream<T, T> {
+public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstream<T, T> {
     final Function<? super T, K> keySelector;
     final Callable<? extends Predicate<? super K>> predicateSupplier;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableDoOnEach<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<T, T> {
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;
     final Runnable onComplete;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnLifecycle.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscribers.observable.SubscriptionLambdaObserver;
 
-public final class ObservableDoOnLifecycle<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableDoOnLifecycle<T> extends AbstractObservableWithUpstream<T, T> {
     private final Consumer<? super Disposable> onSubscribe;
     private final Runnable onCancel;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
@@ -17,7 +17,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableElementAt<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableElementAt<T> extends AbstractObservableWithUpstream<T, T> {
     final long index;
     final T defaultValue;
     public ObservableElementAt(ObservableSource<T> source, long index, T defaultValue) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableFilter<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public ObservableFilter(ObservableSource<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.*;
 
-public final class ObservableFlatMap<T, U> extends ObservableWithUpstream<T, U> {
+public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstream<T, U> {
     final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
     final boolean delayErrors;
     final int maxConcurrency;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.observables.GroupedObservable;
 
-public final class ObservableGroupBy<T, K, V> extends ObservableWithUpstream<T, GroupedObservable<K, V>> {
+public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpstream<T, GroupedObservable<K, V>> {
     final Function<? super T, ? extends K> keySelector;
     final Function<? super T, ? extends V> valueSelector;
     final int bufferSize;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -34,7 +34,7 @@ import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
-public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends ObservableWithUpstream<TLeft, R> {
+public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends AbstractObservableWithUpstream<TLeft, R> {
 
     final ObservableSource<? extends TRight> other;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableIgnoreElements.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableIgnoreElements.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 
-public final class ObservableIgnoreElements<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableIgnoreElements<T> extends AbstractObservableWithUpstream<T, T> {
 
     public ObservableIgnoreElements(ObservableSource<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
@@ -32,7 +32,7 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends ObservableWithUpstream<TLeft, R> {
+public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends AbstractObservableWithUpstream<TLeft, R> {
 
     final ObservableSource<? extends TRight> other;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableLift.java
@@ -25,7 +25,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <T> the upstream value type
  * @param <R> the downstream parameter type
  */
-public final class ObservableLift<R, T> extends ObservableWithUpstream<T, R> {
+public final class ObservableLift<R, T> extends AbstractObservableWithUpstream<T, R> {
     /** The actual operator. */
     final ObservableOperator<? extends R, ? super T> operator;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableMap<T, U> extends ObservableWithUpstream<T, U> {
+public final class ObservableMap<T, U> extends AbstractObservableWithUpstream<T, U> {
     final Function<? super T, ? extends U> function;
     
     public ObservableMap(ObservableSource<T> source, Function<? super T, ? extends U> function) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableMapNotification<T, R> extends ObservableWithUpstream<T, ObservableSource<? extends R>> {
+public final class ObservableMapNotification<T, R> extends AbstractObservableWithUpstream<T, ObservableSource<? extends R>> {
 
     final Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper;
     final Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMaterialize.java
@@ -17,7 +17,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableMaterialize<T> extends ObservableWithUpstream<T, Try<Optional<T>>> {
+public final class ObservableMaterialize<T> extends AbstractObservableWithUpstream<T, Try<Optional<T>>> {
     
     
     public ObservableMaterialize(ObservableSource<T> source) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.schedulers.TrampolineScheduler;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableObserveOn<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream<T, T> {
     final Scheduler scheduler;
     final boolean delayError;
     final int bufferSize;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorNext.java
@@ -19,7 +19,7 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Function;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableOnErrorNext<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableOnErrorNext<T> extends AbstractObservableWithUpstream<T, T> {
     final Function<? super Throwable, ? extends ObservableSource<? extends T>> nextSupplier;
     final boolean allowFatal;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturn.java
@@ -19,7 +19,7 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableOnErrorReturn<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableOnErrorReturn<T> extends AbstractObservableWithUpstream<T, T> {
     final Function<? super Throwable, ? extends T> valueSupplier;
     public ObservableOnErrorReturn(ObservableSource<T> source, Function<? super Throwable, ? extends T> valueSupplier) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRedo.java
@@ -22,7 +22,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscribers.observable.ToNotificationObserver;
 import io.reactivex.subjects.BehaviorSubject;
 
-public final class ObservableRedo<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableRedo<T> extends AbstractObservableWithUpstream<T, T> {
     final Function<? super Observable<Try<Optional<Object>>>, ? extends ObservableSource<?>> manager;
 
     public ObservableRedo(ObservableSource<T> source,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -29,7 +29,7 @@ import io.reactivex.observables.ConnectableObservable;
  * @param <T>
  *            the value type
  */
-public final class ObservableRefCount<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableRefCount<T> extends AbstractObservableWithUpstream<T, T> {
 
     final ConnectableObservable<? extends T> source;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 
-public final class ObservableRepeat<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T, T> {
     final long count;
     public ObservableRepeat(Observable<T> source, long count) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.BooleanSupplier;
 
-public final class ObservableRepeatUntil<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstream<T, T> {
     final BooleanSupplier until;
     public ObservableRepeatUntil(Observable<T> source, BooleanSupplier until) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.BiPredicate;
 
-public final class ObservableRetryBiPredicate<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableRetryBiPredicate<T> extends AbstractObservableWithUpstream<T, T> {
     final BiPredicate<? super Integer, ? super Throwable> predicate;
     public ObservableRetryBiPredicate(
             Observable<T> source,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
 
-public final class ObservableRetryPredicate<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableRetryPredicate<T> extends AbstractObservableWithUpstream<T, T> {
     final Predicate<? super Throwable> predicate;
     final long count;
     public ObservableRetryPredicate(Observable<T> source,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleTimed.java
@@ -21,7 +21,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.observers.SerializedObserver;
 
-public final class ObservableSampleTimed<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long period;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleWithObservable.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.observers.SerializedObserver;
 
-public final class ObservableSampleWithObservable<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSampleWithObservable<T> extends AbstractObservableWithUpstream<T, T> {
     final ObservableSource<?> other;
     
     public ObservableSampleWithObservable(ObservableSource<T> source, ObservableSource<?> other) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableScan<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T> {
     final BiFunction<T, T, T> accumulator;
     public ObservableScan(ObservableSource<T> source, BiFunction<T, T, T> accumulator) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableScanSeed<T, R> extends ObservableWithUpstream<T, R> {
+public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstream<T, R> {
     final BiFunction<R, ? super T, R> accumulator;
     final Callable<R> seedSupplier;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSerialized.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSerialized.java
@@ -16,7 +16,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.observers.SerializedObserver;
 
-public final class ObservableSerialized<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSerialized<T> extends AbstractObservableWithUpstream<T, T> {
     public ObservableSerialized(Observable<T> upstream) {
         super(upstream);
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSingle.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableSingle<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T, T> {
     
     final T defaultValue;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkip.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 
-public final class ObservableSkip<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSkip<T> extends AbstractObservableWithUpstream<T, T> {
     final long n;
     public ObservableSkip(ObservableSource<T> source, long n) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLast.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableSkipLast<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSkipLast<T> extends AbstractObservableWithUpstream<T, T> {
     final int skip;
     
     public ObservableSkipLast(ObservableSource<T> source, int skip) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimed.java
@@ -21,7 +21,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 
-public final class ObservableSkipLastTimed<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSkipLastTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long time;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipUntil.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
 
-public final class ObservableSkipUntil<T, U> extends ObservableWithUpstream<T, T> {
+public final class ObservableSkipUntil<T, U> extends AbstractObservableWithUpstream<T, T> {
     final ObservableSource<U> other;
     public ObservableSkipUntil(ObservableSource<T> source, ObservableSource<U> other) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableSkipWhile<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSkipWhile<T> extends AbstractObservableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public ObservableSkipWhile(ObservableSource<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSubscribeOn.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableSubscribeOn<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstream<T, T> {
     final Scheduler scheduler;
     
     public ObservableSubscribeOn(Observable<T> source, Scheduler scheduler) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmpty.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 
-public final class ObservableSwitchIfEmpty<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableSwitchIfEmpty<T> extends AbstractObservableWithUpstream<T, T> {
     final ObservableSource<? extends T> other;
     public ObservableSwitchIfEmpty(ObservableSource<T> source, ObservableSource<? extends T> other) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -24,7 +24,7 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableSwitchMap<T, R> extends ObservableWithUpstream<T, R> {
+public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstream<T, R> {
     final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
     final int bufferSize;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTake.java
@@ -17,7 +17,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableTake<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTake<T> extends AbstractObservableWithUpstream<T, T> {
     final long limit;
     public ObservableTake(ObservableSource<T> source, long limit) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLast.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLast.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableTakeLast<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTakeLast<T> extends AbstractObservableWithUpstream<T, T> {
     final int count;
     
     public ObservableTakeLast(ObservableSource<T> source, int count) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastOne.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastOne.java
@@ -16,7 +16,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableTakeLastOne<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTakeLastOne<T> extends AbstractObservableWithUpstream<T, T> {
     
     public ObservableTakeLastOne(ObservableSource<T> source) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
@@ -21,7 +21,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 
-public final class ObservableTakeLastTimed<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long count;
     final long time;
     final TimeUnit unit;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntil.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
 
-public final class ObservableTakeUntil<T, U> extends ObservableWithUpstream<T, T> {
+public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstream<T, T> {
     final ObservableSource<? extends U> other;
     public ObservableTakeUntil(ObservableSource<T> source, ObservableSource<? extends U> other) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicate.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableTakeUntilPredicate<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTakeUntilPredicate<T> extends AbstractObservableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public ObservableTakeUntilPredicate(ObservableSource<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeWhile.java
@@ -18,7 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableTakeWhile<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTakeWhile<T> extends AbstractObservableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
     public ObservableTakeWhile(ObservableSource<T> source, Predicate<? super T> predicate) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTimed.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableThrottleFirstTimed<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeInterval.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.schedulers.Timed;
 
-public final class ObservableTimeInterval<T> extends ObservableWithUpstream<T, Timed<T>> {
+public final class ObservableTimeInterval<T> extends AbstractObservableWithUpstream<T, Timed<T>> {
     final Scheduler scheduler;
     final TimeUnit unit;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
@@ -24,7 +24,7 @@ import io.reactivex.internal.subscribers.observable.*;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableTimeout<T, U, V> extends ObservableWithUpstream<T, T> {
+public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpstream<T, T> {
     final Callable<? extends ObservableSource<U>> firstTimeoutSelector;
     final Function<? super T, ? extends ObservableSource<V>> timeoutSelector;
     final ObservableSource<? extends T> other;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -24,7 +24,7 @@ import io.reactivex.internal.subscribers.observable.FullArbiterObserver;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableTimeoutTimed<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
@@ -22,7 +22,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 
 public final class ObservableToList<T, U extends Collection<? super T>> 
-extends ObservableWithUpstream<T, U> {
+extends AbstractObservableWithUpstream<T, U> {
     
     final Callable<U> collectionSupplier;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOn.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableUnsubscribeOn<T> extends ObservableWithUpstream<T, T> {
+public final class ObservableUnsubscribeOn<T> extends AbstractObservableWithUpstream<T, T> {
     final Scheduler scheduler;
     public ObservableUnsubscribeOn(ObservableSource<T> source, Scheduler scheduler) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindow.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindow.java
@@ -21,7 +21,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.subjects.UnicastSubject;
 
-public final class ObservableWindow<T> extends ObservableWithUpstream<T, Observable<T>> {
+public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T, Observable<T>> {
     final long count;
     final long skip;
     final int capacityHint;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundary.java
@@ -27,7 +27,7 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
-public final class ObservableWindowBoundary<T, B> extends ObservableWithUpstream<T, Observable<T>> {
+public final class ObservableWindowBoundary<T, B> extends AbstractObservableWithUpstream<T, Observable<T>> {
     final ObservableSource<B> other;
     final int bufferSize;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -31,7 +31,7 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
-public final class ObservableWindowBoundarySelector<T, B, V> extends ObservableWithUpstream<T, Observable<T>> {
+public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObservableWithUpstream<T, Observable<T>> {
     final ObservableSource<B> open;
     final Function<? super B, ? extends ObservableSource<V>> close;
     final int bufferSize;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
@@ -27,7 +27,7 @@ import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
-public final class ObservableWindowBoundarySupplier<T, B> extends ObservableWithUpstream<T, Observable<T>> {
+public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObservableWithUpstream<T, Observable<T>> {
     final Callable<? extends ObservableSource<B>> other;
     final int bufferSize;
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
@@ -32,7 +32,7 @@ import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.subjects.UnicastSubject;
 
-public final class ObservableWindowTimed<T> extends ObservableWithUpstream<T, Observable<T>> {
+public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstream<T, Observable<T>> {
     final long timespan;
     final long timeskip;
     final TimeUnit unit;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableWithLatestFrom<T, U, R> extends ObservableWithUpstream<T, R> {
+public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableWithUpstream<T, R> {
     final BiFunction<? super T, ? super U, ? extends R> combiner;
     final ObservableSource<? extends U> other;
     public ObservableWithLatestFrom(ObservableSource<T> source,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithUpstream.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithUpstream.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2016 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
@@ -13,34 +13,13 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.*;
+import io.reactivex.ObservableSource;
 
-/**
- * Base class for operators with a source consumable.
- *
- * @param <T> the input source type
- * @param <U> the output type
- */
-public abstract class ObservableWithUpstream<T, U> extends Observable<U> {
-
-    /** The source consumable Observable. */
-    protected final ObservableSource<T> source;
-    
-    /**
-     * Constructs the ObservableSource with the given consumable.
-     * @param source the consumable Observable
-     */
-    public ObservableWithUpstream(ObservableSource<T> source) {
-        this.source = source;
-    }
-    
+public interface ObservableWithUpstream<T> {
     /**
      * Returns the upstream source of this Observable.
      * <p>Allows discovering the chain of observables.
      * @return the source ObservableConsumable
      */
-    public final ObservableSource<T> source() {
-        return source;
-    }
-
+    ObservableSource<T> source();
 }


### PR DESCRIPTION
This allows use with types that do not extend directly from their base stream types.
