### PR TITLE
1.x: compact MultipleAssignment- and Serial-Subscriptions

### DIFF
--- a/src/main/java/rx/internal/subscriptions/SequentialSubscription.java
+++ b/src/main/java/rx/internal/subscriptions/SequentialSubscription.java
@@ -61,7 +61,7 @@ public final class SequentialSubscription extends AtomicReference<Subscription> 
     
     /**
      * Atomically sets the contained Subscription to the provided next value and unsubscribes
-     * the previous value.
+     * the previous value or unsubscribes the next value if this container is unsubscribed.
      * <p>(Remark: named as such because set() is final).
      * @param next the next Subscription to contain, may be null
      * @return true if the update succeded, false if the container was unsubscribed
@@ -88,7 +88,8 @@ public final class SequentialSubscription extends AtomicReference<Subscription> 
 
     /**
      * Atomically replaces the contained Subscription to the provided next value but
-     * does not unsubscribe the previous value.
+     * does not unsubscribe the previous value or unsubscribes the next value if this 
+     * container is unsubscribed.
      * @param next the next Subscription to contain, may be null
      * @return true if the update succeded, false if the container was unsubscribed
      */
@@ -111,7 +112,7 @@ public final class SequentialSubscription extends AtomicReference<Subscription> 
     
     /**
      * Atomically tries to set the contained Subscription to the provided next value and unsubscribes
-     * the previous value; but in case of a concurrent update there is no retry.
+     * the previous value or unsubscribes the next value if this container is unsubscribed.
      * <p>
      * Unlike {@link #update(Subscription)}, this doesn't retry if the replace failed
      * because a concurrent operation changed the underlying contained object.
@@ -140,7 +141,8 @@ public final class SequentialSubscription extends AtomicReference<Subscription> 
     
     /**
      * Atomically tries to replace the contained Subscription to the provided next value but
-     * does not unsubscribe the previous value.
+     * does not unsubscribe the previous value or unsubscribes the next value if this container 
+     * is unsubscribed.
      * <p>
      * Unlike {@link #replace(Subscription)}, this doesn't retry if the replace failed
      * because a concurrent operation changed the underlying contained object.

--- a/src/main/java/rx/internal/subscriptions/SequentialSubscription.java
+++ b/src/main/java/rx/internal/subscriptions/SequentialSubscription.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.subscriptions;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * A container of a Subscription that supports operations of SerialSubscription 
+ * and MultipleAssignmentSubscription via methods (update, replace) and extends
+ * AtomicReference to reduce allocation count (beware the API leak of AtomicReference!).
+ * @since 1.1.9
+ */
+public final class SequentialSubscription extends AtomicReference<Subscription> implements Subscription {
+
+    /** */
+    private static final long serialVersionUID = 995205034283130269L;
+
+    /**
+     * Create an empty SequentialSubscription.
+     */
+    public SequentialSubscription() {
+        
+    }
+    
+    /**
+     * Create a SequentialSubscription with the given initial Subscription.
+     * @param initial the initial Subscription, may be null
+     */
+    public SequentialSubscription(Subscription initial) {
+        lazySet(initial);
+    }
+    
+    /**
+     * Returns the current contained Subscription (may be null).
+     * <p>(Remark: named as such because get() is final).
+     * @return the current contained Subscription (may be null)
+     */
+    public Subscription current() {
+        Subscription current = super.get();
+        if (current == Unsubscribed.INSTANCE) {
+            return Subscriptions.unsubscribed();
+        }
+        return current;
+    }
+    
+    /**
+     * Atomically sets the contained Subscription to the provided next value and unsubscribes
+     * the previous value.
+     * <p>(Remark: named as such because set() is final).
+     * @param next the next Subscription to contain, may be null
+     * @return true if the update succeded, false if the container was unsubscribed
+     */
+    public boolean update(Subscription next) {
+        for (;;) {
+            Subscription current = get();
+
+            if (current == Unsubscribed.INSTANCE) {
+                if (next != null) {
+                    next.unsubscribe();
+                }
+                return false;
+            }
+            
+            if (compareAndSet(current, next)) {
+                if (current != null) {
+                    current.unsubscribe();
+                }
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Atomically replaces the contained Subscription to the provided next value but
+     * does not unsubscribe the previous value.
+     * @param next the next Subscription to contain, may be null
+     * @return true if the update succeded, false if the container was unsubscribed
+     */
+    public boolean replace(Subscription next) {
+        for (;;) {
+            Subscription current = get();
+
+            if (current == Unsubscribed.INSTANCE) {
+                if (next != null) {
+                    next.unsubscribe();
+                }
+                return false;
+            }
+            
+            if (compareAndSet(current, next)) {
+                return true;
+            }
+        }
+    }
+    
+    /**
+     * Atomically tries to set the contained Subscription to the provided next value and unsubscribes
+     * the previous value; but in case of a concurrent update there is no retry.
+     * <p>
+     * Unlike {@link #update(Subscription)}, this doesn't retry if the replace failed
+     * because a concurrent operation changed the underlying contained object.
+     * @param next the next Subscription to contain, may be null
+     * @return true if the update succeded, false if the container was unsubscribed
+     */
+    public boolean updateWeak(Subscription next) {
+        Subscription current = get();
+        if (current == Unsubscribed.INSTANCE) {
+            if (next != null) {
+                next.unsubscribe();
+            }
+            return false;
+        }
+        if (compareAndSet(current, next)) {
+            return true;
+        }
+        
+        current = get();
+        
+        if (next != null) {
+            next.unsubscribe();
+        }
+        return current == Unsubscribed.INSTANCE;
+    }
+    
+    /**
+     * Atomically tries to replace the contained Subscription to the provided next value but
+     * does not unsubscribe the previous value.
+     * <p>
+     * Unlike {@link #replace(Subscription)}, this doesn't retry if the replace failed
+     * because a concurrent operation changed the underlying contained object.
+     * @param next the next Subscription to contain, may be null
+     * @return true if the update succeded, false if the container was unsubscribed
+     */
+    public boolean replaceWeak(Subscription next) {
+        Subscription current = get();
+        if (current == Unsubscribed.INSTANCE) {
+            if (next != null) {
+                next.unsubscribe();
+            }
+            return false;
+        }
+        if (compareAndSet(current, next)) {
+            return true;
+        }
+        
+        current = get();
+        if (current == Unsubscribed.INSTANCE) {
+            if (next != null) {
+                next.unsubscribe();
+            }
+            return false;
+        }
+        return true;
+    }
+    
+    @Override
+    public void unsubscribe() {
+        Subscription current = get();
+        if (current != Unsubscribed.INSTANCE) {
+            current = getAndSet(Unsubscribed.INSTANCE);
+            if (current != null && current != Unsubscribed.INSTANCE) {
+                current.unsubscribe();
+            }
+        }
+    }
+    
+    @Override
+    public boolean isUnsubscribed() {
+        return get() == Unsubscribed.INSTANCE;
+    }
+}

--- a/src/main/java/rx/internal/subscriptions/Unsubscribed.java
+++ b/src/main/java/rx/internal/subscriptions/Unsubscribed.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.subscriptions;
+
+import rx.Subscription;
+
+/**
+ * Represents an unsubscribed Subscription via a singleton; don't leak it!
+ */
+public enum Unsubscribed implements Subscription {
+    INSTANCE;
+    
+    @Override
+    public boolean isUnsubscribed() {
+        return true;
+    }
+    
+    @Override
+    public void unsubscribe() {
+        // deliberately ignored
+    }
+}

--- a/src/test/java/rx/subscriptions/MultipleAssignmentSubscriptionTest.java
+++ b/src/test/java/rx/subscriptions/MultipleAssignmentSubscriptionTest.java
@@ -15,15 +15,11 @@
  */
 package rx.subscriptions;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static rx.subscriptions.Subscriptions.create;
-import org.junit.Assert;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import rx.Subscription;
 import rx.functions.Action0;
@@ -72,6 +68,7 @@ public class MultipleAssignmentSubscriptionTest {
     }
 
     @Test
+    @Ignore("This is prone to leaks")
     public void testSubscriptionRemainsAfterUnsubscribe() {
         MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
 
@@ -80,4 +77,16 @@ public class MultipleAssignmentSubscriptionTest {
 
         Assert.assertEquals(true, mas.get() == s);
     }
+
+    @Test
+    public void subscriptionDoesntRemainAfterUnsubscribe() {
+        MultipleAssignmentSubscription mas = new MultipleAssignmentSubscription();
+
+        mas.set(s);
+        mas.unsubscribe();
+
+        assertNotEquals(s, mas.get());
+        assertSame(mas.get(), Subscriptions.unsubscribed());
+    }
+
 }


### PR DESCRIPTION
This PR reduces the allocation in `MultipleAssignmentSubscription` and `SerialSubscription` by introducing a shared, compact underlying container `SequentialSubscription`.

I've updated `Worker.schedulePeriodically` to use it directly.

In addition, there is a behavior change with `MultipleAssignmentSubscription`: it no longer retains the last `Subscription` as it was likely to cause retention problems (and otherwise didn't make sense to me).

The `SequentialSubscription` feature weak versions of the mutation methods that don't retry if there was a concurrent mutation: for some operations, not winning such races is fine.

/cc @JakeWharton @davidmoten @artem-zinnatullin 
