### PR TITLE
2.x: Remove conditional resource management from async listeners.

### DIFF
--- a/src/main/java/io/reactivex/observers/Observers.java
+++ b/src/main/java/io/reactivex/observers/Observers.java
@@ -29,8 +29,8 @@ public final class Observers {
         throw new IllegalStateException("No instances!");
     }
     
-    public static <T> AsyncObserver<T> emptyAsync() {
-        return new AsyncObserver<T>() {
+    public static <T> ResourceObserver<T> emptyResource() {
+        return new ResourceObserver<T>() {
             @Override
             public void onNext(T t) {
                 
@@ -138,21 +138,21 @@ public final class Observers {
         };
     }
     
-    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext) {
-        return createAsync(onNext, RxJavaPlugins.errorConsumer(), Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
+    public static <T> ResourceObserver<T> createResource(Consumer<? super T> onNext) {
+        return createResource(onNext, RxJavaPlugins.errorConsumer(), Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
     }
 
-    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+    public static <T> ResourceObserver<T> createResource(Consumer<? super T> onNext,
             Consumer<? super Throwable> onError) {
-        return createAsync(onNext, onError, Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
+        return createResource(onNext, onError, Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
     }
 
-    public static <T> AsyncObserver<T> createAsync(Consumer<? super T> onNext, 
+    public static <T> ResourceObserver<T> createResource(Consumer<? super T> onNext,
             Consumer<? super Throwable> onError, Runnable onComplete) {
-        return createAsync(onNext, onError, onComplete, Functions.EMPTY_RUNNABLE);
+        return createResource(onNext, onError, onComplete, Functions.EMPTY_RUNNABLE);
     }
     
-    public static <T> AsyncObserver<T> createAsync(
+    public static <T> ResourceObserver<T> createResource(
             final Consumer<? super T> onNext, 
             final Consumer<? super Throwable> onError, 
             final Runnable onComplete, 
@@ -161,7 +161,7 @@ public final class Observers {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
         Objects.requireNonNull(onStart, "onStart is null");
-        return new AsyncObserver<T>() {
+        return new ResourceObserver<T>() {
             boolean done;
             @Override
             protected void onStart() {

--- a/src/main/java/io/reactivex/subscribers/Subscribers.java
+++ b/src/main/java/io/reactivex/subscribers/Subscribers.java
@@ -255,8 +255,8 @@ public final class Subscribers {
             }
         };
     }
-    public static <T> AsyncSubscriber<T> emptyAsync() {
-        return new AsyncSubscriber<T>() {
+    public static <T> ResourceSubscriber<T> emptyResource() {
+        return new ResourceSubscriber<T>() {
             @Override
             public void onNext(T t) {
                 
@@ -350,21 +350,21 @@ public final class Subscribers {
         };
     }
     
-    public static <T> AsyncSubscriber<T> createAsync(Consumer<? super T> onNext) {
-        return createAsync(onNext, RxJavaPlugins.errorConsumer(), Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
+    public static <T> ResourceSubscriber<T> createResource(Consumer<? super T> onNext) {
+        return createResource(onNext, RxJavaPlugins.errorConsumer(), Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
     }
 
-    public static <T> AsyncSubscriber<T> createAsync(Consumer<? super T> onNext, 
+    public static <T> ResourceSubscriber<T> createResource(Consumer<? super T> onNext,
             Consumer<? super Throwable> onError) {
-        return createAsync(onNext, onError, Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
+        return createResource(onNext, onError, Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
     }
 
-    public static <T> AsyncSubscriber<T> createAsync(Consumer<? super T> onNext, 
+    public static <T> ResourceSubscriber<T> createResource(Consumer<? super T> onNext,
             Consumer<? super Throwable> onError, Runnable onComplete) {
-        return createAsync(onNext, onError, onComplete, Functions.EMPTY_RUNNABLE);
+        return createResource(onNext, onError, onComplete, Functions.EMPTY_RUNNABLE);
     }
     
-    public static <T> AsyncSubscriber<T> createAsync(
+    public static <T> ResourceSubscriber<T> createResource(
             final Consumer<? super T> onNext, 
             final Consumer<? super Throwable> onError, 
             final Runnable onComplete, 
@@ -373,7 +373,7 @@ public final class Subscribers {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
         Objects.requireNonNull(onStart, "onStart is null");
-        return new AsyncSubscriber<T>() {
+        return new ResourceSubscriber<T>() {
             boolean done;
             @Override
             protected void onStart() {

--- a/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
@@ -386,7 +386,7 @@ public class FlowableBackpressureTests {
         final AtomicInteger totalReceived = new AtomicInteger();
         final AtomicInteger batches = new AtomicInteger();
         final AtomicInteger received = new AtomicInteger();
-        incrementingIntegers(c).subscribe(new AsyncSubscriber<Integer>() {
+        incrementingIntegers(c).subscribe(new ResourceSubscriber<Integer>() {
 
             @Override
             public void onStart() {
@@ -433,7 +433,7 @@ public class FlowableBackpressureTests {
         final AtomicInteger batches = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
         incrementingIntegers(c).subscribeOn(Schedulers.newThread()).subscribe(
-                new AsyncSubscriber<Integer>() {
+                new ResourceSubscriber<Integer>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -204,7 +204,7 @@ public class FlowableSubscriberTest {
 
                 });
 
-                AsyncSubscriber<String> as = new AsyncSubscriber<String>() {
+                ResourceSubscriber<String> as = new ResourceSubscriber<String>() {
                     
                     @Override
                     protected void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -989,7 +989,7 @@ public class FlowableBufferTest {
         final Subscriber<Object> o = TestHelper.mockSubscriber();
         
         final CountDownLatch cdl = new CountDownLatch(1);
-        AsyncSubscriber<Object> s = new AsyncSubscriber<Object>() {
+        ResourceSubscriber<Object> s = new ResourceSubscriber<Object>() {
             @Override
             public void onNext(Object t) {
                 o.onNext(t);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -637,7 +637,7 @@ public class FlowableFromSourceTest {
 
             this.current = t;
             
-            final AsyncSubscriber<Integer> as = new AsyncSubscriber<Integer>() {
+            final ResourceSubscriber<Integer> as = new ResourceSubscriber<Integer>() {
 
                 @Override
                 public void onComplete() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -763,7 +763,7 @@ public class ObservableBufferTest {
         final Observer<Object> o = TestHelper.mockObserver();
         
         final CountDownLatch cdl = new CountDownLatch(1);
-        AsyncObserver<Object> s = new AsyncObserver<Object>() {
+        ResourceObserver<Object> s = new ResourceObserver<Object>() {
             @Override
             public void onNext(Object t) {
                 o.onNext(t);

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -317,7 +317,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
     
             final AtomicInteger count = new AtomicInteger();
             final AtomicBoolean completed = new AtomicBoolean(false);
-            AsyncSubscriber<Integer> s = new AsyncSubscriber<Integer>() {
+            ResourceSubscriber<Integer> s = new ResourceSubscriber<Integer>() {
                 @Override
                 public void onComplete() {
                     System.out.println("Completed");

--- a/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedObserverTest.java
@@ -375,13 +375,13 @@ public class SerializedObserverTest {
         AtomicInteger p2 = new AtomicInteger();
 
         o.onSubscribe(EmptySubscription.INSTANCE);
-        AsyncSubscriber<String> as1 = Subscribers.createAsync(new Consumer<String>() {
+        ResourceSubscriber<String> as1 = Subscribers.createResource(new Consumer<String>() {
             @Override
             public void accept(String v) {
                 o.onNext(v);
             }
         });
-        AsyncSubscriber<String> as2 = Subscribers.createAsync(new Consumer<String>() {
+        ResourceSubscriber<String> as2 = Subscribers.createResource(new Consumer<String>() {
             @Override
             public void accept(String v) {
                 o.onNext(v);


### PR DESCRIPTION
Rename them to have a 'Resource' prefix.
