### PR TITLE
Use Throwable to catch Error when get Android version

### DIFF
--- a/src/main/java/rx/internal/util/PlatformDependent.java
+++ b/src/main/java/rx/internal/util/PlatformDependent.java
@@ -70,7 +70,7 @@ public final class PlatformDependent {
                     .forName("android.os.Build$VERSION", true, getSystemClassLoader())
                     .getField("SDK_INT")
                     .get(null);
-        } catch (Exception e) { // NOPMD 
+        } catch (Throwable e) { // NOPMD
             // Can not resolve version of Android API, maybe current platform is not Android
             // or API of resolving current Version of Android API has changed in some release of Android
             return ANDROID_API_VERSION_IS_NOT_ANDROID;


### PR DESCRIPTION
When do JUnit testing with RxRingBuffer, we may have Android platform
classes defined, but contains no Android environment.

So when we call PlatformDependent.resolveAndroidApiVersion in JUnit
testing, an UnsatisfiedLinkError will throw when calling
SystemProperties.native_get(String, String).

The UnsatisfiedLinkError is not an Exception, so the test failed because
of an uncatched exception.

Fix this by catch the Throwable instead of Exception to catch Error.
