### PR TITLE
2.x: Sync Single javadoc with 1.x

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -23,30 +23,67 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.operators.completable.CompletableFromSingle;
+import io.reactivex.internal.operators.flowable.*;
+import io.reactivex.internal.operators.flowable.FlowableConcatMap.ErrorMode;
 import io.reactivex.internal.operators.single.*;
 import io.reactivex.internal.subscribers.single.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 
 /**
- * Represents a deferred computation and emission of a single value or exception.
+ * The Single class implements the Reactive Pattern for a single value response. 
+ * See {@link Flowable} or {@link Observable} for the
+ * implementation of the Reactive Pattern for a stream or vector of values.
+ * <p>
+ * {@code Single} behaves the same as {@link Observable} except that it can only emit either a single successful
+ * value, or an error (there is no "onComplete" notification as there is for {@link Observable})
+ * <p>
+ * Like an {@link Observable}, a {@code Single} is lazy, can be either "hot" or "cold", synchronous or
+ * asynchronous.
+ * <p>
+ * The documentation for this class makes use of marble diagrams. The following legend explains these diagrams:
+ * <p>
+ * <img width="605" height="285" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.legend.png" alt="">
+ * <p>
+ * For more information see the <a href="http://reactivex.io/documentation/observable.html">ReactiveX
+ * documentation</a>.
  * 
- * @param <T> the value type
+ * @param <T>
+ *            the type of the item emitted by the Single
+ * @since 2.0
  */
 public abstract class Single<T> implements SingleSource<T> {
-    static <T> Single<T> wrap(SingleSource<T> source) {
-        Objects.requireNonNull(source, "source is null");
-        if (source instanceof Single) {
-            return (Single<T>)source;
-        }
-        return new SingleFromUnsafeSource<T>(source);
-    }
     
+    /**
+     * Runs multiple Single sources and signals the events of the first one that signals (cancelling
+     * the rest).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param sources the Iterable sequence of sources
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static <T> Single<T> amb(final Iterable<? extends SingleSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return new SingleAmbIterable<T>(sources);
     }
     
+    /**
+     * Runs multiple Single sources and signals the events of the first one that signals (cancelling
+     * the rest).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param sources the array of sources
+     * @return the new Single instance
+     * @since 2.0
+     */
     @SuppressWarnings("unchecked")
     public static <T> Single<T> amb(final SingleSource<? extends T>... sources) {
         if (sources.length == 0) {
@@ -63,19 +100,62 @@ public abstract class Single<T> implements SingleSource<T> {
         return new SingleAmbArray<T>(sources);
     }
 
+    /**
+     * Concatenate the single values, non-overlappingly, of the Single sources provided by
+     * an Iterable sequence. 
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param sources the Iterable sequence of SingleSource instances
+     * @return the new Flowable instance
+     * @since 2.0
+     */
     public static <T> Flowable<T> concat(Iterable<? extends SingleSource<? extends T>> sources) {
         return concat(Flowable.fromIterable(sources));
     }
     
-    public static <T> Flowable<T> concat(Flowable<? extends SingleSource<? extends T>> sources) { // FIXME Publisher
-        return sources.concatMap(new Function<SingleSource<? extends T>, Publisher<? extends T>>() {
-            @Override 
-            public Publisher<? extends T> apply(SingleSource<? extends T> v){
-                return new SingleToFlowable<T>(v);
-            }
-        });
+    /**
+     * Concatenate the single values, non-overlappingly, of the Single sources provided by
+     * a Publisher sequence. 
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param sources the Publisher of SingleSource instances
+     * @return the new Flowable instance
+     * @since 2.0
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources) {
+        return new FlowableConcatMap(sources, 
+            new Function<SingleSource<? extends T>, Publisher<? extends T>>() {
+                @Override 
+                public Publisher<? extends T> apply(SingleSource<? extends T> v){
+                    return new SingleToFlowable<T>(v);
+                }
+            }, 2, ErrorMode.IMMEDIATE);
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by two Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the two source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2
@@ -85,6 +165,25 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by three Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the three source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -96,6 +195,27 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by four Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @param s4
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the four source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -108,6 +228,29 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3, s4));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by five Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @param s4
+     *            a Single to be concatenated
+     * @param s5
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the five source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -122,6 +265,31 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by six Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @param s4
+     *            a Single to be concatenated
+     * @param s5
+     *            a Single to be concatenated
+     * @param s6
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the six source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -137,6 +305,33 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by seven Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @param s4
+     *            a Single to be concatenated
+     * @param s5
+     *            a Single to be concatenated
+     * @param s6
+     *            a Single to be concatenated
+     * @param s7
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the seven source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -154,6 +349,35 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by eight Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @param s4
+     *            a Single to be concatenated
+     * @param s5
+     *            a Single to be concatenated
+     * @param s6
+     *            a Single to be concatenated
+     * @param s7
+     *            a Single to be concatenated
+     * @param s8
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the eight source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -172,6 +396,37 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8));
     }
     
+    /**
+     * Returns a Flowable that emits the items emitted by nine Singles, one after the other.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be concatenated
+     * @param s2
+     *            a Single to be concatenated
+     * @param s3
+     *            a Single to be concatenated
+     * @param s4
+     *            a Single to be concatenated
+     * @param s5
+     *            a Single to be concatenated
+     * @param s6
+     *            a Single to be concatenated
+     * @param s7
+     *            a Single to be concatenated
+     * @param s8
+     *            a Single to be concatenated
+     * @param s9
+     *            a Single to be concatenated
+     * @return a Flowable that emits items emitted by the nine source Singles, one after the other.
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -192,88 +447,352 @@ public abstract class Single<T> implements SingleSource<T> {
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
     }
 
-    public static <T> Single<T> create(SingleSource<T> source) {
+    /**
+     * Creates a Single instance that calls the given callback with an abstracted
+     * instance of a SingleObserver, allows emitting a single signal and allows
+     * registerign a single resource that is disposed upon cancellation or signalling
+     * a success or error from the callback. 
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param source the consumer that is called with a SigleEmitter instance for each
+     * underlying SingleObserver that has subscribed.
+     * @return the new Single instance
+     */
+    public static <T> Single<T> create(SingleSource<T> source) { // FIXME SingleEmitter
         Objects.requireNonNull(source, "source is null");
         // TODO plugin wrapper
         return new SingleFromSource<T>(source);
     }
 
-    public static <T> Single<T> unsafeCreate(SingleSource<T> source) {
-        Objects.requireNonNull(source, "source is null");
-        // TODO plugin wrapper
-        return new SingleFromUnsafeSource<T>(source);
-    }
-    
+    /**
+     * Calls a Callable for each individual SingleObserver to return the actula Single source to
+     * be subscribe to.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param singleSupplier the Callable that is called for each individual SingleObserver and
+     * returns a SingleSource instance to subscribe to
+     * @return the new Single instance
+     */
     public static <T> Single<T> defer(final Callable<? extends SingleSource<? extends T>> singleSupplier) {
         Objects.requireNonNull(singleSupplier, "singleSupplier is null");
         return new SingleDefer<T>(singleSupplier);
     }
     
+    /**
+     * Signals a Throwable returned by the callback function for each individual SingleObserver.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param errorSupplier the callable that is called for each individual SingleObserver and
+     * returns a Throwable instance to be emitted.
+     * @return the new Single instance
+     */
     public static <T> Single<T> error(final Callable<? extends Throwable> errorSupplier) {
         Objects.requireNonNull(errorSupplier, "errorSupplier is null");
         return new SingleError<T>(errorSupplier);
     }
     
-    public static <T> Single<T> error(final Throwable error) {
-        Objects.requireNonNull(error, "error is null");
+    /**
+     * Returns a Single that invokes a subscriber's {@link SingleObserver#onError onError} method when the
+     * subscriber subscribes to it.
+     * <p>
+     * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.error.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param exception
+     *            the particular Throwable to pass to {@link SingleObserver#onError onError}
+     * @param <T>
+     *            the type of the item (ostensibly) emitted by the Single
+     * @return a Single that invokes the subscriber's {@link SingleObserver#onError onError} method when
+     *         the subscriber subscribes to it
+     * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
+     */
+    public static <T> Single<T> error(final Throwable exception) {
+        Objects.requireNonNull(exception, "error is null");
         return error(new Callable<Throwable>() {
             @Override
             public Throwable call() {
-                return error;
+                return exception;
             }
         });
     }
     
+    /**
+     * Returns a {@link Single} that invokes passed function and emits its result for each new Observer that subscribes.
+     * <p>
+     * Allows you to defer execution of passed function until Observer subscribes to the {@link Single}.
+     * It makes passed function "lazy".
+     * Result of the function invocation will be emitted by the {@link Single}.
+     * <dl>
+     *   <dt><b>Scheduler:</b></dt>
+     *   <dd>{@code fromCallable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param callable
+     *         function which execution should be deferred, it will be invoked when SingleObserver will subscribe to the {@link Single}.
+     * @param <T>
+     *         the type of the item emitted by the {@link Single}.
+     * @return a {@link Single} whose {@link Observer}s' subscriptions trigger an invocation of the given function.
+     */
     public static <T> Single<T> fromCallable(final Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return new SingleFromCallable<T>(callable);
     }
     
+    /**
+     * Converts a {@link Future} into a {@code Single}.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.from.Future.png" alt="">
+     * <p>
+     * You can convert any object that supports the {@link Future} interface into a Single that emits the return
+     * value of the {@link Future#get} method of that object, by passing the object into the {@code from}
+     * method.
+     * <p>
+     * <em>Important note:</em> This Single is blocking; you cannot unsubscribe from it.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param future
+     *            the source {@link Future}
+     * @param <T>
+     *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
+     *            the resulting {@code Single}
+     * @return a {@code Single} that emits the item from the source {@link Future}
+     * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     */
     public static <T> Single<T> fromFuture(Future<? extends T> future) {
         return Flowable.<T>fromFuture(future).toSingle();
     }
 
+    /**
+     * Converts a {@link Future} into a {@code Single}, with a timeout on the Future.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.from.Future.png" alt="">
+     * <p>
+     * You can convert any object that supports the {@link Future} interface into a {@code Single} that emits
+     * the return value of the {@link Future#get} method of that object, by passing the object into the
+     * {@code from} method.
+     * <p>
+     * <em>Important note:</em> This {@code Single} is blocking; you cannot unsubscribe from it.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param future
+     *            the source {@link Future}
+     * @param timeout
+     *            the maximum time to wait before calling {@code get}
+     * @param unit
+     *            the {@link TimeUnit} of the {@code timeout} argument
+     * @param <T>
+     *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
+     *            the resulting {@code Single}
+     * @return a {@code Single} that emits the item from the source {@link Future}
+     * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     */
     public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
         return Flowable.<T>fromFuture(future, timeout, unit).toSingle();
     }
 
+    /**
+     * Converts a {@link Future} into a {@code Single}, with a timeout on the Future.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.from.Future.png" alt="">
+     * <p>
+     * You can convert any object that supports the {@link Future} interface into a {@code Single} that emits
+     * the return value of the {@link Future#get} method of that object, by passing the object into the
+     * {@code from} method.
+     * <p>
+     * <em>Important note:</em> This {@code Single} is blocking; you cannot unsubscribe from it.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>You specify the {@link Scheduler} where the blocking wait will happen.</dd>
+     * </dl>
+     * 
+     * @param future
+     *            the source {@link Future}
+     * @param timeout
+     *            the maximum time to wait before calling {@code get}
+     * @param unit
+     *            the {@link TimeUnit} of the {@code timeout} argument
+     * @param scheduler
+     *            the Scheduler to use for the blocking wait
+     * @param <T>
+     *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
+     *            the resulting {@code Single}
+     * @return a {@code Single} that emits the item from the source {@link Future}
+     * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     */
     public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
         return Flowable.<T>fromFuture(future, timeout, unit, scheduler).toSingle();
     }
 
+    /**
+     * Converts a {@link Future}, operating on a specified {@link Scheduler}, into a {@code Single}.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.from.Future.s.png" alt="">
+     * <p>
+     * You can convert any object that supports the {@link Future} interface into a {@code Single} that emits
+     * the return value of the {@link Future#get} method of that object, by passing the object into the
+     * {@code from} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     * 
+     * @param future
+     *            the source {@link Future}
+     * @param scheduler
+     *            the {@link Scheduler} to wait for the Future on. Use a Scheduler such as
+     *            {@link Schedulers#io()} that can block and wait on the Future
+     * @param <T>
+     *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
+     *            the resulting {@code Single}
+     * @return a {@code Single} that emits the item from the source {@link Future}
+     * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     */
     public static <T> Single<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
         return Flowable.<T>fromFuture(future, scheduler).toSingle();
     }
 
+    /**
+     * Wraps a specific Publisher into a Single and signals its single element or error.
+     * <p>If the source Publisher is empty, a NoSuchElementException is signalled. If
+     * the source has more than one element, an IndexOutOfBoundsException is signalled.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param publisher the source Publisher instance, not null
+     * @return the new Single instance
+     */
     public static <T> Single<T> fromPublisher(final Publisher<? extends T> publisher) {
         Objects.requireNonNull(publisher, "publisher is null");
         return new SingleFromPublisher<T>(publisher);
     }
 
+    /**
+     * Returns a {@code Single} that emits a specified item.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.just.png" alt="">
+     * <p>
+     * To convert any object into a {@code Single} that emits that object, pass that object into the
+     * {@code just} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code just} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param value
+     *            the item to emit
+     * @param <T>
+     *            the type of that item
+     * @return a {@code Single} that emits {@code value}
+     * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
+     */
     public static <T> Single<T> just(final T value) {
         Objects.requireNonNull(value, "value is null");
         return new SingleJust<T>(value);
     }
 
+    /**
+     * Merges an Iterable sequence of SingleSource instances into a single Flowable sequence,
+     * running all SingleSources at once.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common and resulting value type
+     * @param sources the Iterable sequence of SingleSource sources
+     * @return the new Flowable instance
+     * @since 2.0
+     */
     public static <T> Flowable<T> merge(Iterable<? extends SingleSource<? extends T>> sources) {
         return merge(Flowable.fromIterable(sources));
     }
 
-    public static <T> Flowable<T> merge(Flowable<? extends SingleSource<? extends T>> sources) { // FIXME Publisher
-        return sources.flatMap(new Function<SingleSource<? extends T>, Publisher<? extends T>>() {
-            @Override 
-            public Publisher<? extends T> apply(SingleSource<? extends T> v){
-                return new SingleToFlowable<T>(v);
-            }
-        });
+    /**
+     * Merges a Flowable sequence of SingleSource instances into a single Flowable sequence,
+     * running all SingleSources at once.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common and resulting value type
+     * @param sources the Flowable sequence of SingleSource sources
+     * @return the new Flowable instance
+     * @since 2.0
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Flowable<T> merge(Publisher<? extends SingleSource<? extends T>> sources) {
+        return new FlowableFlatMap(sources, 
+            new Function<SingleSource<? extends T>, Publisher<? extends T>>() {
+                @Override 
+                public Publisher<? extends T> apply(SingleSource<? extends T> v){
+                    return new SingleToFlowable<T>(v);
+                }
+            }, false, Integer.MAX_VALUE, Flowable.bufferSize());
     }
     
+    /**
+     * Flattens a {@code Single} that emits a {@code Single} into a single {@code Single} that emits the item
+     * emitted by the nested {@code Single}, without any transformation.
+     * <p>
+     * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.oo.png" alt="">
+     * <p>
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the value type of the sources and the output
+     * @param source
+     *            a {@code Single} that emits a {@code Single}
+     * @return a {@code Single} that emits the item that is the result of flattening the {@code Single} emitted
+     *         by {@code source}
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Single<T> merge(SingleSource<? extends SingleSource<? extends T>> source) {
         Objects.requireNonNull(source, "source is null");
         return new SingleFlatMap<SingleSource<? extends T>, T>(source, (Function)Functions.identity());
     }
     
+    /**
+     * Flattens two Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by
+     * using the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2
@@ -283,6 +802,28 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2));
     }
     
+    /**
+     * Flattens three Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -294,6 +835,30 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3));
     }
     
+    /**
+     * Flattens four Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @param s4
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -306,6 +871,32 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3, s4));
     }
     
+    /**
+     * Flattens five Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @param s4
+     *            a Single to be merged
+     * @param s5
+     *            a Single to be merged
+     * @return  that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -320,6 +911,34 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5));
     }
     
+    /**
+     * Flattens six Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @param s4
+     *            a Single to be merged
+     * @param s5
+     *            a Single to be merged
+     * @param s6
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -335,6 +954,36 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6));
     }
 
+    /**
+     * Flattens seven Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @param s4
+     *            a Single to be merged
+     * @param s5
+     *            a Single to be merged
+     * @param s6
+     *            a Single to be merged
+     * @param s7
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -352,6 +1001,38 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7));
     }
 
+    /**
+     * Flattens eight Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @param s4
+     *            a Single to be merged
+     * @param s5
+     *            a Single to be merged
+     * @param s6
+     *            a Single to be merged
+     * @param s7
+     *            a Single to be merged
+     * @param s8
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -370,6 +1051,40 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8));
     }
 
+    /**
+     * Flattens nine Singles into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code merge} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T> the common value type
+     * @param s1
+     *            a Single to be merged
+     * @param s2
+     *            a Single to be merged
+     * @param s3
+     *            a Single to be merged
+     * @param s4
+     *            a Single to be merged
+     * @param s5
+     *            a Single to be merged
+     * @param s6
+     *            a Single to be merged
+     * @param s7
+     *            a Single to be merged
+     * @param s8
+     *            a Single to be merged
+     * @param s9
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
@@ -390,32 +1105,140 @@ public abstract class Single<T> implements SingleSource<T> {
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
     }
     
+    /**
+     * Returns a singleton instance of a never-signalling Single (only calls onSubscribe).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code never} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the target value type
+     * @return the singleton never instance
+     * @since 2.0
+     */
     @SuppressWarnings("unchecked")
     public static <T> Single<T> never() {
         return (Single<T>) SingleNever.INSTANCE;
     }
     
+    /**
+     * Signals success with 0L value after the given delay for each SingleObserver.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code never} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param delay the delay amount
+     * @param unit the time unit of the delay
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static Single<Long> timer(long delay, TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
     
+    /**
+     * Signals success with 0L value after the given delay for each SingleObserver.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>you specify the {@link Scheduler} to signal on.</dd>
+     * </dl>
+     * @param delay the delay amount
+     * @param unit the time unit of the delay
+     * @param scheduler the scheduler where the single 0L will be emitted
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static Single<Long> timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return new SingleTimer(delay, unit, scheduler);
     }
     
+    /**
+     * Compares two SingleSources and emits true if they emit the same value (compared via Object.equals).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code equals} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common value type
+     * @param first the first SingleSource instance
+     * @param second the second SingleSource instance
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static <T> Single<Boolean> equals(final SingleSource<? extends T> first, final SingleSource<? extends T> second) { // NOPMD
         Objects.requireNonNull(first, "first is null");
         Objects.requireNonNull(second, "second is null");
         return new SingleEquals<T>(first, second);
     }
 
+    /**
+     * <strong>Advanced use only:</strong> creates a Single instance without 
+     * any safeguards by using a callback that is called with a SingleObserver.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code unsafeCreate} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type
+     * @param source the function that is called with the subscribing SingleObserver
+     * @return the new Single instance
+     * @since 2.0
+     */
+    public static <T> Single<T> unsafeCreate(SingleSource<T> source) {
+        Objects.requireNonNull(source, "source is null");
+        if (source instanceof Single) {
+            throw new IllegalArgumentException("unsafeCreate(Single) should be upgraded");
+        }
+        // TODO plugin wrapper
+        return new SingleFromUnsafeSource<T>(source);
+    }
+    
+    /**
+     * Allows using and disposing a resource while running a SingleSource instance generated from
+     * that resource (similar to a try-with-resources).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type of the SingleSource generated
+     * @param <U> the resource type
+     * @param resourceSupplier the Callable called for each SingleObserver to generate a resource Object
+     * @param singleFunction the function called with the returned resource 
+     *                  Object from {@code resourceSupplier} and should return a SingleSource instance
+     *                  to be run by the operator
+     * @param disposer the consumer of the generated resource that is called exactly once for
+     *                  that particular resource when the generated SingleSource terminates 
+     *                  (successfully or with an error) or gets cancelled.
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static <T, U> Single<T> using(Callable<U> resourceSupplier,
-                                         Function<? super U, ? extends SingleSource<? extends T>> singleFunction, Consumer<? super U> disposer) {
+                                         Function<? super U, ? extends SingleSource<? extends T>> singleFunction, 
+                                         Consumer<? super U> disposer) {
         return using(resourceSupplier, singleFunction, disposer, true);
     }
         
+    /**
+     * Allows using and disposing a resource while running a SingleSource instance generated from
+     * that resource (similar to a try-with-resources).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type of the SingleSource generated
+     * @param <U> the resource type
+     * @param resourceSupplier the Callable called for each SingleObserver to generate a resource Object
+     * @param singleFunction the function called with the returned resource 
+     *                  Object from {@code resourceSupplier} and should return a SingleSource instance
+     *                  to be run by the operator
+     * @param disposer the consumer of the generated resource that is called exactly once for
+     *                  that particular resource when the generated SingleSource terminates 
+     *                  (successfully or with an error) or gets cancelled.
+     * @param eager
+     *                 if true, the disposer is called before the terminal event is signalled
+     *                 if false, the disposer is called after the terminal event is delivered to downstream
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static <T, U> Single<T> using(
             final Callable<U> resourceSupplier, 
             final Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
@@ -428,6 +1251,42 @@ public abstract class Single<T> implements SingleSource<T> {
         return new SingleUsing<T, U>(resourceSupplier, singleFunction, disposer, eager);
     }
 
+    /**
+     * Wraps a SingleSource instance into a new Single instance if not already a Single
+     * instance.
+     * @param <T> the value type
+     * @param source the source to wrap
+     * @return the Single wrapper or the source cast to Single (if possible)
+     */
+    static <T> Single<T> wrap(SingleSource<T> source) {
+        Objects.requireNonNull(source, "source is null");
+        if (source instanceof Single) {
+            return (Single<T>)source;
+        }
+        return new SingleFromUnsafeSource<T>(source);
+    }
+    
+    /**
+     * Waits until all SingleSource sources provided by the Iterable sequence signal a success
+     * value and calls a zipper function with an array of these values to return a result
+     * to be emitted to downstream.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
+     * <p>
+     * If any of the SingleSources signal an error, all other SingleSources get cancelled and the
+     * error emitted to downstream immediately.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common value type
+     * @param <R> the result value type
+     * @param sources the Iterable sequence of SingleSource instances
+     * @param zipper the function that receives an array with values from each SingleSource
+     *               and should return a value to be emitted to downstream
+     * @return the new Single instance
+     * @since 2.0
+     */
     public static <T, R> Single<R> zip(final Iterable<? extends SingleSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(sources, "sources is null");
         
@@ -457,6 +1316,29 @@ public abstract class Single<T> implements SingleSource<T> {
         return Flowable.zipIterable(it, zipper, false, 1).toSingle();
     }
 
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to two items emitted by
+     * two other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -467,6 +1349,32 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2);
     }
 
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to three items emitted
+     * by three other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -479,6 +1387,35 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3);
     }
 
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to four items
+     * emitted by four other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <T4> the fourth source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param s4
+     *            a fourth source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -492,6 +1429,38 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4);
     }
 
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to five items
+     * emitted by five other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <T4> the fourth source Single's value type
+     * @param <T5> the fifth source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param s4
+     *            a fourth source Single
+     * @param s5
+     *            a fifth source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -507,6 +1476,41 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5);
     }
 
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to six items
+     * emitted by six other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <T4> the fourth source Single's value type
+     * @param <T5> the fifth source Single's value type
+     * @param <T6> the sixth source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param s4
+     *            a fourth source Single
+     * @param s5
+     *            a fifth source Single
+     * @param s6
+     *            a sixth source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -523,6 +1527,44 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6);
     }
 
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to seven items
+     * emitted by seven other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <T4> the fourth source Single's value type
+     * @param <T5> the fifth source Single's value type
+     * @param <T6> the sixth source Single's value type
+     * @param <T7> the seventh source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param s4
+     *            a fourth source Single
+     * @param s5
+     *            a fifth source Single
+     * @param s6
+     *            a sixth source Single
+     * @param s7
+     *            a seventh source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -541,6 +1583,47 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7);
     }
     
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to eight items
+     * emitted by eight other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <T4> the fourth source Single's value type
+     * @param <T5> the fifth source Single's value type
+     * @param <T6> the sixth source Single's value type
+     * @param <T7> the seventh source Single's value type
+     * @param <T8> the eighth source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param s4
+     *            a fourth source Single
+     * @param s5
+     *            a fifth source Single
+     * @param s6
+     *            a sixth source Single
+     * @param s7
+     *            a seventh source Single
+     * @param s8
+     *            an eighth source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -560,6 +1643,50 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7, s8);
     }
     
+    /**
+     * Returns a Single that emits the results of a specified combiner function applied to nine items
+     * emitted by nine other Singles.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <T1> the first source Single's value type
+     * @param <T2> the second source Single's value type
+     * @param <T3> the third source Single's value type
+     * @param <T4> the fourth source Single's value type
+     * @param <T5> the fifth source Single's value type
+     * @param <T6> the sixth source Single's value type
+     * @param <T7> the seventh source Single's value type
+     * @param <T8> the eighth source Single's value type
+     * @param <T9> the ninth source Single's value type
+     * @param <R> the result value type
+     * @param s1
+     *            the first source Single
+     * @param s2
+     *            a second source Single
+     * @param s3
+     *            a third source Single
+     * @param s4
+     *            a fourth source Single
+     * @param s5
+     *            a fifth source Single
+     * @param s6
+     *            a sixth source Single
+     * @param s7
+     *            a seventh source Single
+     * @param s8
+     *            an eighth source Single
+     * @param s9
+     *            a ninth source Single
+     * @param zipper
+     *            a function that, when applied to the item emitted by each of the source Singles, results in an
+     *            item that will be emitted by the resulting Single
+     * @return a Single that emits the zipped results
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
@@ -581,6 +1708,27 @@ public abstract class Single<T> implements SingleSource<T> {
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7, s8, s9);
     }
 
+    /**
+     * Waits until all SingleSource sources provided via an array signal a success
+     * value and calls a zipper function with an array of these values to return a result
+     * to be emitted to downstream.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
+     * <p>
+     * If any of the SingleSources signal an error, all other SingleSources get cancelled and the
+     * error emitted to downstream immediately.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zipArray} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common value type
+     * @param <R> the result value type
+     * @param sources the array of SingleSource instances
+     * @param zipper the function that receives an array with values from each SingleSource
+     *               and should return a value to be emitted to downstream
+     * @return the new Single instance
+     * @since 2.0
+     */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T, R> Single<R> zipArray(Function<? super Object[], ? extends R> zipper, SingleSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
@@ -594,24 +1742,88 @@ public abstract class Single<T> implements SingleSource<T> {
         return Flowable.zipArray(zipper, false, 1, sourcePublishers).toSingle();
     }
 
+    /**
+     * Signals the event of this or the other SingleSource whichever signals first.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code ambWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other SingleSource to race for the first emission of success or error
+     * @return the new Single instance
+     * @since 2.0
+     */
     @SuppressWarnings("unchecked")
     public final Single<T> ambWith(SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
     
-    public final Single<T> asSingle() {
+    /**
+     * Hides the identity of the current Single, including the Disposable that is sent
+     * to the downstream via {@code onSubscribe()}.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code hide} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new Single instance
+     * @since 2.0
+     */
+    public final Single<T> hide() {
         return new SingleHide<T>(this);
     }
     
-    public final <R> Single<R> compose(Function<? super Single<T>, ? extends SingleSource<R>> convert) {
-        return wrap(to(convert));
+    /**
+     * Transform a Single by applying a particular Transformer function to it.
+     * <p>
+     * This method operates on the Single itself whereas {@link #lift} operates on the Single's Subscribers or
+     * Observers.
+     * <p>
+     * If the operator you are creating is designed to act on the individual item emitted by a Single, use
+     * {@link #lift}. If your operator is designed to transform the source Single as a whole (for instance, by
+     * applying a particular set of existing RxJava operators to it) use {@code compose}.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code compose} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <R> the value type of the single returned by the transformer function
+     * @param transformer
+     *            implements the function that transforms the source Single
+     * @return the source Single, transformed by the transformer function
+     * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
+     */
+    public final <R> Single<R> compose(Function<? super Single<T>, ? extends SingleSource<R>> transformer) {
+        return wrap(to(transformer));
     }
 
+    /**
+     * Stores the success value or exception from the current Single and replays it to late SingleObservers.
+     * <p>
+     * The returned Single subscribes to the current Single when the first SingleObserver subscribes.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code compose} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> cache() {
         return new SingleCache<T>(this);
     }
     
+    /**
+     * Casts the success value of the current Single into the target type or signals a
+     * ClassCastException if not compatible.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code cast} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <U> the target type
+     * @param clazz the type token to use for casting the success result from the current Single
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final <U> Single<U> cast(final Class<? extends U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return map(new Function<T, U>() {
@@ -622,170 +1834,740 @@ public abstract class Single<T> implements SingleSource<T> {
         });
     }
     
+    /**
+     * Returns a Flowable that emits the item emitted by the source Single, then the item emitted by the
+     * specified Single.
+     * <p>
+     * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concatWith.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param other
+     *            a Single to be concatenated after the current
+     * @return a Flowable that emits the item emitted by the source Single, followed by the item emitted by
+     *         {@code t1}
+     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     */
     public final Flowable<T> concatWith(SingleSource<? extends T> other) {
         return concat(this, other);
     }
     
+    /**
+     * Delays the emission of the success or error signal from the current Single by
+     * the specified amount.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delay} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param time the time amount to delay the signals
+     * @param unit the time unit
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> delay(long time, TimeUnit unit) {
         return delay(time, unit, Schedulers.computation());
     }
     
+    /**
+     * Delays the emission of the success or error signal from the current Single by
+     * the specified amount.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>you specify the {@link Scheduler} where the non-blocking wait and emission happens</dd>
+     * </dl>
+     * 
+     * @param time the time amount to delay the signals
+     * @param unit the time unit
+     * @param scheduler the target scheduler to use fro the non-blocking wait and emission
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return new SingleDelay<T>(this, time, unit, scheduler);
     }
 
+    /**
+     * Delays the actual subscription to the current Single until the given other CompletableSource
+     * completes.
+     * <p>If the delaying source signals an error, that error is re-emitted and no subscription
+     * to the current Single happens.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the CompletableSource that has to complete before the subscription to the
+     *              current Single happens
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> delaySubscription(CompletableSource other) {
         return new SingleDelayWithCompletable<T>(this, other);
     }
 
+    /**
+     * Delays the actual subscription to the current Single until the given other SingleSource
+     * signals success.
+     * <p>If the delaying source signals an error, that error is re-emitted and no subscription
+     * to the current Single happens.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <U> the element type of the other source
+     * @param other the SingleSource that has to complete before the subscription to the
+     *              current Single happens
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final <U> Single<T> delaySubscription(SingleSource<U> other) {
         return new SingleDelayWithSingle<T, U>(this, other);
     }
 
+    /**
+     * Delays the actual subscription to the current Single until the given other ObservableSource
+     * signals its first value or completes.
+     * <p>If the delaying source signals an error, that error is re-emitted and no subscription
+     * to the current Single happens.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <U> the element type of the other source
+     * @param other the ObservableSource that has to signal a value or complete before the 
+     *              subscription to the current Single happens
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final <U> Single<T> delaySubscription(ObservableSource<U> other) {
         return new SingleDelayWithObservable<T, U>(this, other);
     }
 
+    /**
+     * Delays the actual subscription to the current Single until the given other Publisher
+     * signals its first value or completes.
+     * <p>If the delaying source signals an error, that error is re-emitted and no subscription
+     * to the current Single happens.
+     * <p>The other source is consumed in an unbounded manner (requesting Long.MAX_VALUE from it).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <U> the element type of the other source
+     * @param other the Publisher that has to signal a value or complete before the 
+     *              subscription to the current Single happens
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final <U> Single<T> delaySubscription(Publisher<U> other) {
         return new SingleDelayWithPublisher<T, U>(this, other);
     }
     
+    /**
+     * Delays the actual subscription to the current Single until the given time delay elapsed.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delaySubscription} does by default subscribe to the current Single 
+     * on the {@code computation} {@link Scheduler} after the delay.</dd>
+     * </dl>
+     * @param <U> the element type of the other source
+     * @param time the time amount to wait with the subscription
+     * @param unit the time unit of the waiting
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final <U> Single<T> delaySubscription(long time, TimeUnit unit) {
         return delaySubscription(time, unit, Schedulers.computation());
     }
 
+    /**
+     * Delays the actual subscription to the current Single until the given time delay elapsed.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code delaySubscription} does by default subscribe to the current Single 
+     * on the {@link Scheduler} you provided, after the delay.</dd>
+     * </dl>
+     * @param <U> the element type of the other source
+     * @param time the time amount to wait with the subscription
+     * @param unit the time unit of the waiting
+     * @param scheduler the scheduler to wait on and subscribe on to the current Single
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final <U> Single<T> delaySubscription(long time, TimeUnit unit, Scheduler scheduler) {
         return delaySubscription(Observable.timer(time, unit, scheduler));
     }
 
-
+    /**
+     * Calls the shared consumer with the Disposable sent through the onSubscribe for each
+     * SingleObserver that subscribes to the current Single.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onSubscribe the consumer called with the Disposable sent via onSubscribe
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> doOnSubscribe(final Consumer<? super Disposable> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         return new SingleDoOnSubscribe<T>(this, onSubscribe);
     }
     
+    /**
+     * Calls the shared consumer with the success value sent via onSuccess for each
+     * SingleObserver that subscribes to the current Single.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onSuccess the consumer called with the success value of onSuccess
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> doOnSuccess(final Consumer<? super T> onSuccess) {
         Objects.requireNonNull(onSuccess, "onSuccess is null");
         return new SingleDoOnSuccess<T>(this, onSuccess);
     }
     
+    /**
+     * Calls the shared consumer with the error sent via onError for each
+     * SingleObserver that subscribes to the current Single.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onError the consumer called with the success value of onError
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> doOnError(final Consumer<? super Throwable> onError) {
         Objects.requireNonNull(onError, "onError is null");
         return new SingleDoOnError<T>(this, onError);
     }
     
+    /**
+     * Calls the shared runnable if a SingleObserver subscribed to the current Single
+     * disposes the common Disposable it received via onSubscribe.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onCancel the runnable called when the subscription is cancelled (disposed)
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> doOnCancel(final Runnable onCancel) {
         Objects.requireNonNull(onCancel, "onCancel is null");
         return new SingleDoOnCancel<T>(this, onCancel);
     }
 
+    /**
+     * Returns a Single that is based on applying a specified function to the item emitted by the source Single,
+     * where that function returns a Single.
+     * <p>
+     * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMap.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <R> the result value type
+     * @param mapper
+     *            a function that, when applied to the item emitted by the source Single, returns a Single
+     * @return the Single returned from {@code func} when applied to the item emitted by the source Single
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     */
     public final <R> Single<R> flatMap(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return new SingleFlatMap<T, R>(this, mapper);
     }
 
+    /**
+     * Returns a Flowable that emits items based on applying a specified function to the item emitted by the
+     * source Single, where that function returns a Publisher.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapObservable.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code flatMapObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <R> the result value type
+     * @param mapper
+     *            a function that, when applied to the item emitted by the source Single, returns an
+     *            Observable
+     * @return the Flowable returned from {@code func} when applied to the item emitted by the source Single
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     */
     public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return toFlowable().flatMap(mapper);
     }
+
+    /**
+     * Returns a {@link Completable} that completes based on applying a specified function to the item emitted by the
+     * source {@link Single}, where that function returns a {@link Completable}.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapCompletable.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param mapper
+     *            a function that, when applied to the item emitted by the source Single, returns a
+     *            Completable
+     * @return the Completable returned from {@code func} when applied to the item emitted by the source Single
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @since 2.0
+     */
+    public final Completable flatMapCompletable(final Function<? super T, ? extends Completable> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        // TODO implement
+        throw new UnsupportedOperationException();
+    }
     
-    public final T get() {
+    /**
+     * Blockingly waits until the current Single signals a success value (which is returned) or
+     * an exception (which is propagated).
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code blockingGet} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the success value
+     */
+    public final T blockingGet() {
         return SingleAwait.get(this);
     }
     
-    public final <R> Single<R> lift(final SingleOperator<? extends R, ? super T> onLift) {
-        Objects.requireNonNull(onLift, "onLift is null");
-        return new SingleLift<T, R>(this, onLift);
+    /**
+     * Lifts a function to the current Single and returns a new Single that when subscribed to will pass the
+     * values of the current Single through the Operator function.
+     * <p>
+     * In other words, this allows chaining TaskExecutors together on a Single for acting on the values within
+     * the Single.
+     * <p>
+     * {@code task.map(...).filter(...).lift(new OperatorA()).lift(new OperatorB(...)).subscribe() }
+     * <p>
+     * If the operator you are creating is designed to act on the item emitted by a source Single, use
+     * {@code lift}. If your operator is designed to transform the source Single as a whole (for instance, by
+     * applying a particular set of existing RxJava operators to it) use {@link #compose}.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code lift} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <R> the downstream's value type (output)
+     * @param lift
+     *            the Operator that implements the Single-operating function to be applied to the source Single
+     * @return a Single that is the result of applying the lifted Operator to the source Single
+     * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
+     */
+    public final <R> Single<R> lift(final SingleOperator<? extends R, ? super T> lift) {
+        Objects.requireNonNull(lift, "onLift is null");
+        return new SingleLift<T, R>(this, lift);
     }
     
+    /**
+     * Returns a Single that applies a specified function to the item emitted by the source Single and
+     * emits the result of this function application.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.map.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code map} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the result value type
+     * @param mapper
+     *            a function to apply to the item emitted by the Single
+     * @return a Single that emits the item from the source Single, transformed by the specified function
+     * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
+     */
     public final <R> Single<R> map(Function<? super T, ? extends R> mapper) {
         return new SingleMap<T, R>(this, mapper);
     }
 
+    /**
+     * Signals true if the current Single signals a success value that is Object-equals with the value
+     * provided.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code contains} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param value the value to compare against the success value of this Single
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<Boolean> contains(Object value) {
         return contains(value, Objects.equalsPredicate());
     }
 
+    /**
+     * Signals true if the current Single signals a success value that is equal with
+     * the value provided by calling a bi-predicate.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code contains} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param value the value to compare against the success value of this Single
+     * @param comparer the function that receives the success value of this Single, the value provided
+     *                 and should return true if they are considered equal
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<Boolean> contains(final Object value, final BiPredicate<Object, Object> comparer) {
         Objects.requireNonNull(value, "value is null");
         Objects.requireNonNull(comparer, "comparer is null");
         return new SingleContains<T>(this, value, comparer);
     }
     
+    /**
+     * Flattens this and another Single into a single Observable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * the {@code mergeWith} method.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param other
+     *            a Single to be merged
+     * @return  that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
     public final Flowable<T> mergeWith(SingleSource<? extends T> other) {
         return merge(this, other);
     }
     
-    public final Single<Single<T>> nest() {
-        return just(this);
-    }
-    
+    /**
+     * Modifies a Single to emit its item (or notify of its error) on a specified {@link Scheduler},
+     * asynchronously.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.observeOn.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     * 
+     * @param scheduler
+     *            the {@link Scheduler} to notify subscribers on
+     * @return the source Single modified so that its subscribers are notified on the specified
+     *         {@link Scheduler}
+     * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
+     * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
+     * @see #subscribeOn
+     */
     public final Single<T> observeOn(final Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return new SingleObserveOn<T>(this, scheduler);
     }
 
-    public final Single<T> onErrorReturn(final Callable<? extends T> valueSupplier) {
-        Objects.requireNonNull(valueSupplier, "valueSupplier is null");
-        return new SingleOnErrorReturn<T>(this, valueSupplier, null);
+    /**
+     * Instructs a Single to emit an item (returned by a specified function) rather than invoking
+     * {@link SingleObserver#onError onError} if it encounters an error.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorReturn.png" alt="">
+     * <p>
+     * By default, when a Single encounters an error that prevents it from emitting the expected item to its
+     * subscriber, the Single invokes its subscriber's {@link Subscriber#onError} method, and then quits
+     * without invoking any more of its subscriber's methods. The {@code onErrorReturn} method changes this
+     * behavior. If you pass a function ({@code resumeFunction}) to a Single's {@code onErrorReturn} method, if
+     * the original Single encounters an error, instead of invoking its subscriber's
+     * {@link Subscriber#onError} method, it will instead emit the return value of {@code resumeFunction}.
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param resumeFunction
+     *            a function that returns an item that the new Single will emit if the source Single encounters
+     *            an error
+     * @return the original Single with appropriately modified behavior
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    public final Single<T> onErrorReturn(final Function<Throwable, ? extends T> resumeFunction) {
+        Objects.requireNonNull(resumeFunction, "resumeFunction is null");
+        return new SingleOnErrorReturn<T>(this, resumeFunction, null);
     }
     
-    public final Single<T> onErrorReturn(final T value) {
+    /**
+     * Signals the specified value as success in case the current Single signals an error.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param value the value to signal if the current Single fails
+     * @return the new Single instance
+     * @since 2.0
+     */
+    public final Single<T> onErrorReturnValue(final T value) {
         Objects.requireNonNull(value, "value is null");
         return new SingleOnErrorReturn<T>(this, null, value);
     }
 
-    public final Single<T> onErrorResumeNext(
-            final Function<? super Throwable, ? extends SingleSource<? extends T>> nextFunction) {
-        Objects.requireNonNull(nextFunction, "nextFunction is null");
-        return new SingleResumeNext<T>(this, nextFunction);
+    /**
+     * Instructs a Single to pass control to another Single rather than invoking
+     * {@link Observer#onError(Throwable)} if it encounters an error.
+     * <p/>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <p/>
+     * By default, when a Single encounters an error that prevents it from emitting the expected item to
+     * its {@link Observer}, the Single invokes its Observer's {@code onError} method, and then quits
+     * without invoking any more of its Observer's methods. The {@code onErrorResumeNext} method changes this
+     * behavior. If you pass another Single ({@code resumeSingleInCaseOfError}) to a Single's
+     * {@code onErrorResumeNext} method, if the original Single encounters an error, instead of invoking its
+     * Observer's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
+     * will invoke the Observer's {@link Observer#onNext onNext} method if it is able to do so. In such a case,
+     * because no Single necessarily invokes {@code onError}, the Observer may never know that an error
+     * happened.
+     * <p/>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param resumeSingleInCaseOfError a Single that will take control if source Single encounters an error.
+     * @return the original Single, with appropriately modified behavior.
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    public final Single<T> onErrorResumeNext(final Single<? extends T> resumeSingleInCaseOfError) {
+        Objects.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
+        return onErrorResumeNext(new Function<Throwable, Single<? extends T>>() {
+            @Override
+            public Single<? extends T> apply(Throwable t) throws Exception {
+                return resumeSingleInCaseOfError;
+            }
+        });
     }
     
+    /**
+     * Instructs a Single to pass control to another Single rather than invoking
+     * {@link Observer#onError(Throwable)} if it encounters an error.
+     * <p/>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <p/>
+     * By default, when a Single encounters an error that prevents it from emitting the expected item to
+     * its {@link Observer}, the Single invokes its Observer's {@code onError} method, and then quits
+     * without invoking any more of its Observer's methods. The {@code onErrorResumeNext} method changes this
+     * behavior. If you pass a function that will return another Single ({@code resumeFunctionInCaseOfError}) to a Single's
+     * {@code onErrorResumeNext} method, if the original Single encounters an error, instead of invoking its
+     * Observer's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
+     * will invoke the Observer's {@link Observer#onNext onNext} method if it is able to do so. In such a case,
+     * because no Single necessarily invokes {@code onError}, the Observer may never know that an error
+     * happened.
+     * <p/>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param resumeFunctionInCaseOfError a function that returns a Single that will take control if source Single encounters an error.
+     * @return the original Single, with appropriately modified behavior.
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     * @since .20
+     */
+    public final Single<T> onErrorResumeNext(
+            final Function<? super Throwable, ? extends SingleSource<? extends T>> resumeFunctionInCaseOfError) {
+        Objects.requireNonNull(resumeFunctionInCaseOfError, "resumeFunctionInCaseOfError is null");
+        return new SingleResumeNext<T>(this, resumeFunctionInCaseOfError);
+    }
+    
+    /**
+     * Repeatedly re-subscribes to the current Single and emits each success value.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new Flowable instance
+     * @since 2.0
+     */
     public final Flowable<T> repeat() {
         return toFlowable().repeat();
     }
     
+    /**
+     * Re-subscribes to the current Single at most the given number of times and emits each success value.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param times the number of times to re-subscribe to the current Single
+     * @return the new Flowable instance
+     * @since 2.0
+     */
     public final Flowable<T> repeat(long times) {
         return toFlowable().repeat(times);
     }
     
+    /**
+     * Re-subscribes to the current Single if
+     * the Publisher returned by the handler function signals a value in response to a
+     * value signalled through the Flowable the handle receives.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code repeatWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param handler the function that is called with a Flowable that signals a value when the Single
+     *                signalled a success value and returns a Publisher that has to signal a value to
+     *                trigger a resubscription to the current Single, otherwise the terminal signal of
+     *                the Publisher will be the terminal signal of the sequence as well. 
+     * @return the new Flowable instance
+     * @since 2.0
+     */
     public final Flowable<T> repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
         return toFlowable().repeatWhen(handler);
     }
     
+    /**
+     * Re-subscribes to the current Single until the given BooleanSupplier returns true.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param stop the BooleanSupplier called after the current Single succeeds and if returns false,
+     *             the Single is re-subscribed; otherwise the sequence completes.
+     * @return the new Flowable instance
+     * @since 2.0
+     */
     public final Flowable<T> repeatUntil(BooleanSupplier stop) {
         return toFlowable().repeatUntil(stop);
     }
-    
+
+    /**
+     * Repeatedly re-subscribes to the current Single indefinitely if it fails with an onError.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> retry() {
         return toFlowable().retry().toSingle();
     }
     
+    /**
+     * Repeatedly re-subscribe at most the specified times to the current Single 
+     * if it fails with an onError.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param times the number of times to resubscribe if the current Single fails
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> retry(long times) {
         return toFlowable().retry(times).toSingle();
     }
-    
+
+    /**
+     * Re-subscribe to the current Single if the given predicate returns true when the Single fails
+     * with an onError.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param predicate the predicate called with the resubscription count and the failure Throwable
+     *                  and should return true if a resubscription should happen
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
         return toFlowable().retry(predicate).toSingle();
     }
     
+    /**
+     * Re-subscribe to the current Single if the given predicate returns true when the Single fails
+     * with an onError.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param predicate the predicate called with the failure Throwable
+     *                  and should return true if a resubscription should happen
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> retry(Predicate<? super Throwable> predicate) {
         return toFlowable().retry(predicate).toSingle();
     }
     
+    /**
+     * Re-subscribes to the current Single if and when the Publisher returned by the handler 
+     * function signals a value.
+     * <p>
+     * If the Publisher signals an onComplete, the resulting Single will signal a NoSuchElementException.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param handler the function that receives a Flowable of the error the Single emits and should
+     *                return a Publisher that should signal a normal value (in response to the
+     *                throwable the Flowable emits) to trigger a resubscription or signal an error to 
+     *                be the output of the resulting Single
+     * @return the new Single instance
+     */
     public final Single<T> retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
         return toFlowable().retryWhen(handler).toSingle();
     }
     
+    /**
+     * Subscribes the given Reactive-Streams Subscriber to this Single with a safety wrapper
+     * that handles exceptions thrown from the Subscriber's onXXX methods.
+     * @param s the Subscriber to wrap and subscribe to the current Single
+     * @since 2.0
+     */
     public final void safeSubscribe(Subscriber<? super T> s) {
         toFlowable().safeSubscribe(s);
     }
     
+    /**
+     * Subscribes to a Single but ignore its emission or notification.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @return a {@link Disposable} reference can request the {@link Single} stop work.
+     * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
+     */
     public final Disposable subscribe() {
         return subscribe(Functions.emptyConsumer(), RxJavaPlugins.errorConsumer());
     }
     
+    /**
+     * Subscribes to a Single and provides a composite callback to handle the item it emits 
+     * or any error notification it issues.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param onCallback
+     *            the callback that receives either the success value or the failure Throwable
+     *            (whichever is not null)
+     * @return a {@link Disposable} reference can request the {@link Single} stop work.
+     * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
+     * @throws IllegalArgumentException
+     *             if {@code onCallback} is null
+     */
     public final Disposable subscribe(final BiConsumer<? super T, ? super Throwable> onCallback) {
         Objects.requireNonNull(onCallback, "onCallback is null");
         
@@ -794,10 +2576,43 @@ public abstract class Single<T> implements SingleSource<T> {
         return s;
     }
     
+    /**
+     * Subscribes to a Single and provides a callback to handle the item it emits.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param onSuccess
+     *            the {@code Consumer<T>} you have designed to accept the emission from the Single
+     * @return a {@link Disposable} reference can request the {@link Single} stop work.
+     * @throws NullPointerException
+     *             if {@code onSuccess} is null
+     * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
+     */
     public final Disposable subscribe(Consumer<? super T> onSuccess) {
         return subscribe(onSuccess, RxJavaPlugins.errorConsumer());
     }
     
+    /**
+     * Subscribes to a Single and provides callbacks to handle the item it emits or any error notification it
+     * issues.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param onSuccess
+     *            the {@code Consumer<T>} you have designed to accept the emission from the Single
+     * @param onError
+     *            the {@code Consumer<Throwable>} you have designed to accept any error notification from the
+     *            Single
+     * @return a {@link Disposable} reference can request the {@link Single} stop work.
+     * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
+     * @throws IllegalArgumentException
+     *             if {@code onNext} is null, or
+     *             if {@code onError} is null
+     */
     public final Disposable subscribe(final Consumer<? super T> onSuccess, final Consumer<? super Throwable> onError) {
         Objects.requireNonNull(onSuccess, "onSuccess is null");
         Objects.requireNonNull(onError, "onError is null");
@@ -814,34 +2629,190 @@ public abstract class Single<T> implements SingleSource<T> {
         subscribeActual(subscriber);
     }
     
-    protected abstract void subscribeActual(SingleObserver<? super T> subscriber);
+    /**
+     * Override this method in subclasses to handle the incoming SingleObservers.
+     * @param observer the SingleObserver to handle, not null
+     */
+    protected abstract void subscribeActual(SingleObserver<? super T> observer);
     
+    /**
+     * Subscribe the given Reactive-Streams subscriber to the current Single to receive
+     * its success or error signals.
+     * @param s the Subscriber to subscribe
+     * @see #safeSubscribe(Subscriber)
+     */
     public final void subscribe(Subscriber<? super T> s) {
         toFlowable().subscribe(s);
     }
     
+    /**
+     * Subscribe the given RxJava 2.x Observer to the current Single to receive
+     * its success or error signals.
+     * @param s the Subscriber to subscribe
+     * @see #safeSubscribe(Subscriber)
+     */
     public final void subscribe(Observer<? super T> s) {
         toObservable().subscribe(s);
     }
     
+    /**
+     * Asynchronously subscribes subscribers to this Single on the specified {@link Scheduler}.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribeOn.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     * 
+     * @param scheduler
+     *            the {@link Scheduler} to perform subscription actions on
+     * @return the source Single modified so that its subscriptions happen on the specified {@link Scheduler}
+     * @see <a href="http://reactivex.io/documentation/operators/subscribeon.html">ReactiveX operators documentation: SubscribeOn</a>
+     * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
+     * @see #observeOn
+     */
     public final Single<T> subscribeOn(final Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return new SingleSubscribeOn<T>(this, scheduler);
     }
-    
+
+    /**
+     * Returns a Single that emits the item emitted by the source Single until a Completable terminates. Upon
+     * termination of {@code other}, this will emit a {@link CancellationException} rather than go to
+     * {@link SingleObserver#onSuccess(Object)}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Completable whose termination will cause {@code takeUntil} to emit the item from the source
+     *            Single
+     * @return a Single that emits the item emitted by the source Single until such time as {@code other} terminates.
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    public final Single<T> takeUntil(final Completable other) {
+        // TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a Single that emits the item emitted by the source Single until a Publisher emits an item. Upon
+     * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
+     * {@link SingleObserver#onSuccess(Object)}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Flowable whose first emitted item will cause {@code takeUntil} to emit the item from the source
+     *            Single
+     * @param <E>
+     *            the type of items emitted by {@code other}
+     * @return a Single that emits the item emitted by the source Single until such time as {@code other} emits
+     * its first item
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    public final <E> Single<T> takeUntil(final Publisher<? extends E> other) {
+        // TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a Single that emits the item emitted by the source Single until a second Single emits an item. Upon
+     * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
+     * {@link SingleObserver#onSuccess(Object)}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Single whose emitted item will cause {@code takeUntil} to emit the item from the source Single
+     * @param <E>
+     *            the type of item emitted by {@code other}
+     * @return a Single that emits the item emitted by the source Single until such time as {@code other} emits its item
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    public final <E> Single<T> takeUntil(final Single<? extends E> other) {
+        // TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Signals a TimeoutException if the current Single doesn't signal a success value within the
+     * specified timeout window.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} signals the TimeoutException on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param timeout the timeout amount
+     * @param unit the time unit
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> timeout(long timeout, TimeUnit unit) {
         return timeout0(timeout, unit, Schedulers.computation(), null);
     }
     
+    /**
+     * Signals a TimeoutException if the current Single doesn't signal a success value within the
+     * specified timeout window.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} signals the TimeoutException on the {@link Scheduler} you specify.</dd>
+     * </dl>
+     * @param timeout the timeout amount
+     * @param unit the time unit
+     * @param scheduler the target scheduler where the timeout is awaited and the TimeoutException
+     *                  signalled
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler) {
         return timeout0(timeout, unit, scheduler, null);
     }
 
+    /**
+     * Runs the current Single and if it doesn't signal within the specified timeout window, it is
+     * cancelled and the other SingleSource subscribed to.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} subscribes to the other SingleSource on the {@link Scheduler} you specify.</dd>
+     * </dl>
+     * @param timeout the timeout amount
+     * @param unit the time unit
+     * @param scheduler the scheduler where the timeout is awaited and the subscription to other happens
+     * @param other the other SingleSource that gets subscribed to if the current Single times out
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler, SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, scheduler, other);
     }
 
+    /**
+     * Runs the current Single and if it doesn't signal within the specified timeout window, it is
+     * cancelled and the other SingleSource subscribed to.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} subscribes to the other SingleSource on 
+     *  the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param timeout the timeout amount
+     * @param unit the time unit
+     * @param other the other SingleSource that gets subscribed to if the current Single times out
+     * @return the new Single instance
+     * @since 2.0
+     */
     public final Single<T> timeout(long timeout, TimeUnit unit, SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, Schedulers.computation(), other);
@@ -853,6 +2824,19 @@ public abstract class Single<T> implements SingleSource<T> {
         return new SingleTimeout<T>(this, timeout, unit, scheduler, other);
     }
 
+    /**
+     * Calls the specified converter function with the current Single instance 
+     * during assembly time and returns its result.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <R> the result type
+     * @param convert the function that is called with the current Single instance during
+     *                assembly time that should return some value to be the result
+     *                 
+     * @return the value returned by the convert function
+     */
     public final <R> R to(Function<? super Single<T>, R> convert) {
         try {
             return convert.apply(this);
@@ -860,19 +2844,74 @@ public abstract class Single<T> implements SingleSource<T> {
             throw Exceptions.propagate(ex);
         }
     }
+
+    /**
+     * Returns a {@link Completable} that discards result of the {@link Single} (similar to
+     * {@link Observable#ignoreElements()}) and calls {@code onCompleted} when this source {@link Single} calls
+     * {@code onSuccess}. Error terminal event is propagated.
+     * <p>
+     * <img width="640" height="295" src=
+     * "https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.toCompletable.png"
+     * alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return a {@link Completable} that calls {@code onCompleted} on it's subscriber when the source {@link Single}
+     *         calls {@code onSuccess}.
+     * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation: Completable</a>
+     * @since 2.0
+     */
+    public final Completable toCompletable() {
+        return new CompletableFromSingle<T>(this);
+    }
     
+    /**
+     * Converts this Single into an {@link Flowable}.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
+     * 
+     * @return an {@link Observable} that emits a single item T.
+     */
     public final Flowable<T> toFlowable() {
         return new SingleToFlowable<T>(this);
     }
     
+    /**
+     * Converts this Single into an {@link Observable}.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
+     * 
+     * @return an {@link Observable} that emits a single item T.
+     */
     public final Observable<T> toObservable() {
         return new SingleToObservable<T>(this);
     }
     
-    public final void unsafeSubscribe(Subscriber<? super T> s) {
-        toFlowable().subscribe(s);
-    }
-    
+    /**
+     * Returns a Single that emits the result of applying a specified function to the pair of items emitted by
+     * the source Single and another specified Single.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.zip.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code zipWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * 
+     * @param <U>
+     *            the type of items emitted by the {@code other} Single
+     * @param <R>
+     *            the type of items emitted by the resulting Single
+     * @param other
+     *            the other Observable
+     * @param zipper
+     *            a function that combines the pairs of items from the two Observables to generate the items to
+     *            be emitted by the resulting Single
+     * @return a Single that pairs up values from the source Observable and the {@code other} Observable
+     *         and emits the results of {@code zipFunction} applied to these pairs
+     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     */
     public final <U, R> Single<R> zipWith(SingleSource<U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
         return zip(this, other, zipper);
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
@@ -13,20 +13,20 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
+import io.reactivex.functions.Function;
 
 public final class SingleOnErrorReturn<T> extends Single<T> {
     final SingleSource<? extends T> source;
 
-    final Callable<? extends T> valueSupplier;
+    final Function<? super Throwable, ? extends T> valueSupplier;
     
     final T value;
     
-    public SingleOnErrorReturn(SingleSource<? extends T> source, Callable<? extends T> valueSupplier, T value) {
+    public SingleOnErrorReturn(SingleSource<? extends T> source, 
+            Function<? super Throwable, ? extends T> valueSupplier, T value) {
         this.source = source;
         this.valueSupplier = valueSupplier;
         this.value = value;
@@ -45,7 +45,7 @@ public final class SingleOnErrorReturn<T> extends Single<T> {
 
                 if (valueSupplier != null) {
                     try {
-                        v = valueSupplier.call();
+                        v = valueSupplier.apply(e);
                     } catch (Throwable ex) {
                         s.onError(new CompositeException(ex, e));
                         return;

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2884,7 +2884,7 @@ public class CompletableTest {
             public Object call() {
                 return 1;
             }
-        }).get());
+        }).blockingGet());
     }
 
     @Test(timeout = 1000, expected = TestException.class)
@@ -2894,7 +2894,7 @@ public class CompletableTest {
             public Object call() {
                 return 1;
             }
-        }).get();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2909,7 +2909,7 @@ public class CompletableTest {
             public Object call() {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
 
     @Test(expected = TestException.class)
@@ -2917,17 +2917,17 @@ public class CompletableTest {
         normal.completable.toSingle(new Callable<Object>() {
             @Override
             public Object call() { throw new TestException(); }
-        }).get();
+        }).blockingGet();
     }
 
     @Test(timeout = 1000, expected = TestException.class)
     public void toSingleDefaultError() {
-        error.completable.toSingleDefault(1).get();
+        error.completable.toSingleDefault(1).blockingGet();
     }
     
     @Test(timeout = 1000)
     public void toSingleDefaultNormal() {
-        Assert.assertEquals((Integer)1, normal.completable.toSingleDefault(1).get());
+        Assert.assertEquals((Integer)1, normal.completable.toSingleDefault(1).blockingGet());
     }
     
     @Test(expected = NullPointerException.class)
@@ -3866,13 +3866,13 @@ public class CompletableTest {
         final AtomicBoolean hasRun = new AtomicBoolean(false);
         final Exception e = new Exception();
         Completable.error(e)
-            .andThen(Single.<String>unsafeCreate(new Single<String>() {
+            .andThen(new Single<String>() {
                 @Override
                 public void subscribeActual(SingleObserver<? super String> s) {
                     hasRun.set(true);
                     s.onSuccess("foo");
                 }
-            }))
+            })
             .subscribe(ts);
         ts.assertNoValues();
         ts.assertError(e);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
@@ -79,7 +79,7 @@ public class FlowableToSingleTest {
             public void run() {
                 unsubscribed.set(true);
             }}).toSingle();
-        single.unsafeSubscribe(subscriber);
+        single.subscribe(subscriber);
         subscriber.assertComplete();
         Assert.assertFalse(unsubscribed.get());
     }

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -45,13 +45,13 @@ public class SingleNullTests {
             public Iterator<Single<Object>> iterator() {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambIterableOneIsNull() {
-        Single.amb(Arrays.asList(null, just1)).get();
+        Single.amb(Arrays.asList(null, just1)).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -62,7 +62,7 @@ public class SingleNullTests {
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambArrayOneIsNull() {
-        Single.amb(null, just1).get();
+        Single.amb(null, just1).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -130,7 +130,7 @@ public class SingleNullTests {
     
     @Test(expected = NullPointerException.class)
     public void deferReturnsNull() {
-        Single.defer(Functions.<Single<Object>>nullSupplier()).get();
+        Single.defer(Functions.<Single<Object>>nullSupplier()).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -140,7 +140,7 @@ public class SingleNullTests {
     
     @Test(expected = NullPointerException.class)
     public void errorSupplierReturnsNull() {
-        Single.error(Functions.<Throwable>nullSupplier()).get();
+        Single.error(Functions.<Throwable>nullSupplier()).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -160,7 +160,7 @@ public class SingleNullTests {
             public Object call() throws Exception {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -172,7 +172,7 @@ public class SingleNullTests {
     public void fromFutureReturnsNull() {
         FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
         f.run();
-        Single.fromFuture(f).get();
+        Single.fromFuture(f).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -204,7 +204,7 @@ public class SingleNullTests {
     public void fromFutureTimedReturnsNull() {
         FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
         f.run();
-        Single.fromFuture(f, 1, TimeUnit.SECONDS).get();
+        Single.fromFuture(f, 1, TimeUnit.SECONDS).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -332,7 +332,7 @@ public class SingleNullTests {
             public Single<Object> apply(Object d) {
                 return null;
             }
-        }, Functions.emptyConsumer()).get();
+        }, Functions.emptyConsumer()).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -372,7 +372,7 @@ public class SingleNullTests {
             public Object apply(Object[] v) {
                 return 1;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @SuppressWarnings("unchecked")
@@ -383,13 +383,13 @@ public class SingleNullTests {
             public Object apply(Object[] v) {
                 return 1;
             }
-        }).get();
+        }).blockingGet();
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableOneFunctionNull() {
-        Single.zip(Arrays.asList(just1, just1), null).get();
+        Single.zip(Arrays.asList(just1, just1), null).blockingGet();
     }
 
     @SuppressWarnings("unchecked")
@@ -400,7 +400,7 @@ public class SingleNullTests {
             public Object apply(Object[] v) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
 
     @SuppressWarnings("unchecked")
@@ -443,7 +443,7 @@ public class SingleNullTests {
                     }
                 });
                 try {
-                    ((Single<Object>)m.invoke(null, values)).get();
+                    ((Single<Object>)m.invoke(null, values)).blockingGet();
                     Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
                 } catch (InvocationTargetException ex) {
                     if (!(ex.getCause() instanceof NullPointerException)) {
@@ -507,7 +507,7 @@ public class SingleNullTests {
             public Object apply(Integer a, Object b) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -545,7 +545,7 @@ public class SingleNullTests {
             public Object apply(Object[] v) {
                 return null;
             }
-        }, just1, just1).get();
+        }, just1, just1).blockingGet();
     }
 
     //**************************************************
@@ -614,7 +614,7 @@ public class SingleNullTests {
             public Single<Object> apply(Integer v) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -644,7 +644,7 @@ public class SingleNullTests {
             public SingleObserver<? super Integer> apply(SingleObserver<? super Object> s) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -669,24 +669,34 @@ public class SingleNullTests {
     
     @Test(expected = NullPointerException.class)
     public void onErrorReturnSupplierNull() {
-        just1.onErrorReturn((Callable<Integer>)null);
+        just1.onErrorReturn((Function<Throwable, Integer>)null);
     }
     
     @Test(expected = NullPointerException.class)
     public void onErrorReturnsSupplierReturnsNull() {
-        error.onErrorReturn(Functions.<Integer>nullSupplier()).get();
+        error.onErrorReturn(new Function<Throwable, Integer>() {
+            @Override
+            public Integer apply(Throwable t) throws Exception {
+                return null;
+            }
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
     public void onErrorReturnValueNull() {
-        error.onErrorReturn((Integer)null);
+        error.onErrorReturnValue(null);
     }
     
     @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextNull() {
-        error.onErrorResumeNext(null);
+    public void onErrorResumeNextSingleNull() {
+        error.onErrorResumeNext((Single<Integer>)null);
     }
-    
+
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFunctionNull() {
+        error.onErrorResumeNext((Function<Throwable, Single<Integer>>)null);
+    }
+
     @Test(expected = NullPointerException.class)
     public void onErrorResumeNextFunctionReturnsNull() {
         error.onErrorResumeNext(new Function<Throwable, Single<Integer>>() {
@@ -694,7 +704,7 @@ public class SingleNullTests {
             public Single<Integer> apply(Throwable e) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -739,7 +749,7 @@ public class SingleNullTests {
             public Publisher<Object> apply(Flowable<? extends Throwable> e) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)
@@ -813,11 +823,6 @@ public class SingleNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void unsafeSubscribeNull() {
-        just1.unsafeSubscribe(null);
-    }
-    
-    @Test(expected = NullPointerException.class)
     public void zipWithNull() {
         just1.zipWith(null, new BiFunction<Integer, Object, Object>() {
             @Override
@@ -839,6 +844,6 @@ public class SingleNullTests {
             public Object apply(Integer a, Integer b) {
                 return null;
             }
-        }).get();
+        }).blockingGet();
     }
 }


### PR DESCRIPTION
This PR adds javadoc to the `Single` methods, fixes a few API differences.
