### PR TITLE
2.x: sync Completable javadoc and related changes

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -22,6 +22,9 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.operators.completable.*;
+import io.reactivex.internal.operators.flowable.FlowableDelaySubscriptionOther;
+import io.reactivex.internal.operators.observable.ObservableDelaySubscriptionOther;
+import io.reactivex.internal.operators.single.*;
 import io.reactivex.internal.subscribers.completable.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
@@ -33,23 +36,12 @@ import io.reactivex.schedulers.Schedulers;
  */
 public abstract class Completable implements CompletableSource {
     /**
-     * Wraps the given CompletableSource into a Completable
-     * if not already Completable.
-     * @param source the source to wrap
-     * @return the source or its wrapper Completable
-     * @throws NullPointerException if source is null
-     */
-    public static Completable wrap(CompletableSource source) {
-        Objects.requireNonNull(source, "source is null");
-        if (source instanceof Completable) {
-            return (Completable)source;
-        }
-        return new CompletableFromUnsafeSource(source);
-    }
-    
-    /**
      * Returns a Completable which terminates as soon as one of the source Completables
      * terminates (normally or with an error) and cancels all other Completables.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the array of source Completables
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
@@ -70,6 +62,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which terminates as soon as one of the source Completables
      * terminates (normally or with an error) and cancels all other Completables.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the array of source Completables
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
@@ -83,6 +79,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable instance that completes immediately when subscribed to.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code complete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return a Completable instance that completes immediately 
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -92,6 +92,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable which completes only when all sources complete, one after another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sources to concatenate
      * @return the Completable instance which completes only when all sources complete
      * @throws NullPointerException if sources is null
@@ -110,6 +114,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable which completes only when all sources complete, one after another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sources to concatenate
      * @return the Completable instance which completes only when all sources complete
      * @throws NullPointerException if sources is null
@@ -123,6 +131,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable which completes only when all sources complete, one after another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sources to concatenate
      * @return the Completable instance which completes only when all sources complete
      * @throws NullPointerException if sources is null
@@ -134,6 +146,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable which completes only when all sources complete, one after another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sources to concatenate
      * @param prefetch the number of sources to prefetch from the sources
      * @return the Completable instance which completes only when all sources complete
@@ -150,6 +166,10 @@ public abstract class Completable implements CompletableSource {
 
     /**
      * Constructs a Completable instance by wrapping the given source callback.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param source the callback which will receive the CompletableObserver instances
      * when the Completable is subscribed to.
      * @return the created Completable instance
@@ -174,7 +194,13 @@ public abstract class Completable implements CompletableSource {
     }
     
     /**
-     * Constructs a Completable instance by wrapping the given source callback.
+     * Constructs a Completable instance by wrapping the given source callback
+     * <strong>without any safeguards; you should manage the lifecycle and response
+     * to downstream cancellation/dispose</strong>.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code unsafeCreate} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param source the callback which will receive the CompletableObserver instances
      * when the Completable is subscribed to.
      * @return the created Completable instance
@@ -200,6 +226,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Defers the subscription to a Completable instance returned by a supplier.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param completableSupplier the supplier that returns the Completable that will be subscribed to.
      * @return the Completable instance
      */
@@ -215,6 +245,10 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * If the errorSupplier returns null, the child CompletableSubscribers will receive a
      * NullPointerException.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param errorSupplier the error supplier, not null
      * @return the new Completable instance
      * @throws NullPointerException if errorSupplier is null
@@ -227,6 +261,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Creates a Completable instance that emits the given Throwable exception to subscribers.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param error the Throwable instance to emit, not null
      * @return the new Completable instance
      * @throws NullPointerException if error is null
@@ -240,6 +278,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which when subscribed, executes the callable function, ignores its
      * normal result and emits onError or onCompleted only.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromCallable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param callable the callable instance to execute for each subscriber
      * @return the new Completable instance
      */
@@ -252,7 +294,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that subscribes to the given publisher, ignores all values and
      * emits only the terminal event.
-     * 
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the type of the publisher
      * @param publisher the Publisher instance to subscribe to, not null
      * @return the new Completable instance
@@ -264,6 +309,17 @@ public abstract class Completable implements CompletableSource {
         return new CompletableFromPublisher<T>(publisher);
     }
     
+    /**
+     * Returns a Completable instance that reacts to the termination of the given Future in a blocking fashion.
+     * <p>
+     * Note that cancellation from any of the subscribers to this Completable will cancel the future.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param future the future to react to
+     * @return the new Completable instance
+     */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromFuture(final Future<?> future) {
         Objects.requireNonNull(future, "future is null");
@@ -279,6 +335,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that subscribes to the given Observable, ignores all values and
      * emits only the terminal event.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the type of the Observable
      * @param observable the Observable instance to subscribe to, not null
      * @return the new Completable instance
@@ -294,6 +354,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that runs the given Runnable for each subscriber and
      * emits either an unchecked exception or simply completes.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromRunnable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param run the runnable to run for each subscriber
      * @return the new Completable instance
      * @throws NullPointerException if run is null
@@ -307,6 +371,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that when subscribed to, subscribes to the Single instance and
      * emits a completion event if the single emits onSuccess or forwards any onError events.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromSingle} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type of the Single
      * @param single the Single instance to subscribe to, not null
      * @return the new Completable instance
@@ -321,10 +389,15 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that subscribes to all sources at once and
      * completes only when all source Completables complete or one of them emits an error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the iterable sequence of sources.
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
@@ -339,6 +412,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that subscribes to all sources at once and
      * completes only when all source Completables complete or one of them emits an error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the iterable sequence of sources.
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
@@ -352,10 +429,15 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that subscribes to all sources at once and
      * completes only when all source Completables complete or one of them emits an error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the iterable sequence of sources.
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(Publisher<? extends CompletableSource> sources) {
         return merge0(sources, Integer.MAX_VALUE, false);
     }
@@ -363,21 +445,29 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that keeps subscriptions to a limited number of sources at once and
      * completes only when all source Completables complete or one of them emits an error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the iterable sequence of sources.
      * @param maxConcurrency the maximum number of concurrent subscriptions
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      * @throws IllegalArgumentException if maxConcurrency is less than 1
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(Publisher<? extends CompletableSource> sources, int maxConcurrency) {
         return merge0(sources, maxConcurrency, false);
-        
     }
     
     /**
      * Returns a Completable instance that keeps subscriptions to a limited number of sources at once and
      * completes only when all source Completables terminate in one way or another, combining any exceptions
      * thrown by either the sources Observable or the inner Completable instances.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code merge0} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the iterable sequence of sources.
      * @param maxConcurrency the maximum number of concurrent subscriptions
      * @param delayErrors delay all errors from the main source and from the inner Completables?
@@ -385,6 +475,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      * @throws IllegalArgumentException if maxConcurrency is less than 1
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     private static Completable merge0(Publisher<? extends CompletableSource> sources, int maxConcurrency, boolean delayErrors) {
         Objects.requireNonNull(sources, "sources is null");
         if (maxConcurrency < 1) {
@@ -397,10 +488,15 @@ public abstract class Completable implements CompletableSource {
      * Returns a CompletableConsumable that subscribes to all Completables in the source array and delays
      * any error emitted by either the sources observable or any of the inner Completables until all of
      * them terminate in a way or another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the array of Completables
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         return new CompletableMergeDelayErrorArray(sources);
@@ -410,10 +506,15 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable that subscribes to all Completables in the source sequence and delays
      * any error emitted by either the sources observable or any of the inner Completables until all of
      * them terminate in a way or another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sequence of Completables
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(Iterable<? extends CompletableSource> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return new CompletableMergeDelayErrorIterable(sources);
@@ -424,10 +525,15 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable that subscribes to all Completables in the source sequence and delays
      * any error emitted by either the sources observable or any of the inner Completables until all of
      * them terminate in a way or another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sequence of Completables
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(Publisher<? extends CompletableSource> sources) {
         return merge0(sources, Integer.MAX_VALUE, true);
     }
@@ -437,25 +543,39 @@ public abstract class Completable implements CompletableSource {
      * the source sequence and delays any error emitted by either the sources 
      * observable or any of the inner Completables until all of
      * them terminate in a way or another.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the sequence of Completables
      * @param maxConcurrency the maximum number of concurrent subscriptions to Completables
      * @return the new Completable instance
      * @throws NullPointerException if sources is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(Publisher<? extends CompletableSource> sources, int maxConcurrency) {
         return merge0(sources, maxConcurrency, true);
     }
     
     /**
      * Returns a Completable that never calls onError or onComplete.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code never} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the singleton instance that never calls onError or onComplete
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable never() {
         return CompletableNever.INSTANCE;
     }
     
     /**
      * Returns a Completable instance that fires its onComplete event after the given delay ellapsed.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timer} does operate by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
      * @param delay the delay time
      * @param unit the delay unit
      * @return the new Completable instance
@@ -468,6 +588,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that fires its onComplete event after the given delay ellapsed
      * by using the supplied scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timer} operates on the {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param delay the delay time
      * @param unit the delay unit
      * @param scheduler the scheduler where to emit the complete event
@@ -496,13 +620,17 @@ public abstract class Completable implements CompletableSource {
      * with a custom Completable instance while the subscription is active.
      * <p>
      * This overload performs an eager unsubscription before the terminal event is emitted.
-     *
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <R> the resource type
      * @param resourceSupplier the supplier that returns a resource to be managed. 
      * @param completableFunction the function that given a resource returns a Completable instance that will be subscribed to
      * @param disposer the consumer that disposes the resource created by the resource supplier
      * @return the new Completable instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <R> Completable using(Callable<R> resourceSupplier, 
             Function<? super R, ? extends CompletableSource> completableFunction,
             Consumer<? super R> disposer) {
@@ -516,7 +644,10 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * If this overload performs a lazy unsubscription after the terminal event is emitted.
      * Exceptions thrown at this time will be delivered to RxJavaPlugins only.
-     * 
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <R> the resource type
      * @param resourceSupplier the supplier that returns a resource to be managed
      * @param completableFunction the function that given a resource returns a non-null
@@ -526,6 +657,7 @@ public abstract class Completable implements CompletableSource {
      * resource is disposed after the terminal event has been emitted
      * @return the new Completable instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <R> Completable using(
             final Callable<R> resourceSupplier, 
             final Function<? super R, ? extends CompletableSource> completableFunction,
@@ -537,10 +669,34 @@ public abstract class Completable implements CompletableSource {
         
         return new CompletableUsing<R>(resourceSupplier, completableFunction, disposer, eager);
     }
+
+    /**
+     * Wraps the given CompletableSource into a Completable
+     * if not already Completable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param source the source to wrap
+     * @return the source or its wrapper Completable
+     * @throws NullPointerException if source is null
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static Completable wrap(CompletableSource source) {
+        Objects.requireNonNull(source, "source is null");
+        if (source instanceof Completable) {
+            return (Completable)source;
+        }
+        return new CompletableFromUnsafeSource(source);
+    }
     
     /**
      * Returns a Completable that emits the a terminated event of either this Completable
      * or the other Completable whichever fires first.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code ambWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param other the other Completable, not null
      * @return the new Completable instance
      * @throws NullPointerException if other is null
@@ -550,20 +706,106 @@ public abstract class Completable implements CompletableSource {
         Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
+
+    /**
+     * Returns an Observable which will subscribe to this Completable and once that is completed then 
+     * will subscribe to the {@code next} ObservableSource. An error event from this Completable will be 
+     * propagated to the downstream subscriber and will result in skipping the subscription of the 
+     * Observable.  
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type of the next ObservableSource
+     * @param next the Observable to subscribe after this Completable is completed, not null
+     * @return Observable that composes this Completable and next
+     * @throws NullPointerException if next is null
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <T> Observable<T> andThen(ObservableSource<T> next) {
+        Objects.requireNonNull(next, "next is null");
+        return new ObservableDelaySubscriptionOther<T, Object>(next, toObservable());
+    }
+
+    /**
+     * Returns an Flowable which will subscribe to this Completable and once that is completed then 
+     * will subscribe to the {@code next} Flowable. An error event from this Completable will be 
+     * propagated to the downstream subscriber and will result in skipping the subscription of the 
+     * Observable.  
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the value type of the next Publisher
+     * @param next the Observable to subscribe after this Completable is completed, not null
+     * @return Flowable that composes this Completable and next
+     * @throws NullPointerException if next is null
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <T> Flowable<T> andThen(Publisher<T> next) {
+        Objects.requireNonNull(next, "next is null");
+        return new FlowableDelaySubscriptionOther<T, Object>(next, toFlowable());
+    }
+
+    /**
+     * Returns a Single which will subscribe to this Completable and once that is completed then
+     * will subscribe to the {@code next} SingleSource. An error event from this Completable will be
+     * propagated to the downstream subscriber and will result in skipping the subscription of the
+     * Single.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the value type of the next SingleSource
+     * @param next the Single to subscribe after this Completable is completed, not null
+     * @return Single that composes this Completable and next
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <T> Single<T> andThen(SingleSource<T> next) {
+        Objects.requireNonNull(next, "next is null");
+        return new SingleDelayWithCompletable<T>(next, this);
+    }
+
+    /**
+     * Returns a Completable that first runs this Completable
+     * and then the other completable.
+     * <p>
+     * This is an alias for {@link #concatWith(CompletableSource)}.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param next the other Completable, not null
+     * @return the new Completable instance
+     * @throws NullPointerException if other is null
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Completable andThen(CompletableSource next) {
+        return concatWith(next);
+    }
     
     /**
      * Subscribes to and awaits the termination of this Completable instance in a blocking manner and
      * rethrows any exception emitted.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code blockingAwait} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @throws RuntimeException wrapping an InterruptedException if the current thread is interrupted
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void await() {
+    public final void blockingAwait() {
         CompletableAwait.await(this);
     }
     
     /**
      * Subscribes to and awaits the termination of this Completable instance in a blocking manner
      * with a specific timeout and rethrows any exception emitted within the timeout window.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code blockingAwait} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
      * @return true if the this Completable instance completed normally within the time limit,
@@ -571,13 +813,46 @@ public abstract class Completable implements CompletableSource {
      * @throws RuntimeException wrapping an InterruptedException if the current thread is interrupted
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final boolean await(long timeout, TimeUnit unit) {
+    public final boolean blockingAwait(long timeout, TimeUnit unit) {
         return CompletableAwait.await(this, timeout, unit);
+    }
+
+    /**
+     * Subscribes to this Completable instance and blocks until it terminates, then returns null or
+     * the emitted exception if any.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doAfterTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the throwable if this terminated with an error, null otherwise
+     * @throws RuntimeException that wraps an InterruptedException if the wait is interrupted
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Throwable blockingGet() {
+        return CompletableAwait.get(this);
     }
     
     /**
+     * Subscribes to this Completable instance and blocks until it terminates or the specified timeout 
+     * ellapses, then returns null for normal termination or the emitted exception if any.
+     * @param timeout the timeout value
+     * @param unit the time unit
+     * @return the throwable if this terminated with an error, null otherwise
+     * @throws RuntimeException that wraps an InterruptedException if the wait is interrupted or
+     * TimeoutException if the specified timeout ellapsed before it
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Throwable blockingGet(long timeout, TimeUnit unit) {
+        return CompletableAwait.get(this, timeout, unit);
+    }
+
+    /**
      * Calls the given transformer function with this instance and returns the function's resulting
      * Completable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code compose} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param transformer the transformer function, not null
      * @return the Completable returned by the function
      * @throws NullPointerException if transformer is null
@@ -588,72 +863,11 @@ public abstract class Completable implements CompletableSource {
     }
     
     /**
-     * Returns an Observable which will subscribe to this Completable and once that is completed then 
-     * will subscribe to the {@code next} Observable. An error event from this Completable will be 
-     * propagated to the downstream subscriber and will result in skipping the subscription of the 
-     * Observable.  
-     * 
-     * @param <T> the value type of the next Observable
-     * @param next the Observable to subscribe after this Completable is completed, not null
-     * @return Observable that composes this Completable and next
-     * @throws NullPointerException if next is null
-     */
-    public final <T> Observable<T> andThen(Observable<T> next) {
-        Objects.requireNonNull(next, "next is null");
-        return next.delaySubscription(toObservable());
-    }
-
-    /**
-     * Returns an Flowable which will subscribe to this Completable and once that is completed then 
-     * will subscribe to the {@code next} Flowable. An error event from this Completable will be 
-     * propagated to the downstream subscriber and will result in skipping the subscription of the 
-     * Observable.  
-     * 
-     * @param <T> the value type of the next Flowable
-     * @param next the Observable to subscribe after this Completable is completed, not null
-     * @return Flowable that composes this Completable and next
-     * @throws NullPointerException if next is null
-     */
-    public final <T> Flowable<T> andThen(Flowable<T> next) {
-        Objects.requireNonNull(next, "next is null");
-        return next.delaySubscription(toFlowable());
-    }
-
-    /**
-     * Returns a Single which will subscribe to this Completable and once that is completed then
-     * will subscribe to the {@code next} Single. An error event from this Completable will be
-     * propagated to the downstream subscriber and will result in skipping the subscription of the
-     * Single.
+     * Concatenates this Completable with another Completable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
-     * @param <T> the value type of the next Single
-     * @param next the Single to subscribe after this Completable is completed, not null
-     * @return Single that composes this Completable and next
-     */
-    public final <T> Single<T> andThen(Single<T> next) {
-        Objects.requireNonNull(next, "next is null");
-        return next.delaySubscription(toObservable());
-    }
-
-    /**
-     * Returns a Completable that first runs this Completable
-     * and then the other completable.
-     * <p>
-     * This is an alias for {@link #concatWith(CompletableSource)}.
-     * @param next the other Completable, not null
-     * @return the new Completable instance
-     * @throws NullPointerException if other is null
-     */
-    public final Completable andThen(Completable next) {
-        return concatWith(next);
-    }
-    
-
-    /**
-     * Concatenates this Completable with another Completable.
      * @param other the other Completable, not null
      * @return the new Completable which subscribes to this and then the other Completable
      * @throws NullPointerException if other is null
@@ -666,6 +880,10 @@ public abstract class Completable implements CompletableSource {
 
     /**
      * Returns a Completable which delays the emission of the completion event by the given time.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code delay} does operate by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
      * @param delay the delay time
      * @param unit the delay unit
      * @return the new Completable instance
@@ -679,6 +897,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which delays the emission of the completion event by the given time while
      * running on the specified scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code delay} operates on the {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param delay the delay time
      * @param unit the delay unit
      * @param scheduler the scheduler to run the delayed completion on
@@ -693,6 +915,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which delays the emission of the completion event, and optionally the error as well, by the given time while
      * running on the specified scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code delay} operates on the {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param delay the delay time
      * @param unit the delay unit
      * @param scheduler the scheduler to run the delayed completion on
@@ -709,6 +935,10 @@ public abstract class Completable implements CompletableSource {
 
     /**
      * Returns a Completable which calls the given onComplete callback if this Completable completes.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doOnComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onComplete the callback to call when this emits an onComplete event
      * @return the new Completable instance
      * @throws NullPointerException if onComplete is null
@@ -723,6 +953,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which calls the giveon onDispose callback if the child subscriber cancels
      * the subscription.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onDispose the callback to call when the child subscriber cancels the subscription
      * @return the new Completable instance
      * @throws NullPointerException if onDispose is null
@@ -736,6 +970,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable which calls the given onError callback if this Completable emits an error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doOnError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onError the error callback
      * @return the new Completable instance
      * @throws NullPointerException if onError is null
@@ -750,6 +988,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that calls the various callbacks on the specific
      * lifecycle events.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doOnLifecycle} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onSubscribe the consumer called when a CompletableSubscriber subscribes.
      * @param onError the consumer called when this emits an onError event
      * @param onComplete the runnable called just before when this Completable completes normally
@@ -777,6 +1019,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that calls the given onSubscribe callback with the disposable
      * that child subscribers receive on subscription.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onSubscribe the callback called when a child subscriber subscribes
      * @return the new Completable instance
      * @throws NullPointerException if onSubscribe is null
@@ -791,6 +1037,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that calls the given onTerminate callback just before this Completable
      * completes normally or with an exception
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doOnTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onTerminate the callback to call just before this Completable terminates
      * @return the new Completable instance
      */
@@ -804,6 +1054,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that calls the given onTerminate callback after this Completable
      * completes normally or with an exception
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doAfterTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onAfterTerminate the callback to call after this Completable terminates
      * @return the new Completable instance
      */
@@ -815,86 +1069,12 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns a completable that first runs this Completable
-     * and then the other completable.
-     * <p>
-     * This is an alias for {@link #concatWith(CompletableSource)}.
-     * @param other the other CompletableConsumable, not null
-     * @return the new Completable instance
-     * @throws NullPointerException if other is null
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable endWith(CompletableSource other) {
-        return concatWith(other);
-    }
-    /**
-     * Returns an NbpObservable that first runs this Completable instance and
-     * resumes with the given next Observable.
-     * @param <T> the type of the NbpObservable
-     * @param next the next Observable to continue
-     * @return the new Observable instance
-     * @throws NullPointerException if next is null
-     */
-    @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <T> Observable<T> endWith(ObservableSource<T> next) {
-        return this.<T>toObservable().concatWith(next);
-    }
-    
-    /**
-     * Returns an Observable that first runs this Completable instance and
-     * resumes with the given next Observable.
-     * @param <T> the value type of the observable
-     * @param next the next Observable to continue
-     * @return the new Observable instance
-     * @throws NullPointerException if next is null
-     */
-    @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <T> Flowable<T> endWith(Publisher<T> next) {
-        return this.<T>toFlowable().concatWith(next);
-    }
-
-    /**
-     * Returns a Completable instace that calls the given onAfterComplete callback after this
-     * Completable completes normally.
-     * @param onAfterComplete the callback to call after this Completable emits an onComplete event.
-     * @return the new Completable instance
-     * @throws NullPointerException if onAfterComplete is null
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @Deprecated
-    public final Completable finallyDo(Runnable onAfterComplete) {
-        return doOnLifecycle(Functions.emptyConsumer(), Functions.emptyConsumer(),
-                Functions.EMPTY_RUNNABLE, onAfterComplete,
-                Functions.EMPTY_RUNNABLE, Functions.EMPTY_RUNNABLE);
-    }
-    
-    /**
-     * Subscribes to this Completable instance and blocks until it terminates, then returns null or
-     * the emitted exception if any.
-     * @return the throwable if this terminated with an error, null otherwise
-     * @throws RuntimeException that wraps an InterruptedException if the wait is interrupted
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final Throwable get() {
-        return CompletableAwait.get(this);
-    }
-    
-    /**
-     * Subscribes to this Completable instance and blocks until it terminates or the specified timeout 
-     * ellapses, then returns null for normal termination or the emitted exception if any.
-     * @param timeout the timeout value
-     * @param unit the time unit
-     * @return the throwable if this terminated with an error, null otherwise
-     * @throws RuntimeException that wraps an InterruptedException if the wait is interrupted or
-     * TimeoutException if the specified timeout ellapsed before it
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final Throwable get(long timeout, TimeUnit unit) {
-        return CompletableAwait.get(this, timeout, unit);
-    }
-    
-    /**
-     * Lifts a CompletableSubscriber transformation into the chain of Completables.
+     * <strong>Advanced use without safeguards:</strong> lifts a CompletableSubscriber 
+     * transformation into the chain of Completables.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code lift} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onLift the lifting function that transforms the child subscriber with a parent subscriber.
      * @return the new Completable instance
      * @throws NullPointerException if onLift is null
@@ -908,6 +1088,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which subscribes to this and the other Completable and completes
      * when both of them complete or one emits an error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param other the other Completable instance
      * @return the new Completable instance
      * @throws NullPointerException if other is null
@@ -920,6 +1104,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable which emits the terminal events from the thread of the specified scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code observeOn} operates on a {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param scheduler the scheduler to emit terminal events on
      * @return the new Completable instance
      * @throws NullPointerException if scheduler is null
@@ -933,6 +1121,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that if this Completable emits an error, it will emit an onComplete
      * and swallow the throwable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new Completable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -943,6 +1135,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that if this Completable emits an error and the predicate returns
      * true, it will emit an onComplete and swallow the throwable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param predicate the predicate to call when an Throwable is emitted which should return true
      * if the Throwable should be swallowed and replaced with an onComplete.
      * @return the new Completable instance
@@ -958,6 +1154,10 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable instance that when encounters an error from this Completable, calls the
      * specified mapper function that returns another Completable instance for it and resumes the
      * execution with it.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param errorMapper the mapper function that takes the error and should return a Completable as
      * continuation.
      * @return the new Completable instance
@@ -970,6 +1170,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable that repeatedly subscribes to this Completable until cancelled.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new Completable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -979,6 +1183,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Returns a Completable that subscribes repeatedly at most the given times to this Completable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param times the number of times the resubscription should happen
      * @return the new Completable instance
      * @throws IllegalArgumentException if times is less than zero
@@ -991,6 +1199,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that repeatedly subscribes to this Completable so long as the given
      * stop supplier returns false.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param stop the supplier that should return true to stop resubscribing.
      * @return the new Completable instance
      * @throws NullPointerException if stop is null
@@ -1003,6 +1215,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable instance that repeats when the Publisher returned by the handler
      * emits an item or completes when this Publisher emits a completed event.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeatWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param handler the function that transforms the stream of values indicating the completion of
      * this Completable and returns a Publisher that emits items for repeating or completes to indicate the
      * repetition should stop
@@ -1010,16 +1226,16 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if stop is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    /*
-     * FIXME the Observable<Void> type doesn't make sense here because nulls are not allowed
-     * FIXME add unit test once the type has been fixed
-     */ 
     public final Completable repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
         return fromPublisher(toFlowable().repeatWhen(handler));
     }
     
     /**
      * Returns a Completable that retries this Completable as long as it emits an onError event.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new Completable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1030,6 +1246,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that retries this Completable in case of an error as long as the predicate
      * returns true.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param predicate the predicate called when this emits an error with the repeat count and the latest exception
      * and should return true to retry.
      * @return the new Completable instance
@@ -1042,6 +1262,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that when this Completable emits an error, retries at most the given
      * number of times before giving up and emitting the last error.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param times the number of times the returned Completable should retry this Completable
      * @return the new Completable instance
      * @throws IllegalArgumentException if times is negative
@@ -1054,6 +1278,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that when this Completable emits an error, calls the given predicate with
      * the latest exception to decide whether to resubscribe to this or not.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param predicate the predicate that is called with the latest throwable and should return
      * true to indicate the returned Completable should resubscribe to this Completable.
      * @return the new Completable instance
@@ -1068,6 +1296,10 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable which given a Publisher and when this Completable emits an error, delivers
      * that error through an Observable and the Publisher should return a value indicating a retry in response
      * or a terminal event indicating a termination.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param handler the handler that receives an Observable delivering Throwables and should return a Publisher that
      * emits items to indicate retries or emits terminal events to indicate termination.
      * @return the new Completable instance
@@ -1081,6 +1313,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which first runs the other Completable
      * then this completable if the other completed normally.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param other the other completable to run first
      * @return the new Completable instance
      * @throws NullPointerException if other is null
@@ -1094,6 +1330,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns an NbpObservable which first delivers the events
      * of the other NbpObservable then runs this CompletableConsumable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type
      * @param other the other NbpObservable to run first
      * @return the new NbpObservable instance
@@ -1107,6 +1347,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns an Observable which first delivers the events
      * of the other Observable then runs this Completable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type
      * @param other the other Observable to run first
      * @return the new Observable instance
@@ -1121,6 +1365,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Subscribes to this CompletableConsumable and returns a Disposable which can be used to cancel
      * the subscription.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the Disposable that allows cancelling the subscription
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1129,11 +1377,7 @@ public abstract class Completable implements CompletableSource {
         subscribe(s);
         return s;
     }
-    /**
-     * Subscribes the given CompletableSubscriber to this Completable instance.
-     * @param s the CompletableSubscriber, not null
-     * @throws NullPointerException if s is null
-     */
+    
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
     public final void subscribe(CompletableObserver s) {
@@ -1151,13 +1395,21 @@ public abstract class Completable implements CompletableSource {
         }
     }
     
+    /**
+     * Implement this to handle the incoming CompletableObserver and
+     * perform the business logic in your operator.
+     * @param s the CompletableObserver instance, never null
+     */
     protected abstract void subscribeActual(CompletableObserver s);
 
     /**
      * Subscribes to this Completable and calls back either the onError or onComplete functions.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onComplete the runnable that is called if the Completable completes normally
      * @param onError the consumer that is called if this Completable emits an error
-     * 
      * @return the Disposable that can be used for cancelling the subscription asynchronously
      * @throws NullPointerException if either callback is null
      */
@@ -1172,17 +1424,21 @@ public abstract class Completable implements CompletableSource {
     }
     
     /**
-     * Subscribes a non-backpressure NbpSubscriberto this Completable instance which
+     * Subscribes a non-backpressure Observer to this Completable instance which
      * will receive only an onError or onComplete event.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the Observer's value type
-     * @param s the NbpSubscriber instance, not null
+     * @param observer the Observer instance, not null
      * @throws NullPointerException if s is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> void subscribe(final Observer<? super T> s) {
-        Objects.requireNonNull(s, "s is null");
+    public final <T> void subscribe(final Observer<? super T> observer) {
+        Objects.requireNonNull(observer, "s is null");
         
-        ObserverCompletableObserver<T> os = new ObserverCompletableObserver<T>(s);
+        ObserverCompletableObserver<T> os = new ObserverCompletableObserver<T>(observer);
         subscribe(os);
     }
     
@@ -1191,6 +1447,10 @@ public abstract class Completable implements CompletableSource {
      * completes normally.
      * <p>
      * If this Completable emits an error, it is sent to RxJavaPlugins.onError and gets swallowed.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param onComplete the runnable called when this Completable completes normally
      * @return the Disposable that allows cancelling the subscription
      */
@@ -1206,6 +1466,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Subscribes a reactive-streams Subscriber to this Completable instance which
      * will receive only an onError or onComplete event.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type of the subscriber
      * @param s the reactive-streams Subscriber, not null
      * @throws NullPointerException if s is null
@@ -1220,6 +1484,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which subscribes the child subscriber on the specified scheduler, making
      * sure the subscription side-effects happen on that specific thread of the scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribeOn} operates on a {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param scheduler the Scheduler to subscribe on
      * @return the new Completable instance
      * @throws NullPointerException if scheduler is null
@@ -1234,6 +1502,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that runs this Completable and emits a TimeoutException in case
      * this Completable doesn't complete within the given time.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} signals the TimeoutException on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
      * @return the new Completable instance
@@ -1247,6 +1519,11 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that runs this Completable and switches to the other Completable
      * in case this Completable doesn't complete within the given time.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} subscribes to the other CompletableSource on 
+     *  the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
      * @param other the other Completable instance to switch to in case of a timeout
@@ -1263,6 +1540,10 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable that runs this Completable and emits a TimeoutException in case
      * this Completable doesn't complete within the given time while "waiting" on the specified
      * Scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} signals the TimeoutException on the {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
      * @param scheduler the scheduler to use to wait for completion
@@ -1278,6 +1559,11 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable that runs this Completable and switches to the other Completable
      * in case this Completable doesn't complete within the given time while "waiting" on
      * the specified scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code timeout} subscribes to the other CompletableSource on 
+     *  the {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
      * @param scheduler the scheduler to use to wait for completion
@@ -1312,6 +1598,10 @@ public abstract class Completable implements CompletableSource {
     
     /**
      * Allows fluent conversion to another type via a function callback.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <U> the output type
      * @param converter the function called with this which should return some other value.
      * @return the converted value
@@ -1329,6 +1619,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns an Observable which when subscribed to subscribes to this Completable and
      * relays the terminal events to the subscriber.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type
      * @return the new Observable created
      */
@@ -1340,6 +1634,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns an NbpObservable which when subscribed to subscribes to this Completable and
      * relays the terminal events to the subscriber.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type
      * @return the new NbpObservable created
      */
@@ -1351,6 +1649,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Convers this Completable into a Single which when this Completable completes normally,
      * calls the given supplier and emits its returned value through onSuccess.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toSingle} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type
      * @param completionValueSupplier the value supplier called when this Completable completes normally
      * @return the new Single instance
@@ -1365,6 +1667,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Convers this Completable into a Single which when this Completable completes normally,
      * emits the given value through onSuccess.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toSingleDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <T> the value type
      * @param completionValue the value to emit when this Completable completes normally
      * @return the new Single instance
@@ -1379,6 +1685,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which makes sure when a subscriber cancels the subscription, the 
      * dispose is called on the specified scheduler
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
+     * </dl>
      * @param scheduler the target scheduler where to execute the cancellation
      * @return the new Completable instance
      * @throws NullPointerException if scheduler is null

--- a/src/main/java/io/reactivex/CompletableSource.java
+++ b/src/main/java/io/reactivex/CompletableSource.java
@@ -23,5 +23,10 @@ package io.reactivex;
  */
 public interface CompletableSource {
     
+    /**
+     * Subscribes the given CompletableObserver to this CompletableSource instance.
+     * @param cs the CompletableObserver, not null
+     * @throws NullPointerException if {@code cs} is null
+     */
     void subscribe(CompletableObserver cs);
 }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -157,7 +157,7 @@ public class CompletableTest {
     public void complete() {
         Completable c = Completable.complete();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -169,14 +169,14 @@ public class CompletableTest {
     public void concatEmpty() {
         Completable c = Completable.concat();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatSingleSource() {
         Completable c = Completable.concat(normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -185,14 +185,14 @@ public class CompletableTest {
     public void concatSingleSourceThrows() {
         Completable c = Completable.concat(error.completable);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatMultipleSources() {
         Completable c = Completable.concat(normal.completable, normal.completable, normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -201,21 +201,21 @@ public class CompletableTest {
     public void concatMultipleOneThrows() {
         Completable c = Completable.concat(normal.completable, error.completable, normal.completable);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void concatMultipleOneIsNull() {
         Completable c = Completable.concat(normal.completable, null);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatIterableEmpty() {
         Completable c = Completable.concat(Collections.<Completable>emptyList());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -232,21 +232,21 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void concatIterableWithNull() {
         Completable c = Completable.concat(Arrays.asList(normal.completable, (Completable)null));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatIterableSingle() {
         Completable c = Completable.concat(Collections.singleton(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -255,7 +255,7 @@ public class CompletableTest {
     public void concatIterableMany() {
         Completable c = Completable.concat(Arrays.asList(normal.completable, normal.completable, normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -264,14 +264,14 @@ public class CompletableTest {
     public void concatIterableOneThrows() {
         Completable c = Completable.concat(Collections.singleton(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
     public void concatIterableManyOneThrows() {
         Completable c = Completable.concat(Arrays.asList(normal.completable, error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
@@ -283,28 +283,28 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void concatIterableIteratorHasNextThrows() {
         Completable c = Completable.concat(new IterableIteratorHasNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void concatIterableIteratorNextThrows() {
         Completable c = Completable.concat(new IterableIteratorNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatObservableEmpty() {
         Completable c = Completable.concat(Flowable.<Completable>empty());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -316,14 +316,14 @@ public class CompletableTest {
             }
         }));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatObservableSingle() {
         Completable c = Completable.concat(Flowable.just(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -332,14 +332,14 @@ public class CompletableTest {
     public void concatObservableSingleThrows() {
         Completable c = Completable.concat(Flowable.just(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatObservableMany() {
         Completable c = Completable.concat(Flowable.just(normal.completable).repeat(3));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -348,7 +348,7 @@ public class CompletableTest {
     public void concatObservableManyOneThrows() {
         Completable c = Completable.concat(Flowable.just(normal.completable, error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -366,7 +366,7 @@ public class CompletableTest {
         
         Completable c = Completable.concat(cs, 5);
         
-        c.await();
+        c.blockingAwait();
         
         // FIXME this request pattern looks odd because all 10 completions trigger 1 requests
         Assert.assertEquals(Arrays.asList(5L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), requested);
@@ -384,7 +384,7 @@ public class CompletableTest {
             public void subscribe(CompletableObserver s) { throw new NullPointerException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -397,7 +397,7 @@ public class CompletableTest {
                 }
             });
             
-            c.await();
+            c.blockingAwait();
             
             Assert.fail("Did not throw exception");
         } catch (NullPointerException ex) {
@@ -419,7 +419,7 @@ public class CompletableTest {
         
         normal.assertSubscriptions(0);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -438,7 +438,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -448,7 +448,7 @@ public class CompletableTest {
             public Completable call() { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -460,7 +460,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -477,7 +477,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
@@ -489,7 +489,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(timeout = 1000, expected = TestException.class)
@@ -499,7 +499,7 @@ public class CompletableTest {
             public Throwable call() { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -511,7 +511,7 @@ public class CompletableTest {
     public void errorNormal() {
         Completable c = Completable.error(new TestException());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -530,7 +530,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }
@@ -542,7 +542,7 @@ public class CompletableTest {
             public Object call() throws Exception { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -554,7 +554,7 @@ public class CompletableTest {
     public void fromFlowableEmpty() {
         Completable c = Completable.fromPublisher(Flowable.empty());
         
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(timeout = 5000)
@@ -562,7 +562,7 @@ public class CompletableTest {
         for (int n = 1; n < 10000; n *= 10) {
             Completable c = Completable.fromPublisher(Flowable.range(1, n));
             
-            c.await();
+            c.blockingAwait();
         }
     }
     
@@ -575,7 +575,7 @@ public class CompletableTest {
             }
         }));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -587,7 +587,7 @@ public class CompletableTest {
     public void fromNbpObservableEmpty() {
         Completable c = Completable.fromObservable(Observable.empty());
         
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(timeout = 5000)
@@ -595,7 +595,7 @@ public class CompletableTest {
         for (int n = 1; n < 10000; n *= 10) {
             Completable c = Completable.fromObservable(Observable.range(1, n));
             
-            c.await();
+            c.blockingAwait();
         }
     }
     
@@ -608,7 +608,7 @@ public class CompletableTest {
             }
         }));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -627,7 +627,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }
@@ -639,7 +639,7 @@ public class CompletableTest {
             public void run() { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -651,7 +651,7 @@ public class CompletableTest {
     public void fromSingleNormal() {
         Completable c = Completable.fromSingle(Single.just(1));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -663,7 +663,7 @@ public class CompletableTest {
             }
         }));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -675,14 +675,14 @@ public class CompletableTest {
     public void mergeEmpty() {
         Completable c = Completable.merge();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeSingleSource() {
         Completable c = Completable.merge(normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -691,14 +691,14 @@ public class CompletableTest {
     public void mergeSingleSourceThrows() {
         Completable c = Completable.merge(error.completable);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeMultipleSources() {
         Completable c = Completable.merge(normal.completable, normal.completable, normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -707,21 +707,21 @@ public class CompletableTest {
     public void mergeMultipleOneThrows() {
         Completable c = Completable.merge(normal.completable, error.completable, normal.completable);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void mergeMultipleOneIsNull() {
         Completable c = Completable.merge(normal.completable, null);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeIterableEmpty() {
         Completable c = Completable.merge(Collections.<Completable>emptyList());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -738,21 +738,21 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void mergeIterableWithNull() {
         Completable c = Completable.merge(Arrays.asList(normal.completable, (Completable)null));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeIterableSingle() {
         Completable c = Completable.merge(Collections.singleton(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -761,7 +761,7 @@ public class CompletableTest {
     public void mergeIterableMany() {
         Completable c = Completable.merge(Arrays.asList(normal.completable, normal.completable, normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -770,14 +770,14 @@ public class CompletableTest {
     public void mergeIterableOneThrows() {
         Completable c = Completable.merge(Collections.singleton(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
     public void mergeIterableManyOneThrows() {
         Completable c = Completable.merge(Arrays.asList(normal.completable, error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
@@ -789,28 +789,28 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void mergeIterableIteratorHasNextThrows() {
         Completable c = Completable.merge(new IterableIteratorHasNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void mergeIterableIteratorNextThrows() {
         Completable c = Completable.merge(new IterableIteratorNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeObservableEmpty() {
         Completable c = Completable.merge(Flowable.<Completable>empty());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -822,14 +822,14 @@ public class CompletableTest {
             }
         }));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeObservableSingle() {
         Completable c = Completable.merge(Flowable.just(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -838,14 +838,14 @@ public class CompletableTest {
     public void mergeObservableSingleThrows() {
         Completable c = Completable.merge(Flowable.just(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeObservableMany() {
         Completable c = Completable.merge(Flowable.just(normal.completable).repeat(3));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -854,7 +854,7 @@ public class CompletableTest {
     public void mergeObservableManyOneThrows() {
         Completable c = Completable.merge(Flowable.just(normal.completable, error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -872,7 +872,7 @@ public class CompletableTest {
         
         Completable c = Completable.merge(cs, 5);
         
-        c.await();
+        c.blockingAwait();
         
         // FIXME this request pattern looks odd because all 10 completions trigger 1 requests
         Assert.assertEquals(Arrays.asList(5L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), requested);
@@ -887,14 +887,14 @@ public class CompletableTest {
     public void mergeDelayErrorEmpty() {
         Completable c = Completable.mergeDelayError();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorSingleSource() {
         Completable c = Completable.mergeDelayError(normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -903,14 +903,14 @@ public class CompletableTest {
     public void mergeDelayErrorSingleSourceThrows() {
         Completable c = Completable.mergeDelayError(error.completable);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorMultipleSources() {
         Completable c = Completable.mergeDelayError(normal.completable, normal.completable, normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -920,7 +920,7 @@ public class CompletableTest {
         Completable c = Completable.mergeDelayError(normal.completable, error.completable, normal.completable);
         
         try {
-            c.await();
+            c.blockingAwait();
         } catch (TestException ex) {
             normal.assertSubscriptions(2);
         }
@@ -930,14 +930,14 @@ public class CompletableTest {
     public void mergeDelayErrorMultipleOneIsNull() {
         Completable c = Completable.mergeDelayError(normal.completable, null);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorIterableEmpty() {
         Completable c = Completable.mergeDelayError(Collections.<Completable>emptyList());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -954,21 +954,21 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void mergeDelayErrorIterableWithNull() {
         Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, (Completable)null));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorIterableSingle() {
         Completable c = Completable.mergeDelayError(Collections.singleton(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -977,7 +977,7 @@ public class CompletableTest {
     public void mergeDelayErrorIterableMany() {
         Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, normal.completable, normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -986,7 +986,7 @@ public class CompletableTest {
     public void mergeDelayErrorIterableOneThrows() {
         Completable c = Completable.mergeDelayError(Collections.singleton(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -994,7 +994,7 @@ public class CompletableTest {
         Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, error.completable, normal.completable));
         
         try {
-            c.await();
+            c.blockingAwait();
         } catch (TestException ex) {
             normal.assertSubscriptions(2);
         }
@@ -1009,28 +1009,28 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableIteratorHasNextThrows() {
         Completable c = Completable.mergeDelayError(new IterableIteratorHasNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableIteratorNextThrows() {
         Completable c = Completable.mergeDelayError(new IterableIteratorNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorObservableEmpty() {
         Completable c = Completable.mergeDelayError(Flowable.<Completable>empty());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -1042,14 +1042,14 @@ public class CompletableTest {
             }
         }));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorObservableSingle() {
         Completable c = Completable.mergeDelayError(Flowable.just(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -1058,14 +1058,14 @@ public class CompletableTest {
     public void mergeDelayErrorObservableSingleThrows() {
         Completable c = Completable.mergeDelayError(Flowable.just(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorObservableMany() {
         Completable c = Completable.mergeDelayError(Flowable.just(normal.completable).repeat(3));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(3);
     }
@@ -1074,7 +1074,7 @@ public class CompletableTest {
     public void mergeDelayErrorObservableManyOneThrows() {
         Completable c = Completable.mergeDelayError(Flowable.just(normal.completable, error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -1092,7 +1092,7 @@ public class CompletableTest {
         
         Completable c = Completable.mergeDelayError(cs, 5);
         
-        c.await();
+        c.blockingAwait();
         
         // FIXME this request pattern looks odd because all 10 completions trigger 1 requests
         Assert.assertEquals(Arrays.asList(5L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), requested);
@@ -1127,14 +1127,14 @@ public class CompletableTest {
     public void timer() {
         Completable c = Completable.timer(500, TimeUnit.MILLISECONDS);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1500)
     public void timerNewThread() {
         Completable c = Completable.timer(500, TimeUnit.MILLISECONDS, Schedulers.newThread());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -1441,7 +1441,7 @@ public class CompletableTest {
             public void accept(Object v) { }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -1475,7 +1475,7 @@ public class CompletableTest {
                     public void accept(Object v) { }
                 });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
@@ -1494,7 +1494,7 @@ public class CompletableTest {
                     public void accept(Object v) { }
                 });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
@@ -1515,7 +1515,7 @@ public class CompletableTest {
                     public void accept(Object v) { throw new TestException(); }
                 });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -1527,7 +1527,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -1539,7 +1539,7 @@ public class CompletableTest {
     public void concatWithNormal() {
         Completable c = normal.completable.concatWith(normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(2);
     }
@@ -1548,7 +1548,7 @@ public class CompletableTest {
     public void concatWithError() {
         Completable c = normal.completable.concatWith(error.completable);
         
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(expected = NullPointerException.class)
@@ -1681,7 +1681,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }
@@ -1698,7 +1698,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Failed to throw TestException");
         } catch (TestException ex) {
             // expected
@@ -1719,7 +1719,7 @@ public class CompletableTest {
             public void run() { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -1733,7 +1733,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(0, calls.get());
     }
@@ -1750,7 +1750,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("No exception thrown");
         } catch (TestException ex) {
             // expected
@@ -1830,7 +1830,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertNull(error.get());
     }
@@ -1847,7 +1847,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did not throw exception");
         } catch (Throwable e) {
             // expected
@@ -1869,7 +1869,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
         } catch (CompositeException ex) {
             List<Throwable> a = ex.getExceptions();
             Assert.assertEquals(2, a.size());
@@ -1890,7 +1890,7 @@ public class CompletableTest {
         });
         
         for (int i = 0; i < 10; i++) {
-            c.await();
+            c.blockingAwait();
         }
         
         Assert.assertEquals(10, calls.get());
@@ -1908,7 +1908,7 @@ public class CompletableTest {
             public void accept(Disposable d) { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -1922,7 +1922,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }
@@ -1939,7 +1939,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did dot throw exception");
         } catch (TestException ex) {
             // expected
@@ -1948,86 +1948,20 @@ public class CompletableTest {
         Assert.assertEquals(1, calls.get());
     }
     
-    @Ignore("deprecated behavior")
-    @Test(timeout = 1000)
-    public void finallyDoNormal() {
-        final AtomicBoolean doneAfter = new AtomicBoolean();
-        final AtomicBoolean complete = new AtomicBoolean();
-        
-        @SuppressWarnings("deprecation")
-        Completable c = normal.completable.finallyDo(new Runnable() {
-            @Override
-            public void run() {
-                doneAfter.set(complete.get());
-            }
-        });
-        
-        c.subscribe(new CompletableObserver() {
-            @Override
-            public void onSubscribe(Disposable d) {
-                
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                
-            }
-            
-            @Override
-            public void onComplete() {
-                complete.set(true);
-            }
-        });
-        
-        c.await();
-        
-        Assert.assertTrue("Not completed", complete.get());
-        Assert.assertTrue("Finally called before onComplete", doneAfter.get());
-    }
-    
-    @Ignore("deprecated behavior")
-    @Test(timeout = 1000)
-    public void finallyDoWithError() {
-        final AtomicBoolean doneAfter = new AtomicBoolean();
-        
-        @SuppressWarnings("deprecation")
-        Completable c = error.completable.finallyDo(new Runnable() {
-            @Override
-            public void run() {
-                doneAfter.set(true);
-            }
-        });
-        
-        try {
-            c.await();
-            Assert.fail("Did not throw TestException");
-        } catch (TestException ex) {
-            // expected
-        }
-        
-        Assert.assertFalse("FinallyDo called", doneAfter.get());
-    }
-    
-    @SuppressWarnings("deprecation")
-    @Test(expected = NullPointerException.class)
-    public void finallyDoNull() {
-        normal.completable.finallyDo(null);
-    }
-    
     @Test(timeout = 1000)
     public void getNormal() {
-        Assert.assertNull(normal.completable.get());
+        Assert.assertNull(normal.completable.blockingGet());
     }
     
     @Test(timeout = 1000)
     public void getError() {
-        Assert.assertTrue(error.completable.get() instanceof TestException);
+        Assert.assertTrue(error.completable.blockingGet() instanceof TestException);
     }
     
     @Test(timeout = 1000)
     public void getTimeout() {
         try {
-            Completable.never().get(100, TimeUnit.MILLISECONDS);
+            Completable.never().blockingGet(100, TimeUnit.MILLISECONDS);
         } catch (RuntimeException ex) {
             if (!(ex.getCause() instanceof TimeoutException)) {
                 Assert.fail("Wrong exception cause: " + ex.getCause());
@@ -2037,7 +1971,7 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void getNullUnit() {
-        normal.completable.get(1, null);
+        normal.completable.blockingGet(1, null);
     }
     
     @Test(expected = NullPointerException.class)
@@ -2054,7 +1988,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
 
     final static class CompletableOperatorSwap implements CompletableOperator {
@@ -2084,14 +2018,14 @@ public class CompletableTest {
     public void liftOnCompleteError() {
         Completable c = normal.completable.lift(new CompletableOperatorSwap());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void liftOnErrorComplete() {
         Completable c = error.completable.lift(new CompletableOperatorSwap());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -2103,7 +2037,7 @@ public class CompletableTest {
     public void mergeWithNormal() {
         Completable c = normal.completable.mergeWith(normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(2);
     }
@@ -2184,7 +2118,7 @@ public class CompletableTest {
     public void onErrorComplete() {
         Completable c = error.completable.onErrorComplete();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -2196,7 +2130,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -2219,7 +2153,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did not throw an exception");
         } catch (NullPointerException ex) {
             Assert.assertTrue(ex.getCause() instanceof TestException);
@@ -2234,7 +2168,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did not throw an exception");
         } catch (CompositeException ex) {
             List<Throwable> a = ex.getExceptions();
@@ -2254,7 +2188,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -2266,7 +2200,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 2000)
@@ -2313,7 +2247,7 @@ public class CompletableTest {
     public void repeatError() {
         Completable c = error.completable.repeat();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -2328,7 +2262,7 @@ public class CompletableTest {
             }
         }).repeat(5);
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(5, calls.get());
     }
@@ -2345,7 +2279,7 @@ public class CompletableTest {
             }
         }).repeat(1);
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }
@@ -2362,7 +2296,7 @@ public class CompletableTest {
             }
         }).repeat(0);
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(0, calls.get());
     }
@@ -2385,7 +2319,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(5, calls.get());
     }
@@ -2404,7 +2338,7 @@ public class CompletableTest {
     public void retryNormal() {
         Completable c = normal.completable.retry();
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -2421,7 +2355,7 @@ public class CompletableTest {
             }
         }).retry();
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
@@ -2433,14 +2367,14 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
     public void retryTimes5Error() {
         Completable c = error.completable.retry(5);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -2456,7 +2390,7 @@ public class CompletableTest {
             }
         }).retry(5);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = IllegalArgumentException.class)
@@ -2473,7 +2407,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -2499,7 +2433,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -2521,7 +2455,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -2761,7 +2695,7 @@ public class CompletableTest {
             }
         }).subscribeOn(Schedulers.computation());
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertTrue(name.get().startsWith("RxComputation"));
     }
@@ -2780,7 +2714,7 @@ public class CompletableTest {
         }).subscribeOn(Schedulers.computation());
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("No exception thrown");
         } catch (TestException ex) {
             // expected
@@ -2791,7 +2725,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000)
     public void timeoutEmitError() {
-        Throwable e = Completable.never().timeout(100, TimeUnit.MILLISECONDS).get();
+        Throwable e = Completable.never().timeout(100, TimeUnit.MILLISECONDS).blockingGet();
         
         Assert.assertTrue(e instanceof TimeoutException);
     }
@@ -2800,7 +2734,7 @@ public class CompletableTest {
     public void timeoutSwitchNormal() {
         Completable c = Completable.never().timeout(100, TimeUnit.MILLISECONDS, normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -2815,7 +2749,7 @@ public class CompletableTest {
             }
         }).timeout(100, TimeUnit.MILLISECONDS, normal.completable);
         
-        c.await();
+        c.blockingAwait();
         
         Thread.sleep(100);
         
@@ -2985,21 +2919,21 @@ public class CompletableTest {
     public void ambArrayEmpty() {
         Completable c = Completable.amb();
                 
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(timeout = 1000)
     public void ambArraySingleNormal() {
         Completable c = Completable.amb(normal.completable);
                 
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(timeout = 1000, expected = TestException.class)
     public void ambArraySingleError() {
         Completable c = Completable.amb(error.completable);
                 
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
@@ -3130,14 +3064,14 @@ public class CompletableTest {
     public void ambMultipleOneIsNull() {
         Completable c = Completable.amb(null, normal.completable);
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void ambIterableEmpty() {
         Completable c = Completable.amb(Collections.<Completable>emptyList());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -3154,21 +3088,21 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void ambIterableWithNull() {
         Completable c = Completable.amb(Arrays.asList(null, normal.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void ambIterableSingle() {
         Completable c = Completable.amb(Collections.singleton(normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -3177,7 +3111,7 @@ public class CompletableTest {
     public void ambIterableMany() {
         Completable c = Completable.amb(Arrays.asList(normal.completable, normal.completable, normal.completable));
         
-        c.await();
+        c.blockingAwait();
         
         normal.assertSubscriptions(1);
     }
@@ -3186,14 +3120,14 @@ public class CompletableTest {
     public void ambIterableOneThrows() {
         Completable c = Completable.amb(Collections.singleton(error.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = TestException.class)
     public void ambIterableManyOneThrows() {
         Completable c = Completable.amb(Arrays.asList(error.completable, normal.completable));
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
@@ -3205,21 +3139,21 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void ambIterableIteratorHasNextThrows() {
         Completable c = Completable.amb(new IterableIteratorHasNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = TestException.class)
     public void ambIterableIteratorNextThrows() {
         Completable c = Completable.amb(new IterableIteratorNextThrows());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(expected = NullPointerException.class)
@@ -3363,7 +3297,7 @@ public class CompletableTest {
                     }
                 }));
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertTrue("Did not start with other", run.get());
         normal.assertSubscriptions(1);
@@ -3374,7 +3308,7 @@ public class CompletableTest {
         Completable c = normal.completable.startWith(error.completable);
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did not throw TestException");
         } catch (TestException ex) {
             normal.assertSubscriptions(0);
@@ -3477,132 +3411,6 @@ public class CompletableTest {
         normal.completable.startWith((Observable<Object>)null);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void endWithCompletableNull() {
-        normal.completable.endWith((Completable)null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void endWithFlowableNull() {
-        normal.completable.endWith((Flowable<Object>)null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void endWithNbpObservableNull() {
-        normal.completable.endWith((Observable<Object>)null);
-    }
-    
-    @Test(timeout = 1000)
-    public void endWithCompletableNormal() {
-        final AtomicBoolean run = new AtomicBoolean();
-        Completable c = normal.completable
-                .endWith(Completable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        run.set(normal.get() == 0);
-                        return null;
-                    }
-                }));
-        
-        c.await();
-        
-        Assert.assertFalse("Start with other", run.get());
-        normal.assertSubscriptions(1);
-    }
-    
-    @Test(timeout = 1000)
-    public void endWithCompletableError() {
-        Completable c = normal.completable.endWith(error.completable);
-        
-        try {
-            c.await();
-            Assert.fail("Did not throw TestException");
-        } catch (TestException ex) {
-            normal.assertSubscriptions(1);
-            error.assertSubscriptions(1);
-        }
-    }
-    
-    @Test(timeout = 1000)
-    public void endWithFlowableNormal() {
-        final AtomicBoolean run = new AtomicBoolean();
-        Flowable<Object> c = normal.completable
-                .endWith(Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        run.set(normal.get() == 0);
-                        return 1;
-                    }
-                }));
-        
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
-        
-        c.subscribe(ts);
-        
-        Assert.assertFalse("Start with other", run.get());
-        normal.assertSubscriptions(1);
-        
-        ts.assertValue(1);
-        ts.assertComplete();
-        ts.assertNoErrors();
-    }
-    
-    @Test(timeout = 1000)
-    public void endWithFlowableError() {
-        Flowable<Object> c = normal.completable
-                .endWith(Flowable.error(new TestException()));
-        
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
-        
-        c.subscribe(ts);
-        
-        normal.assertSubscriptions(1);
-        
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
-    }
-    
-    @Test(timeout = 1000)
-    public void endWithNbpObservableNormal() {
-        final AtomicBoolean run = new AtomicBoolean();
-        Observable<Object> c = normal.completable
-                .endWith(Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        run.set(normal.get() == 0);
-                        return 1;
-                    }
-                }));
-        
-        TestObserver<Object> ts = new TestObserver<Object>();
-        
-        c.subscribe(ts);
-        
-        Assert.assertFalse("Start with other", run.get());
-        normal.assertSubscriptions(1);
-        
-        ts.assertValue(1);
-        ts.assertComplete();
-        ts.assertNoErrors();
-    }
-    
-    @Test(timeout = 1000)
-    public void endWithNbpObservableError() {
-        Observable<Object> c = normal.completable
-                .endWith(Observable.error(new TestException()));
-        
-        TestObserver<Object> ts = new TestObserver<Object>();
-        
-        c.subscribe(ts);
-        
-        normal.assertSubscriptions(1);
-        
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
-    }
-    
     @Test
     public void andThen() {
         TestSubscriber<String> ts = new TestSubscriber<String>(0);
@@ -3905,7 +3713,7 @@ public class CompletableTest {
     public void fromObservableEmpty() {
         Completable c = Completable.fromObservable(Observable.empty());
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 5000)
@@ -3913,7 +3721,7 @@ public class CompletableTest {
         for (int n = 1; n < 10000; n *= 10) {
             Completable c = Completable.fromObservable(Observable.range(1, n));
             
-            c.await();
+            c.blockingAwait();
         }
     }
     
@@ -3921,7 +3729,7 @@ public class CompletableTest {
     public void fromObservableError() {
         Completable c = Completable.fromObservable(Observable.error(new TestException()));
         
-        c.await();
+        c.blockingAwait();
     }
 
     @Test(timeout = 5000, expected = TestException.class)
@@ -3931,7 +3739,7 @@ public class CompletableTest {
             public void run() { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
 
     private Function<Completable, Completable> onCreate;
@@ -3983,7 +3791,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }
@@ -4000,7 +3808,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Failed to throw TestException");
         } catch (TestException ex) {
             // expected
@@ -4021,7 +3829,7 @@ public class CompletableTest {
             public void run() { throw new TestException(); }
         });
         
-        c.await();
+        c.blockingAwait();
     }
     
     @Test(timeout = 5000)
@@ -4053,7 +3861,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertTrue("Not completed", complete.get());
         Assert.assertTrue("Closure called before onComplete", doneAfter.get());
@@ -4071,7 +3879,7 @@ public class CompletableTest {
         });
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did not throw TestException");
         } catch (TestException ex) {
             // expected
@@ -4189,7 +3997,7 @@ public class CompletableTest {
                     }
                 }));
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertFalse("Start with other", run.get());
         normal.assertSubscriptions(1);
@@ -4200,7 +4008,7 @@ public class CompletableTest {
         Completable c = normal.completable.andThen(error.completable);
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Did not throw TestException");
         } catch (TestException ex) {
             normal.assertSubscriptions(1);
@@ -4714,7 +4522,7 @@ public class CompletableTest {
                 }
             }));
             
-            c.await();
+            c.blockingAwait();
         } finally {
             exec.shutdown();
         }
@@ -4732,7 +4540,7 @@ public class CompletableTest {
         }));
         
         try {
-            c.await();
+            c.blockingAwait();
             Assert.fail("Failed to throw Exception");
         } catch (RuntimeException ex) {
             if (!((ex.getCause() instanceof ExecutionException) && (ex.getCause().getCause() instanceof TestException))) {
@@ -4760,7 +4568,7 @@ public class CompletableTest {
             }
         });
         
-        c.await();
+        c.blockingAwait();
         
         Assert.assertEquals(1, calls.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -275,9 +275,16 @@ public class ObservableRefCountTest {
         System.out.println("send unsubscribe");
         // now immediately unsubscribe while subscribeOn is racing to subscribe
         s.dispose();
+        
         // this generally will mean it won't even subscribe as it is already unsubscribed by the time connect() gets scheduled
         // give time to the counter to update
         Thread.sleep(10);
+
+        // make sure we wait a bit in case the counter is still nonzero
+        int counter = 200;
+        while (subUnsubCount.get() != 0 && counter-- != 0) {
+            Thread.sleep(10);
+        }
         // either we subscribed and then unsubscribed, or we didn't ever even subscribe
         assertEquals(0, subUnsubCount.get());
 


### PR DESCRIPTION
This PR mainly adds `Scheduler:` descriptions to `Completable`, removes deprecated operators or unnecessary aliases. In addition, blocking methods now are named `blockingAwait` and `blockingGet`.
