### PR TITLE
2.x: switch to throwing Action, switchMapDelayError, other cleanup

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2061,7 +2061,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
-    public final Single<T> doOnCancel(final Runnable onCancel) {
+    public final Single<T> doOnCancel(final Action onCancel) {
         Objects.requireNonNull(onCancel, "onCancel is null");
         return new SingleDoOnCancel<T>(this, onCancel);
     }

--- a/src/main/java/io/reactivex/disposables/ActionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ActionDisposable.java
@@ -1,31 +1,34 @@
 /**
  * Copyright 2016 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
  */
+package io.reactivex.disposables;
 
-package io.reactivex.functions;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
 
-/**
- * A functional interface that takes a value and returns another value, possibly with a
- * different type and allows throwing a checked exception.
- *
- * @param <T> the input value type
- * @param <R> the output value type
- */
-public interface Function<T, R> {
-    /**
-     * Apply some calculation to the input value and return some other value.
-     * @param t the input value
-     * @return the output value
-     * @throws Exception on error
-     */
-    R apply(T t) throws Exception;
+final class ActionDisposable extends ReferenceDisposable<Action> {
+    /** */
+    private static final long serialVersionUID = -8219729196779211169L;
+
+    ActionDisposable(Action value) {
+        super(value);
+    }
+
+    @Override
+    protected void onDisposed(Action value) {
+        try {
+            value.run();
+        } catch (Throwable ex) {
+            throw Exceptions.propagate(ex);
+        }
+    }
 }

--- a/src/main/java/io/reactivex/disposables/Disposables.java
+++ b/src/main/java/io/reactivex/disposables/Disposables.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Future;
 
 import org.reactivestreams.Subscription;
 
+import io.reactivex.functions.Action;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.Functions;
 
@@ -32,6 +33,10 @@ public final class Disposables {
     
     public static Disposable from(Runnable run) {
         return new RunnableDisposable(run);
+    }
+
+    public static Disposable from(Action run) {
+        return new ActionDisposable(run);
     }
 
     public static Disposable from(Future<?> future) {

--- a/src/main/java/io/reactivex/flowables/BlockingFlowable.java
+++ b/src/main/java/io/reactivex/flowables/BlockingFlowable.java
@@ -23,7 +23,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Optional;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.subscribers.flowable.*;
@@ -276,7 +276,7 @@ public final class BlockingFlowable<T> implements Publisher<T>, Iterable<T> {
                 error[0] = e;
                 cdl.countDown();
             }
-        }, new Runnable() {
+        }, new Action() {
             @Override
             public void run() {
                 cdl.countDown();

--- a/src/main/java/io/reactivex/functions/Action.java
+++ b/src/main/java/io/reactivex/functions/Action.java
@@ -14,18 +14,12 @@
 package io.reactivex.functions;
 
 /**
- * A functional interface that takes a value and returns another value, possibly with a
- * different type and allows throwing a checked exception.
- *
- * @param <T> the input value type
- * @param <R> the output value type
+ * A functional interface similar to Runnable but allows throwing a checked exception.
  */
-public interface Function<T, R> {
+public interface Action {
     /**
-     * Apply some calculation to the input value and return some other value.
-     * @param t the input value
-     * @return the output value
-     * @throws Exception on error
+     * Runs the action and optionally throws a checked exception
+     * @throws Exception if the implementation wishes to throw a checked exception
      */
-    R apply(T t) throws Exception;
+    void run() throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Cancellable.java
+++ b/src/main/java/io/reactivex/functions/Cancellable.java
@@ -14,18 +14,14 @@
 package io.reactivex.functions;
 
 /**
- * A functional interface that takes a value and returns another value, possibly with a
- * different type and allows throwing a checked exception.
- *
- * @param <T> the input value type
- * @param <R> the output value type
+ * A functional interface that has a single cancel method
+ * that can throw.
  */
-public interface Function<T, R> {
+public interface Cancellable {
+    
     /**
-     * Apply some calculation to the input value and return some other value.
-     * @param t the input value
-     * @return the output value
+     * Cancel the action or free a resource.
      * @throws Exception on error
      */
-    R apply(T t) throws Exception;
+    void cancel() throws Exception;
 }

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -162,6 +162,11 @@ public enum Functions {
         public void run() { }
     };
 
+    public static final Action EMPTY_ACTION = new Action() {
+        @Override
+        public void run() { }
+    };
+
     static final Consumer<Object> EMPTY_CONSUMER = new Consumer<Object>() {
         @Override
         public void accept(Object v) { }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
@@ -15,12 +15,13 @@ package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.functions.Action;
 
-public final class CompletableFromRunnable extends Completable {
+public final class CompletableFromAction extends Completable {
 
-    final Runnable run;
+    final Action run;
 
-    public CompletableFromRunnable(Runnable run) {
+    public CompletableFromAction(Action run) {
         this.run = run;
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.completable;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -25,17 +25,17 @@ public final class CompletablePeek extends Completable {
     final CompletableSource source;
     final Consumer<? super Disposable> onSubscribe; 
     final Consumer<? super Throwable> onError;
-    final Runnable onComplete;
-    final Runnable onTerminate;
-    final Runnable onAfterTerminate;
-    final Runnable onDisposed;
+    final Action onComplete;
+    final Action onTerminate;
+    final Action onAfterTerminate;
+    final Action onDisposed;
     
     public CompletablePeek(CompletableSource source, Consumer<? super Disposable> onSubscribe,
                            Consumer<? super Throwable> onError,
-                           Runnable onComplete,
-                           Runnable onTerminate,
-                           Runnable onAfterTerminate,
-                           Runnable onDisposed) {
+                           Action onComplete,
+                           Action onTerminate,
+                           Action onAfterTerminate,
+                           Action onDisposed) {
         this.source = source;
         this.onSubscribe = onSubscribe;
         this.onError = onError;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.flowable.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -24,13 +24,13 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T> {
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;
-    final Runnable onComplete;
-    final Runnable onAfterTerminate;
+    final Action onComplete;
+    final Action onAfterTerminate;
     
     public FlowableDoOnEach(Publisher<T> source, Consumer<? super T> onNext, 
             Consumer<? super Throwable> onError, 
-            Runnable onComplete,
-            Runnable onAfterTerminate) {
+            Action onComplete,
+            Action onAfterTerminate) {
         super(source);
         this.onNext = onNext;
         this.onError = onError;
@@ -52,15 +52,15 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
     static final class DoOnEachSubscriber<T> extends BasicFuseableSubscriber<T, T> {
         final Consumer<? super T> onNext;
         final Consumer<? super Throwable> onError;
-        final Runnable onComplete;
-        final Runnable onAfterTerminate;
+        final Action onComplete;
+        final Action onAfterTerminate;
         
         public DoOnEachSubscriber(
                 Subscriber<? super T> actual,
                 Consumer<? super T> onNext, 
                 Consumer<? super Throwable> onError, 
-                Runnable onComplete,
-                Runnable onAfterTerminate) {
+                Action onComplete,
+                Action onAfterTerminate) {
             super(actual);
             this.onNext = onNext;
             this.onError = onError;
@@ -166,15 +166,15 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
     static final class DoOnEachConditionalSubscriber<T> extends BasicFuseableConditionalSubscriber<T, T> {
         final Consumer<? super T> onNext;
         final Consumer<? super Throwable> onError;
-        final Runnable onComplete;
-        final Runnable onAfterTerminate;
+        final Action onComplete;
+        final Action onAfterTerminate;
         
         public DoOnEachConditionalSubscriber(
                 ConditionalSubscriber<? super T> actual,
                 Consumer<? super T> onNext, 
                 Consumer<? super Throwable> onError, 
-                Runnable onComplete,
-                Runnable onAfterTerminate) {
+                Action onComplete,
+                Action onAfterTerminate) {
             super(actual);
             this.onNext = onNext;
             this.onError = onError;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -13,8 +13,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.LongConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscribers.flowable.SubscriptionLambdaSubscriber;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -22,10 +21,10 @@ import org.reactivestreams.Subscription;
 public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream<T, T> {
     private final Consumer<? super Subscription> onSubscribe;
     private final LongConsumer onRequest;
-    private final Runnable onCancel;
+    private final Action onCancel;
 
     public FlowableDoOnLifecycle(Flowable<T> source, Consumer<? super Subscription> onSubscribe,
-            LongConsumer onRequest, Runnable onCancel) {
+            LongConsumer onRequest, Action onCancel) {
         super(source);
         this.onSubscribe = onSubscribe;
         this.onRequest = onRequest;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
+import io.reactivex.functions.Action;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -27,9 +28,10 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
     final int bufferSize;
     final boolean unbounded;
     final boolean delayError;
-    final Runnable onOverflow;
+    final Action onOverflow;
     
-    public FlowableOnBackpressureBuffer(Publisher<T> source, int bufferSize, boolean unbounded, boolean delayError, Runnable onOverflow) {
+    public FlowableOnBackpressureBuffer(Publisher<T> source, int bufferSize, boolean unbounded, 
+            boolean delayError, Action onOverflow) {
         super(source);
         this.bufferSize = bufferSize;
         this.unbounded = unbounded;
@@ -48,7 +50,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
         final Subscriber<? super T> actual;
         final SimpleQueue<T> queue;
         final boolean delayError;
-        final Runnable onOverflow;
+        final Action onOverflow;
         
         Subscription s;
         
@@ -60,7 +62,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
         final AtomicLong requested = new AtomicLong();
         
         public BackpressureBufferSubscriber(Subscriber<? super T> actual, int bufferSize, 
-                boolean unbounded, boolean delayError, Runnable onOverflow) {
+                boolean unbounded, boolean delayError, Action onOverflow) {
             this.actual = actual;
             this.onOverflow = onOverflow;
             this.delayError = delayError;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
@@ -16,20 +16,20 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<T, T> {
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;
-    final Runnable onComplete;
-    final Runnable onAfterTerminate;
+    final Action onComplete;
+    final Action onAfterTerminate;
     
     public ObservableDoOnEach(ObservableSource<T> source, Consumer<? super T> onNext,
                               Consumer<? super Throwable> onError,
-                              Runnable onComplete,
-                              Runnable onAfterTerminate) {
+                              Action onComplete,
+                              Action onAfterTerminate) {
         super(source);
         this.onNext = onNext;
         this.onError = onError;
@@ -46,8 +46,8 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
         final Observer<? super T> actual;
         final Consumer<? super T> onNext;
         final Consumer<? super Throwable> onError;
-        final Runnable onComplete;
-        final Runnable onAfterTerminate;
+        final Action onComplete;
+        final Action onAfterTerminate;
         
         Disposable s;
         
@@ -57,8 +57,8 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
                 Observer<? super T> actual,
                 Consumer<? super T> onNext, 
                 Consumer<? super Throwable> onError, 
-                Runnable onComplete,
-                Runnable onAfterTerminate) {
+                Action onComplete,
+                Action onAfterTerminate) {
             this.actual = actual;
             this.onNext = onNext;
             this.onError = onError;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnLifecycle.java
@@ -12,18 +12,17 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.Observable;
-import io.reactivex.Observer;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscribers.observable.SubscriptionLambdaObserver;
 
 public final class ObservableDoOnLifecycle<T> extends AbstractObservableWithUpstream<T, T> {
     private final Consumer<? super Disposable> onSubscribe;
-    private final Runnable onCancel;
+    private final Action onCancel;
 
     public ObservableDoOnLifecycle(Observable<T> upstream, Consumer<? super Disposable> onSubscribe,
-            Runnable onCancel) {
+            Action onCancel) {
         super(upstream);
         this.onSubscribe = onSubscribe;
         this.onCancel = onCancel;

--- a/src/main/java/io/reactivex/internal/subscribers/completable/CallbackCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/completable/CallbackCompletableObserver.java
@@ -18,34 +18,32 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CallbackCompletableObserver
-extends AtomicReference<Disposable> implements CompletableObserver, Disposable {
+extends AtomicReference<Disposable> implements CompletableObserver, Disposable, Consumer<Throwable> {
 
     /** */
     private static final long serialVersionUID = -4361286194466301354L;
 
     final Consumer<? super Throwable> onError;
-    final Runnable onComplete;
+    final Action onComplete;
     
-    static final Consumer<? super Throwable> DEFAULT_ON_ERROR = new Consumer<Throwable>() {
-        @Override
-        public void accept(Throwable e) {
-            RxJavaPlugins.onError(e);
-        }
-    };
-
-    public CallbackCompletableObserver(Runnable onComplete) {
-        this.onError = DEFAULT_ON_ERROR;
+    public CallbackCompletableObserver(Action onComplete) {
+        this.onError = this;
         this.onComplete = onComplete;
     }
 
-    public CallbackCompletableObserver(Consumer<? super Throwable> onError, Runnable onComplete) {
+    public CallbackCompletableObserver(Consumer<? super Throwable> onError, Action onComplete) {
         this.onError = onError;
         this.onComplete = onComplete;
+    }
+
+    @Override
+    public void accept(Throwable e) {
+        RxJavaPlugins.onError(e);
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/LambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/LambdaSubscriber.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -28,11 +28,11 @@ public final class LambdaSubscriber<T> extends AtomicReference<Subscription> imp
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;
-    final Runnable onComplete;
+    final Action onComplete;
     final Consumer<? super Subscription> onSubscribe;
     
     public LambdaSubscriber(Consumer<? super T> onNext, Consumer<? super Throwable> onError, 
-            Runnable onComplete,
+            Action onComplete,
             Consumer<? super Subscription> onSubscribe) {
         super();
         this.onNext = onNext;

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriptionLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriptionLambdaSubscriber.java
@@ -23,14 +23,14 @@ public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Sub
     final Subscriber<? super T> actual;
     final Consumer<? super Subscription> onSubscribe;
     final LongConsumer onRequest;
-    final Runnable onCancel;
+    final Action onCancel;
     
     Subscription s;
     
     public SubscriptionLambdaSubscriber(Subscriber<? super T> actual, 
             Consumer<? super Subscription> onSubscribe,
             LongConsumer onRequest,
-            Runnable onCancel) {
+            Action onCancel) {
         this.actual = actual;
         this.onSubscribe = onSubscribe;
         this.onCancel = onCancel;

--- a/src/main/java/io/reactivex/internal/subscribers/observable/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/LambdaObserver.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -27,11 +27,11 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;
-    final Runnable onComplete;
+    final Action onComplete;
     final Consumer<? super Disposable> onSubscribe;
     
     public LambdaObserver(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-            Runnable onComplete,
+            Action onComplete,
             Consumer<? super Disposable> onSubscribe) {
         super();
         this.onNext = onNext;

--- a/src/main/java/io/reactivex/internal/subscribers/observable/SubscriptionLambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/SubscriptionLambdaObserver.java
@@ -15,20 +15,20 @@ package io.reactivex.internal.subscribers.observable;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SubscriptionLambdaObserver<T> implements Observer<T>, Disposable {
     final Observer<? super T> actual;
     final Consumer<? super Disposable> onSubscribe;
-    final Runnable onCancel;
+    final Action onCancel;
     
     Disposable s;
     
     public SubscriptionLambdaObserver(Observer<? super T> actual, 
             Consumer<? super Disposable> onSubscribe,
-            Runnable onCancel) {
+            Action onCancel) {
         this.actual = actual;
         this.onSubscribe = onSubscribe;
         this.onCancel = onCancel;

--- a/src/main/java/io/reactivex/internal/util/AtomicThrowable.java
+++ b/src/main/java/io/reactivex/internal/util/AtomicThrowable.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Atomic container for Throwables including combining and having a 
+ * terminal state via ExceptionHelper.
+ * <p>
+ * Watch out for the leaked AtomicReference methods!
+ */
+public final class AtomicThrowable extends AtomicReference<Throwable> {
+
+    /** */
+    private static final long serialVersionUID = 3949248817947090603L;
+
+    /**
+     * Atomically adds a Throwable to this container (combining with a previous Throwable is necessary).
+     * @param t the throwable to add
+     * @return true if successful, false if the container has been terminated
+     */
+    public boolean addThrowable(Throwable t) {
+        return ExceptionHelper.addThrowable(this, t);
+    }
+    
+    /**
+     * Atomically terminate the container and return the contents of the last
+     * non-terminal Throwable of it.
+     * @return the last Throwable
+     */
+    public Throwable terminate() {
+        return ExceptionHelper.terminate(this);
+    }
+    
+    public boolean isTerminated() {
+        return get() == ExceptionHelper.TERMINATED;
+    }
+}

--- a/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.util;
 
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.exceptions.CompositeException;
@@ -55,5 +56,31 @@ public enum ExceptionHelper {
             current = field.getAndSet(TERMINATED);
         }
         return current;
+    }
+    
+    /**
+     * Returns a flattened list of Throwables from tree-like CompositeException chain
+     * @param t the starting throwable
+     * @return the list of Throwables flattened in a depth-first manner
+     */
+    public static List<Throwable> flatten(Throwable t) {
+        List<Throwable> list = new ArrayList<Throwable>();
+        ArrayDeque<Throwable> deque = new ArrayDeque<Throwable>();
+        deque.offer(t);
+        
+        while (!deque.isEmpty()) {
+            Throwable e = deque.removeFirst();
+            if (e instanceof CompositeException) {
+                CompositeException ce = (CompositeException) e;
+                List<Throwable> exceptions = ce.getExceptions();
+                for (int i = exceptions.size() - 1; i >= 0; i--) {
+                    deque.offerFirst(exceptions.get(i));
+                }
+            } else {
+                list.add(e);
+            }
+        }
+        
+        return list;
     }
 }

--- a/src/main/java/io/reactivex/observables/BlockingObservable.java
+++ b/src/main/java/io/reactivex/observables/BlockingObservable.java
@@ -23,7 +23,7 @@ import io.reactivex.Observer;
 import io.reactivex.Optional;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.subscribers.flowable.BlockingSubscriber;
@@ -75,7 +75,7 @@ public final class BlockingObservable<T> implements Iterable<T> {
                     queue.offer(NotificationLite.error(e));
                 }
             },
-            new Runnable() {
+            new Action() {
                 @Override
                 public void run() {
                     queue.offer(NotificationLite.complete());
@@ -354,7 +354,7 @@ public final class BlockingObservable<T> implements Iterable<T> {
                     error[0] = e;
                     cdl.countDown();
                 }
-            }, new Runnable() {
+            }, new Action() {
                 @Override
                 public void run() {
                     cdl.countDown();

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -612,15 +612,15 @@ public class CompletableTest {
     }
     
     @Test(expected = NullPointerException.class)
-    public void fromRunnableNull() {
-        Completable.fromRunnable(null);
+    public void fromActionNull() {
+        Completable.fromAction(null);
     }
     
     @Test(timeout = 1000)
-    public void fromRunnableNormal() {
+    public void fromActionNormal() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = Completable.fromRunnable(new Runnable() {
+        Completable c = Completable.fromAction(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -633,8 +633,8 @@ public class CompletableTest {
     }
     
     @Test(timeout = 1000, expected = TestException.class)
-    public void fromRunnableThrows() {
-        Completable c = Completable.fromRunnable(new Runnable() {
+    public void fromActionThrows() {
+        Completable c = Completable.fromAction(new Action() {
             @Override
             public void run() { throw new TestException(); }
         });
@@ -1674,7 +1674,7 @@ public class CompletableTest {
     public void doOnCompleteNormal() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = normal.completable.doOnComplete(new Runnable() {
+        Completable c = normal.completable.doOnComplete(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -1690,7 +1690,7 @@ public class CompletableTest {
     public void doOnCompleteError() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = error.completable.doOnComplete(new Runnable() {
+        Completable c = error.completable.doOnComplete(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -1714,7 +1714,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void doOnCompleteThrows() {
-        Completable c = normal.completable.doOnComplete(new Runnable() {
+        Completable c = normal.completable.doOnComplete(new Action() {
             @Override
             public void run() { throw new TestException(); }
         });
@@ -1726,7 +1726,7 @@ public class CompletableTest {
     public void doOnDisposeNormalDoesntCall() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = normal.completable.doOnDispose(new Runnable() {
+        Completable c = normal.completable.doOnDispose(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -1742,7 +1742,7 @@ public class CompletableTest {
     public void doOnDisposeErrorDoesntCall() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = error.completable.doOnDispose(new Runnable() {
+        Completable c = error.completable.doOnDispose(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -1762,7 +1762,7 @@ public class CompletableTest {
     public void doOnDisposeChildCancels() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = normal.completable.doOnDispose(new Runnable() {
+        Completable c = normal.completable.doOnDispose(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -1796,7 +1796,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000)
     public void doOnDisposeThrows() {
-        Completable c = normal.completable.doOnDispose(new Runnable() {
+        Completable c = normal.completable.doOnDispose(new Action() {
             @Override
             public void run() { throw new TestException(); }
         });
@@ -1915,7 +1915,7 @@ public class CompletableTest {
     public void doOnTerminateNormal() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = normal.completable.doOnTerminate(new Runnable() {
+        Completable c = normal.completable.doOnTerminate(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -1931,7 +1931,7 @@ public class CompletableTest {
     public void doOnTerminateError() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = error.completable.doOnTerminate(new Runnable() {
+        Completable c = error.completable.doOnTerminate(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -2346,7 +2346,7 @@ public class CompletableTest {
     @Test(timeout = 1000)
     public void retry5Times() {
         final AtomicInteger calls = new AtomicInteger(5);
-        Completable c = Completable.fromRunnable(new Runnable() {
+        Completable c = Completable.fromAction(new Action() {
             @Override
             public void run() {
                 if (calls.decrementAndGet() != 0) {
@@ -2381,7 +2381,7 @@ public class CompletableTest {
     public void retryTimes5Normal() {
         final AtomicInteger calls = new AtomicInteger(5);
 
-        Completable c = Completable.fromRunnable(new Runnable() {
+        Completable c = Completable.fromAction(new Action() {
             @Override
             public void run() {
                 if (calls.decrementAndGet() != 0) {
@@ -2419,7 +2419,7 @@ public class CompletableTest {
     public void retryPredicate5Times() {
         final AtomicInteger calls = new AtomicInteger(5);
 
-        Completable c = Completable.fromRunnable(new Runnable() {
+        Completable c = Completable.fromAction(new Action() {
             @Override
             public void run() {
                 if (calls.decrementAndGet() != 0) {
@@ -2440,7 +2440,7 @@ public class CompletableTest {
     public void retryWhen5Times() {
         final AtomicInteger calls = new AtomicInteger(5);
 
-        Completable c = Completable.fromRunnable(new Runnable() {
+        Completable c = Completable.fromAction(new Action() {
             @Override
             public void run() {
                 if (calls.decrementAndGet() != 0) {
@@ -2464,7 +2464,7 @@ public class CompletableTest {
         
         Completable c = normal.completable
                 .delay(100, TimeUnit.MILLISECONDS)
-                .doOnComplete(new Runnable() {
+                .doOnComplete(new Action() {
                     @Override
                     public void run() {
                         complete.set(true);
@@ -2484,7 +2484,7 @@ public class CompletableTest {
         
         Completable c = normal.completable
                 .delay(200, TimeUnit.MILLISECONDS)
-                .doOnComplete(new Runnable() {
+                .doOnComplete(new Action() {
                     @Override
                     public void run() {
                         complete.set(true);
@@ -2506,7 +2506,7 @@ public class CompletableTest {
     public void subscribeTwoCallbacksNormal() {
         final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
         final AtomicBoolean complete = new AtomicBoolean();
-        normal.completable.subscribe(new Runnable() {
+        normal.completable.subscribe(new Action() {
             @Override
             public void run() {
                 complete.set(true);
@@ -2526,7 +2526,7 @@ public class CompletableTest {
     public void subscribeTwoCallbacksError() {
         final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
         final AtomicBoolean complete = new AtomicBoolean();
-        error.completable.subscribe(new Runnable() {
+        error.completable.subscribe(new Action() {
             @Override
             public void run() {
                 complete.set(true);
@@ -2544,7 +2544,7 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void subscribeTwoCallbacksFirstNull() {
-        normal.completable.subscribe(new Runnable() {
+        normal.completable.subscribe(new Action() {
             @Override
             public void run() { }
         }, null);
@@ -2552,7 +2552,7 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void subscribeTwoCallbacksSecondNull() {
-        normal.completable.subscribe(new Runnable() {
+        normal.completable.subscribe(new Action() {
             @Override
             public void run() { }
         }, null);
@@ -2561,7 +2561,7 @@ public class CompletableTest {
     @Test(timeout = 1000)
     public void subscribeTwoCallbacksCompleteThrows() {
         final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
-        normal.completable.subscribe(new Runnable() {
+        normal.completable.subscribe(new Action() {
             @Override
             public void run() { throw new TestException(); }
         }, new Consumer<Throwable>() {
@@ -2576,7 +2576,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000)
     public void subscribeTwoCallbacksOnErrorThrows() {
-        error.completable.subscribe(new Runnable() {
+        error.completable.subscribe(new Action() {
             @Override
             public void run() { }
         }, new Consumer<Throwable>() {
@@ -2608,10 +2608,10 @@ public class CompletableTest {
     }
     
     @Test(timeout = 1000)
-    public void subscribeRunnableNormal() {
+    public void subscribeActionNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         
-        normal.completable.subscribe(new Runnable() {
+        normal.completable.subscribe(new Action() {
             @Override
             public void run() {
                 run.set(true);
@@ -2622,10 +2622,10 @@ public class CompletableTest {
     }
 
     @Test(timeout = 1000)
-    public void subscribeRunnableError() {
+    public void subscribeActionError() {
         final AtomicBoolean run = new AtomicBoolean();
         
-        error.completable.subscribe(new Runnable() {
+        error.completable.subscribe(new Action() {
             @Override
             public void run() {
                 run.set(true);
@@ -2636,8 +2636,8 @@ public class CompletableTest {
     }
     
     @Test(expected = NullPointerException.class)
-    public void subscribeRunnableNull() {
-        normal.completable.subscribe((Runnable)null);
+    public void subscribeActionNull() {
+        normal.completable.subscribe((Action)null);
     }
     
     @Test(expected = NullPointerException.class)
@@ -2875,7 +2875,7 @@ public class CompletableTest {
         final CountDownLatch cdl = new CountDownLatch(1);
         
         normal.completable.delay(1, TimeUnit.SECONDS)
-        .doOnDispose(new Runnable() {
+        .doOnDispose(new Action() {
             @Override
             public void run() {
                 name.set(Thread.currentThread().getName());
@@ -2949,7 +2949,7 @@ public class CompletableTest {
         
         final AtomicBoolean complete = new AtomicBoolean();
         
-        c.subscribe(new Runnable() {
+        c.subscribe(new Action() {
             @Override
             public void run() {
                 complete.set(true);
@@ -2980,7 +2980,7 @@ public class CompletableTest {
         
         final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
 
-        c.subscribe(Functions.EMPTY_RUNNABLE, new Consumer<Throwable>() {
+        c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
             public void accept(Throwable v) {
                 complete.set(v);
@@ -3011,7 +3011,7 @@ public class CompletableTest {
         
         final AtomicBoolean complete = new AtomicBoolean();
         
-        c.subscribe(new Runnable() {
+        c.subscribe(new Action() {
             @Override
             public void run() {
                 complete.set(true);
@@ -3042,7 +3042,7 @@ public class CompletableTest {
         
         final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
 
-        c.subscribe(Functions.EMPTY_RUNNABLE, new Consumer<Throwable>() {
+        c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
             public void accept(Throwable v) {
                 complete.set(v);
@@ -3174,7 +3174,7 @@ public class CompletableTest {
         
         final AtomicBoolean complete = new AtomicBoolean();
         
-        c.subscribe(new Runnable() {
+        c.subscribe(new Action() {
             @Override
             public void run() {
                 complete.set(true);
@@ -3205,7 +3205,7 @@ public class CompletableTest {
         
         final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
 
-        c.subscribe(Functions.EMPTY_RUNNABLE, new Consumer<Throwable>() {
+        c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
             public void accept(Throwable v) {
                 complete.set(v);
@@ -3236,7 +3236,7 @@ public class CompletableTest {
         
         final AtomicBoolean complete = new AtomicBoolean();
         
-        c.subscribe(new Runnable() {
+        c.subscribe(new Action() {
             @Override
             public void run() {
                 complete.set(true);
@@ -3267,7 +3267,7 @@ public class CompletableTest {
         
         final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
 
-        c.subscribe(Functions.EMPTY_RUNNABLE, new Consumer<Throwable>() {
+        c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
             public void accept(Throwable v) {
                 complete.set(v);
@@ -3427,7 +3427,7 @@ public class CompletableTest {
         to.assertNoErrors();
     }
     
-    private static void expectUncaughtTestException(Runnable action) {
+    private static void expectUncaughtTestException(Action action) {
         Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();
         CapturingUncaughtExceptionHandler handler = new CapturingUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(handler);
@@ -3442,6 +3442,8 @@ public class CompletableTest {
             }
             assertTrue("A TestException should have been delivered to the handler",
                     caught instanceof TestException);
+        } catch (Throwable ex) {
+            throw Exceptions.propagate(ex);
         } finally {
             Thread.setDefaultUncaughtExceptionHandler(originalHandler);
         }
@@ -3449,10 +3451,10 @@ public class CompletableTest {
     
     @Test
     public void subscribeOneActionThrowFromOnCompleted() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override
             public void run() {
-                normal.completable.subscribe(new Runnable() {
+                normal.completable.subscribe(new Action() {
                     @Override
                     public void run() {
                         throw new TestException();
@@ -3464,11 +3466,11 @@ public class CompletableTest {
     
     @Test
     public void subscribeTwoActionsThrowFromOnError() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override
             public void run() {
                 error.completable.subscribe(
-                new Runnable() {
+                new Action() {
                     @Override
                     public void run() {
                     }
@@ -3485,7 +3487,7 @@ public class CompletableTest {
     
     @Test
     public void propagateExceptionSubscribeOneAction() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override
             public void run() {
                 error.completable.toSingleDefault(1).subscribe(new Consumer<Integer>() {
@@ -3552,7 +3554,7 @@ public class CompletableTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.toCompletable();
         
-        Disposable completableSubscription = completable.subscribe(new Runnable() {
+        Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
                 
@@ -3570,7 +3572,7 @@ public class CompletableTest {
         Completable completable = stringSubject.toCompletable();
         
         final AtomicReference<Disposable> subscriptionRef = new AtomicReference<Disposable>();
-        Disposable completableSubscription = completable.subscribe(new Runnable() {
+        Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
                 if (subscriptionRef.get().isDisposed()) {
@@ -3591,7 +3593,7 @@ public class CompletableTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.toCompletable();
         
-        Disposable completableSubscription = completable.subscribe(new Runnable() {
+        Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
             }
@@ -3607,7 +3609,7 @@ public class CompletableTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.toCompletable();
         
-        Disposable completableSubscription = completable.subscribe(new Runnable() {
+        Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
                 
@@ -3629,7 +3631,7 @@ public class CompletableTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.toCompletable();
         
-        Disposable completableSubscription = completable.subscribe(new Runnable() {
+        Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() { }
         }, new Consumer<Throwable>() {
@@ -3732,16 +3734,6 @@ public class CompletableTest {
         c.blockingAwait();
     }
 
-    @Test(timeout = 5000, expected = TestException.class)
-    public void fromActionThrows() {
-        Completable c = Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() { throw new TestException(); }
-        });
-        
-        c.blockingAwait();
-    }
-
     private Function<Completable, Completable> onCreate;
     
     private BiFunction<Completable, CompletableObserver, CompletableObserver> onStart;
@@ -3784,7 +3776,7 @@ public class CompletableTest {
     public void doOnCompletedNormal() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = normal.completable.doOnComplete(new Runnable() {
+        Completable c = normal.completable.doOnComplete(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -3800,7 +3792,7 @@ public class CompletableTest {
     public void doOnCompletedError() {
         final AtomicInteger calls = new AtomicInteger();
         
-        Completable c = error.completable.doOnComplete(new Runnable() {
+        Completable c = error.completable.doOnComplete(new Action() {
             @Override
             public void run() {
                 calls.getAndIncrement();
@@ -3824,7 +3816,7 @@ public class CompletableTest {
     
     @Test(timeout = 5000, expected = TestException.class)
     public void doOnCompletedThrows() {
-        Completable c = normal.completable.doOnComplete(new Runnable() {
+        Completable c = normal.completable.doOnComplete(new Action() {
             @Override
             public void run() { throw new TestException(); }
         });
@@ -3837,7 +3829,7 @@ public class CompletableTest {
         final AtomicBoolean doneAfter = new AtomicBoolean();
         final AtomicBoolean complete = new AtomicBoolean();
         
-        Completable c = normal.completable.doAfterTerminate(new Runnable() {
+        Completable c = normal.completable.doAfterTerminate(new Action() {
             @Override
             public void run() {
                 doneAfter.set(complete.get());
@@ -3871,7 +3863,7 @@ public class CompletableTest {
     public void doAfterTerminateWithError() {
         final AtomicBoolean doneAfter = new AtomicBoolean();
         
-        Completable c = error.completable.doAfterTerminate(new Runnable() {
+        Completable c = error.completable.doAfterTerminate(new Action() {
             @Override
             public void run() {
                 doneAfter.set(true);
@@ -3893,42 +3885,9 @@ public class CompletableTest {
         normal.completable.doAfterTerminate(null);
     }
     
-    @Test(timeout = 5000)
-    public void subscribeActionNormal() {
-        final AtomicBoolean run = new AtomicBoolean();
-        
-        normal.completable.subscribe(new Runnable() {
-            @Override
-            public void run() {
-                run.set(true);
-            }
-        });
-        
-        Assert.assertTrue("Not completed", run.get());
-    }
-
-    @Test(timeout = 5000)
-    public void subscribeActionError() {
-        final AtomicBoolean run = new AtomicBoolean();
-        
-        error.completable.subscribe(new Runnable() {
-            @Override
-            public void run() {
-                run.set(true);
-            }
-        });
-        
-        Assert.assertFalse("Completed", run.get());
-    }
-    
-    @Test(expected = NullPointerException.class)
-    public void subscribeActionNull() {
-        normal.completable.subscribe((Runnable)null);
-    }
-    
     @Test
     public void subscribeEmptyOnError() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override public void run() {
                 error.completable.subscribe();
             }
@@ -3937,10 +3896,10 @@ public class CompletableTest {
 
     @Test
     public void subscribeOneActionOnError() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override
             public void run() {
-                error.completable.subscribe(new Runnable() {
+                error.completable.subscribe(new Action() {
                     @Override
                     public void run() {
                     }
@@ -3951,7 +3910,7 @@ public class CompletableTest {
     
     @Test
     public void propagateExceptionSubscribeEmpty() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override
             public void run() {
                 error.completable.toSingleDefault(0).subscribe();
@@ -4332,7 +4291,7 @@ public class CompletableTest {
         Completable completable = stringSubject.toCompletable();
         
         final AtomicReference<Disposable> subscriptionRef = new AtomicReference<Disposable>();
-        Disposable completableSubscription = completable.subscribe(new Runnable() {
+        Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
                 if (subscriptionRef.get().isDisposed()) {
@@ -4354,7 +4313,7 @@ public class CompletableTest {
         Completable completable = stringSubject.toCompletable();
         
         final AtomicReference<Disposable> subscriptionRef = new AtomicReference<Disposable>();
-        Disposable completableSubscription = completable.subscribe(Functions.EMPTY_RUNNABLE,
+        Disposable completableSubscription = completable.subscribe(Functions.EMPTY_ACTION,
         new Consumer<Throwable>() {
             @Override
             public void accept(Throwable e) {
@@ -4447,7 +4406,7 @@ public class CompletableTest {
     
     @Test
     public void propagateExceptionSubscribeOneActionThrowFromOnSuccess() {
-        expectUncaughtTestException(new Runnable() {
+        expectUncaughtTestException(new Action() {
             @Override
             public void run() {
                 normal.completable.toSingleDefault(1).subscribe(new Consumer<Integer>() {
@@ -4550,26 +4509,5 @@ public class CompletableTest {
         } finally {
             exec.shutdown();
         }
-    }
-    
-    @Test(expected = NullPointerException.class)
-    public void fromActionNull() {
-        Completable.fromRunnable(null);
-    }
-    
-    @Test(timeout = 5000)
-    public void fromActionNormal() {
-        final AtomicInteger calls = new AtomicInteger();
-        
-        Completable c = Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        });
-        
-        c.blockingAwait();
-        
-        Assert.assertEquals(1, calls.get());
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableDoOnTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableDoOnTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 
 public class FlowableDoOnTest {
 
@@ -62,7 +62,7 @@ public class FlowableDoOnTest {
     @Test
     public void testDoOnCompleted() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Flowable.just("one").doOnComplete(new Runnable() {
+        String output = Flowable.just("one").doOnComplete(new Action() {
             @Override
             public void run() {
                 r.set(true);

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1200,7 +1200,7 @@ public class FlowableNullTests {
         just1.doOnLifecycle(null, new LongConsumer() {
             @Override
             public void accept(long v) { }
-        }, new Runnable() {
+        }, new Action() {
             @Override
             public void run() { }
         });
@@ -1211,7 +1211,7 @@ public class FlowableNullTests {
         just1.doOnLifecycle(new Consumer<Subscription>() {
             @Override
             public void accept(Subscription s) { }
-        }, null, new Runnable() {
+        }, null, new Action() {
             @Override
             public void run() { }
         });
@@ -2132,7 +2132,7 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void subscribeOnSubscribeNull() {
-        just1.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_RUNNABLE, null);
+        just1.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION, null);
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -131,8 +131,8 @@ public class FlowableCacheTest {
     }
 
     @Test
-    public void testUnsubscribeSource() {
-        Runnable unsubscribe = mock(Runnable.class);
+    public void testUnsubscribeSource() throws Exception {
+        Action unsubscribe = mock(Action.class);
         Flowable<Integer> o = Flowable.just(1).doOnCancel(unsubscribe).cache();
         o.subscribe();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterTerminateTest.java
@@ -23,22 +23,28 @@ import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableDoAfterTerminateTest {
 
-    private Runnable aAction0;
+    private Action aAction0;
     private Subscriber<String> observer;
 
     @Before
     public void before() {
-        aAction0 = Mockito.mock(Runnable.class);
+        aAction0 = Mockito.mock(Action.class);
         observer = TestHelper.mockSubscriber();
     }
 
     private void checkActionCalled(Flowable<String> input) {
         input.doAfterTerminate(aAction0).subscribe(observer);
-        verify(aAction0, times(1)).run();
+        try {
+            verify(aAction0, times(1)).run();
+        } catch (Throwable ex) {
+            throw Exceptions.propagate(ex);
+        }
     }
 
     @Test
@@ -75,8 +81,8 @@ public class FlowableDoAfterTerminateTest {
     }
 
     @Test
-    public void ifFinallyActionThrowsExceptionShouldNotBeSwallowedAndActionShouldBeCalledOnce() {
-        Runnable finallyAction = Mockito.mock(Runnable.class);
+    public void ifFinallyActionThrowsExceptionShouldNotBeSwallowedAndActionShouldBeCalledOnce() throws Exception {
+        Action finallyAction = Mockito.mock(Action.class);
         doThrow(new IllegalStateException()).when(finallyAction).run();
 
         TestSubscriber<String> testSubscriber = new TestSubscriber<String>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnRequestTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.*;
 
 import io.reactivex.Flowable;
-import io.reactivex.functions.LongConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.subscribers.DefaultSubscriber;
 
 public class FlowableDoOnRequestTest {
@@ -31,7 +31,7 @@ public class FlowableDoOnRequestTest {
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
         Flowable.just(1)
         //
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         unsubscribed.set(true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableDoOnUnsubscribeTest {
@@ -41,7 +41,7 @@ public class FlowableDoOnUnsubscribeTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
@@ -57,7 +57,7 @@ public class FlowableDoOnUnsubscribeTest {
                             onNextLatch.countDown();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that lower stream will be notified for a direct un-subscription
@@ -103,7 +103,7 @@ public class FlowableDoOnUnsubscribeTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
@@ -118,7 +118,7 @@ public class FlowableDoOnUnsubscribeTest {
                             onNextLatch.countDown();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that lower stream will be notified for un-subscription

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -310,7 +310,7 @@ public class FlowableFlatMapTest {
                         Assert.fail("Too many subscriptions! " + (n + 1));
                     }
             }
-        }).doOnComplete(new Runnable() {
+        }).doOnComplete(new Action() {
             @Override
             public void run() {
                     int n = subscriptionCount.decrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -18,6 +18,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
+import io.reactivex.functions.Cancellable;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 
@@ -658,7 +659,7 @@ public class FlowableFromSourceTest {
             
             subject.subscribe(as);
             
-            t.setCancellation(new FlowableEmitter.Cancellable() {
+            t.setCancellation(new Cancellable() {
                 @Override
                 public void cancel() throws Exception {
                     as.dispose();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -635,7 +635,7 @@ public class FlowableGroupByTest {
 
                     })
                             // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Runnable() {
+                            .take(2).doOnComplete(new Action() {
 
                                 @Override
                                 public void run() {
@@ -714,7 +714,7 @@ public class FlowableGroupByTest {
 
                     })
                             // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Runnable() {
+                            .take(2).doOnComplete(new Action() {
 
                                 @Override
                                 public void run() {
@@ -806,7 +806,7 @@ public class FlowableGroupByTest {
 
                     })
                             // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Runnable() {
+                            .take(2).doOnComplete(new Action() {
 
                                 @Override
                                 public void run() {
@@ -1253,7 +1253,7 @@ public class FlowableGroupByTest {
 
             @Override
             public Flowable<String> apply(final GroupedFlowable<Boolean, Integer> g) {
-                return g.doOnComplete(new Runnable() {
+                return g.doOnComplete(new Action() {
 
                     @Override
                     public void run() {
@@ -1279,7 +1279,7 @@ public class FlowableGroupByTest {
                         }
                     }
 
-                }).doOnComplete(new Runnable() {
+                }).doOnComplete(new Action() {
 
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableIgnoreElementsTest {
@@ -80,7 +80,7 @@ public class FlowableIgnoreElementsTest {
     @Test
     public void testUnsubscribesFromUpstream() {
         final AtomicBoolean unsub = new AtomicBoolean();
-        Flowable.range(1, 10).doOnCancel(new Runnable() {
+        Flowable.range(1, 10).doOnCancel(new Action() {
             @Override
             public void run() {
                 unsub.set(true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -1241,7 +1241,7 @@ public class FlowableMergeTest {
                     // log count
                     .doOnNext(printCount())
                     // release latch
-                    .doOnComplete(new Runnable() {
+                    .doOnComplete(new Action() {
                         @Override
                         public void run() {
                                 latch.countDown();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -117,7 +117,7 @@ public class FlowableObserveOnTest {
                 assertTrue(correctThreadName);
             }
 
-        }).doAfterTerminate(new Runnable() {
+        }).doAfterTerminate(new Action() {
 
             @Override
             public void run() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -22,6 +22,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.functions.Action;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
@@ -122,7 +123,7 @@ public class FlowableOnBackpressureBufferTest {
 
         ts.request(100);
         infinite.subscribeOn(Schedulers.computation())
-             .onBackpressureBuffer(500, new Runnable() {
+             .onBackpressureBuffer(500, new Action() {
                  @Override
                  public void run() {
                      backpressureCallback.countDown();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -89,7 +89,7 @@ public class FlowablePublishTest {
     public void testBackpressureFastSlow() {
         ConnectableFlowable<Integer> is = Flowable.range(1, Flowable.bufferSize() * 2).publish();
         Flowable<Integer> fast = is.observeOn(Schedulers.computation())
-        .doOnComplete(new Runnable() {
+        .doOnComplete(new Action() {
             @Override
             public void run() {
                 System.out.println("^^^^^^^^^^^^^ completed FAST");
@@ -111,7 +111,7 @@ public class FlowablePublishTest {
                 return i;
             }
 
-        }).doOnComplete(new Runnable() {
+        }).doOnComplete(new Action() {
 
             @Override
             public void run() {
@@ -192,7 +192,7 @@ public class FlowablePublishTest {
                         sourceEmission.incrementAndGet();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         sourceUnsubscribed.set(true);
@@ -209,7 +209,7 @@ public class FlowablePublishTest {
             @Override
             public void onNext(Integer t) {
                 if (valueCount() == 2) {
-                    source.doOnCancel(new Runnable() {
+                    source.doOnCancel(new Action() {
                         @Override
                         public void run() {
                             child2Unsubscribed.set(true);
@@ -220,7 +220,7 @@ public class FlowablePublishTest {
             }
         };
         
-        source.doOnCancel(new Runnable() {
+        source.doOnCancel(new Action() {
             @Override
             public void run() {
                 child1Unsubscribed.set(true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -169,7 +169,7 @@ public class FlowableRefCountTest {
                             subscribeCount.incrementAndGet();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");
@@ -214,7 +214,7 @@ public class FlowableRefCountTest {
                             subscribeLatch.countDown();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");
@@ -252,7 +252,7 @@ public class FlowableRefCountTest {
     public void testConnectUnsubscribeRaceCondition() throws InterruptedException {
         final AtomicInteger subUnsubCount = new AtomicInteger();
         Flowable<Long> o = synchronousInterval()
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -492,7 +492,7 @@ public class FlowableReplayTest {
                     t1.printStackTrace();
                 }
             }, 
-            new Runnable() {
+            new Action() {
                 @Override
                 public void run() {
                     System.out.println("Done");
@@ -511,8 +511,8 @@ public class FlowableReplayTest {
     public void testIssue2191_UnsubscribeSource() throws Exception {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
-        Runnable sourceCompleted = mock(Runnable.class);
-        Runnable sourceUnsubscribed = mock(Runnable.class);
+        Action sourceCompleted = mock(Action.class);
+        Action sourceUnsubscribed = mock(Action.class);
         Subscriber<Integer> spiedSubscriberBeforeConnect = TestHelper.mockSubscriber();
         Subscriber<Integer> spiedSubscriberAfterConnect = TestHelper.mockSubscriber();
 
@@ -561,8 +561,8 @@ public class FlowableReplayTest {
     public void testIssue2191_SchedulerUnsubscribe() throws Exception {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
-        Runnable sourceCompleted = mock(Runnable.class);
-        Runnable sourceUnsubscribed = mock(Runnable.class);
+        Action sourceCompleted = mock(Action.class);
+        Action sourceUnsubscribed = mock(Action.class);
         final Scheduler mockScheduler = mock(Scheduler.class);
         final Disposable mockSubscription = mock(Disposable.class);
         Worker spiedWorker = workerSpy(mockSubscription);
@@ -623,9 +623,9 @@ public class FlowableReplayTest {
     public void testIssue2191_SchedulerUnsubscribeOnError() throws Exception {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
-        Runnable sourceCompleted = mock(Runnable.class);
+        Action sourceCompleted = mock(Action.class);
         Consumer<Throwable> sourceError = mock(Consumer.class);
-        Runnable sourceUnsubscribed = mock(Runnable.class);
+        Action sourceUnsubscribed = mock(Action.class);
         final Scheduler mockScheduler = mock(Scheduler.class);
         final Disposable mockSubscription = mock(Disposable.class);
         Worker spiedWorker = workerSpy(mockSubscription);
@@ -948,8 +948,8 @@ public class FlowableReplayTest {
     }
 
     @Test
-    public void testUnsubscribeSource() {
-        Runnable unsubscribe = mock(Runnable.class);
+    public void testUnsubscribeSource() throws Exception {
+        Action unsubscribe = mock(Action.class);
         Flowable<Integer> o = Flowable.just(1).doOnCancel(unsubscribe).cache();
         o.subscribe();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableTakeLastOneTest {
@@ -62,7 +62,7 @@ public class FlowableTakeLastOneTest {
     @Test
     public void testUnsubscribesFromUpstream() {
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Runnable unsubscribeAction = new Runnable() {
+        Action unsubscribeAction = new Action() {
             @Override
             public void run() {
                 unsubscribed.set(true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.functions.Action;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableToCompletableTest {
@@ -83,7 +84,7 @@ public class FlowableToCompletableTest {
     public void testShouldUseUnsafeSubscribeInternallyNotSubscribe() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Completable cmp = Flowable.just("Hello World!").doOnCancel(new Runnable() {
+        Completable cmp = Flowable.just("Hello World!").doOnCancel(new Action() {
 
             @Override
             public void run() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.*;
 
 import io.reactivex.*;
+import io.reactivex.functions.Action;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableToSingleTest {
@@ -73,7 +74,7 @@ public class FlowableToSingleTest {
     public void testShouldUseUnsafeSubscribeInternallyNotSubscribe() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Single<String> single = Flowable.just("Hello World!").doOnCancel(new Runnable() {
+        Single<String> single = Flowable.just("Hello World!").doOnCancel(new Action() {
 
             @Override
             public void run() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -280,8 +280,8 @@ public class FlowableUsingTest {
     public void testUsingDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
         Callable<Resource> resourceFactory = createResourceFactory(events);
-        final Runnable completion = createOnCompletedAction(events);
-        final Runnable unsub =createUnsubAction(events);
+        final Action completion = createOnCompletedAction(events);
+        final Action unsub = createUnsubAction(events);
 
         Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
             @Override
@@ -307,8 +307,8 @@ public class FlowableUsingTest {
     public void testUsingDoesNotDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
         Callable<Resource> resourceFactory = createResourceFactory(events);
-        final Runnable completion = createOnCompletedAction(events);
-        final Runnable unsub = createUnsubAction(events);
+        final Action completion = createOnCompletedAction(events);
+        final Action unsub = createUnsubAction(events);
 
         Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
             @Override
@@ -337,7 +337,7 @@ public class FlowableUsingTest {
         final List<String> events = new ArrayList<String>();
         Callable<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
-        final Runnable unsub = createUnsubAction(events);
+        final Action unsub = createUnsubAction(events);
         
         Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
             @Override
@@ -365,7 +365,7 @@ public class FlowableUsingTest {
         final List<String> events = new ArrayList<String>();
         final Callable<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
-        final Runnable unsub = createUnsubAction(events);
+        final Action unsub = createUnsubAction(events);
         
         Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
             @Override
@@ -387,8 +387,8 @@ public class FlowableUsingTest {
         assertEquals(Arrays.asList("error", "unsub", "disposed"), events);
     }
 
-    private static Runnable createUnsubAction(final List<String> events) {
-        return new Runnable() {
+    private static Action createUnsubAction(final List<String> events) {
+        return new Action() {
             @Override
             public void run() {
                 events.add("unsub");
@@ -425,8 +425,8 @@ public class FlowableUsingTest {
         };
     }
     
-    private static Runnable createOnCompletedAction(final List<String> events) {
-        return new Runnable() {
+    private static Action createOnCompletedAction(final List<String> events) {
+        return new Action() {
             @Override
             public void run() {
                 events.add("completed");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -186,7 +186,7 @@ public class FlowableWindowWithTimeTest {
         FlowableWindowWithSizeTest.hotStream()
         .window(300, TimeUnit.MILLISECONDS)
         .take(10)
-        .doOnComplete(new Runnable() {
+        .doOnComplete(new Action() {
             @Override
             public void run() {
                 System.out.println("Main done!");
@@ -196,7 +196,7 @@ public class FlowableWindowWithTimeTest {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> w) {
                 return w.startWith(indicator)
-                        .doOnComplete(new Runnable() {
+                        .doOnComplete(new Action() {
                             @Override
                             public void run() {
                                 System.out.println("inner done: " + wip.incrementAndGet());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -26,7 +26,7 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
@@ -106,8 +106,8 @@ public class ObservableCacheTest {
     }
 
     @Test
-    public void testUnsubscribeSource() {
-        Runnable unsubscribe = mock(Runnable.class);
+    public void testUnsubscribeSource() throws Exception {
+        Action unsubscribe = mock(Action.class);
         Observable<Integer> o = Observable.just(1).doOnCancel(unsubscribe).cache();
         o.subscribe();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 
 public class ObservableDoOnUnsubscribeTest {
@@ -41,7 +41,7 @@ public class ObservableDoOnUnsubscribeTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
@@ -57,7 +57,7 @@ public class ObservableDoOnUnsubscribeTest {
                             onNextLatch.countDown();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that lower stream will be notified for a direct un-subscription
@@ -103,7 +103,7 @@ public class ObservableDoOnUnsubscribeTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
@@ -118,7 +118,7 @@ public class ObservableDoOnUnsubscribeTest {
                             onNextLatch.countDown();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         // Test that lower stream will be notified for un-subscription

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFinallyTest.java
@@ -18,22 +18,28 @@ import static org.mockito.Mockito.*;
 import org.junit.*;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
 
 public class ObservableFinallyTest {
 
-    private Runnable aAction0;
-    private Observer<String> NbpObserver;
+    private Action aAction0;
+    private Observer<String> observer;
 
     // mocking has to be unchecked, unfortunately
     @Before
     public void before() {
-        aAction0 = mock(Runnable.class);
-        NbpObserver = TestHelper.mockObserver();
+        aAction0 = mock(Action.class);
+        observer = TestHelper.mockObserver();
     }
 
     private void checkActionCalled(Observable<String> input) {
-        input.doAfterTerminate(aAction0).subscribe(NbpObserver);
-        verify(aAction0, times(1)).run();
+        input.doAfterTerminate(aAction0).subscribe(observer);
+        try {
+            verify(aAction0, times(1)).run();
+        } catch (Throwable e) {
+            throw Exceptions.propagate(e);
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -311,7 +311,7 @@ public class ObservableFlatMapTest {
                         Assert.fail("Too many subscriptions! " + (n + 1));
                     }
             }
-        }).doOnComplete(new Runnable() {
+        }).doOnComplete(new Action() {
             @Override
             public void run() {
                     int n = subscriptionCount.decrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -636,7 +636,7 @@ public class ObservableGroupByTest {
 
                     })
                             // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Runnable() {
+                            .take(2).doOnComplete(new Action() {
 
                                 @Override
                                 public void run() {
@@ -715,7 +715,7 @@ public class ObservableGroupByTest {
 
                     })
                             // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Runnable() {
+                            .take(2).doOnComplete(new Action() {
 
                                 @Override
                                 public void run() {
@@ -807,7 +807,7 @@ public class ObservableGroupByTest {
 
                     })
                             // must take(2) so an onCompleted + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Runnable() {
+                            .take(2).doOnComplete(new Action() {
 
                                 @Override
                                 public void run() {
@@ -1254,7 +1254,7 @@ public class ObservableGroupByTest {
 
             @Override
             public Observable<String> apply(final GroupedObservable<Boolean, Integer> g) {
-                return g.doOnComplete(new Runnable() {
+                return g.doOnComplete(new Action() {
 
                     @Override
                     public void run() {
@@ -1280,7 +1280,7 @@ public class ObservableGroupByTest {
                         }
                     }
 
-                }).doOnComplete(new Runnable() {
+                }).doOnComplete(new Action() {
 
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import io.reactivex.Observable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 
 public class ObservableIgnoreElementsTest {
@@ -80,7 +80,7 @@ public class ObservableIgnoreElementsTest {
     @Test
     public void testUnsubscribesFromUpstream() {
         final AtomicBoolean unsub = new AtomicBoolean();
-        Observable.range(1, 10).doOnCancel(new Runnable() {
+        Observable.range(1, 10).doOnCancel(new Action() {
             @Override
             public void run() {
                 unsub.set(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -113,7 +113,7 @@ public class ObservableObserveOnTest {
                 assertTrue(correctThreadName);
             }
 
-        }).doAfterTerminate(new Runnable() {
+        }).doAfterTerminate(new Action() {
 
             @Override
             public void run() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -90,7 +90,7 @@ public class ObservablePublishTest {
     public void testBackpressureFastSlow() {
         ConnectableObservable<Integer> is = Observable.range(1, Flowable.bufferSize() * 2).publish();
         Observable<Integer> fast = is.observeOn(Schedulers.computation())
-        .doOnComplete(new Runnable() {
+        .doOnComplete(new Action() {
             @Override
             public void run() {
                 System.out.println("^^^^^^^^^^^^^ completed FAST");
@@ -112,7 +112,7 @@ public class ObservablePublishTest {
                 return i;
             }
 
-        }).doOnComplete(new Runnable() {
+        }).doOnComplete(new Action() {
 
             @Override
             public void run() {
@@ -193,7 +193,7 @@ public class ObservablePublishTest {
                         sourceEmission.incrementAndGet();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         sourceUnsubscribed.set(true);
@@ -210,7 +210,7 @@ public class ObservablePublishTest {
             @Override
             public void onNext(Integer t) {
                 if (valueCount() == 2) {
-                    source.doOnCancel(new Runnable() {
+                    source.doOnCancel(new Action() {
                         @Override
                         public void run() {
                             child2Unsubscribed.set(true);
@@ -221,7 +221,7 @@ public class ObservablePublishTest {
             }
         };
         
-        source.doOnCancel(new Runnable() {
+        source.doOnCancel(new Action() {
             @Override
             public void run() {
                 child1Unsubscribed.set(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -170,7 +170,7 @@ public class ObservableRefCountTest {
                             subscribeCount.incrementAndGet();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");
@@ -215,7 +215,7 @@ public class ObservableRefCountTest {
                             subscribeLatch.countDown();
                     }
                 })
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");
@@ -253,7 +253,7 @@ public class ObservableRefCountTest {
     public void testConnectUnsubscribeRaceCondition() throws InterruptedException {
         final AtomicInteger subUnsubCount = new AtomicInteger();
         Observable<Long> o = synchronousInterval()
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -493,7 +493,7 @@ public class ObservableReplayTest {
                     t1.printStackTrace();
                 }
             }, 
-            new Runnable() {
+            new Action() {
                 @Override
                 public void run() {
                     System.out.println("Done");
@@ -512,8 +512,8 @@ public class ObservableReplayTest {
     public void testIssue2191_UnsubscribeSource() throws Exception {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
-        Runnable sourceCompleted = mock(Runnable.class);
-        Runnable sourceUnsubscribed = mock(Runnable.class);
+        Action sourceCompleted = mock(Action.class);
+        Action sourceUnsubscribed = mock(Action.class);
         Observer<Integer> spiedSubscriberBeforeConnect = TestHelper.mockObserver();
         Observer<Integer> spiedSubscriberAfterConnect = TestHelper.mockObserver();
 
@@ -562,8 +562,8 @@ public class ObservableReplayTest {
     public void testIssue2191_SchedulerUnsubscribe() throws Exception {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
-        Runnable sourceCompleted = mock(Runnable.class);
-        Runnable sourceUnsubscribed = mock(Runnable.class);
+        Action sourceCompleted = mock(Action.class);
+        Action sourceUnsubscribed = mock(Action.class);
         final TestScheduler mockScheduler = Schedulers.test();
         
         Observer<Integer> mockObserverBeforeConnect = TestHelper.mockObserver();
@@ -615,9 +615,9 @@ public class ObservableReplayTest {
     public void testIssue2191_SchedulerUnsubscribeOnError() throws Exception {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
-        Runnable sourceCompleted = mock(Runnable.class);
+        Action sourceCompleted = mock(Action.class);
         Consumer<Throwable> sourceError = mock(Consumer.class);
-        Runnable sourceUnsubscribed = mock(Runnable.class);
+        Action sourceUnsubscribed = mock(Action.class);
         final TestScheduler mockScheduler = new TestScheduler();
         Observer<Integer> mockObserverBeforeConnect = TestHelper.mockObserver();
         Observer<Integer> mockObserverAfterConnect = TestHelper.mockObserver();
@@ -848,8 +848,8 @@ public class ObservableReplayTest {
     }
 
     @Test
-    public void testUnsubscribeSource() {
-        Runnable unsubscribe = mock(Runnable.class);
+    public void testUnsubscribeSource() throws Exception {
+        Action unsubscribe = mock(Action.class);
         Observable<Integer> o = Observable.just(1).doOnCancel(unsubscribe).cache();
         o.subscribe();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.Observable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 
 public class ObservableTakeLastOneTest {
@@ -61,7 +61,7 @@ public class ObservableTakeLastOneTest {
     @Test
     public void testUnsubscribesFromUpstream() {
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Runnable unsubscribeAction = new Runnable() {
+        Action unsubscribeAction = new Action() {
             @Override
             public void run() {
                 unsubscribed.set(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -279,8 +279,8 @@ public class ObservableUsingTest {
     public void testUsingDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
         Callable<Resource> resourceFactory = createResourceFactory(events);
-        final Runnable completion = createOnCompletedAction(events);
-        final Runnable unsub =createUnsubAction(events);
+        final Action completion = createOnCompletedAction(events);
+        final Action unsub = createUnsubAction(events);
 
         Function<Resource, Observable<String>> observableFactory = new Function<Resource, Observable<String>>() {
             @Override
@@ -306,8 +306,8 @@ public class ObservableUsingTest {
     public void testUsingDoesNotDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
         Callable<Resource> resourceFactory = createResourceFactory(events);
-        final Runnable completion = createOnCompletedAction(events);
-        final Runnable unsub = createUnsubAction(events);
+        final Action completion = createOnCompletedAction(events);
+        final Action unsub = createUnsubAction(events);
 
         Function<Resource, Observable<String>> observableFactory = new Function<Resource, Observable<String>>() {
             @Override
@@ -336,7 +336,7 @@ public class ObservableUsingTest {
         final List<String> events = new ArrayList<String>();
         Callable<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
-        final Runnable unsub = createUnsubAction(events);
+        final Action unsub = createUnsubAction(events);
         
         Function<Resource, Observable<String>> observableFactory = new Function<Resource, Observable<String>>() {
             @Override
@@ -364,7 +364,7 @@ public class ObservableUsingTest {
         final List<String> events = new ArrayList<String>();
         final Callable<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
-        final Runnable unsub = createUnsubAction(events);
+        final Action unsub = createUnsubAction(events);
         
         Function<Resource, Observable<String>> observableFactory = new Function<Resource, Observable<String>>() {
             @Override
@@ -386,8 +386,8 @@ public class ObservableUsingTest {
         assertEquals(Arrays.asList("error", "unsub", "disposed"), events);
     }
 
-    private static Runnable createUnsubAction(final List<String> events) {
-        return new Runnable() {
+    private static Action createUnsubAction(final List<String> events) {
+        return new Action() {
             @Override
             public void run() {
                 events.add("unsub");
@@ -424,8 +424,8 @@ public class ObservableUsingTest {
         };
     }
     
-    private static Runnable createOnCompletedAction(final List<String> events) {
-        return new Runnable() {
+    private static Action createOnCompletedAction(final List<String> events) {
+        return new Action() {
             @Override
             public void run() {
                 events.add("completed");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -187,7 +187,7 @@ public class ObservableWindowWithTimeTest {
         ObservableWindowWithSizeTest.hotStream()
         .window(300, TimeUnit.MILLISECONDS)
         .take(10)
-        .doOnComplete(new Runnable() {
+        .doOnComplete(new Action() {
             @Override
             public void run() {
                 System.out.println("Main done!");
@@ -197,7 +197,7 @@ public class ObservableWindowWithTimeTest {
             @Override
             public Observable<Integer> apply(Observable<Integer> w) {
                 return w.startWith(indicator)
-                        .doOnComplete(new Runnable() {
+                        .doOnComplete(new Action() {
                             @Override
                             public void run() {
                                 System.out.println("inner done: " + wip.incrementAndGet());

--- a/src/test/java/io/reactivex/observable/ObservableDoOnTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableDoOnTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.Observable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 
 public class ObservableDoOnTest {
 
@@ -62,7 +62,7 @@ public class ObservableDoOnTest {
     @Test
     public void testDoOnCompleted() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Observable.just("one").doOnComplete(new Runnable() {
+        String output = Observable.just("one").doOnComplete(new Action() {
             @Override
             public void run() {
                 r.set(true);

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1294,7 +1294,7 @@ public class ObservableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void doOnLifecycleOnSubscribeNull() {
-        just1.doOnLifecycle(null, Functions.EMPTY_RUNNABLE);
+        just1.doOnLifecycle(null, Functions.EMPTY_ACTION);
     }
     
     @Test(expected = NullPointerException.class)
@@ -2209,7 +2209,7 @@ public class ObservableNullTests {
         }, new Consumer<Throwable>() {
             @Override
             public void accept(Throwable e) { }
-        }, Functions.EMPTY_RUNNABLE, null);
+        }, Functions.EMPTY_ACTION, null);
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -28,6 +28,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.exceptions.*;
+import io.reactivex.functions.Action;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
@@ -146,7 +147,7 @@ public class TestSubscriberTest {
         final AtomicBoolean unsub = new AtomicBoolean(false);
         Flowable.just(1)
         //
-                .doOnCancel(new Runnable() {
+                .doOnCancel(new Action() {
                     @Override
                     public void run() {
                         unsub.set(true);


### PR DESCRIPTION
Notable changes:
- Replace the use of `Runnable` in the base reactive types to `Action` whose `run` method can throw a checked exception.
- Fix javadoc referencing 1.x types no longer available.
- The `switchMap` operator has been enhanced to support delaying errors.
- Update `concat(Iterable)` to use `concatMapDelayError` because Iterable can't throw just anytime but on the boundary, reducing the per-element overhead.
- `FlowableEmitter` has been enhanced with a `serialize()` method that serializes calls to `onXXX` methods.
- Factored out `FlowableEmitter.Cancellable` into `io.reactivex.functions` as it will be used by the other base reactive types with their `XEmitter` implementations.
- Added `AtomicThrowable` with convenience methods that use `ExceptionHelper`'s terminal atomics with `Throwable`s.
