### PR TITLE
Add missing @Test annotation

### DIFF
--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -152,6 +152,7 @@ public class ObservableTests {
         verify(w, times(1)).onError(any(RuntimeException.class));
     }
 
+    @Test
     public void testTakeFirstWithPredicateOfSome() {
         Observable<Integer> observable = Observable.just(1, 3, 5, 4, 6, 3);
         observable.takeFirst(IS_EVEN).subscribe(w);


### PR DESCRIPTION
This annotation has been accidentally omitted when resolving a conflict during the merging of:
96feb27e1b90cb93a64295de077cffb1a7d9ea9b and 98cccec27252f30578cd3cf1b7aeddcb9837a2fd
into:
d6bf9d15c6802c74d8e5a3fc4f908a2d01d3d335

We made PRs for both versions 1.x and 2.x.

We found the missing annotation while processing RxJava's git repository using a tool for structured code merge that we're developing as part of the Envision IDE: www.pm.inf.ethz.ch/research/envision.html
