### PR TITLE
2.x: factor out inner classes from the base reactive types

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -323,13 +323,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromFuture(final Future<?> future) {
         Objects.requireNonNull(future, "future is null");
-        return fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                future.get();
-                return null;
-            }
-        });
+        return fromAction(Functions.futureAction(future));
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -12,10 +12,13 @@
  */
 package io.reactivex.internal.functions;
 
-import java.util.Comparator;
-import java.util.concurrent.Callable;
+import java.util.*;
+import java.util.concurrent.*;
 
+import io.reactivex.*;
+import io.reactivex.Optional;
 import io.reactivex.functions.*;
+import io.reactivex.schedulers.Timed;
 
 /**
  * Utility methods to convert the Function3..Function9 instances to Function of Object array.
@@ -197,7 +200,7 @@ public enum Functions {
     static final Predicate<Object> ALWAYS_FALSE = new Predicate<Object>() {
         @Override
         public boolean test(Object o) {
-            return true;
+            return false;
         }
     };
     
@@ -240,4 +243,367 @@ public enum Functions {
     public static <T> Comparator<T> naturalOrder() {
         return (Comparator<T>)NATURAL_COMPARATOR;
     }
+    
+    static final class FutureAction implements Action {
+        final Future<?> future;
+        
+        public FutureAction(Future<?> future) {
+            this.future = future;
+        }
+        
+        @Override
+        public void run() throws Exception {
+            future.get();
+        }
+    }
+    
+    /**
+     * Wraps the blocking get call of the Future into an Action.
+     * @param future the future to call get() on, not null
+     * @return the new Action instance
+     */
+    public static Action futureAction(Future<?> future) {
+        return new FutureAction(future);
+    }
+    
+    static final class JustValue<T, U> implements Callable<U>, Function<T, U> {
+        final U value;
+        
+        public JustValue(U value) {
+            this.value = value;
+        }
+        
+        @Override
+        public U call() throws Exception {
+            return value;
+        }
+        
+        @Override
+        public U apply(T t) throws Exception {
+            return value;
+        }
+    }
+    
+    /**
+     * Returns a Callable that returns the given value.
+     * @param <T> the value type
+     * @param value the value to return
+     * @return the new Callable instance
+     */
+    public static <T> Callable<T> justCallable(T value) {
+        return new JustValue<Object, T>(value);
+    }
+
+    /**
+     * Returns a Function that ignores its parameter and returns the given value.
+     * @param <T> the function's input type
+     * @param <U> the value and return type of the function
+     * @param value the value to return
+     * @return the new Function instance
+     */
+    public static <T, U> Function<T, U> justFunction(U value) {
+        return new JustValue<T, U>(value);
+    }
+
+    static final class CastToClass<T, U> implements Function<T, U> {
+        final Class<U> clazz;
+        
+        public CastToClass(Class<U> clazz) {
+            this.clazz = clazz;
+        }
+        
+        @Override
+        public U apply(T t) throws Exception {
+            return clazz.cast(t);
+        }
+    }
+    
+    /**
+     * Returns a function that cast the incoming values via a Class object.
+     * @param <T> the input value type
+     * @param <U> the output and target type
+     * @param target the target class
+     * @return the new Function instance
+     */
+    public static <T, U> Function<T, U> castFunction(Class<U> target) {
+        return new CastToClass<T, U>(target);
+    }
+
+    static final class ArrayListCapacityCallable<T> implements Callable<List<T>> {
+        final int capacity;
+        
+        public ArrayListCapacityCallable(int capacity) {
+            this.capacity = capacity;
+        }
+        
+        @Override
+        public List<T> call() throws Exception {
+            return new ArrayList<T>(capacity);
+        }
+    }
+    
+    public static <T> Callable<List<T>> createArrayList(int capacity) {
+        return new ArrayListCapacityCallable<T>(capacity);
+    }
+    
+    static final class EqualsPredicate<T> implements Predicate<T> {
+        final T value;
+        
+        public EqualsPredicate(T value) {
+            this.value = value;
+        }
+        
+        @Override
+        public boolean test(T t) throws Exception {
+            return Objects.equals(t, value);
+        }
+    }
+    
+    public static <T> Predicate<T> equalsWith(T value) {
+        return new EqualsPredicate<T>(value);
+    }
+
+    enum HashSetCallable implements Callable<Set<Object>> {
+        INSTANCE;
+        @Override
+        public Set<Object> call() throws Exception {
+            return new HashSet<Object>();
+        }
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Callable<Set<T>> createHashSet() {
+        return (Callable)HashSetCallable.INSTANCE;
+    }
+    
+    static final class NotificationOnNext<T> implements Consumer<T> {
+        final Consumer<? super Try<Optional<T>>> onNotification;
+        
+        public NotificationOnNext(Consumer<? super Try<Optional<T>>> onNotification) {
+            this.onNotification = onNotification;
+        }
+        
+        @Override
+        public void accept(T v) throws Exception {
+            onNotification.accept(Try.ofValue(Optional.of(v)));
+        }
+    }
+    
+    static final class NotificationOnError<T> implements Consumer<Throwable> {
+        final Consumer<? super Try<Optional<T>>> onNotification;
+        
+        public NotificationOnError(Consumer<? super Try<Optional<T>>> onNotification) {
+            this.onNotification = onNotification;
+        }
+        
+        @Override
+        public void accept(Throwable v) throws Exception {
+            onNotification.accept(Try.<Optional<T>>ofError(v));
+        }
+    }
+    
+    static final class NotificationOnComplete<T> implements Action {
+        final Consumer<? super Try<Optional<T>>> onNotification;
+        
+        public NotificationOnComplete(Consumer<? super Try<Optional<T>>> onNotification) {
+            this.onNotification = onNotification;
+        }
+        
+        @Override
+        public void run() throws Exception {
+            onNotification.accept(Try.ofValue(Optional.<T>empty()));
+        }
+    }
+    
+    public static <T> Consumer<T> notificationOnNext(Consumer<? super Try<Optional<T>>> onNotification) {
+        return new NotificationOnNext<T>(onNotification);
+    }
+    
+    public static <T> Consumer<Throwable> notificationOnError(Consumer<? super Try<Optional<T>>> onNotification) {
+        return new NotificationOnError<T>(onNotification);
+    }
+
+    public static <T> Action notificationOnComplete(Consumer<? super Try<Optional<T>>> onNotification) {
+        return new NotificationOnComplete<T>(onNotification);
+    }
+    
+    static final class ActionConsumer<T> implements Consumer<T> {
+        final Action action;
+        
+        public ActionConsumer(Action action) {
+            this.action = action;
+        }
+        
+        @Override
+        public void accept(T t) throws Exception {
+            action.run();
+        }
+    }
+    
+    public static <T> Consumer<T> actionConsumer(Action action) {
+        return new ActionConsumer<T>(action);
+    }
+
+    static final class ClassFilter<T, U> implements Predicate<T> {
+        final Class<U> clazz;
+
+        public ClassFilter(Class<U> clazz) {
+            this.clazz = clazz;
+        }
+        
+        @Override
+        public boolean test(T t) throws Exception {
+            return clazz.isInstance(t);
+        }
+    }
+    
+    public static <T, U> Predicate<T> isInstanceOf(Class<U> clazz) {
+        return new ClassFilter<T, U>(clazz);
+    }
+    
+    static final class BooleanSupplierPredicateReverse<T> implements Predicate<T> {
+        final BooleanSupplier supplier;
+
+        public BooleanSupplierPredicateReverse(BooleanSupplier supplier) {
+            this.supplier = supplier;
+        }
+        
+        @Override
+        public boolean test(T t) throws Exception {
+            return !supplier.getAsBoolean();
+        }
+    }
+    
+    public static <T> Predicate<T> predicateReverseFor(BooleanSupplier supplier) {
+        return new BooleanSupplierPredicateReverse<T>(supplier);
+    }
+
+    static final class TimestampingFunction<T> implements Function<T, Timed<T>> {
+        final TimeUnit unit;
+        
+        final Scheduler scheduler;
+
+        public TimestampingFunction(TimeUnit unit, Scheduler scheduler) {
+            this.unit = unit;
+            this.scheduler = scheduler;
+        }
+        
+        @Override
+        public Timed<T> apply(T t) throws Exception {
+            return new Timed<T>(t, scheduler.now(unit), unit);
+        }
+    }
+    
+    public static <T> Function<T, Timed<T>> timestampWith(TimeUnit unit, Scheduler scheduler) {
+        return new TimestampingFunction<T>(unit, scheduler);
+    }
+
+    static final class ToMapKeySelector<K, T> implements BiConsumer<Map<K, T>, T> {
+        private final Function<? super T, ? extends K> keySelector;
+
+        ToMapKeySelector(Function<? super T, ? extends K> keySelector) {
+            this.keySelector = keySelector;
+        }
+
+        @Override
+        public void accept(Map<K, T> m, T t) throws Exception {
+            K key = keySelector.apply(t);
+            m.put(key, t);
+        }
+    }
+
+    public static <T, K> BiConsumer<Map<K, T>, T> toMapKeySelector(final Function<? super T, ? extends K> keySelector) {
+        return new ToMapKeySelector<K, T>(keySelector);
+    }
+
+    static final class ToMapKeyValueSelector<K, V, T> implements BiConsumer<Map<K, V>, T> {
+        private final Function<? super T, ? extends V> valueSelector;
+        private final Function<? super T, ? extends K> keySelector;
+
+        ToMapKeyValueSelector(Function<? super T, ? extends V> valueSelector,
+                Function<? super T, ? extends K> keySelector) {
+            this.valueSelector = valueSelector;
+            this.keySelector = keySelector;
+        }
+
+        @Override
+        public void accept(Map<K, V> m, T t) throws Exception {
+            K key = keySelector.apply(t);
+            V value = valueSelector.apply(t);
+            m.put(key, value);
+        }
+    }
+
+    public static <T, K, V> BiConsumer<Map<K, V>, T> toMapKeyValueSelector(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
+        return new ToMapKeyValueSelector<K, V, T>(valueSelector, keySelector);
+    }
+
+    static final class ToMultimapKeyValueSelector<K, V, T> implements BiConsumer<Map<K, Collection<V>>, T> {
+        private final Function<? super K, ? extends Collection<? super V>> collectionFactory;
+        private final Function<? super T, ? extends V> valueSelector;
+        private final Function<? super T, ? extends K> keySelector;
+
+        ToMultimapKeyValueSelector(Function<? super K, ? extends Collection<? super V>> collectionFactory,
+                Function<? super T, ? extends V> valueSelector, Function<? super T, ? extends K> keySelector) {
+            this.collectionFactory = collectionFactory;
+            this.valueSelector = valueSelector;
+            this.keySelector = keySelector;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void accept(Map<K, Collection<V>> m, T t) throws Exception {
+            K key = keySelector.apply(t);
+
+            Collection<V> coll = m.get(key);
+            if (coll == null) {
+                coll = (Collection<V>)collectionFactory.apply(key);
+                m.put(key, coll);
+            }
+
+            V value = valueSelector.apply(t);
+
+            coll.add(value);
+        }
+    }
+
+    public static <T, K, V> BiConsumer<Map<K, Collection<V>>, T> toMultimapKeyValueSelector(
+            final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector,
+            final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
+        return new ToMultimapKeyValueSelector<K, V, T>(collectionFactory, valueSelector, keySelector);
+    }
+    
+    enum NaturalComparator implements Comparator<Object> {
+        INSTANCE;
+        
+        @SuppressWarnings("unchecked")
+        @Override
+        public int compare(Object o1, Object o2) {
+            return ((Comparable<Object>)o1).compareTo(o2);
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Comparator<T> naturalComparator() {
+        return (Comparator<T>)NaturalComparator.INSTANCE;
+    }
+
+    static final class ListSorter<T> implements Function<List<T>, List<T>> {
+        private final Comparator<? super T> comparator;
+
+        ListSorter(Comparator<? super T> comparator) {
+            this.comparator = comparator;
+        }
+
+        @Override
+        public List<T> apply(List<T> v) {
+            Collections.sort(v, comparator);
+            return v;
+        }
+    }
+
+    public static <T> Function<List<T>, List<T>> listSorter(final Comparator<? super T> comparator) {
+        return new ListSorter<T>(comparator);
+    }
+
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
@@ -1,0 +1,328 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+
+/**
+ * Helper utility class to support Flowable with inner classes.
+ */
+public enum FlowableInternalHelper {
+    ;
+
+    static final class SimpleGenerator<T, S> implements BiFunction<S, Subscriber<T>, S> {
+        final Consumer<Subscriber<T>> consumer;
+        
+        public SimpleGenerator(Consumer<Subscriber<T>> consumer) {
+            this.consumer = consumer;
+        }
+        
+        @Override
+        public S apply(S t1, Subscriber<T> t2) throws Exception {
+            consumer.accept(t2);
+            return t1;
+        }
+    }
+    
+    public static <T, S> BiFunction<S, Subscriber<T>, S> simpleGenerator(Consumer<Subscriber<T>> consumer) {
+        return new SimpleGenerator<T, S>(consumer);
+    }
+    
+    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Subscriber<T>, S> {
+        final BiConsumer<S, Subscriber<T>> consumer;
+        
+        public SimpleBiGenerator(BiConsumer<S, Subscriber<T>> consumer) {
+            this.consumer = consumer;
+        }
+        
+        @Override
+        public S apply(S t1, Subscriber<T> t2) throws Exception {
+            consumer.accept(t1, t2);
+            return t1;
+        }
+    }
+    
+    public static <T, S> BiFunction<S, Subscriber<T>, S> simpleBiGenerator(BiConsumer<S, Subscriber<T>> consumer) {
+        return new SimpleBiGenerator<T, S>(consumer);
+    }
+    
+    static final class ItemDelayFunction<T, U> implements Function<T, Publisher<T>> {
+        final Function<? super T, ? extends Publisher<U>> itemDelay;
+
+        public ItemDelayFunction(Function<? super T, ? extends Publisher<U>> itemDelay) {
+            this.itemDelay = itemDelay;
+        }
+
+        @Override
+        public Publisher<T> apply(final T v) throws Exception {
+            return new FlowableTake<U>(itemDelay.apply(v), 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+        }
+    }
+
+    public static <T, U> Function<T, Publisher<T>> itemDelay(final Function<? super T, ? extends Publisher<U>> itemDelay) {
+        return new ItemDelayFunction<T, U>(itemDelay);
+    }
+    
+    static final class SubscriberOnNext<T> implements Consumer<T> {
+        final Subscriber<T> subscriber;
+        
+        public SubscriberOnNext(Subscriber<T> subscriber) {
+            this.subscriber = subscriber;
+        }
+        
+        @Override
+        public void accept(T v) throws Exception {
+            subscriber.onNext(v);
+        }
+    }
+    
+    static final class SubscriberOnError<T> implements Consumer<Throwable> {
+        final Subscriber<T> subscriber;
+        
+        public SubscriberOnError(Subscriber<T> subscriber) {
+            this.subscriber = subscriber;
+        }
+        
+        @Override
+        public void accept(Throwable v) throws Exception {
+            subscriber.onError(v);
+        }
+    }
+    
+    static final class SubscriberOnComplete<T> implements Action {
+        final Subscriber<T> subscriber;
+        
+        public SubscriberOnComplete(Subscriber<T> subscriber) {
+            this.subscriber = subscriber;
+        }
+        
+        @Override
+        public void run() throws Exception {
+            subscriber.onComplete();
+        }
+    }
+    
+    public static <T> Consumer<T> subscriberOnNext(Subscriber<T> subscriber) {
+        return new SubscriberOnNext<T>(subscriber);
+    }
+    
+    public static <T> Consumer<Throwable> subscriberOnError(Subscriber<T> subscriber) {
+        return new SubscriberOnError<T>(subscriber);
+    }
+
+    public static <T> Action subscriberOnComplete(Subscriber<T> subscriber) {
+        return new SubscriberOnComplete<T>(subscriber);
+    }
+
+    static final class FlatMapWithCombinerInner<U, R, T> implements Function<U, R> {
+        private final BiFunction<? super T, ? super U, ? extends R> combiner;
+        private final T t;
+
+        FlatMapWithCombinerInner(BiFunction<? super T, ? super U, ? extends R> combiner, T t) {
+            this.combiner = combiner;
+            this.t = t;
+        }
+
+        @Override
+        public R apply(U w) throws Exception {
+            return combiner.apply(t, w);
+        }
+    }
+
+    static final class FlatMapWithCombinerOuter<T, R, U> implements Function<T, Publisher<R>> {
+        private final BiFunction<? super T, ? super U, ? extends R> combiner;
+        private final Function<? super T, ? extends Publisher<? extends U>> mapper;
+
+        FlatMapWithCombinerOuter(BiFunction<? super T, ? super U, ? extends R> combiner,
+                Function<? super T, ? extends Publisher<? extends U>> mapper) {
+            this.combiner = combiner;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public Publisher<R> apply(final T t) throws Exception {
+            @SuppressWarnings("unchecked")
+            Publisher<U> u = (Publisher<U>)mapper.apply(t);
+            return new FlowableMap<U, R>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
+        }
+    }
+
+    public static <T, U, R> Function<T, Publisher<R>> flatMapWithCombiner(
+            final Function<? super T, ? extends Publisher<? extends U>> mapper,
+                    final BiFunction<? super T, ? super U, ? extends R> combiner) {
+        return new FlatMapWithCombinerOuter<T, R, U>(combiner, mapper);
+    }
+
+    static final class FlatMapIntoIterable<T, U> implements Function<T, Publisher<U>> {
+        private final Function<? super T, ? extends Iterable<? extends U>> mapper;
+
+        FlatMapIntoIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+            this.mapper = mapper;
+        }
+
+        @Override
+        public Publisher<U> apply(T t) throws Exception {
+            return new FlowableFromIterable<U>(mapper.apply(t));
+        }
+    }
+
+    public static <T, U> Function<T, Publisher<U>> flatMapIntoIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        return new FlatMapIntoIterable<T, U>(mapper);
+    }
+    
+    enum MapToInt implements Function<Object, Object>{
+        INSTANCE;
+        @Override
+        public Object apply(Object t) throws Exception {
+            return 0;
+        }
+    }
+    
+    static final class RepeatWhenOuterHandler
+    implements Function<Flowable<Try<Optional<Object>>>, Publisher<?>> {
+        private final Function<? super Flowable<Object>, ? extends Publisher<?>> handler;
+
+        RepeatWhenOuterHandler(Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public Publisher<?> apply(Flowable<Try<Optional<Object>>> no) throws Exception {
+            return handler.apply(no.map(MapToInt.INSTANCE));
+        }
+    }
+
+    public static Function<Flowable<Try<Optional<Object>>>, Publisher<?>> repeatWhenHandler(final Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+        return new RepeatWhenOuterHandler(handler);
+    }
+    
+    public static <T> Callable<ConnectableFlowable<T>> replayCallable(final Flowable<T> parent) {
+        return new Callable<ConnectableFlowable<T>>() {
+            @Override
+            public ConnectableFlowable<T> call() {
+                return parent.replay();
+            }
+        };
+    }
+
+    public static <T> Callable<ConnectableFlowable<T>> replayCallable(final Flowable<T> parent, final int bufferSize) {
+        return new Callable<ConnectableFlowable<T>>() {
+            @Override
+            public ConnectableFlowable<T> call() {
+                return parent.replay(bufferSize);
+            }
+        };
+    }
+    
+    public static <T> Callable<ConnectableFlowable<T>> replayCallable(final Flowable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+        return new Callable<ConnectableFlowable<T>>() {
+            @Override
+            public ConnectableFlowable<T> call() {
+                return parent.replay(bufferSize, time, unit, scheduler);
+            }
+        };
+    }
+
+    public static <T> Callable<ConnectableFlowable<T>> replayCallable(final Flowable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler) {
+        return new Callable<ConnectableFlowable<T>>() {
+            @Override
+            public ConnectableFlowable<T> call() {
+                return parent.replay(time, unit, scheduler);
+            }
+        };
+    }
+
+    public static <T, R> Function<Flowable<T>, Publisher<R>> replayFunction(final Function<? super Flowable<T>, ? extends Publisher<R>> selector, final Scheduler scheduler) {
+        return new Function<Flowable<T>, Publisher<R>>() {
+            @Override
+            public Publisher<R> apply(Flowable<T> t) throws Exception {
+                return Flowable.fromPublisher(selector.apply(t)).observeOn(scheduler);
+            }
+        };
+    }
+    
+    enum ErrorMapperFilter implements Function<Try<Optional<Object>>, Throwable>, Predicate<Try<Optional<Object>>> {
+        INSTANCE;
+        
+        @Override
+        public Throwable apply(Try<Optional<Object>> t) throws Exception {
+            return t.error();
+        }
+        
+        @Override
+        public boolean test(Try<Optional<Object>> t) throws Exception {
+            return t.hasError();
+        }
+    }
+
+    static final class RetryWhenInner
+    implements Function<Flowable<Try<Optional<Object>>>, Publisher<?>> {
+        private final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler;
+
+        RetryWhenInner(
+                Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public Publisher<?> apply(Flowable<Try<Optional<Object>>> no) throws Exception {
+            Flowable<Throwable> map = no
+                    .takeWhile(ErrorMapperFilter.INSTANCE)
+                    .map(ErrorMapperFilter.INSTANCE);
+            return handler.apply(map);
+        }
+    }
+
+    public static <T> Function<Flowable<Try<Optional<Object>>>, Publisher<?>> retryWhenHandler(final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
+        return new RetryWhenInner(handler);
+    }
+
+    enum RequestMax implements Consumer<Subscription> {
+        INSTANCE;
+        @Override
+        public void accept(Subscription t) throws Exception {
+            t.request(Long.MAX_VALUE);
+        }
+    }
+    
+    public static Consumer<Subscription> requestMax() {
+        return RequestMax.INSTANCE;
+    }
+    
+    static final class ZipIterableFunction<T, R>
+    implements Function<List<Publisher<? extends T>>, Publisher<? extends R>> {
+        private final Function<? super Object[], ? extends R> zipper;
+
+        ZipIterableFunction(Function<? super Object[], ? extends R> zipper) {
+            this.zipper = zipper;
+        }
+
+        @Override
+        public Publisher<? extends R> apply(List<Publisher<? extends T>> list) {
+            return Flowable.zipIterable(list, zipper, false, Flowable.bufferSize());
+        }
+    }
+
+    public static <T, R> Function<List<Publisher<? extends T>>, Publisher<? extends R>> zipIterable(final Function<? super Object[], ? extends R> zipper) {
+        return new ZipIterableFunction<T, R>(zipper);
+    }
+    
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -1,0 +1,315 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observables.ConnectableObservable;
+
+/**
+ * Helper utility class to support Flowable with inner classes.
+ */
+public enum ObservableInternalHelper {
+    ;
+
+    static final class SimpleGenerator<T, S> implements BiFunction<S, Observer<T>, S> {
+        final Consumer<Observer<T>> consumer;
+        
+        public SimpleGenerator(Consumer<Observer<T>> consumer) {
+            this.consumer = consumer;
+        }
+        
+        @Override
+        public S apply(S t1, Observer<T> t2) throws Exception {
+            consumer.accept(t2);
+            return t1;
+        }
+    }
+    
+    public static <T, S> BiFunction<S, Observer<T>, S> simpleGenerator(Consumer<Observer<T>> consumer) {
+        return new SimpleGenerator<T, S>(consumer);
+    }
+    
+    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Observer<T>, S> {
+        final BiConsumer<S, Observer<T>> consumer;
+        
+        public SimpleBiGenerator(BiConsumer<S, Observer<T>> consumer) {
+            this.consumer = consumer;
+        }
+        
+        @Override
+        public S apply(S t1, Observer<T> t2) throws Exception {
+            consumer.accept(t1, t2);
+            return t1;
+        }
+    }
+    
+    public static <T, S> BiFunction<S, Observer<T>, S> simpleBiGenerator(BiConsumer<S, Observer<T>> consumer) {
+        return new SimpleBiGenerator<T, S>(consumer);
+    }
+    
+    static final class ItemDelayFunction<T, U> implements Function<T, ObservableSource<T>> {
+        final Function<? super T, ? extends ObservableSource<U>> itemDelay;
+
+        public ItemDelayFunction(Function<? super T, ? extends ObservableSource<U>> itemDelay) {
+            this.itemDelay = itemDelay;
+        }
+
+        @Override
+        public ObservableSource<T> apply(final T v) throws Exception {
+            return new ObservableTake<U>(itemDelay.apply(v), 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+        }
+    }
+
+    public static <T, U> Function<T, ObservableSource<T>> itemDelay(final Function<? super T, ? extends ObservableSource<U>> itemDelay) {
+        return new ItemDelayFunction<T, U>(itemDelay);
+    }
+    
+    
+    static final class ObserverOnNext<T> implements Consumer<T> {
+        final Observer<T> observer;
+        
+        public ObserverOnNext(Observer<T> observer) {
+            this.observer = observer;
+        }
+        
+        @Override
+        public void accept(T v) throws Exception {
+            observer.onNext(v);
+        }
+    }
+    
+    static final class ObserverOnError<T> implements Consumer<Throwable> {
+        final Observer<T> observer;
+        
+        public ObserverOnError(Observer<T> observer) {
+            this.observer = observer;
+        }
+        
+        @Override
+        public void accept(Throwable v) throws Exception {
+            observer.onError(v);
+        }
+    }
+    
+    static final class ObserverOnComplete<T> implements Action {
+        final Observer<T> observer;
+        
+        public ObserverOnComplete(Observer<T> observer) {
+            this.observer = observer;
+        }
+        
+        @Override
+        public void run() throws Exception {
+            observer.onComplete();
+        }
+    }
+    
+    public static <T> Consumer<T> observerOnNext(Observer<T> observer) {
+        return new ObserverOnNext<T>(observer);
+    }
+    
+    public static <T> Consumer<Throwable> observerOnError(Observer<T> observer) {
+        return new ObserverOnError<T>(observer);
+    }
+
+    public static <T> Action observerOnComplete(Observer<T> observer) {
+        return new ObserverOnComplete<T>(observer);
+    }
+
+    static final class FlatMapWithCombinerInner<U, R, T> implements Function<U, R> {
+        private final BiFunction<? super T, ? super U, ? extends R> combiner;
+        private final T t;
+
+        FlatMapWithCombinerInner(BiFunction<? super T, ? super U, ? extends R> combiner, T t) {
+            this.combiner = combiner;
+            this.t = t;
+        }
+
+        @Override
+        public R apply(U w) throws Exception {
+            return combiner.apply(t, w);
+        }
+    }
+
+    static final class FlatMapWithCombinerOuter<T, R, U> implements Function<T, ObservableSource<R>> {
+        private final BiFunction<? super T, ? super U, ? extends R> combiner;
+        private final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
+
+        FlatMapWithCombinerOuter(BiFunction<? super T, ? super U, ? extends R> combiner,
+                Function<? super T, ? extends ObservableSource<? extends U>> mapper) {
+            this.combiner = combiner;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public ObservableSource<R> apply(final T t) throws Exception {
+            @SuppressWarnings("unchecked")
+            ObservableSource<U> u = (ObservableSource<U>)mapper.apply(t);
+            return new ObservableMap<U, R>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
+        }
+    }
+
+    public static <T, U, R> Function<T, ObservableSource<R>> flatMapWithCombiner(
+            final Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+                    final BiFunction<? super T, ? super U, ? extends R> combiner) {
+        return new FlatMapWithCombinerOuter<T, R, U>(combiner, mapper);
+    }
+
+    static final class FlatMapIntoIterable<T, U> implements Function<T, ObservableSource<U>> {
+        private final Function<? super T, ? extends Iterable<? extends U>> mapper;
+
+        FlatMapIntoIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+            this.mapper = mapper;
+        }
+
+        @Override
+        public ObservableSource<U> apply(T t) throws Exception {
+            return new ObservableFromIterable<U>(mapper.apply(t));
+        }
+    }
+
+    public static <T, U> Function<T, ObservableSource<U>> flatMapIntoIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        return new FlatMapIntoIterable<T, U>(mapper);
+    }
+    
+    enum MapToInt implements Function<Object, Object>{
+        INSTANCE;
+        @Override
+        public Object apply(Object t) throws Exception {
+            return 0;
+        }
+    }
+    
+    static final class RepeatWhenOuterHandler
+    implements Function<Observable<Try<Optional<Object>>>, ObservableSource<?>> {
+        private final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler;
+
+        RepeatWhenOuterHandler(Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public ObservableSource<?> apply(Observable<Try<Optional<Object>>> no) throws Exception {
+            return handler.apply(no.map(MapToInt.INSTANCE));
+        }
+    }
+
+    public static Function<Observable<Try<Optional<Object>>>, ObservableSource<?>> repeatWhenHandler(final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
+        return new RepeatWhenOuterHandler(handler);
+    }
+    
+    public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent) {
+        return new Callable<ConnectableObservable<T>>() {
+            @Override
+            public ConnectableObservable<T> call() {
+                return parent.replay();
+            }
+        };
+    }
+
+    public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent, final int bufferSize) {
+        return new Callable<ConnectableObservable<T>>() {
+            @Override
+            public ConnectableObservable<T> call() {
+                return parent.replay(bufferSize);
+            }
+        };
+    }
+    
+    public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+        return new Callable<ConnectableObservable<T>>() {
+            @Override
+            public ConnectableObservable<T> call() {
+                return parent.replay(bufferSize, time, unit, scheduler);
+            }
+        };
+    }
+
+    public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler) {
+        return new Callable<ConnectableObservable<T>>() {
+            @Override
+            public ConnectableObservable<T> call() {
+                return parent.replay(time, unit, scheduler);
+            }
+        };
+    }
+
+    public static <T, R> Function<Observable<T>, ObservableSource<R>> replayFunction(final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final Scheduler scheduler) {
+        return new Function<Observable<T>, ObservableSource<R>>() {
+            @Override
+            public ObservableSource<R> apply(Observable<T> t) throws Exception {
+                return Observable.wrap(selector.apply(t)).observeOn(scheduler);
+            }
+        };
+    }
+    
+    enum ErrorMapperFilter implements Function<Try<Optional<Object>>, Throwable>, Predicate<Try<Optional<Object>>> {
+        INSTANCE;
+        
+        @Override
+        public Throwable apply(Try<Optional<Object>> t) throws Exception {
+            return t.error();
+        }
+        
+        @Override
+        public boolean test(Try<Optional<Object>> t) throws Exception {
+            return t.hasError();
+        }
+    }
+
+    static final class RetryWhenInner
+    implements Function<Observable<Try<Optional<Object>>>, ObservableSource<?>> {
+        private final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler;
+
+        RetryWhenInner(
+                Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public ObservableSource<?> apply(Observable<Try<Optional<Object>>> no) throws Exception {
+            Observable<Throwable> map = no
+                    .takeWhile(ErrorMapperFilter.INSTANCE)
+                    .map(ErrorMapperFilter.INSTANCE);
+            return handler.apply(map);
+        }
+    }
+
+    public static <T> Function<Observable<Try<Optional<Object>>>, ObservableSource<?>> retryWhenHandler(final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
+        return new RetryWhenInner(handler);
+    }
+
+    static final class ZipIterableFunction<T, R>
+    implements Function<List<ObservableSource<? extends T>>, ObservableSource<? extends R>> {
+        private final Function<? super T[], ? extends R> zipper;
+
+        ZipIterableFunction(Function<? super T[], ? extends R> zipper) {
+            this.zipper = zipper;
+        }
+
+        @Override
+        public ObservableSource<? extends R> apply(List<ObservableSource<? extends T>> list) {
+            return Observable.zipIterable(list, zipper, false, Flowable.bufferSize());
+        }
+    }
+
+    public static <T, R> Function<List<ObservableSource<? extends T>>, ObservableSource<? extends R>> zipIterable(final Function<? super T[], ? extends R> zipper) {
+        return new ZipIterableFunction<T, R>(zipper);
+    }
+    
+}

--- a/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+/**
+ * Helper utility class to support Single with inner classes.
+ */
+public enum SingleInternalHelper {
+    ;
+
+    enum NoSuchElementCallable implements Callable<NoSuchElementException> {
+        INSTANCE;
+        
+        @Override
+        public NoSuchElementException call() throws Exception {
+            return new NoSuchElementException();
+        }
+    }
+    
+    public static <T> Callable<NoSuchElementException> emptyThrower() {
+        return NoSuchElementCallable.INSTANCE;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    enum ToFlowable implements Function<SingleSource, Publisher> {
+        INSTANCE;
+        @SuppressWarnings("unchecked")
+        @Override 
+        public Publisher apply(SingleSource v){
+            return new SingleToFlowable(v);
+        }
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Function<SingleSource<? extends T>, Publisher<? extends T>> toFlowable() {
+        return (Function)ToFlowable.INSTANCE;
+    }
+
+    static final class ToFlowableIterator<T> implements Iterator<Flowable<T>> {
+        private final Iterator<? extends SingleSource<? extends T>> sit;
+
+        ToFlowableIterator(Iterator<? extends SingleSource<? extends T>> sit) {
+            this.sit = sit;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return sit.hasNext();
+        }
+
+        @Override
+        public Flowable<T> next() {
+            return new SingleToFlowable<T>(sit.next());
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static final class ToFlowableIterable<T> implements Iterable<Flowable<T>> {
+
+        private final Iterable<? extends SingleSource<? extends T>> sources;
+
+        ToFlowableIterable(Iterable<? extends SingleSource<? extends T>> sources) {
+            this.sources = sources;
+        }
+
+        @Override
+        public Iterator<Flowable<T>> iterator() {
+            return new ToFlowableIterator<T>(sources.iterator());
+        }
+    }
+
+    public static <T> Iterable<? extends Flowable<T>> iterableToFlowable(final Iterable<? extends SingleSource<? extends T>> sources) {
+        return new ToFlowableIterable<T>(sources);
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/ForEachWhileSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/ForEachWhileSubscriber.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ForEachWhileSubscriber<T> 
+extends AtomicReference<Subscription>
+implements Subscriber<T>, Disposable {
+
+    /** */
+    private static final long serialVersionUID = -4403180040475402120L;
+
+    final Predicate<? super T> onNext;
+    
+    final Consumer<? super Throwable> onError;
+    
+    final Action onComplete;
+
+    boolean done;
+    
+    public ForEachWhileSubscriber(Predicate<? super T> onNext, 
+            Consumer<? super Throwable> onError, Action onComplete) {
+        this.onNext = onNext;
+        this.onError = onError;
+        this.onComplete = onComplete;
+    }
+    
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.setOnce(this, s)) {
+            s.request(Long.MAX_VALUE);
+        }
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (done) {
+            return;
+        }
+
+        boolean b;
+        try {
+            b = onNext.test(t);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            dispose();
+            onError(ex);
+            return;
+        }
+        
+        if (!b) {
+            dispose();
+            onComplete();
+        }
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        done = true;
+        try {
+            onError.accept(t);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        done = true;
+        try {
+            onComplete.run();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+    
+    @Override
+    public void dispose() {
+        SubscriptionHelper.dispose(this);
+    }
+    
+    @Override
+    public boolean isDisposed() {
+        return SubscriptionHelper.isCancelled(this.get());
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/observable/ForEachWhileObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/ForEachWhileObserver.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.observable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ForEachWhileObserver<T> 
+extends AtomicReference<Disposable>
+implements Observer<T>, Disposable {
+
+    /** */
+    private static final long serialVersionUID = -4403180040475402120L;
+
+    final Predicate<? super T> onNext;
+    
+    final Consumer<? super Throwable> onError;
+    
+    final Action onComplete;
+
+    boolean done;
+    
+    public ForEachWhileObserver(Predicate<? super T> onNext, 
+            Consumer<? super Throwable> onError, Action onComplete) {
+        this.onNext = onNext;
+        this.onError = onError;
+        this.onComplete = onComplete;
+    }
+    
+    @Override
+    public void onSubscribe(Disposable s) {
+        DisposableHelper.setOnce(this, s);
+    }
+    
+    @Override
+    public void onNext(T t) {
+        if (done) {
+            return;
+        }
+
+        boolean b;
+        try {
+            b = onNext.test(t);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            dispose();
+            onError(ex);
+            return;
+        }
+        
+        if (!b) {
+            dispose();
+            onComplete();
+        }
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        done = true;
+        try {
+            onError.accept(t);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+    
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        done = true;
+        try {
+            onComplete.run();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+    
+    @Override
+    public void dispose() {
+        DisposableHelper.dispose(this);
+    }
+    
+    @Override
+    public boolean isDisposed() {
+        return DisposableHelper.isDisposed(this.get());
+    }
+}


### PR DESCRIPTION
This PR factors out the anonymous inner classes from the base reactive types and introduces the appropriate classes and methods in `*Helper` enums.
