### PR TITLE
2.x: add withLatestFrom many, cleanups and other enhancements

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -188,6 +188,7 @@ public abstract class Completable implements CompletableSource {
         } catch (NullPointerException ex) { // NOPMD
             throw ex;
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             RxJavaPlugins.onError(ex);
             throw toNpe(ex);
         }
@@ -219,6 +220,7 @@ public abstract class Completable implements CompletableSource {
         } catch (NullPointerException ex) { // NOPMD
             throw ex;
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             RxJavaPlugins.onError(ex);
             throw toNpe(ex);
         } 
@@ -1384,6 +1386,7 @@ public abstract class Completable implements CompletableSource {
         } catch (NullPointerException ex) { // NOPMD
             throw ex;
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             RxJavaPlugins.onError(ex);
             throw toNpe(ex);
         }
@@ -1606,6 +1609,7 @@ public abstract class Completable implements CompletableSource {
         try {
             return converter.apply(this);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
     }

--- a/src/main/java/io/reactivex/CompletableObserver.java
+++ b/src/main/java/io/reactivex/CompletableObserver.java
@@ -20,6 +20,13 @@ import io.reactivex.disposables.Disposable;
  */
 public interface CompletableObserver {
     /**
+     * Called once by the Completable to set a Disposable on this instance which
+     * then can be used to cancel the subscription at any time.
+     * @param d the Disposable instance to call dispose on for cancellation, not null
+     */
+    void onSubscribe(Disposable d);
+
+    /**
      * Called once the deferred computation completes normally.
      */
     void onComplete();
@@ -29,11 +36,4 @@ public interface CompletableObserver {
      * @param e the exception, not null.
      */
     void onError(Throwable e);
-    
-    /**
-     * Called once by the Completable to set a Disposable on this instance which
-     * then can be used to cancel the subscription at any time.
-     * @param d the Disposable instance to call dispose on for cancellation, not null
-     */
-    void onSubscribe(Disposable d);
 }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -3842,8 +3842,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the items emitted by the Publisher most recently emitted by the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3883,8 +3882,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the items emitted by the Publisher most recently emitted by the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4036,8 +4034,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the Publisher whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -6737,8 +6734,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *        to this Publisher.
      * @return a Flowable that delays the subscription to this Publisher
      *         until the other Publisher emits an element or completes normally.
+     * @since 2.0
      */
-    @Experimental
     public final <U> Flowable<T> delaySubscription(Publisher<U> other) {
         Objects.requireNonNull(other, "other is null");
         return new FlowableDelaySubscriptionOther<T, U>(this, other);
@@ -9068,9 +9065,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param overflowStrategy how should the {@code Publisher} react to buffer overflows.  Null is not allowed.
      * @return the source {@code Publisher} modified to buffer items up to the given capacity
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final Publisher<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
         Objects.requireNonNull(overflowStrategy, "strategy is null");
         verifyPositive(capacity, "capacity");
@@ -9121,7 +9117,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onDrop the action to invoke for each item dropped. onDrop action should be fast and should never block.
      * @return the source Publisher modified to drop {@code onNext} notifications on overflow
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
-     * @Experimental The behavior of this can change at any time. 
      * @since 1.1.0
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
@@ -11752,8 +11747,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     public final <R> Flowable<R> switchMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return switchMapDelayError(mapper, bufferSize());
@@ -11787,8 +11781,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the number of elements to prefetch from the current active inner Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     public final <R> Flowable<R> switchMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize) {
         return switchMap0(mapper, bufferSize, true);
@@ -13198,6 +13191,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         try {
             return converter.apply(this);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
     }
@@ -14480,8 +14474,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that merges the specified Publisher into this Publisher by using the
      *         {@code resultSelector} function only when the source Publisher sequence (this instance) emits an
      *         item
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
@@ -14514,18 +14507,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T1> the first other source's value type
      * @param <T2> the second other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
-    public final <T1, T2, R> Flowable<R> withLatestFrom(Publisher<T1> o1, Publisher<T2> o2, 
+    public final <T1, T2, R> Flowable<R> withLatestFrom(Publisher<T1> p1, Publisher<T2> p2, 
             Function3<? super T, ? super T1, ? super T2, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2 }, f);
     }
 
     /**
@@ -14549,21 +14540,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T2> the second other source's value type
      * @param <T3> the third other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
-     * @param o3 the third other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
+     * @param p3 the third other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, R> Flowable<R> withLatestFrom(
-            Publisher<T1> o1, Publisher<T2> o2, 
-            Publisher<T3> o3, 
+            Publisher<T1> p1, Publisher<T2> p2, 
+            Publisher<T3> p3, 
             Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2, p3 }, f);
     }
 
     /**
@@ -14588,22 +14577,20 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T3> the third other source's value type
      * @param <T4> the fourth other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
-     * @param o3 the third other Publisher
-     * @param o4 the fourth other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
+     * @param p3 the third other Publisher
+     * @param p4 the fourth other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, R> Flowable<R> withLatestFrom(
-            Publisher<T1> o1, Publisher<T2> o2, 
-            Publisher<T3> o3, Publisher<T4> o4, 
+            Publisher<T1> p1, Publisher<T2> p2, 
+            Publisher<T3> p3, Publisher<T4> p4, 
             Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2, p3, p4 }, f);
     }
     /**
      * Combines the value emission from this Publisher with the latest emissions from the
@@ -14628,24 +14615,22 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T4> the fourth other source's value type
      * @param <T5> the fifth other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
-     * @param o3 the third other Publisher
-     * @param o4 the fourth other Publisher
-     * @param o5 the fifth other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
+     * @param p3 the third other Publisher
+     * @param p4 the fourth other Publisher
+     * @param p5 the fifth other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, R> Flowable<R> withLatestFrom(
-            Publisher<T1> o1, Publisher<T2> o2, 
-            Publisher<T1> o3, Publisher<T2> o4, 
-            Publisher<T1> o5, 
+            Publisher<T1> p1, Publisher<T2> p2, 
+            Publisher<T1> p3, Publisher<T2> p4, 
+            Publisher<T1> p5, 
             Function6<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2, p3, p4, p5 }, f);
     }
 
     /**
@@ -14672,25 +14657,23 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T5> the fifth other source's value type
      * @param <T6> the sixth other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
-     * @param o3 the third other Publisher
-     * @param o4 the fourth other Publisher
-     * @param o5 the fifth other Publisher
-     * @param o6 the sixth other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
+     * @param p3 the third other Publisher
+     * @param p4 the fourth other Publisher
+     * @param p5 the fifth other Publisher
+     * @param p6 the sixth other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, R> Flowable<R> withLatestFrom(
-            Publisher<T1> o1, Publisher<T2> o2, 
-            Publisher<T1> o3, Publisher<T2> o4, 
-            Publisher<T1> o5, Publisher<T2> o6, 
+            Publisher<T1> p1, Publisher<T2> p2, 
+            Publisher<T1> p3, Publisher<T2> p4, 
+            Publisher<T1> p5, Publisher<T2> p6, 
             Function7<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2, p3, p4, p5, p6 }, f);
     }
 
     /**
@@ -14718,27 +14701,25 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T6> the sixth other source's value type
      * @param <T7> the seventh other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
-     * @param o3 the third other Publisher
-     * @param o4 the fourth other Publisher
-     * @param o5 the fifth other Publisher
-     * @param o6 the sixth other Publisher
-     * @param o7 the seventh other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
+     * @param p3 the third other Publisher
+     * @param p4 the fourth other Publisher
+     * @param p5 the fifth other Publisher
+     * @param p6 the sixth other Publisher
+     * @param p7 the seventh other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, T7, R> Flowable<R> withLatestFrom(
-            Publisher<T1> o1, Publisher<T2> o2, 
-            Publisher<T1> o3, Publisher<T2> o4, 
-            Publisher<T1> o5, Publisher<T2> o6, 
-            Publisher<T1> o7,
+            Publisher<T1> p1, Publisher<T2> p2, 
+            Publisher<T1> p3, Publisher<T2> p4, 
+            Publisher<T1> p5, Publisher<T2> p6, 
+            Publisher<T1> p7,
             Function8<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2, p3, p4, p5, p6, p7 }, f);
     }
 
     /**
@@ -14767,28 +14748,35 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T7> the seventh other source's value type
      * @param <T8> the eighth other source's value type
      * @param <R> the result value type
-     * @param o1 the first other Publisher
-     * @param o2 the second other Publisher
-     * @param o3 the third other Publisher
-     * @param o4 the fourth other Publisher
-     * @param o5 the fifth other Publisher
-     * @param o6 the sixth other Publisher
-     * @param o7 the seventh other Publisher
-     * @param o8 the eighth other Publisher
+     * @param p1 the first other Publisher
+     * @param p2 the second other Publisher
+     * @param p3 the third other Publisher
+     * @param p4 the fourth other Publisher
+     * @param p5 the fifth other Publisher
+     * @param p6 the sixth other Publisher
+     * @param p7 the seventh other Publisher
+     * @param p8 the eighth other Publisher
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, T7, T8, R> Flowable<R> withLatestFrom(
-            Publisher<T1> o1, Publisher<T2> o2, 
-            Publisher<T1> o3, Publisher<T2> o4, 
-            Publisher<T1> o5, Publisher<T2> o6, 
-            Publisher<T1> o7, Publisher<T2> o8, 
+            Publisher<T1> p1, Publisher<T2> p2, 
+            Publisher<T1> p3, Publisher<T2> p4, 
+            Publisher<T1> p5, Publisher<T2> p6, 
+            Publisher<T1> p7, Publisher<T2> p8, 
             Function9<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(p1, "p1 is null");
+        Objects.requireNonNull(p2, "p2 is null");
+        Objects.requireNonNull(p3, "p3 is null");
+        Objects.requireNonNull(p4, "p4 is null");
+        Objects.requireNonNull(p5, "p5 is null");
+        Objects.requireNonNull(p6, "p6 is null");
+        Objects.requireNonNull(p7, "p7 is null");
+        Objects.requireNonNull(p8, "p8 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new Publisher[] { p1, p2, p3, p4, p5, p6, p7, p8 }, f);
     }
 
     /**
@@ -14812,13 +14800,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param others the array of other sources
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
-    public final <R> Flowable<R> withLatestFrom(Publisher<?>[] others, Function<Object[], R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+    public final <R> Flowable<R> withLatestFrom(Publisher<?>[] others, Function<? super Object[], R> combiner) {
+        Objects.requireNonNull(others, "others is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        return new FlowableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
     /**
@@ -14837,18 +14824,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This operator does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * 
+     *
      * @param <R> the result value type
      * @param others the iterable of other sources
      * @param combiner the function called with an array of values from each participating Publisher
      * @return the new Publisher instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
-    public final <R> Flowable<R> withLatestFrom(Iterable<Publisher<?>> others, Function<Object[], R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+    public final <R> Flowable<R> withLatestFrom(Iterable<? extends Publisher<?>> others, Function<? super Object[], R> combiner) {
+        Objects.requireNonNull(others, "others is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        return new FlowableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
     /**
@@ -14977,6 +14963,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that pairs up values from the source Publisher and the {@code other} Publisher
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -15028,6 +15015,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that pairs up values from the source Publisher and the {@code other} Publisher
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -15043,6 +15031,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Creates a TestSubscriber that requests Long.MAX_VALUE and subscribes
      * it to this Flowable.
      * @return the new TestSubscriber instance
+     * @since 2.0
      */
     public final TestSubscriber<T> test() { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>();
@@ -15055,6 +15044,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * it to this Flowable.
      * @param initialRequest the initial request amount, positive
      * @return the new TestSubscriber instance
+     * @since 2.0
      */
     public final TestSubscriber<T> test(long initialRequest) { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
@@ -15070,7 +15060,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
      * Flowable.
      * @return the new TestSubscriber instance
-     */
+      * @since 2.0
+    */
     public final TestSubscriber<T> test(long initialRequest, int fusionMode, boolean cancelled) { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
         ts.setInitialFusionMode(fusionMode);

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1207,7 +1207,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T> the value type
      * @param sources a sequence of ObservableSources that need to be eagerly concatenated
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArrayEager(ObservableSource<? extends T>... sources) {
@@ -1230,7 +1230,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                       is interpreted as indication to subscribe to all sources at once
      * @param prefetch the number of elements to prefetch from each ObservableSource source
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArrayEager(int maxConcurrency, int prefetch, ObservableSource<? extends T>... sources) {
@@ -1311,7 +1311,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T> the value type
      * @param sources a sequence of ObservableSources that need to be eagerly concatenated
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources) {
@@ -1334,7 +1334,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                       is interpreted as all inner ObservableSources can be active at the same time
      * @param prefetch the number of elements to prefetch from each inner ObservableSource source
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
@@ -1355,7 +1355,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T> the value type
      * @param sources a sequence of ObservableSources that need to be eagerly concatenated
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources) {
@@ -1378,7 +1378,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                       is interpreted as all inner ObservableSources can be active at the same time
      * @param prefetch the number of elements to prefetch from each inner ObservableSource source
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
@@ -1579,7 +1579,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         the type of the item emitted by the ObservableSource
      * @return a Observable whose {@link Observer}s' subscriptions trigger an invocation of the given function
      * @see #defer(Callable)
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromCallable(Callable<? extends T> supplier) {
@@ -2988,7 +2988,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits all of the items emitted by the ObservableSources emitted by the
      *         {@code source} ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3404,8 +3404,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits the items emitted by the ObservableSource most recently emitted by the source
      *         ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
@@ -3440,8 +3439,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits the items emitted by the ObservableSource most recently emitted by the source
      *         ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
@@ -3574,8 +3572,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the ObservableSource whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, D> Observable<T> using(Callable<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
@@ -5463,7 +5460,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param mapper the function that maps a sequence of values into a sequence of ObservableSources that will be
      *               eagerly concatenated
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEager(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
@@ -5488,7 +5485,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param maxConcurrency the maximum number of concurrent subscribed ObservableSources
      * @param prefetch hints about the number of expected source sequence values
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEager(Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
@@ -5515,7 +5512,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            if true, all errors from the outer and inner ObservableSource sources are delayed until the end,
      *            if false, an error from the main source is signalled when the current ObservableSource source terminates
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
@@ -5546,7 +5543,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *               all of them terminate, if false, exception from the current Observable is delayed until the
      *               currently running ObservableSource terminates
      * @return the new ObservableSource instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
@@ -5974,8 +5971,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *        to this Observable.
      * @return an Observable that delays the subscription to this Observable
      *         until the other Observable emits an element or completes normally.
+     * @since 2.0
      */
-    @Experimental
     public final <U> Observable<T> delaySubscription(ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
         return new ObservableDelaySubscriptionOther<T, U>(this, other);
@@ -6639,7 +6636,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         by the source ObservableSource and merging the results of the ObservableSources obtained from this
      *         transformation
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
@@ -6673,7 +6670,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         by the source ObservableSource and merging the results of the ObservableSources obtained from this
      *         transformation
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
@@ -6751,7 +6748,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits the results of merging the ObservableSources returned from applying the
      *         specified functions to the emissions and notifications of the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(
@@ -6787,7 +6784,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         by the source ObservableSource and merging the results of the ObservableSources obtained from this
      *         transformation
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int maxConcurrency) {
@@ -6889,7 +6886,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits the results of applying a function to a pair of values emitted by the
      *         source ObservableSource and the collection ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper, 
@@ -6927,7 +6924,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits the results of applying a function to a pair of values emitted by the
      *         source ObservableSource and the collection ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends ObservableSource<? extends U>> mapper, 
@@ -6962,7 +6959,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits the results of applying a function to a pair of values emitted by the
      *         source ObservableSource and the collection ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper, 
@@ -7897,7 +7894,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @return a Observable which out references to the upstream producer and downstream Subscriber if
      * the sequence is terminated or downstream unsubscribes
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onTerminateDetach() {
@@ -9902,8 +9899,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            ObservableSource
      * @return a Observable that emits the items emitted by the ObservableSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return switchMapDelayError(mapper, bufferSize());
@@ -9932,8 +9928,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the number of elements to prefetch from the current active inner ObservableSource
      * @return a Observable that emits the items emitted by the ObservableSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
         // TODO implement
@@ -11531,7 +11526,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @throws NoSuchElementException
      *             if the source ObservableSource emits no items
      * @see <a href="http://reactivex.io/documentation/single.html">ReactiveX documentation: Single</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
@@ -11602,7 +11597,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that emits a list that contains the items emitted by the source ObservableSource in
      *         sorted order
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
@@ -11629,7 +11624,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             if any item emitted by the ObservableSource does not implement {@link Comparable} with respect to
      *             all other items emitted by the ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<List<T>> toSortedList(int capacityHint) {
@@ -12256,8 +12251,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that merges the specified ObservableSource into this ObservableSource by using the
      *         {@code resultSelector} function only when the source ObservableSource sequence (this instance) emits an
      *         item
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12289,14 +12283,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o2 the second other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
-    public final <T1, T2, R> Observable<R> withLatestFrom(ObservableSource<T1> o1, ObservableSource<T2> o2, 
+    public final <T1, T2, R> Observable<R> withLatestFrom(
+            ObservableSource<T1> o1, ObservableSource<T2> o2, 
             Function3<? super T, ? super T1, ? super T2, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2 }, f);
     }
 
     /**
@@ -12322,16 +12318,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o3 the third other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T3> o3, 
             Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(o3, "o3 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3 }, f);
     }
 
     /**
@@ -12359,16 +12357,19 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o4 the fourth other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T3> o3, ObservableSource<T4> o4, 
             Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(o3, "o3 is null");
+        Objects.requireNonNull(o4, "o4 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4 }, f);
     }
     /**
      * Combines the value emission from this ObservableSource with the latest emissions from the
@@ -12397,17 +12398,21 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o5 the fifth other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T1> o3, ObservableSource<T2> o4, 
             ObservableSource<T1> o5, 
             Function6<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(o3, "o3 is null");
+        Objects.requireNonNull(o4, "o4 is null");
+        Objects.requireNonNull(o5, "o5 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5 }, f);
     }
 
     /**
@@ -12439,17 +12444,22 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o6 the sixth other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T1> o3, ObservableSource<T2> o4, 
             ObservableSource<T1> o5, ObservableSource<T2> o6, 
             Function7<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(o3, "o3 is null");
+        Objects.requireNonNull(o4, "o4 is null");
+        Objects.requireNonNull(o5, "o5 is null");
+        Objects.requireNonNull(o6, "o6 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5, o6 }, f);
     }
 
     /**
@@ -12483,18 +12493,24 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o7 the seventh other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T1> o3, ObservableSource<T2> o4, 
             ObservableSource<T1> o5, ObservableSource<T2> o6, 
             ObservableSource<T1> o7,
             Function8<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(o3, "o3 is null");
+        Objects.requireNonNull(o4, "o4 is null");
+        Objects.requireNonNull(o5, "o5 is null");
+        Objects.requireNonNull(o6, "o6 is null");
+        Objects.requireNonNull(o7, "o7 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5, o6, o7 }, f);
     }
 
     /**
@@ -12530,18 +12546,25 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param o8 the eighth other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T1> o3, ObservableSource<T2> o4, 
             ObservableSource<T1> o5, ObservableSource<T2> o6, 
             ObservableSource<T1> o7, ObservableSource<T2> o8, 
             Function9<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+        Objects.requireNonNull(o1, "o1 is null");
+        Objects.requireNonNull(o2, "o2 is null");
+        Objects.requireNonNull(o3, "o3 is null");
+        Objects.requireNonNull(o4, "o4 is null");
+        Objects.requireNonNull(o5, "o5 is null");
+        Objects.requireNonNull(o6, "o6 is null");
+        Objects.requireNonNull(o7, "o7 is null");
+        Objects.requireNonNull(o8, "o8 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        Function<Object[], R> f = Functions.toFunction(combiner);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5, o6, o7, o8 }, f);
     }
 
     /**
@@ -12562,13 +12585,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param others the array of other sources
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
-    public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<Object[], R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+    public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<? super Object[], R> combiner) {
+        Objects.requireNonNull(others, "others is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        return new ObservableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
     /**
@@ -12589,13 +12611,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param others the iterable of other sources
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 2.0
      */
-    @Experimental
-    public final <R> Observable<R> withLatestFrom(Iterable<ObservableSource<?>> others, Function<Object[], R> combiner) {
-        // TODO implement
-        throw new UnsupportedOperationException();
+    public final <R> Observable<R> withLatestFrom(Iterable<? extends ObservableSource<?>> others, Function<? super Object[], R> combiner) {
+        Objects.requireNonNull(others, "others is null");
+        Objects.requireNonNull(combiner, "combiner is null");
+        return new ObservableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
     /**
@@ -12711,6 +12732,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that pairs up values from the source ObservableSource and the {@code other} ObservableSource
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other, 
@@ -12757,6 +12779,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Observable that pairs up values from the source ObservableSource and the {@code other} ObservableSource
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other, 
@@ -12771,6 +12794,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Creates a TestObserver and subscribes
      * it to this Observable.
      * @return the new TestObserver instance
+     * @since 2.0
      */
     public final TestObserver<T> test() { // NoPMD
         TestObserver<T> ts = new TestObserver<T>();
@@ -12785,6 +12809,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
      * Observable.
      * @return the new TestObserver instance
+     * @since 2.0
      */
     public final TestObserver<T> test(int fusionMode, boolean cancelled) { // NoPMD
         TestObserver<T> ts = new TestObserver<T>();

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -15,14 +15,62 @@ package io.reactivex;
 
 import io.reactivex.disposables.Disposable;
 
+/**
+ * Provides a mechanism for receiving push-based notifications.
+ * <p>
+ * After an Observer calls an {@link Observable}'s {@link Observable#subscribe subscribe} method, 
+ * first the Observable calls {@link #onSubscribe(Disposable)} with a {@link Disposable} that allows
+ * cancelling the sequence at any time, then the
+ * {@code Observable} may call the Observer's {@link #onNext} method any number of times
+ * to provide notifications. A well-behaved
+ * {@code Observable} will call an Observer's {@link #onComplete} method exactly once or the Observer's
+ * {@link #onError} method exactly once.
+ * 
+ * @see <a href="http://reactivex.io/documentation/observable.html">ReactiveX documentation: Observable</a>
+ * @param <T>
+ *          the type of item the Observer expects to observe
+ */
 public interface Observer<T> {
-    
+
+    /**
+     * Provides the Observer with the means of cancelling (disposing) the
+     * connection (channel) with the Observable in both
+     * synchronous (from within {@link #onNext(Object)}) and asynchronous manner. 
+     * @param d the Disposable instance whose {@link Disposable#dispose()} can
+     * be called anytime to cancel the connection
+     * @since 2.0
+     */
     void onSubscribe(Disposable d);
 
+    /**
+     * Provides the Observer with a new item to observe.
+     * <p>
+     * The {@link Observable} may call this method 0 or more times.
+     * <p>
+     * The {@code Observable} will not call this method again after it calls either {@link #onComplete} or
+     * {@link #onError}.
+     * 
+     * @param value
+     *          the item emitted by the Observable
+     */
     void onNext(T value);
     
+    /**
+     * Notifies the Observer that the {@link Observable} has experienced an error condition.
+     * <p>
+     * If the {@link Observable} calls this method, it will not thereafter call {@link #onNext} or
+     * {@link #onComplete}.
+     * 
+     * @param e
+     *          the exception encountered by the Observable
+     */
     void onError(Throwable e);
     
+    /**
+     * Notifies the Observer that the {@link Observable} has finished sending push-based notifications.
+     * <p>
+     * The {@link Observable} will not call this method if it calls {@link #onError}.
+     */
     void onComplete();
     
 }

--- a/src/main/java/io/reactivex/Scheduler.java
+++ b/src/main/java/io/reactivex/Scheduler.java
@@ -15,8 +15,9 @@ package io.reactivex;
 
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public abstract class Scheduler {
@@ -106,9 +107,9 @@ public abstract class Scheduler {
         }
         
         public Disposable schedulePeriodically(Runnable run, final long initialDelay, final long period, final TimeUnit unit) {
-            final SerialDisposable first = new SerialDisposable();
+            final SequentialDisposable first = new SequentialDisposable();
 
-            final SerialDisposable sd = new SerialDisposable(first);
+            final SequentialDisposable sd = new SequentialDisposable(first);
             
             final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
             
@@ -182,6 +183,7 @@ public abstract class Scheduler {
                 try {
                     run.run();
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     worker.dispose();
                     throw Exceptions.propagate(ex);
                 }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2783,6 +2783,7 @@ public abstract class Single<T> implements SingleSource<T> {
         try {
             return convert.apply(this);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
     }

--- a/src/main/java/io/reactivex/SingleObserver.java
+++ b/src/main/java/io/reactivex/SingleObserver.java
@@ -15,11 +15,50 @@ package io.reactivex;
 
 import io.reactivex.disposables.Disposable;
 
+/**
+ * Provides a mechanism for receiving push-based notifications.
+ * <p>
+ * After a SingleSubscriber calls a {@link Single}'s {@link Single#subscribe subscribe} method, 
+ * first the Single calls {@link #onSubscribe(Disposable)} with a {@link Disposable} that allows
+ * cancelling the sequence at any time, then the
+ * {@code Single} calls only one of the SingleSubscriber's {@link #onSuccess} and {@link #onError} methods to provide
+ * notifications.
+ * 
+ * @see <a href="http://reactivex.io/documentation/observable.html">ReactiveX documentation: Observable</a>
+ * @param <T>
+ *          the type of item the SingleSubscriber expects to observe
+ * @since 2.0
+ */
 public interface SingleObserver<T> {
     
+    /**
+     * Provides the SingleObserver with the means of cancelling (disposing) the
+     * connection (channel) with the Single in both
+     * synchronous (from within {@link #onSubscribe(Disposable)} itself) and asynchronous manner. 
+     * @param d the Disposable instance whose {@link Disposable#dispose()} can
+     * be called anytime to cancel the connection
+     * @since 2.0
+     */
     void onSubscribe(Disposable d);
     
+    /**
+     * Notifies the SingleSubscriber with a single item and that the {@link Single} has finished sending
+     * push-based notifications.
+     * <p>
+     * The {@link Single} will not call this method if it calls {@link #onError}.
+     * 
+     * @param value
+     *          the item emitted by the Single
+     */
     void onSuccess(T value);
 
+    /**
+     * Notifies the SingleSubscriber that the {@link Single} has experienced an error condition.
+     * <p>
+     * If the {@link Single} calls this method, it will not thereafter call {@link #onSuccess}.
+     * 
+     * @param e
+     *          the exception encountered by the Single
+     */
     void onError(Throwable e);
 }

--- a/src/main/java/io/reactivex/annotations/package-info.java
+++ b/src/main/java/io/reactivex/annotations/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Annotations for indicating experimental and beta operators, classes, methods, types or fields.
+ */
+package io.reactivex.annotations;

--- a/src/main/java/io/reactivex/disposables/ActionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ActionDisposable.java
@@ -28,6 +28,7 @@ final class ActionDisposable extends ReferenceDisposable<Action> {
         try {
             value.run();
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
     }

--- a/src/main/java/io/reactivex/disposables/FutureDisposable.java
+++ b/src/main/java/io/reactivex/disposables/FutureDisposable.java
@@ -14,6 +14,9 @@ package io.reactivex.disposables;
 
 import java.util.concurrent.Future;
 
+/**
+ * A Disposable container that cancels a Future instance.
+ */
 final class FutureDisposable extends ReferenceDisposable<Future<?>> {
     /** */
     private static final long serialVersionUID = 6545242830671168775L;

--- a/src/main/java/io/reactivex/disposables/RefCountDisposable.java
+++ b/src/main/java/io/reactivex/disposables/RefCountDisposable.java
@@ -18,6 +18,10 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.Objects;
 
+/**
+ * Keeps track of the sub-subscriptions and unsubscribes the underlying subscription once all sub-subscriptions
+ * have unsubscribed.
+ */
 public final class RefCountDisposable implements Disposable {
 
     final AtomicReference<Disposable> resource = new AtomicReference<Disposable>();
@@ -26,6 +30,14 @@ public final class RefCountDisposable implements Disposable {
 
     final AtomicBoolean once = new AtomicBoolean();
 
+    /**
+     * Creates a {@code RefCountDisposable} by wrapping the given non-null {@code Subscription}.
+     * 
+     * @param resource
+     *          the {@link Disposable} to wrap
+     * @throws NullPointerException
+     *          if {@code s} is {@code null}
+     */
     public RefCountDisposable(Disposable resource) {
         Objects.requireNonNull(resource, "resource is null");
         this.resource.lazySet(resource);
@@ -39,6 +51,11 @@ public final class RefCountDisposable implements Disposable {
         }
     }
 
+    /**
+     * Returns a new sub-Disposable
+     *
+     * @return a new sub-Disposable.
+     */
     public Disposable get() {
         count.getAndIncrement();
         return new InnerDisposable(this);

--- a/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
@@ -17,6 +17,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.internal.functions.Objects;
 
+/**
+ * Base class for Disposable containers that manage some other type that
+ * has to be run when the container is disposed.
+ *
+ * @param <T> the type contained
+ */
 abstract class ReferenceDisposable<T> extends AtomicReference<T> implements Disposable {
     /** */
     private static final long serialVersionUID = 6537757548749041217L;

--- a/src/main/java/io/reactivex/disposables/RunnableDisposable.java
+++ b/src/main/java/io/reactivex/disposables/RunnableDisposable.java
@@ -12,6 +12,9 @@
  */
 package io.reactivex.disposables;
 
+/**
+ * A disposable container that manages a Runnable instance.
+ */
 final class RunnableDisposable extends ReferenceDisposable<Runnable> {
     /** */
     private static final long serialVersionUID = -8219729196779211169L;

--- a/src/main/java/io/reactivex/disposables/SubscriptionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/SubscriptionDisposable.java
@@ -14,6 +14,9 @@ package io.reactivex.disposables;
 
 import org.reactivestreams.Subscription;
 
+/**
+ * A Disposable container that handles a {@link Subscription}.
+ */
 final class SubscriptionDisposable extends ReferenceDisposable<Subscription> {
     /** */
     private static final long serialVersionUID = -707001650852963139L;

--- a/src/main/java/io/reactivex/disposables/package-info.java
+++ b/src/main/java/io/reactivex/disposables/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default implementations for Disposable-based resource management
+ * (Disposable container types) and utility classes to construct
+ * Disposables from callbacks and other types.
+ */
+package io.reactivex.disposables;

--- a/src/main/java/io/reactivex/exceptions/package-info.java
+++ b/src/main/java/io/reactivex/exceptions/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Exception handling utilities, safe subscriber exception classes, 
+ * lifecycle exception classes.
+ */
+package io.reactivex.exceptions;

--- a/src/main/java/io/reactivex/flowables/BlockingFlowable.java
+++ b/src/main/java/io/reactivex/flowables/BlockingFlowable.java
@@ -24,6 +24,7 @@ import io.reactivex.Optional;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.subscribers.flowable.*;
@@ -56,6 +57,7 @@ public final class BlockingFlowable<T> implements Publisher<T>, Iterable<T> {
             try {
                 action.accept(it.next());
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 it.dispose();
                 throw Exceptions.propagate(e);
             }
@@ -148,7 +150,7 @@ public final class BlockingFlowable<T> implements Publisher<T>, Iterable<T> {
         final CountDownLatch cdl = new CountDownLatch(1);
         final AtomicReference<T> value = new AtomicReference<T>();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        final SerialDisposable sd = new SerialDisposable();
+        final SequentialDisposable sd = new SequentialDisposable();
         
         o.subscribe(new Subscriber<T>() {
 

--- a/src/main/java/io/reactivex/flowables/package-info.java
+++ b/src/main/java/io/reactivex/flowables/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes supporting the Flowable base reactive class: blocking, connectable and grouped
+ * flowables.
+ */
+package io.reactivex.flowables;

--- a/src/main/java/io/reactivex/functions/package-info.java
+++ b/src/main/java/io/reactivex/functions/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Functional interfaces of functions and actions of arity 0 to 9 and related
+ * utility classes.
+ */
+package io.reactivex.functions;

--- a/src/main/java/io/reactivex/internal/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableContainer.java
@@ -17,6 +17,7 @@ import io.reactivex.disposables.Disposable;
 
 /**
  * Common interface to add and remove disposables from a container.
+ * @since 2.0
  */
 public interface DisposableContainer {
     

--- a/src/main/java/io/reactivex/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/ListCompositeDisposable.java
@@ -168,6 +168,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
             try {
                 o.dispose();
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 if (errors == null) {
                     errors = new ArrayList<Throwable>();
                 }

--- a/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
+++ b/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class NbpFullArbiter<T> extends FullArbiterPad1 implements Disposable {
+public final class ObserverFullArbiter<T> extends FullArbiterPad1 implements Disposable {
     final Observer<? super T> actual;
     final SpscLinkedArrayQueue<Object> queue;
 
@@ -37,7 +37,7 @@ public final class NbpFullArbiter<T> extends FullArbiterPad1 implements Disposab
 
     volatile boolean cancelled;
 
-    public NbpFullArbiter(Observer<? super T> actual, Disposable resource, int capacity) {
+    public ObserverFullArbiter(Observer<? super T> actual, Disposable resource, int capacity) {
         this.actual = actual;
         this.resource = resource;
         this.queue = new SpscLinkedArrayQueue<Object>(capacity);

--- a/src/main/java/io/reactivex/internal/disposables/SequentialDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/SequentialDisposable.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A Disposable container that allows updating/replacing a Disposable
+ * atomically and with respect of disposing the container itself.
+ * <p>
+ * The class extends AtomicReference directly so watch out for the API leak!
+ * @since 2.0
+ */
+public final class SequentialDisposable 
+extends AtomicReference<Disposable>
+implements Disposable {
+
+    /** */
+    private static final long serialVersionUID = -754898800686245608L;
+
+    /**
+     * Constructs an empty SequentialDisposable.
+     */
+    public SequentialDisposable() {
+        // nothing to do
+    }
+    
+    /**
+     * Construct a SequentialDisposable with the initial Disposable provided.
+     * @param initial the initial disposable, null allowed
+     */
+    public SequentialDisposable(Disposable initial) {
+        lazySet(initial);
+    }
+    
+    /**
+     * Atomically: set the next disposable on this container and dispose the previous
+     * one (if any) or dispose next if the container has been disposed.
+     * @param next the Disposable to set, may be null
+     * @return true if the operation succeeded, false if the container has been disposed
+     * @see #replace(Disposable)
+     */
+    public boolean update(Disposable next) {
+        return DisposableHelper.set(this, next);
+    }
+    
+    /**
+     * Atomically: set the next disposable on this container but don't dispose the previous
+     * one (if any) or dispose next if the container has been disposed.
+     * @param next the Disposable to set, may be null
+     * @return true if the operation succeeded, false if the container has been disposed
+     * @see #update(Disposable)
+     */
+    public boolean replace(Disposable next) {
+        return DisposableHelper.replace(this, next);
+    }
+    
+    @Override
+    public void dispose() {
+        DisposableHelper.dispose(this);
+    }
+    
+    @Override
+    public boolean isDisposed() {
+        return DisposableHelper.isDisposed(get());
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableAmbIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableAmbIterable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableAmbIterable extends Completable {
@@ -38,6 +39,7 @@ public final class CompletableAmbIterable extends Completable {
         try {
             it = sources.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.onError(e);
             return;
         }
@@ -87,6 +89,7 @@ public final class CompletableAmbIterable extends Completable {
             try {
                 b = it.hasNext();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 if (once.compareAndSet(false, true)) {
                     set.dispose();
                     s.onError(e);
@@ -114,6 +117,7 @@ public final class CompletableAmbIterable extends Completable {
             try {
                 c = it.next();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 if (once.compareAndSet(false, true)) {
                     set.dispose();
                     s.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
@@ -18,8 +18,9 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -46,7 +47,7 @@ public final class CompletableConcat extends Completable {
         private static final long serialVersionUID = 7412667182931235013L;
         final CompletableObserver actual;
         final int prefetch;
-        final SerialDisposable sd;
+        final SequentialDisposable sd;
         
         final SpscArrayQueue<CompletableSource> queue;
         
@@ -62,7 +63,7 @@ public final class CompletableConcat extends Completable {
             this.actual = actual;
             this.prefetch = prefetch;
             this.queue = new SpscArrayQueue<CompletableSource>(prefetch);
-            this.sd = new SerialDisposable();
+            this.sd = new SequentialDisposable();
             this.inner = new ConcatInnerObserver();
         }
         
@@ -151,7 +152,7 @@ public final class CompletableConcat extends Completable {
         final class ConcatInnerObserver implements CompletableObserver {
             @Override
             public void onSubscribe(Disposable d) {
-                sd.set(d);
+                sd.update(d);
             }
             
             @Override

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatArray.java
@@ -16,7 +16,8 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class CompletableConcatArray extends Completable {
     final CompletableSource[] sources;
@@ -41,17 +42,17 @@ public final class CompletableConcatArray extends Completable {
         
         int index;
         
-        final SerialDisposable sd;
+        final SequentialDisposable sd;
         
         public ConcatInnerObserver(CompletableObserver actual, CompletableSource[] sources) {
             this.actual = actual;
             this.sources = sources;
-            this.sd = new SerialDisposable();
+            this.sd = new SequentialDisposable();
         }
         
         @Override
         public void onSubscribe(Disposable d) {
-            sd.set(d);
+            sd.update(d);
         }
         
         @Override

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class CompletableDefer extends Completable {
@@ -33,8 +34,8 @@ public final class CompletableDefer extends Completable {
         try {
             c = completableSupplier.call();
         } catch (Throwable e) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(e);
+            Exceptions.throwIfFatal(e);
+            EmptyDisposable.error(e, s);
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class CompletableErrorSupplier extends Completable {
@@ -34,6 +35,7 @@ public final class CompletableErrorSupplier extends Completable {
         try {
             error = errorSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             error = e;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
 
 public final class CompletableFromAction extends Completable {
@@ -32,6 +33,7 @@ public final class CompletableFromAction extends Completable {
         try {
             run.run();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
                 s.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromCallable.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 
 public final class CompletableFromCallable extends Completable {
     
@@ -33,6 +34,7 @@ public final class CompletableFromCallable extends Completable {
         try {
             callable.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
                 s.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 
@@ -39,6 +40,7 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
         try {
             iterator = sources.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.onError(e);
             return;
         }
@@ -61,6 +63,7 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
             try {
                 b = iterator.hasNext();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 queue.offer(e);
                 if (wip.decrementAndGet() == 0) {
                     if (queue.isEmpty()) {
@@ -85,6 +88,7 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
             try {
                 c = iterator.next();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 queue.offer(e);
                 if (wip.decrementAndGet() == 0) {
                     if (queue.isEmpty()) {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeIterable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableMergeIterable extends Completable {
@@ -38,6 +39,7 @@ public final class CompletableMergeIterable extends Completable {
         try {
             iterator = sources.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.onError(e);
             return;
         }
@@ -59,6 +61,7 @@ public final class CompletableMergeIterable extends Completable {
             try {
                 b = iterator.hasNext();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 set.dispose();
                 if (once.compareAndSet(false, true)) {
                     s.onError(e);
@@ -81,6 +84,7 @@ public final class CompletableMergeIterable extends Completable {
             try {
                 c = iterator.next();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 set.dispose();
                 if (once.compareAndSet(false, true)) {
                     s.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnErrorComplete.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Predicate;
 
 public final class CompletableOnErrorComplete extends Completable {
@@ -46,6 +46,7 @@ public final class CompletableOnErrorComplete extends Completable {
                 try {
                     b = predicate.test(e);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     s.onError(new CompositeException(e, ex));
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -14,9 +14,10 @@
 package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class CompletableResumeNext extends Completable {
 
@@ -35,7 +36,7 @@ public final class CompletableResumeNext extends Completable {
     @Override
     protected void subscribeActual(final CompletableObserver s) {
 
-        final SerialDisposable sd = new SerialDisposable();
+        final SequentialDisposable sd = new SequentialDisposable();
         source.subscribe(new CompletableObserver() {
 
             @Override
@@ -50,6 +51,7 @@ public final class CompletableResumeNext extends Completable {
                 try {
                     c = errorMapper.apply(e);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     s.onError(new CompositeException(ex, e));
                     return;
                 }
@@ -75,7 +77,7 @@ public final class CompletableResumeNext extends Completable {
 
                     @Override
                     public void onSubscribe(Disposable d) {
-                        sd.set(d);
+                        sd.update(d);
                     }
                     
                 });
@@ -83,7 +85,7 @@ public final class CompletableResumeNext extends Completable {
 
             @Override
             public void onSubscribe(Disposable d) {
-                sd.set(d);
+                sd.update(d);
             }
             
         });

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimer.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.*;
-import io.reactivex.disposables.SerialDisposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class CompletableTimer extends Completable {
 
@@ -34,7 +34,7 @@ public final class CompletableTimer extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver s) {
-        SerialDisposable sd = new SerialDisposable();
+        SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
         if (!sd.isDisposed()) {
             sd.replace(scheduler.scheduleDirect(new Runnable() {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableToSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableToSingle.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 
 public final class CompletableToSingle<T> extends Single<T> {
     final CompletableSource source;
@@ -44,6 +45,7 @@ public final class CompletableToSingle<T> extends Single<T> {
                     try {
                         v = completionValueSupplier.call();
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         s.onError(e);
                         return;
                     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterator.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterator.java
@@ -127,7 +127,7 @@ implements Subscriber<T>, Iterator<T>, Runnable, Disposable {
     @Override
     public void onNext(T t) {
         if (!queue.offer(t)) {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
             
             onError(new IllegalStateException("Queue full?!"));
         } else {
@@ -159,7 +159,7 @@ implements Subscriber<T>, Iterator<T>, Runnable, Disposable {
 
     @Override
     public void run() {
-        SubscriptionHelper.dispose(this);
+        SubscriptionHelper.cancel(this);
         signalConsumer();
     }
     
@@ -170,7 +170,7 @@ implements Subscriber<T>, Iterator<T>, Runnable, Disposable {
     
     @Override
     public void dispose() {
-        SubscriptionHelper.dispose(this);
+        SubscriptionHelper.cancel(this);
     }
     
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
@@ -14,6 +14,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -63,9 +64,9 @@ public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolea
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 s.cancel();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             if (!b) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAmb.java
@@ -229,7 +229,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
         
         @Override
         public void cancel() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
         
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
@@ -14,6 +14,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.*;
 
@@ -61,9 +62,9 @@ public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolea
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 s.cancel();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             if (b) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -236,10 +236,11 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
             long i = index;
 
-            if (i % skip == 0L) {
+            if (i % skip == 0L) { // FIXME no need for modulo
                 try {
                     b = bufferSupplier.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     cancel();
 
                     onError(e);
@@ -392,7 +393,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
             long i = index;
 
-            if (i % skip == 0L) {
+            if (i % skip == 0L) { // FIXME no need for modulo
                 C b;
 
                 try {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -174,6 +175,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 onError(e);
                 return;
             }
@@ -188,6 +190,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 p = bufferClose.apply(window);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
@@ -77,6 +78,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancelled = true;
                 s.cancel();
                 EmptySubscription.error(e, actual);
@@ -96,6 +98,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 boundary = boundarySupplier.call();
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 cancelled = true;
                 s.cancel();
                 EmptySubscription.error(ex, actual);
@@ -184,6 +187,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;
@@ -200,6 +204,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 boundary = boundarySupplier.call();
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 cancelled = true;
                 s.cancel();
                 actual.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;
@@ -72,6 +73,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancelled = true;
                 s.cancel();
                 EmptySubscription.error(e, actual);
@@ -157,6 +159,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -22,6 +22,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
@@ -114,6 +115,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 EmptySubscription.error(e, actual);
                 return;
@@ -206,6 +208,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 selfCancel = true;
                 cancel();
                 actual.onError(e);
@@ -291,6 +294,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 w.dispose();
                 s.cancel();
                 EmptySubscription.error(e, actual);
@@ -386,6 +390,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;
@@ -467,6 +472,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 w.dispose();
                 s.cancel();
                 EmptySubscription.error(e, actual);
@@ -517,6 +523,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;
@@ -611,6 +618,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -19,6 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
@@ -211,7 +212,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
                 sourceDone = true;
                 Object o = NotificationLite.error(e);
                 add(o);
-                SubscriptionHelper.dispose(connection);
+                SubscriptionHelper.cancel(connection);
                 dispatch();
             }
         }
@@ -221,7 +222,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
                 sourceDone = true;
                 Object o = NotificationLite.complete();
                 add(o);
-                SubscriptionHelper.dispose(connection);
+                SubscriptionHelper.cancel(connection);
                 dispatch();
             }
         }
@@ -396,6 +397,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
                                         return;
                                     }
                                 } catch (Throwable err) {
+                                    Exceptions.throwIfFatal(err);
                                     skipFinal = true;
                                     dispose();
                                     if (!NotificationLite.isError(o) && !NotificationLite.isComplete(o)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -88,6 +88,7 @@ extends Flowable<R> {
             try {
                 it = iterable.iterator();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, s);
                 return;
             }
@@ -104,6 +105,7 @@ extends Flowable<R> {
                 try {
                     b = it.hasNext();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, s);
                     return;
                 }
@@ -117,6 +119,7 @@ extends Flowable<R> {
                 try {
                     p = it.next();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, s);
                     return;
                 }
@@ -552,7 +555,7 @@ extends Flowable<R> {
         }
         
         public void cancel() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
         
         public void requestOne() {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -89,6 +90,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
             try {
                 p = debounceSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 public final class FlowableDefer<T> extends Flowable<T> {
@@ -31,6 +32,7 @@ public final class FlowableDefer<T> extends Flowable<T> {
         try {
             pub = supplier.call();
         } catch (Throwable t) {
+            Exceptions.throwIfFatal(t);
             EmptySubscription.error(t, s);
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.subscriptions.*;
@@ -107,6 +107,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
         try {
             coll = predicateSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }
@@ -147,6 +148,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             try {
                 key = keySelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.cancel();
                 actual.onError(e);
                 return;
@@ -163,6 +165,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             try {
                 b = predicate.test(key);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.cancel();
                 actual.onError(e);
                 return;
@@ -180,6 +183,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             try {
                 predicate.test(null); // special case: poison pill
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 return;
             }
@@ -191,6 +195,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             try {
                 predicate.test(null); // special case: poison pill
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -111,6 +111,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
             try {
                 onAfterTerminate.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(e);
             }
         }
@@ -133,6 +134,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
             try {
                 onAfterTerminate.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(e);
             }
         }
@@ -245,6 +247,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
             try {
                 onAfterTerminate.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(e);
             }
         }
@@ -267,6 +270,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
             try {
                 onAfterTerminate.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(e);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 public final class FlowableError<T> extends Flowable<T> {
@@ -31,6 +32,7 @@ public final class FlowableError<T> extends Flowable<T> {
         try {
             error = errorSupplier.call();
         } catch (Throwable t) {
+            Exceptions.throwIfFatal(t);
             error = t;
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -124,6 +124,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.cancel();
                 onError(e);
                 return;
@@ -134,6 +135,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 try {
                     u  = ((Callable<U>)p).call();
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     s.cancel();
                     onError(ex);
                     return;
@@ -690,7 +692,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
         
         @Override
         public void dispose() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
 
         @Override 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromFuture.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromFuture.java
@@ -18,6 +18,7 @@ import java.util.concurrent.*;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.DeferredScalarSubscription;
 
 public final class FlowableFromFuture<T> extends Flowable<T> {
@@ -40,6 +41,7 @@ public final class FlowableFromFuture<T> extends Flowable<T> {
         try {
             v = unit != null ? future.get(timeout, unit) : future.get();
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             if (!deferred.isCancelled()) {
                 s.onError(ex);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromSource.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromSource.java
@@ -18,9 +18,10 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -215,6 +216,7 @@ public final class FlowableFromSource<T> extends Flowable<T> {
                     try {
                         v = q.poll();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         // should never happen
                         v = null;
                     }
@@ -274,11 +276,11 @@ public final class FlowableFromSource<T> extends Flowable<T> {
 
         final Subscriber<? super T> actual;
         
-        final SerialDisposable serial;
+        final SequentialDisposable serial;
 
         public BaseEmitter(Subscriber<? super T> actual) {
             this.actual = actual;
-            this.serial = new SerialDisposable();
+            this.serial = new SequentialDisposable();
         }
 
         @Override
@@ -334,7 +336,7 @@ public final class FlowableFromSource<T> extends Flowable<T> {
         
         @Override
         public final void setDisposable(Disposable s) {
-            serial.set(s);
+            serial.update(s);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -43,6 +44,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
         try {
             state = stateSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }
@@ -108,6 +110,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
                     try {
                         s = f.apply(s, this);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         cancelled = true;
                         actual.onError(ex);
                         return;
@@ -151,6 +154,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
             try {
                 disposeState.accept(s);
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 RxJavaPlugins.onError(ex);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -407,7 +407,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
         
         @Override
         public void dispose() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
 
         @Override
@@ -460,7 +460,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
         
         @Override
         public void dispose() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
 
         @Override
@@ -477,7 +477,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
 
         @Override
         public void onNext(Object t) {
-            if (SubscriptionHelper.dispose(this)) {
+            if (SubscriptionHelper.cancel(this)) {
                 parent.innerClose(isLeft, this);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.*;
 
 import io.reactivex.FlowableOperator;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -60,7 +61,7 @@ public final class FlowableLift<R, T> extends AbstractFlowableWithUpstream<T, R>
         } catch (NullPointerException e) { // NOPMD
             throw e;
         } catch (Throwable e) {
-            // TODO throw if fatal?
+            Exceptions.throwIfFatal(e);
             // can't call onError because no way to know if a Subscription has been set or not
             // can't call onSubscribe because the call might have set a Subscription already
             RxJavaPlugins.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -94,6 +95,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             try {
                 p = onNextMapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }
@@ -118,6 +120,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             try {
                 p = onErrorMapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }
@@ -137,6 +140,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             try {
                 p = onCompleteSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -95,6 +95,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
                 try {
                     onOverflow.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     ex.initCause(e);
                 }
                 onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -86,9 +87,9 @@ public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUps
                 try {
                     onDrop.accept(t);
                 } catch (Throwable e) {
-                    done = true;
+                    Exceptions.throwIfFatal(e);
                     cancel();
-                    actual.onError(e);
+                    onError(e);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -93,6 +93,7 @@ public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T
             try {
                 p = nextSupplier.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -83,6 +83,7 @@ public final class FlowableOnErrorReturn<T> extends AbstractFlowableWithUpstream
             try {
                 v = valueSupplier.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 state.lazySet(HAS_REQUEST_HAS_VALUE);
                 actual.onError(new CompositeException(e, t));
                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
@@ -198,7 +198,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
         
         @Override
         public void dispose() {
-            SubscriptionHelper.dispose(s);
+            SubscriptionHelper.cancel(s);
             if (wip.getAndIncrement() == 0) {
                 queue.clear();
             }
@@ -216,7 +216,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             }
             if (sourceMode == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
-                    SubscriptionHelper.dispose(s);
+                    SubscriptionHelper.cancel(s);
                     onError(new MissingBackpressureException());
                     return;
                 }
@@ -363,7 +363,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
                             v = q.poll();
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
-                            SubscriptionHelper.dispose(s);
+                            SubscriptionHelper.cancel(s);
                             errorAll(ex);
                             return;
                         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BooleanSupplier;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
@@ -73,6 +74,7 @@ public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T
             try {
                 b = stop.getAsBoolean();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
@@ -126,7 +126,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         
         @Override
         public void cancel() {
-            SubscriptionHelper.dispose(subscription);
+            SubscriptionHelper.cancel(subscription);
         }
     }
     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -67,6 +67,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                 try {
                     co = connectableFactory.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, child);
                     return;
                 }
@@ -79,6 +80,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                 try {
                     observable = selector.apply(co);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, child);
                     return;
                 }
@@ -214,6 +216,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                         try {
                             buf = bufferFactory.call();
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             throw Exceptions.propagate(ex);
                         }
                         // create a new subscriber to source
@@ -283,6 +286,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                 try {
                     buf = bufferFactory.call();
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     throw Exceptions.propagate(ex);
                 }
                 
@@ -317,6 +321,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
         try {
             connection.accept(ps);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
         if (doConnect) {
@@ -838,6 +843,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                             return;
                         }
                     } catch (Throwable err) {
+                        Exceptions.throwIfFatal(err);
                         output.dispose();
                         if (!NotificationLite.isError(o) && !NotificationLite.isComplete(o)) {
                             child.onError(err);
@@ -1005,6 +1011,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                                 return;
                             }
                         } catch (Throwable err) {
+                            Exceptions.throwIfFatal(err);
                             output.index = null;
                             output.dispose();
                             if (!NotificationLite.isError(o) && !NotificationLite.isComplete(o)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
@@ -73,6 +73,7 @@ public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstr
             try {
                 b = predicate.test(++retries, t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
@@ -83,6 +83,7 @@ public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstrea
                 try {
                     b = predicate.test(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     actual.onError(new CompositeException(e, t));
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
@@ -75,13 +75,13 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         
         @Override
         public void onError(Throwable t) {
-            SubscriptionHelper.dispose(other);
+            SubscriptionHelper.cancel(other);
             actual.onError(t);
         }
         
         @Override
         public void onComplete() {
-            SubscriptionHelper.dispose(other);
+            SubscriptionHelper.cancel(other);
             actual.onComplete();
         }
 
@@ -104,7 +104,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         
         @Override
         public void cancel() {
-            SubscriptionHelper.dispose(other);
+            SubscriptionHelper.cancel(other);
             s.cancel();
         }
         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
@@ -64,6 +65,7 @@ public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
                 try {
                     u = accumulator.apply(v, t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     s.cancel();
                     a.onError(e);
                     return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
@@ -39,6 +40,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
         try {
             r = seedSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }
@@ -83,6 +85,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
             try {
                 u = accumulator.apply(v, t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.cancel();
                 onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqual.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
@@ -193,6 +194,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
                         try {
                             c = comparer.test(v1, v2);
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             cancel(q1, q2);
                             
                             actual.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
@@ -57,6 +58,7 @@ public final class FlowableSkipWhile<T> extends AbstractFlowableWithUpstream<T, 
                 try {
                     b = predicate.test(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     s.cancel();
                     actual.onError(e);
                     return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
@@ -131,7 +131,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
         
         @Override
         public void cancel() {
-            SubscriptionHelper.dispose(s);
+            SubscriptionHelper.cancel(s);
             worker.dispose();
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -105,6 +106,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.cancel();
                 onError(e);
                 return;
@@ -407,7 +409,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
         }
         
         public void cancel() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
@@ -56,9 +57,9 @@ public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUps
                 try {
                     b = predicate.test(t);
                 } catch (Throwable e) {
-                    done = true;
+                    Exceptions.throwIfFatal(e);
                     s.cancel();
-                    actual.onError(e);
+                    onError(e);
                     return;
                 }
                 if (b) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
@@ -60,9 +61,9 @@ public final class FlowableTakeWhile<T> extends AbstractFlowableWithUpstream<T, 
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 s.cancel();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscribers.flowable.FullArbiterSubscriber;
@@ -94,6 +95,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
                 try {
                     p = firstTimeoutSelector.call();
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     cancel();
                     EmptySubscription.error(ex, a);
                     return;
@@ -133,6 +135,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
             try {
                 p = timeoutSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;
@@ -271,6 +274,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
                 try {
                     p = firstTimeoutSelector.call();
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     dispose();
                     EmptySubscription.error(ex, a);
                     return;
@@ -315,6 +319,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
             try {
                 p = timeoutSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.ArrayListSupplier;
 
@@ -40,6 +41,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
         try {
             coll = collectionSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -47,6 +47,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
         try {
             resource = resourceSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }
@@ -55,9 +56,11 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
         try {
             source = sourceSupplier.apply(resource);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             try {
                 disposer.accept(resource);
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 EmptySubscription.error(new CompositeException(ex, e), s);
                 return;
             }
@@ -109,6 +112,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         innerError = e;
                     }
                 }
@@ -133,6 +137,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         actual.onError(e);
                         return;
                     }
@@ -163,6 +168,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
                 try {
                     disposer.accept(resource);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     // can't call actual.onError unless it is serialized, which is expensive
                     RxJavaPlugins.onError(e);
                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -92,6 +92,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
             try {
                 p = other.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.cancel();
                 a.onError(e);
                 return;
@@ -250,6 +251,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                         try {
                             p = other.call();
                         } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
                             DisposableHelper.dispose(boundary);
                             a.onError(e);
                             return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -23,6 +23,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -239,6 +240,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     try {
                         o = q.poll();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         s.cancel();
                         dispose();
                         a.onError(ex);
@@ -526,6 +528,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     try {
                         o = q.poll();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         s.cancel();
                         dispose();
                         a.onError(ex);
@@ -820,6 +823,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     try {
                         v = q.poll();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         s.cancel();
                         dispose();
                         a.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -93,6 +94,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
                 try {
                     r = combiner.apply(t, u);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     cancel();
                     actual.onError(e);
                     return;
@@ -103,13 +105,13 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
         
         @Override
         public void onError(Throwable t) {
-            SubscriptionHelper.dispose(other);
+            SubscriptionHelper.cancel(other);
             actual.onError(t);
         }
         
         @Override
         public void onComplete() {
-            SubscriptionHelper.dispose(other);
+            SubscriptionHelper.cancel(other);
             actual.onComplete();
         }
         
@@ -121,7 +123,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
         @Override
         public void cancel() {
             s.get().cancel();
-            SubscriptionHelper.dispose(other);
+            SubscriptionHelper.cancel(other);
         }
 
         public boolean setOther(Subscription o) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Combines a main sequence of values with the latest from multiple other sequences via
+ * a selector function.
+ *
+ * @param <T> the main sequence's type
+ * @param <R> the output type
+ */
+public class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWithUpstream<T, R> {
+
+    final Publisher<?>[] otherArray;
+    
+    final Iterable<? extends Publisher<?>> otherIterable;
+    
+    final Function<? super Object[], R> combiner;
+    
+    public FlowableWithLatestFromMany(Publisher<T> source, Publisher<?>[] otherArray, Function<? super Object[], R> combiner) {
+        super(source);
+        this.otherArray = otherArray;
+        this.otherIterable = null;
+        this.combiner = combiner;
+    }
+
+    public FlowableWithLatestFromMany(Publisher<T> source, Iterable<? extends Publisher<?>> otherIterable, Function<? super Object[], R> combiner) {
+        super(source);
+        this.otherArray = null;
+        this.otherIterable = otherIterable;
+        this.combiner = combiner;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        Publisher<?>[] others = otherArray;
+        int n = 0;
+        if (others == null) {
+            others = new Publisher[8];
+            
+            try {
+                for (Publisher<?> p : otherIterable) {
+                    if (n == others.length) {
+                        others = Arrays.copyOf(others, n + (n >> 1));
+                    }
+                    others[n++] = p;
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptySubscription.error(ex, s);
+                return;
+            }
+            
+        } else {
+            n = others.length;
+        }
+        
+        if (n == 0) {
+            new FlowableMap<T, R>(source, new Function<T, R>() {
+                @Override
+                public R apply(T t) throws Exception {
+                    return combiner.apply(new Object[] { t });
+                }
+            }).subscribeActual(s);
+            return;
+        }
+        
+        WithLatestFromSubscriber<T, R> parent = new WithLatestFromSubscriber<T, R>(s, combiner, n);
+        s.onSubscribe(parent);
+        parent.subscribe(others, n);
+        
+        source.subscribe(parent);
+    }
+    
+    static final class WithLatestFromSubscriber<T, R> 
+    extends AtomicInteger
+    implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = 1577321883966341961L;
+
+        final Subscriber<? super R> actual;
+        
+        final Function<? super Object[], R> combiner;
+        
+        final WithLatestInnerSubscriber[] subscribers;
+        
+        final AtomicReferenceArray<Object> values;
+        
+        final AtomicReference<Subscription> s;
+        
+        final AtomicLong requested;
+        
+        final AtomicThrowable error;
+        
+        volatile boolean done;
+        
+        public WithLatestFromSubscriber(Subscriber<? super R> actual, Function<? super Object[], R> combiner, int n) {
+            this.actual = actual;
+            this.combiner = combiner;
+            WithLatestInnerSubscriber[] s = new WithLatestInnerSubscriber[n];
+            for (int i = 0; i < n; i++) {
+                s[i] = new WithLatestInnerSubscriber(this, i);
+            }
+            this.subscribers = s;
+            this.values = new AtomicReferenceArray<Object>(n);
+            this.s = new AtomicReference<Subscription>();
+            this.requested = new AtomicLong();
+            this.error = new AtomicThrowable();
+        }
+        
+        void subscribe(Publisher<?>[] others, int n) {
+            WithLatestInnerSubscriber[] subscribers = this.subscribers;
+            AtomicReference<Subscription> s = this.s;
+            for (int i = 0; i < n; i++) {
+                if (SubscriptionHelper.isCancelled(s.get()) || done) {
+                    return;
+                }
+                others[i].subscribe(subscribers[i]);
+            }
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            SubscriptionHelper.deferredSetOnce(this.s, requested, s);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            AtomicReferenceArray<Object> ara = values;
+            int n = ara.length();
+            Object[] objects = new Object[n + 1];
+            objects[0] = t;
+            
+            for (int i = 0; i < n; i++) {
+                Object o = ara.get(i);
+                if (o == null) {
+                    // somebody hasn't signalled yet, skip this T
+                    s.get().request(1);
+                    return;
+                }
+                objects[i + 1] = o;
+            }
+            
+            R v;
+            
+            try {
+                v = Objects.requireNonNull(combiner.apply(objects), "combiner returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                cancel();
+                onError(ex);
+                return;
+            }
+            
+            HalfSerializer.onNext(actual, v, this, error);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            cancelAllBut(-1);
+            HalfSerializer.onError(actual, t, this, error);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                cancelAllBut(-1);
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+        
+        @Override
+        public void request(long n) {
+            SubscriptionHelper.deferredRequest(s, requested, n);
+        }
+        
+        @Override
+        public void cancel() {
+            SubscriptionHelper.cancel(s);
+            for (Disposable s : subscribers) {
+                s.dispose();
+            }
+        }
+        
+        void innerNext(int index, Object o) {
+            values.set(index, o);
+        }
+        
+        void innerError(int index, Throwable t) {
+            done = true;
+            SubscriptionHelper.cancel(s);
+            cancelAllBut(index);
+            HalfSerializer.onError(actual, t, this, error);
+        }
+        
+        void innerComplete(int index, boolean nonEmpty) {
+            if (!nonEmpty) {
+                done = true;
+                cancelAllBut(index);
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+        
+        void cancelAllBut(int index) {
+            WithLatestInnerSubscriber[] subscribers = this.subscribers;
+            for (int i = 0; i < subscribers.length; i++) {
+                if (i != index) {
+                    subscribers[i].dispose();
+                }
+            }
+        }
+    }
+
+    static final class WithLatestInnerSubscriber 
+    extends AtomicReference<Subscription>
+    implements Subscriber<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 3256684027868224024L;
+
+        final WithLatestFromSubscriber<?, ?> parent;
+        
+        final int index;
+        
+        boolean hasValue;
+        
+        public WithLatestInnerSubscriber(WithLatestFromSubscriber<?, ?> parent, int index) {
+            this.parent = parent;
+            this.index = index;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+        
+        @Override
+        public void onNext(Object t) {
+            if (!hasValue) {
+                hasValue = true;
+            }
+            parent.innerNext(index, t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(index, t);
+        }
+        
+        @Override
+        public void onComplete() {
+            parent.innerComplete(index, hasValue);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return SubscriptionHelper.isCancelled(get());
+        }
+        
+        @Override
+        public void dispose() {
+            SubscriptionHelper.cancel(this);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
@@ -421,7 +421,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
 
         @Override
         public void cancel() {
-            SubscriptionHelper.dispose(this);
+            SubscriptionHelper.cancel(this);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -42,6 +43,7 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
         try {
             it = other.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, t);
             return;
         }
@@ -56,6 +58,7 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
         try {
             b = it.hasNext();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, t);
             return;
         }
@@ -144,6 +147,7 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
         }
         
         void error(Throwable e) {
+            Exceptions.throwIfFatal(e);
             done = true;
             s.cancel();
             actual.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAll.java
@@ -14,6 +14,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -59,9 +60,9 @@ public final class ObservableAll<T> extends AbstractObservableWithUpstream<T, Bo
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 s.dispose();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             if (!b) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAny.java
@@ -14,6 +14,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -59,9 +60,9 @@ public final class ObservableAny<T> extends AbstractObservableWithUpstream<T, Bo
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 s.dispose();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             if (b) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
 
 public final class ObservableBuffer<T, U extends Collection<? super T>> extends AbstractObservableWithUpstream<T, U> {
@@ -67,6 +68,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
             try {
                 b = bufferSupplier.call();
             } catch (Throwable t) {
+                Exceptions.throwIfFatal(t);
                 buffer = null;
                 if (s == null) {
                     EmptyDisposable.error(t, actual);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
@@ -160,6 +161,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 onError(e);
                 return;
             }
@@ -174,6 +176,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 p = bufferClose.apply(window);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.observable.*;
@@ -73,6 +74,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 try {
                     b = bufferSupplier.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     cancelled = true;
                     s.dispose();
                     EmptyDisposable.error(e, actual);
@@ -92,6 +94,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 try {
                     boundary = boundarySupplier.call();
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     cancelled = true;
                     s.dispose();
                     EmptyDisposable.error(ex, actual);
@@ -179,6 +182,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;
@@ -195,6 +199,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 boundary = boundarySupplier.call();
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 cancelled = true;
                 s.dispose();
                 actual.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.observable.*;
@@ -69,6 +70,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 try {
                     b = bufferSupplier.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     cancelled = true;
                     s.dispose();
                     EmptyDisposable.error(e, actual);
@@ -153,6 +155,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -21,6 +21,7 @@ import io.reactivex.*;
 import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.observable.QueueDrainObserver;
@@ -111,6 +112,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 try {
                     b = bufferSupplier.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     dispose();
                     EmptyDisposable.error(e, actual);
                     return;
@@ -201,6 +203,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 selfCancel = true;
                 dispose();
                 actual.onError(e);
@@ -272,6 +275,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 try {
                     b = bufferSupplier.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     w.dispose();
                     s.dispose();
                     EmptyDisposable.error(e, actual);
@@ -369,6 +373,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;
@@ -447,6 +452,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 try {
                     b = bufferSupplier.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     w.dispose();
                     s.dispose();
                     EmptyDisposable.error(e, actual);
@@ -496,6 +502,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 b = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;
@@ -579,6 +586,7 @@ extends AbstractObservableWithUpstream<T, U> {
             try {
                 next = bufferSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -241,6 +241,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
                     try {
                         v = combiner.apply(array);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         cancelled = true;
                         cancel(q);
                         a.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -15,10 +15,10 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.Objects;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -43,7 +43,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
         /** */
         private static final long serialVersionUID = 8828587559905699186L;
         final Observer<? super U> actual;
-        final SerialDisposable sa;
+        final SequentialDisposable sa;
         final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
         final Observer<U> inner;
         final int bufferSize;
@@ -66,7 +66,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             this.mapper = mapper;
             this.bufferSize = bufferSize;
             this.inner = new InnerSubscriber<U>(actual, this);
-            this.sa = new SerialDisposable();
+            this.sa = new SequentialDisposable();
         }
         @Override
         public void onSubscribe(Disposable s) {
@@ -156,7 +156,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
         }
         
         void innerSubscribe(Disposable s) {
-            sa.set(s);
+            sa.update(s);
         }
         
         void drain() {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.observers.*;
@@ -83,6 +84,7 @@ public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstre
             try {
                 p = debounceSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class ObservableDefer<T> extends Observable<T> {
@@ -29,6 +30,7 @@ public final class ObservableDefer<T> extends Observable<T> {
         try {
             pub = supplier.call();
         } catch (Throwable t) {
+            Exceptions.throwIfFatal(t);
             EmptyDisposable.error(t, s);
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
@@ -14,7 +14,8 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -34,14 +35,14 @@ public final class ObservableDelaySubscriptionOther<T, U> extends Observable<T> 
     
     @Override
     public void subscribeActual(final Observer<? super T> child) {
-        final SerialDisposable serial = new SerialDisposable();
+        final SequentialDisposable serial = new SequentialDisposable();
         child.onSubscribe(serial);
         
         Observer<U> otherSubscriber = new Observer<U>() {
             boolean done;
             @Override
             public void onSubscribe(Disposable d) {
-                serial.set(d);
+                serial.update(d);
             }
             
             @Override
@@ -69,7 +70,7 @@ public final class ObservableDelaySubscriptionOther<T, U> extends Observable<T> 
                 main.subscribe(new Observer<T>() {
                     @Override
                     public void onSubscribe(Disposable d) {
-                        serial.set(d);
+                        serial.update(d);
                     }
                     
                     @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -160,6 +160,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             try {
                 key = keySelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 actual.onError(e);
                 return;
@@ -176,6 +177,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             try {
                 b = predicate.test(key);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 actual.onError(e);
                 return;
@@ -191,6 +193,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             try {
                 predicate.test(null); // special case: poison pill
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 return;
             }
@@ -202,6 +205,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             try {
                 predicate.test(null); // special case: poison pill
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -94,6 +94,7 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
             try {
                 onNext.accept(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
                 return;
@@ -112,6 +113,7 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
             try {
                 onError.accept(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 t = new CompositeException(e, t);
             }
             actual.onError(t);
@@ -119,6 +121,7 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
             try {
                 onAfterTerminate.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(e);
             }
         }
@@ -132,6 +135,7 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
             try {
                 onComplete.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 onError(e);
                 return;
             }
@@ -141,6 +145,7 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
             try {
                 onAfterTerminate.run();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(e);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class ObservableError<T> extends Observable<T> {
@@ -29,6 +30,7 @@ public final class ObservableError<T> extends Observable<T> {
         try {
             error = errorSupplier.call();
         } catch (Throwable t) {
+            Exceptions.throwIfFatal(t);
             error = t;
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -67,6 +68,7 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
             try {
                 b = filter.test(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 actual.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -113,6 +113,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 onError(e);
                 return;
             }
@@ -472,6 +473,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 try {
                     t = q.poll();
                 } catch (Throwable exc) {
+                    Exceptions.throwIfFatal(exc);
                     if (composite == null) {
                         composite = new CompositeException(exc);
                     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 
 public final class ObservableFromCallable<T> extends Observable<T> {
     final Callable<? extends T> callable;
@@ -34,6 +35,7 @@ public final class ObservableFromCallable<T> extends Observable<T> {
         try {
             value = callable.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
                 s.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromFuture.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromFuture.java
@@ -17,6 +17,7 @@ import java.util.concurrent.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 
 public final class ObservableFromFuture<T> extends Observable<T> {
     final Future<? extends T> future;
@@ -38,6 +39,7 @@ public final class ObservableFromFuture<T> extends Observable<T> {
             try {
                 v = unit != null ? future.get(timeout, unit) : future.get();
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 if (!d.isDisposed()) {
                     s.onError(ex);
                 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.Iterator;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.Objects;
 import io.reactivex.internal.subscribers.observable.BaseQueueDisposable;
@@ -32,6 +33,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
         try {
             it = source.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
             return;
         }
@@ -39,6 +41,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
         try {
             hasNext = it.hasNext();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
             return;
         }
@@ -86,6 +89,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
                 try {
                     v = Objects.requireNonNull(it.next(), "The iterator returned a null value");
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     actual.onError(e);
                     return;
                 }
@@ -98,6 +102,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
                 try {
                     hasNext = it.hasNext();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     actual.onError(e);
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -40,6 +41,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
         try {
             state = stateSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
             return;
         }
@@ -91,6 +93,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
                 try {
                     s = f.apply(s, this);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     cancelled = true;
                     actual.onError(ex);
                     return;
@@ -109,6 +112,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
             try {
                 disposeState.accept(s);
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 RxJavaPlugins.onError(ex);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -87,6 +88,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
             try {
                 key = keySelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
                 return;
@@ -113,6 +115,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
             try {
                 v = valueSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJust.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJust.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
@@ -46,6 +47,7 @@ public final class ObservableJust<T> extends Observable<T> {
                 try {
                     other = mapper.apply(value);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     EmptyDisposable.error(e, s);
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableLift.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -58,7 +59,7 @@ public final class ObservableLift<R, T> extends AbstractObservableWithUpstream<T
         } catch (NullPointerException e) { // NOPMD
             throw e;
         } catch (Throwable e) {
-            // TODO throw if fatal?
+            Exceptions.throwIfFatal(e);
             // can't call onError because no way to know if a Subscription has been set or not
             // can't call onSubscribe because the call might have set a Subscription already
             RxJavaPlugins.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -61,15 +62,14 @@ public final class ObservableMap<T, U> extends AbstractObservableWithUpstream<T,
             try {
                 u = function.apply(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 subscription.dispose();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             if (u == null) {
-                done = true;
                 subscription.dispose();
-                actual.onError(new NullPointerException("Value returned by the function is null"));
+                onError(new NullPointerException("Value returned by the function is null"));
                 return;
             }
             actual.onNext(u);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -92,6 +93,7 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             try {
                 p = onNextMapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }
@@ -111,6 +113,7 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             try {
                 p = onErrorMapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }
@@ -131,6 +134,7 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             try {
                 p = onCompleteSupplier.call();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorNext.java
@@ -14,9 +14,10 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableOnErrorNext<T> extends AbstractObservableWithUpstream<T, T> {
@@ -41,7 +42,7 @@ public final class ObservableOnErrorNext<T> extends AbstractObservableWithUpstre
         final Observer<? super T> actual;
         final Function<? super Throwable, ? extends ObservableSource<? extends T>> nextSupplier;
         final boolean allowFatal;
-        final SerialDisposable arbiter;
+        final SequentialDisposable arbiter;
         
         boolean once;
         
@@ -51,7 +52,7 @@ public final class ObservableOnErrorNext<T> extends AbstractObservableWithUpstre
             this.actual = actual;
             this.nextSupplier = nextSupplier;
             this.allowFatal = allowFatal;
-            this.arbiter = new SerialDisposable();
+            this.arbiter = new SequentialDisposable();
         }
         
         @Override
@@ -89,6 +90,7 @@ public final class ObservableOnErrorNext<T> extends AbstractObservableWithUpstre
             try {
                 p = nextSupplier.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturn.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -75,6 +75,7 @@ public final class ObservableOnErrorReturn<T> extends AbstractObservableWithUpst
             try {
                 v = valueSupplier.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(new CompositeException(e, t));
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservablePublish.java
@@ -575,14 +575,7 @@ public final class ObservablePublish<T> extends ConnectableObservable<T> impleme
                                 // this eager behavior will skip unsubscribed children in case
                                 // multiple values are available in the queue
                                 if (!ip.cancelled) {
-                                    try {
-                                        ip.child.onNext(value);
-                                    } catch (Throwable t) {
-                                        // we bounce back exceptions and kick out the child subscriber
-                                        ip.dispose();
-                                        ip.child.onError(t);
-                                        continue;
-                                    }
+                                    ip.child.onNext(value);
                                 }
                             }
                         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRedo.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRedo.java
@@ -19,6 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.subscribers.observable.ToNotificationObserver;
 import io.reactivex.subjects.BehaviorSubject;
 
@@ -68,7 +69,7 @@ public final class ObservableRedo<T> extends AbstractObservableWithUpstream<T, T
         final Observer<? super T> actual;
         final BehaviorSubject<Try<Optional<Object>>> subject;
         final ObservableSource<? extends T> source;
-        final SerialDisposable arbiter;
+        final SequentialDisposable arbiter;
         
         final AtomicInteger wip = new AtomicInteger();
         
@@ -76,7 +77,7 @@ public final class ObservableRedo<T> extends AbstractObservableWithUpstream<T, T
             this.actual = actual;
             this.subject = subject;
             this.source = source;
-            this.arbiter = new SerialDisposable();
+            this.arbiter = new SequentialDisposable();
             this.lazySet(true);
         }
         

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
@@ -16,7 +16,8 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T, T> {
     final long count;
@@ -27,7 +28,7 @@ public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T,
     
     @Override
     public void subscribeActual(Observer<? super T> s) {
-        SerialDisposable sd = new SerialDisposable();
+        SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
         
         RepeatSubscriber<T> rs = new RepeatSubscriber<T>(s, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sd, source);
@@ -39,10 +40,10 @@ public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T,
         private static final long serialVersionUID = -7098360935104053232L;
         
         final Observer<? super T> actual;
-        final SerialDisposable sd;
+        final SequentialDisposable sd;
         final ObservableSource<? extends T> source;
         long remaining;
-        public RepeatSubscriber(Observer<? super T> actual, long count, SerialDisposable sd, ObservableSource<? extends T> source) {
+        public RepeatSubscriber(Observer<? super T> actual, long count, SequentialDisposable sd, ObservableSource<? extends T> source) {
             this.actual = actual;
             this.sd = sd;
             this.source = source;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
@@ -16,8 +16,10 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstream<T, T> {
     final BooleanSupplier until;
@@ -28,7 +30,7 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
     
     @Override
     public void subscribeActual(Observer<? super T> s) {
-        SerialDisposable sd = new SerialDisposable();
+        SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
         
         RepeatSubscriber<T> rs = new RepeatSubscriber<T>(s, until, sd, source);
@@ -40,10 +42,10 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
         private static final long serialVersionUID = -7098360935104053232L;
         
         final Observer<? super T> actual;
-        final SerialDisposable sd;
+        final SequentialDisposable sd;
         final ObservableSource<? extends T> source;
         final BooleanSupplier stop;
-        public RepeatSubscriber(Observer<? super T> actual, BooleanSupplier until, SerialDisposable sd, ObservableSource<? extends T> source) {
+        public RepeatSubscriber(Observer<? super T> actual, BooleanSupplier until, SequentialDisposable sd, ObservableSource<? extends T> source) {
             this.actual = actual;
             this.sd = sd;
             this.source = source;
@@ -70,6 +72,7 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
             try {
                 b = stop.getAsBoolean();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -67,6 +67,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                     co = connectableFactory.call();
                     observable = selector.apply(co);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     EmptyDisposable.error(e, child);
                     return;
                 }
@@ -646,6 +647,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                             return;
                         }
                     } catch (Throwable err) {
+                        Exceptions.throwIfFatal(err);
                         output.dispose();
                         if (!NotificationLite.isError(o) && !NotificationLite.isComplete(o)) {
                             child.onError(err);
@@ -797,6 +799,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                                 return;
                             }
                         } catch (Throwable err) {
+                            Exceptions.throwIfFatal(err);
                             output.index = null;
                             output.dispose();
                             if (!NotificationLite.isError(o) && !NotificationLite.isComplete(o)) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -76,6 +77,7 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
                 try {
                     u = accumulator.apply(v, t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     s.dispose();
                     a.onError(e);
                     return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -37,6 +38,7 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
         try {
             r = seedSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
             return;
         }
@@ -96,6 +98,7 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
             try {
                 u = accumulator.apply(v, t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqual.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.disposables.ArrayCompositeDisposable;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -181,6 +182,7 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
                         try {
                             c = comparer.test(v1, v2);
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             cancel(q1, q2);
                             
                             actual.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -69,6 +70,7 @@ public final class ObservableSkipWhile<T> extends AbstractObservableWithUpstream
                 try {
                     b = predicate.test(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     s.dispose();
                     actual.onError(e);
                     return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmpty.java
@@ -14,7 +14,8 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class ObservableSwitchIfEmpty<T> extends AbstractObservableWithUpstream<T, T> {
     final ObservableSource<? extends T> other;
@@ -33,7 +34,7 @@ public final class ObservableSwitchIfEmpty<T> extends AbstractObservableWithUpst
     static final class SwitchIfEmptySubscriber<T> implements Observer<T> {
         final Observer<? super T> actual;
         final ObservableSource<? extends T> other;
-        final SerialDisposable arbiter;
+        final SequentialDisposable arbiter;
         
         boolean empty;
         
@@ -41,12 +42,12 @@ public final class ObservableSwitchIfEmpty<T> extends AbstractObservableWithUpst
             this.actual = actual;
             this.other = other;
             this.empty = true;
-            this.arbiter = new SerialDisposable();
+            this.arbiter = new SequentialDisposable();
         }
         
         @Override
         public void onSubscribe(Disposable s) {
-            arbiter.set(s);
+            arbiter.update(s);
         }
         
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -19,6 +19,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -93,6 +94,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
             try {
                 p = mapper.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicate.java
@@ -15,8 +15,10 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableTakeUntilPredicate<T> extends AbstractObservableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
@@ -66,9 +68,9 @@ public final class ObservableTakeUntilPredicate<T> extends AbstractObservableWit
                 try {
                     b = predicate.test(t);
                 } catch (Throwable e) {
-                    done = true;
+                    Exceptions.throwIfFatal(e);
                     s.dispose();
-                    actual.onError(e);
+                    onError(e);
                     return;
                 }
                 if (b) {
@@ -84,6 +86,8 @@ public final class ObservableTakeUntilPredicate<T> extends AbstractObservableWit
             if (!done) {
                 done = true;
                 actual.onError(t);
+            } else {
+                RxJavaPlugins.onError(t);
             }
         }
         

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeWhile.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -72,9 +73,9 @@ public final class ObservableTakeWhile<T> extends AbstractObservableWithUpstream
             try {
                 b = predicate.test(t);
             } catch (Throwable e) {
-                done = true;
+                Exceptions.throwIfFatal(e);
                 s.dispose();
-                actual.onError(e);
+                onError(e);
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscribers.observable.*;
@@ -86,6 +87,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
                     try {
                         p = firstTimeoutSelector.call();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         dispose();
                         EmptyDisposable.error(ex, a);
                         return;
@@ -126,6 +128,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             try {
                 p = timeoutSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;
@@ -228,7 +231,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
         final Callable<? extends ObservableSource<U>> firstTimeoutSelector;
         final Function<? super T, ? extends ObservableSource<V>> timeoutSelector;
         final ObservableSource<? extends T> other;
-        final NbpFullArbiter<T> arbiter;
+        final ObserverFullArbiter<T> arbiter;
         
         Disposable s;
         
@@ -243,7 +246,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             this.firstTimeoutSelector = firstTimeoutSelector;
             this.timeoutSelector = timeoutSelector;
             this.other = other;
-            this.arbiter = new NbpFullArbiter<T>(actual, this, 8);
+            this.arbiter = new ObserverFullArbiter<T>(actual, this, 8);
         }
         
         @Override
@@ -262,6 +265,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
                     try {
                         p = firstTimeoutSelector.call();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         dispose();
                         EmptyDisposable.error(ex, a);
                         return;
@@ -307,6 +311,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             try {
                 p = timeoutSelector.apply(t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -61,7 +61,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
         
         Disposable s; 
         
-        final NbpFullArbiter<T> arbiter;
+        final ObserverFullArbiter<T> arbiter;
 
         final AtomicReference<Disposable> timer = new AtomicReference<Disposable>();
 
@@ -86,7 +86,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
             this.unit = unit;
             this.worker = worker;
             this.other = other;
-            this.arbiter = new NbpFullArbiter<T>(actual, this, 8);
+            this.arbiter = new ObserverFullArbiter<T>(actual, this, 8);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
 
 public final class ObservableToList<T, U extends Collection<? super T>> 
@@ -48,6 +49,7 @@ extends AbstractObservableWithUpstream<T, U> {
         try {
             coll = collectionSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableUsing.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -46,6 +46,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
         try {
             resource = resourceSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
             return;
         }
@@ -54,9 +55,11 @@ public final class ObservableUsing<T, D> extends Observable<T> {
         try {
             source = sourceSupplier.apply(resource);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             try {
                 disposer.accept(resource);
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 EmptyDisposable.error(new CompositeException(ex, e), s);
                 return;
             }
@@ -107,6 +110,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         t = new CompositeException(e, t);
                     }
                 }
@@ -127,6 +131,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         actual.onError(e);
                         return;
                     }
@@ -157,6 +162,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
                 try {
                     disposer.accept(resource);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     // can't call actual.onError unless it is serialized, which is expensive
                     RxJavaPlugins.onError(e);
                 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -268,6 +268,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                         try {
                             p = close.apply(wo.open);
                         } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
                             cancelled = true;
                             a.onError(e);
                             continue;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -86,6 +87,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                 try {
                     p = other.call();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     s.dispose();
                     a.onError(e);
                     return;
@@ -194,6 +196,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                     try {
                         o = q.poll();
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         DisposableHelper.dispose(boundary);
                         w.onError(ex);
                         return;
@@ -232,6 +235,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                         try {
                             p = other.call();
                         } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
                             DisposableHelper.dispose(boundary);
                             a.onError(e);
                             return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
@@ -92,6 +93,7 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
                 try {
                     r = combiner.apply(t, u);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     dispose();
                     actual.onError(e);
                     return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Combines a main sequence of values with the latest from multiple other sequences via
+ * a selector function.
+ *
+ * @param <T> the main sequence's type
+ * @param <R> the output type
+ */
+public class ObservableWithLatestFromMany<T, R> extends AbstractObservableWithUpstream<T, R> {
+
+    final ObservableSource<?>[] otherArray;
+    
+    final Iterable<? extends ObservableSource<?>> otherIterable;
+    
+    final Function<? super Object[], R> combiner;
+    
+    public ObservableWithLatestFromMany(ObservableSource<T> source, ObservableSource<?>[] otherArray, Function<? super Object[], R> combiner) {
+        super(source);
+        this.otherArray = otherArray;
+        this.otherIterable = null;
+        this.combiner = combiner;
+    }
+
+    public ObservableWithLatestFromMany(ObservableSource<T> source, Iterable<? extends ObservableSource<?>> otherIterable, Function<? super Object[], R> combiner) {
+        super(source);
+        this.otherArray = null;
+        this.otherIterable = otherIterable;
+        this.combiner = combiner;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> s) {
+        ObservableSource<?>[] others = otherArray;
+        int n = 0;
+        if (others == null) {
+            others = new ObservableSource[8];
+            
+            try {
+                for (ObservableSource<?> p : otherIterable) {
+                    if (n == others.length) {
+                        others = Arrays.copyOf(others, n + (n >> 1));
+                    }
+                    others[n++] = p;
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptyDisposable.error(ex, s);
+                return;
+            }
+            
+        } else {
+            n = others.length;
+        }
+        
+        if (n == 0) {
+            new ObservableMap<T, R>(source, new Function<T, R>() {
+                @Override
+                public R apply(T t) throws Exception {
+                    return combiner.apply(new Object[] { t });
+                }
+            }).subscribeActual(s);
+            return;
+        }
+        
+        WithLatestFromObserver<T, R> parent = new WithLatestFromObserver<T, R>(s, combiner, n);
+        s.onSubscribe(parent);
+        parent.subscribe(others, n);
+        
+        source.subscribe(parent);
+    }
+    
+    static final class WithLatestFromObserver<T, R> 
+    extends AtomicInteger
+    implements Observer<T>, Disposable {
+        /** */
+        private static final long serialVersionUID = 1577321883966341961L;
+
+        final Observer<? super R> actual;
+        
+        final Function<? super Object[], R> combiner;
+        
+        final WithlatestInnerSubscriber[] subscribers;
+        
+        final AtomicReferenceArray<Object> values;
+        
+        final AtomicReference<Disposable> d;
+        
+        final AtomicThrowable error;
+        
+        volatile boolean done;
+        
+        public WithLatestFromObserver(Observer<? super R> actual, Function<? super Object[], R> combiner, int n) {
+            this.actual = actual;
+            this.combiner = combiner;
+            WithlatestInnerSubscriber[] s = new WithlatestInnerSubscriber[n];
+            for (int i = 0; i < n; i++) {
+                s[i] = new WithlatestInnerSubscriber(this, i);
+            }
+            this.subscribers = s;
+            this.values = new AtomicReferenceArray<Object>(n);
+            this.d = new AtomicReference<Disposable>();
+            this.error = new AtomicThrowable();
+        }
+        
+        void subscribe(ObservableSource<?>[] others, int n) {
+            WithlatestInnerSubscriber[] subscribers = this.subscribers;
+            AtomicReference<Disposable> s = this.d;
+            for (int i = 0; i < n; i++) {
+                if (DisposableHelper.isDisposed(s.get()) || done) {
+                    return;
+                }
+                others[i].subscribe(subscribers[i]);
+            }
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this.d, d);
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            AtomicReferenceArray<Object> ara = values;
+            int n = ara.length();
+            Object[] objects = new Object[n + 1];
+            objects[0] = t;
+            
+            for (int i = 0; i < n; i++) {
+                Object o = ara.get(i);
+                if (o == null) {
+                    // no latest, skip this value
+                    return;
+                }
+                objects[i + 1] = o;
+            }
+            
+            R v;
+            
+            try {
+                v = Objects.requireNonNull(combiner.apply(objects), "combiner returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                dispose();
+                onError(ex);
+                return;
+            }
+            
+            HalfSerializer.onNext(actual, v, this, error);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            cancelAllBut(-1);
+            HalfSerializer.onError(actual, t, this, error);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                cancelAllBut(-1);
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(d.get());
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(d);
+            for (Disposable s : subscribers) {
+                s.dispose();
+            }
+        }
+        
+        void innerNext(int index, Object o) {
+            values.set(index, o);
+        }
+        
+        void innerError(int index, Throwable t) {
+            done = true;
+            DisposableHelper.dispose(d);
+            cancelAllBut(index);
+            HalfSerializer.onError(actual, t, this, error);
+        }
+        
+        void innerComplete(int index, boolean nonEmpty) {
+            if (!nonEmpty) {
+                done = true;
+                cancelAllBut(index);
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+        
+        void cancelAllBut(int index) {
+            WithlatestInnerSubscriber[] subscribers = this.subscribers;
+            for (int i = 0; i < subscribers.length; i++) {
+                if (i != index) {
+                    subscribers[i].dispose();
+                }
+            }
+        }
+    }
+
+    static final class WithlatestInnerSubscriber 
+    extends AtomicReference<Disposable>
+    implements Observer<Object>, Disposable {
+        /** */
+        private static final long serialVersionUID = 3256684027868224024L;
+
+        final WithLatestFromObserver<?, ?> parent;
+        
+        final int index;
+        
+        boolean hasValue;
+        
+        public WithlatestInnerSubscriber(WithLatestFromObserver<?, ?> parent, int index) {
+            this.parent = parent;
+            this.index = index;
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+        
+        @Override
+        public void onNext(Object t) {
+            if (!hasValue) {
+                hasValue = true;
+            }
+            parent.innerNext(index, t);
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(index, t);
+        }
+        
+        @Override
+        public void onComplete() {
+            parent.innerComplete(index, hasValue);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -183,6 +184,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
                     try {
                         v = zipper.apply(os.clone());
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         clear();
                         a.onError(ex);
                         return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZipIterable.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -41,6 +42,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
         try {
             it = other.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
             return;
         }
@@ -55,6 +57,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
         try {
             b = it.hasNext();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
             return;
         }
@@ -114,6 +117,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
             try {
                 u = iterator.next();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 error(e);
                 return;
             }
@@ -127,6 +131,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
             try {
                 v = zipper.apply(t, u);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 error(new NullPointerException("The iterator returned a null value"));
                 return;
             }
@@ -143,6 +148,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
             try {
                 b = iterator.hasNext();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 error(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleAmbIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleAmbIterable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SingleAmbIterable<T> extends Single<T> {
@@ -38,6 +39,7 @@ public final class SingleAmbIterable<T> extends Single<T> {
         try {
             iterator = sources.iterator();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.onError(e);
             return;
         }
@@ -60,6 +62,7 @@ public final class SingleAmbIterable<T> extends Single<T> {
             try {
                 b = iterator.hasNext();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 s.onError(e);
                 return;
             }
@@ -81,6 +84,7 @@ public final class SingleAmbIterable<T> extends Single<T> {
             try {
                 s1 = iterator.next();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 set.dispose();
                 s.onError(e);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class SingleDefer<T> extends Single<T> {
@@ -33,8 +34,8 @@ public final class SingleDefer<T> extends Single<T> {
         try {
             next = singleSupplier.call();
         } catch (Throwable e) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(e);
+            Exceptions.throwIfFatal(e);
+            EmptyDisposable.error(e, s);
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
@@ -16,7 +16,8 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class SingleDelay<T> extends Single<T> {
 
@@ -36,7 +37,7 @@ public final class SingleDelay<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
 
-        final SerialDisposable sd = new SerialDisposable();
+        final SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
         source.subscribe(new SingleObserver<T>() {
             @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Consumer;
 
 public final class SingleDoOnError<T> extends Single<T> {
@@ -48,6 +48,7 @@ public final class SingleDoOnError<T> extends Single<T> {
                 try {
                     onError.accept(e);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     e = new CompositeException(ex, e);
                 }
                 s.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSubscribe.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -40,6 +41,7 @@ public final class SingleDoOnSubscribe<T> extends Single<T> {
                 try {
                     onSubscribe.accept(d);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     done = true;
                     d.dispose();
                     s.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSuccess.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
 
 public class SingleDoOnSuccess<T> extends Single<T> {
@@ -42,6 +43,7 @@ public class SingleDoOnSuccess<T> extends Single<T> {
                 try {
                     onSuccess.accept(value);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     s.onError(ex);
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleError.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class SingleError<T> extends Single<T> {
@@ -33,6 +34,7 @@ public final class SingleError<T> extends Single<T> {
         try {
             error = errorSupplier.call();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             error = e;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMap.java
@@ -14,8 +14,10 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class SingleFlatMap<T, R> extends Single<R> {
     final SingleSource<? extends T> source;
@@ -38,13 +40,13 @@ public final class SingleFlatMap<T, R> extends Single<R> {
         final SingleObserver<? super R> actual;
         final Function<? super T, ? extends SingleSource<? extends R>> mapper;
         
-        final SerialDisposable sd;
+        final SequentialDisposable sd;
 
         public SingleFlatMapCallback(SingleObserver<? super R> actual,
                 Function<? super T, ? extends SingleSource<? extends R>> mapper) {
             this.actual = actual;
             this.mapper = mapper;
-            this.sd = new SerialDisposable();
+            this.sd = new SequentialDisposable();
         }
         
         @Override
@@ -59,6 +61,7 @@ public final class SingleFlatMap<T, R> extends Single<R> {
             try {
                 o = mapper.apply(value);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 actual.onError(e);
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromCallable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
 public final class SingleFromCallable<T> extends Single<T> {
@@ -38,6 +39,7 @@ public final class SingleFromCallable<T> extends Single<T> {
                 s.onError(new NullPointerException());
             }
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.onError(e);
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleMap.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleMap.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 
 public final class SingleMap<T, R> extends Single<R> {
@@ -41,6 +42,7 @@ public final class SingleMap<T, R> extends Single<R> {
                 try {
                     v = mapper.apply(value);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     onError(e);
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 
 public final class SingleOnErrorReturn<T> extends Single<T> {
@@ -47,6 +47,7 @@ public final class SingleOnErrorReturn<T> extends Single<T> {
                     try {
                         v = valueSupplier.apply(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         s.onError(new CompositeException(ex, e));
                         return;
                     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleResumeNext.java
@@ -14,9 +14,10 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class SingleResumeNext<T> extends Single<T> {
     final SingleSource<? extends T> source;
@@ -32,7 +33,7 @@ public final class SingleResumeNext<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
 
-        final SerialDisposable sd = new SerialDisposable();
+        final SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
         
         source.subscribe(new SingleObserver<T>() {
@@ -54,6 +55,7 @@ public final class SingleResumeNext<T> extends Single<T> {
                 try {
                     next = nextFunction.apply(e);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     s.onError(new CompositeException(ex, e));
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.*;
-import io.reactivex.disposables.SerialDisposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
 
 public final class SingleTimer extends Single<Long> {
 
@@ -32,7 +32,7 @@ public final class SingleTimer extends Single<Long> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super Long> s) {
-        SerialDisposable sd = new SerialDisposable();
+        SequentialDisposable sd = new SequentialDisposable();
         
         s.onSubscribe(sd);
         

--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -48,8 +48,8 @@ public final class SingleUsing<T, U> extends Single<T> {
         try {
             resource = resourceSupplier.call();
         } catch (Throwable ex) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(ex);
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, s);
             return;
         }
         
@@ -58,8 +58,8 @@ public final class SingleUsing<T, U> extends Single<T> {
         try {
             s1 = singleFunction.apply(resource);
         } catch (Throwable ex) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(ex);
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, s);
             return;
         }
         
@@ -82,6 +82,7 @@ public final class SingleUsing<T, U> extends Single<T> {
                             try {
                                 disposer.accept(resource);
                             } catch (Throwable e) {
+                                Exceptions.throwIfFatal(e);
                                 RxJavaPlugins.onError(e);
                             }
                         }
@@ -97,6 +98,7 @@ public final class SingleUsing<T, U> extends Single<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         s.onError(e);
                         return;
                     }
@@ -106,6 +108,7 @@ public final class SingleUsing<T, U> extends Single<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         RxJavaPlugins.onError(e);
                     }
                 }
@@ -117,6 +120,7 @@ public final class SingleUsing<T, U> extends Single<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         e = new CompositeException(ex, e);
                     }
                 }
@@ -125,6 +129,7 @@ public final class SingleUsing<T, U> extends Single<T> {
                     try {
                         disposer.accept(resource);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                     }
                 }

--- a/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.schedulers.ExecutorScheduler.ExecutorWorker.BooleanRunnable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -69,9 +69,9 @@ public final class ExecutorScheduler extends Scheduler {
                 return EmptyDisposable.INSTANCE;
             }
         }
-        SerialDisposable first = new SerialDisposable();
+        SequentialDisposable first = new SequentialDisposable();
 
-        final SerialDisposable mar = new SerialDisposable(first);
+        final SequentialDisposable mar = new SequentialDisposable(first);
 
         Disposable delayed = HELPER.scheduleDirect(new Runnable() {
             @Override
@@ -151,9 +151,9 @@ public final class ExecutorScheduler extends Scheduler {
             }
             
 
-            SerialDisposable first = new SerialDisposable();
+            SequentialDisposable first = new SequentialDisposable();
 
-            final SerialDisposable mar = new SerialDisposable(first);
+            final SequentialDisposable mar = new SequentialDisposable(first);
             
             final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
             
@@ -167,7 +167,7 @@ public final class ExecutorScheduler extends Scheduler {
             
             if (executor instanceof ScheduledExecutorService) {
                 try {
-                    Future<?> f = ((ScheduledExecutorService)executor).schedule(sr, delay, unit);
+                    Future<?> f = ((ScheduledExecutorService)executor).schedule((Callable<Object>)sr, delay, unit);
                     sr.setFuture(f);
                 } catch (RejectedExecutionException ex) {
                     disposed = true;

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -118,9 +118,9 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
         Future<?> f;
         try {
             if (delayTime <= 0) {
-                f = executor.submit(sr);
+                f = executor.submit((Callable<Object>)sr);
             } else {
-                f = executor.schedule(sr, delayTime, unit);
+                f = executor.schedule((Callable<Object>)sr, delayTime, unit);
             }
             sr.setFuture(f);
         } catch (RejectedExecutionException ex) {

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
@@ -74,6 +74,7 @@ public enum SchedulerPoolFactory {
                                 }
                             }
                         } catch (Throwable e) {
+                            // Exceptions.throwIfFatal(e); nowhere to go
                             RxJavaPlugins.onError(e);
                         }
                     }

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -131,9 +131,9 @@ public final class SingleScheduler extends Scheduler {
             try {
                 Future<?> f;
                 if (delay <= 0L) {
-                    f = executor.submit(sr);
+                    f = executor.submit((Callable<Object>)sr);
                 } else {
-                    f = executor.schedule(sr, delay, unit);
+                    f = executor.schedule((Callable<Object>)sr, delay, unit);
                 }
                 
                 sr.setFuture(f);

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingSubscriber.java
@@ -67,7 +67,7 @@ public final class BlockingSubscriber<T> extends AtomicReference<Subscription> i
     
     @Override
     public void cancel() {
-        if (SubscriptionHelper.dispose(this)) {
+        if (SubscriptionHelper.cancel(this)) {
             queue.offer(TERMINATED);
         }
     }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/ForEachWhileSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/ForEachWhileSubscriber.java
@@ -105,7 +105,7 @@ implements Subscriber<T>, Disposable {
     
     @Override
     public void dispose() {
-        SubscriptionHelper.dispose(this);
+        SubscriptionHelper.cancel(this);
     }
     
     @Override

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriber.java
@@ -125,7 +125,7 @@ implements Subscriber<T>, Subscription {
     
     @Override
     public void cancel() {
-        SubscriptionHelper.dispose(this);
+        SubscriptionHelper.cancel(this);
     }
     
     public boolean isDone() {

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/LambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/LambdaSubscriber.java
@@ -58,6 +58,7 @@ public final class LambdaSubscriber<T> extends AtomicReference<Subscription> imp
         try {
             onNext.accept(t);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             onError(e);
         }
     }
@@ -68,6 +69,7 @@ public final class LambdaSubscriber<T> extends AtomicReference<Subscription> imp
         try {
             onError.accept(t);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
             RxJavaPlugins.onError(t);
         }
@@ -79,6 +81,7 @@ public final class LambdaSubscriber<T> extends AtomicReference<Subscription> imp
         try {
             onComplete.run();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
     }
@@ -100,6 +103,6 @@ public final class LambdaSubscriber<T> extends AtomicReference<Subscription> imp
     
     @Override
     public void cancel() {
-        SubscriptionHelper.dispose(this);
+        SubscriptionHelper.cancel(this);
     }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriberResourceWrapper.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriberResourceWrapper.java
@@ -81,7 +81,7 @@ public final class SubscriberResourceWrapper<T> extends AtomicReference<Disposab
     
     @Override
     public void dispose() {
-        SubscriptionHelper.dispose(subscription);
+        SubscriptionHelper.cancel(subscription);
 
         DisposableHelper.dispose(this);
     }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriptionLambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/SubscriptionLambdaSubscriber.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscribers.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -43,6 +44,7 @@ public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Sub
         try {
             onSubscribe.accept(s);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.cancel();
             RxJavaPlugins.onError(e);
             EmptySubscription.error(e, actual);
@@ -74,6 +76,7 @@ public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Sub
         try {
             onRequest.accept(n);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
         s.request(n);
@@ -84,6 +87,7 @@ public final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Sub
         try {
             onCancel.run();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
         s.cancel();

--- a/src/main/java/io/reactivex/internal/subscribers/observable/FullArbiterObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/FullArbiterObserver.java
@@ -23,11 +23,11 @@ import io.reactivex.internal.disposables.*;
  * @param <T> the value type
  */
 public final class FullArbiterObserver<T> implements Observer<T> {
-    final NbpFullArbiter<T> arbiter;
+    final ObserverFullArbiter<T> arbiter;
 
     Disposable s;
 
-    public FullArbiterObserver(NbpFullArbiter<T> arbiter) {
+    public FullArbiterObserver(ObserverFullArbiter<T> arbiter) {
         this.arbiter = arbiter;
     }
 

--- a/src/main/java/io/reactivex/internal/subscribers/observable/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/LambdaObserver.java
@@ -58,6 +58,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
         try {
             onNext.accept(t);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             onError(e);
         }
     }
@@ -68,6 +69,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
         try {
             onError.accept(t);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
             RxJavaPlugins.onError(t);
         }
@@ -79,6 +81,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
         try {
             onComplete.run();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
     }

--- a/src/main/java/io/reactivex/internal/subscribers/observable/SubscriptionLambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/SubscriptionLambdaObserver.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscribers.observable;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -40,6 +41,7 @@ public final class SubscriptionLambdaObserver<T> implements Observer<T>, Disposa
         try {
             onSubscribe.accept(s);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             s.dispose();
             RxJavaPlugins.onError(e);
             
@@ -73,6 +75,7 @@ public final class SubscriptionLambdaObserver<T> implements Observer<T>, Disposa
         try {
             onCancel.run();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
         s.dispose();

--- a/src/main/java/io/reactivex/internal/subscriptions/AsyncSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/AsyncSubscription.java
@@ -69,7 +69,7 @@ public final class AsyncSubscription extends AtomicLong implements Subscription,
     
     @Override
     public void dispose() {
-        SubscriptionHelper.dispose(actual);
+        SubscriptionHelper.cancel(actual);
         DisposableHelper.dispose(resource);
     }
 

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -77,11 +77,11 @@ public enum SubscriptionHelper {
     }
     /**
      * Check if the given subscription is the common cancelled subscription.
-     * @param d the subscription to check
+     * @param s the subscription to check
      * @return true if the subscription is the common cancelled subscription
      */
-    public static boolean isCancelled(Subscription d) {
-        return d == CANCELLED;
+    public static boolean isCancelled(Subscription s) {
+        return s == CANCELLED;
     }
     
     /**
@@ -135,21 +135,21 @@ public enum SubscriptionHelper {
      * Atomically sets the subscription on the field but does not
      * cancel the previouls subscription.
      * @param field the target field to set the new subscription on
-     * @param d the new subscription
+     * @param s the new subscription
      * @return true if the operation succeeded, false if the target field
      * holds the {@link #CANCELLED} instance.
      * @see #set(AtomicReference, Subscription)
      */
-    public static boolean replace(AtomicReference<Subscription> field, Subscription d) {
+    public static boolean replace(AtomicReference<Subscription> field, Subscription s) {
         for (;;) {
             Subscription current = field.get();
             if (current == CANCELLED) {
-                if (d != null) {
-                    d.cancel();
+                if (s != null) {
+                    s.cancel();
                 }
                 return false;
             }
-            if (field.compareAndSet(current, d)) {
+            if (field.compareAndSet(current, s)) {
                 return true;
             }
         }
@@ -163,7 +163,7 @@ public enum SubscriptionHelper {
      * common cancelled instance happened in the caller's thread (allows
      * further one-time actions).
      */
-    public static boolean dispose(AtomicReference<Subscription> field) {
+    public static boolean cancel(AtomicReference<Subscription> field) {
         Subscription current = field.get();
         if (current != CANCELLED) {
             current = field.getAndSet(CANCELLED);
@@ -196,7 +196,8 @@ public enum SubscriptionHelper {
         
     }
     
-    public static void deferredSetOnce(AtomicReference<Subscription> field, AtomicLong requested, Subscription s) {
+    public static void deferredSetOnce(AtomicReference<Subscription> field, AtomicLong requested, 
+            Subscription s) {
         if (SubscriptionHelper.setOnce(field, s)) {
             long r = requested.getAndSet(0L);
             if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/util/HalfSerializer.java
+++ b/src/main/java/io/reactivex/internal/util/HalfSerializer.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Observer;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Utility methods to perform half-serialization: a form of serialization
+ * where onNext is guaranteed to be called from a single thread but
+ * onError or onCompleted may be called from any threads.
+ */
+public enum HalfSerializer {
+    ;
+    
+    public static <T> void onNext(Subscriber<? super T> subscriber, T value, 
+            AtomicInteger wip, AtomicThrowable error) {
+        if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
+            subscriber.onNext(value);
+            if (wip.decrementAndGet() != 0) {
+                Throwable ex = error.terminate();
+                if (ex != null) {
+                    subscriber.onError(ex);
+                } else {
+                    subscriber.onComplete();
+                }
+            }
+        }
+    }
+    
+    public static void onError(Subscriber<?> subscriber, Throwable ex, 
+            AtomicInteger wip, AtomicThrowable error) {
+        if (error.addThrowable(ex)) {
+            if (wip.getAndIncrement() == 0) {
+                subscriber.onError(error.terminate());
+            }
+        } else {
+            RxJavaPlugins.onError(ex);
+        }
+    }
+    
+    public static void onComplete(Subscriber<?> subscriber, AtomicInteger wip, AtomicThrowable error) {
+        if (wip.getAndIncrement() == 0) {
+            Throwable ex = error.terminate();
+            if (ex != null) {
+                subscriber.onError(ex);
+            } else {
+                subscriber.onComplete();
+            }
+        }
+    }
+
+    public static <T> void onNext(Observer<? super T> subscriber, T value, 
+            AtomicInteger wip, AtomicThrowable error) {
+        if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
+            subscriber.onNext(value);
+            if (wip.decrementAndGet() != 0) {
+                Throwable ex = error.terminate();
+                if (ex != null) {
+                    subscriber.onError(ex);
+                } else {
+                    subscriber.onComplete();
+                }
+            }
+        }
+    }
+    
+    public static void onError(Observer<?> subscriber, Throwable ex, 
+            AtomicInteger wip, AtomicThrowable error) {
+        if (error.addThrowable(ex)) {
+            if (wip.getAndIncrement() == 0) {
+                subscriber.onError(error.terminate());
+            }
+        } else {
+            RxJavaPlugins.onError(ex);
+        }
+    }
+    
+    public static void onComplete(Observer<?> subscriber, AtomicInteger wip, AtomicThrowable error) {
+        if (wip.getAndIncrement() == 0) {
+            Throwable ex = error.terminate();
+            if (ex != null) {
+                subscriber.onError(ex);
+            } else {
+                subscriber.onComplete();
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/util/OpenHashSet.java
+++ b/src/main/java/io/reactivex/internal/util/OpenHashSet.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.util;
 
 import java.util.Arrays;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Consumer;
 
 /**
@@ -208,6 +208,7 @@ public final class OpenHashSet<T> {
                 try {
                     consumer.accept(k);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     if (ex == null) {
                         ex = new CompositeException();
                     }

--- a/src/main/java/io/reactivex/observables/BlockingObservable.java
+++ b/src/main/java/io/reactivex/observables/BlockingObservable.java
@@ -21,9 +21,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Optional;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.subscribers.flowable.BlockingSubscriber;
@@ -53,6 +54,7 @@ public final class BlockingObservable<T> implements Iterable<T> {
             try {
                 action.accept(it.next());
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 it.dispose();
                 Exceptions.propagate(e);
             }
@@ -243,7 +245,7 @@ public final class BlockingObservable<T> implements Iterable<T> {
         final CountDownLatch cdl = new CountDownLatch(1);
         final AtomicReference<T> value = new AtomicReference<T>();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        final SerialDisposable sd = new SerialDisposable();
+        final SequentialDisposable sd = new SequentialDisposable();
         
         o.subscribe(new Observer<T>() {
 

--- a/src/main/java/io/reactivex/observables/package-info.java
+++ b/src/main/java/io/reactivex/observables/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes supporting the Observable base reactive class: blocking, connectable and grouped
+ * flowables.
+ */
+package io.reactivex.observables;

--- a/src/main/java/io/reactivex/observers/Observers.java
+++ b/src/main/java/io/reactivex/observers/Observers.java
@@ -15,6 +15,7 @@ package io.reactivex.observers;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.*;
@@ -79,11 +80,13 @@ public final class Observers {
                 try {
                     onStart.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -97,11 +100,13 @@ public final class Observers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -118,6 +123,7 @@ public final class Observers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -132,6 +138,7 @@ public final class Observers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }
@@ -168,11 +175,13 @@ public final class Observers {
                 try {
                     onStart.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -186,11 +195,13 @@ public final class Observers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -207,6 +218,7 @@ public final class Observers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -221,6 +233,7 @@ public final class Observers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }
@@ -285,11 +298,13 @@ public final class Observers {
                 try {
                     onStart.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     dispose();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -303,11 +318,13 @@ public final class Observers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     dispose();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -324,6 +341,7 @@ public final class Observers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -338,6 +356,7 @@ public final class Observers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }
@@ -365,11 +384,13 @@ public final class Observers {
                     try {
                         onStart.accept(s);
                     } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
                         done = true;
                         s.dispose();
                         try {
                             onError.accept(e);
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             RxJavaPlugins.onError(ex);
                             RxJavaPlugins.onError(e);
                         }
@@ -385,11 +406,13 @@ public final class Observers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     s.dispose();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -406,6 +429,7 @@ public final class Observers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -420,6 +444,7 @@ public final class Observers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }

--- a/src/main/java/io/reactivex/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/observers/SafeObserver.java
@@ -14,7 +14,7 @@ package io.reactivex.observers;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -46,11 +46,13 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
             try {
                 actual.onSubscribe(this);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 done = true;
                 // can't call onError because the actual's state may be corrupt at this point
                 try {
                     s.dispose();
                 } catch (Throwable e1) {
+                    Exceptions.throwIfFatal(e1);
                     RxJavaPlugins.onError(e1);
                 }
                 RxJavaPlugins.onError(e);
@@ -85,6 +87,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         try {
             actual.onNext(t);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             onError(e);
         }
     }
@@ -102,6 +105,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
             try {
                 actual.onSubscribe(EmptyDisposable.INSTANCE);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 // can't call onError because the actual's state may be corrupt at this point
                 t2.suppress(e);
                 
@@ -111,6 +115,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
             try {
                 actual.onError(t2);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 // if onError failed, all that's left is to report the error to plugins
                 t2.suppress(e);
                 
@@ -127,6 +132,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         try {
             s.dispose();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             t2 = new CompositeException(e, t);
         }
 
@@ -137,6 +143,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
                 actual.onError(t);
             }
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             t2.suppress(e);
             
             RxJavaPlugins.onError(t2);
@@ -158,9 +165,11 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         try {
             s.dispose();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             try {
                 actual.onError(e);
             } catch (Throwable e1) {
+                Exceptions.throwIfFatal(e1);
                 RxJavaPlugins.onError(new CompositeException(e1, e));
             }
             return;
@@ -169,6 +178,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         try {
             actual.onComplete();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
     }

--- a/src/main/java/io/reactivex/observers/completable/package-info.java
+++ b/src/main/java/io/reactivex/observers/completable/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default wrappers and implementations for CompletableObserver-based consumer classes and interfaces;
+ * utility classes for creating them from callbacks.
+ */
+package io.reactivex.observers.completable;

--- a/src/main/java/io/reactivex/observers/package-info.java
+++ b/src/main/java/io/reactivex/observers/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default wrappers and implementations for Observer-based consumer classes and interfaces;
+ * utility classes for creating them from callbacks.
+ */
+package io.reactivex.observers;

--- a/src/main/java/io/reactivex/observers/single/package-info.java
+++ b/src/main/java/io/reactivex/observers/single/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default wrappers and implementations for SingleObserver-based consumer classes and interfaces;
+ * utility classes for creating them from callbacks.
+ */
+package io.reactivex.observers.single;

--- a/src/main/java/io/reactivex/package-info.java
+++ b/src/main/java/io/reactivex/package-info.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Base reactive classes: Flowable, Observable, Single and Completable; base reactive consumers;
+ * other common base interfaces.
+ * 
+ * <p>A library that enables subscribing to and composing asynchronous events and
+ * callbacks.</p>
+ * <p>The Flowable/Subscriber, Observable/Observer, Single/SingleObserver and 
+ * Completable/CompletableObserver interfaces and associated operators (in
+ * the {@code io.reactivex.internal.operators} package) are inspired by the
+ * Reactive Rx library in Microsoft .NET but designed and implemented on 
+ * the more advanced Reactive-Streams ( http://www.reactivestreams.org ) principles.</p>
+ * <p>
+ * More information can be found at <a
+ * href="http://msdn.microsoft.com/en-us/data/gg577609">http://msdn.microsoft.com/en-us/data/gg577609</a>.
+ * </p>
+ * 
+ * 
+ * <p>Compared with the Microsoft implementation:
+ * <ul>
+ * <li>Observable == IObservable (base type)</li>
+ * <li>Observer == IObserver (event consumer)</li>
+ * <li>Disposable == IDisposable (resource/cancellation management)</li>
+ * <li>Observable == Observable (factory methods)</li>
+ * <li>Flowable == IAsyncEnumerable (backpressure)</li>
+ * <li>Subscriber == IAsyncEnumerator</li>
+ * <li>
+ * </ul>
+ * The Single and Completable reactive base types have no equivalent in Rx.NET as of 3.x.
+ * </p>
+ * <p>Services which intend on exposing data asynchronously and wish
+ * to allow reactive processing and composition can implement the
+ * {@link io.reactivex.Flowable}, {@link io.reactivex.Observable}, {@link io.reactivex.Single}
+ * or {@link io.reactivex.Completable} class which then allow consumers to subscribe to them
+ * and receive events.</p>
+ * <p>Usage examples can be found on the {@link rx.Observable} and {@link org.reactivestreams.Subscriber} classes.</p>
+ */
+package io.reactivex;
+

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -177,6 +177,7 @@ public final class RxJavaPlugins {
                 f.accept(error);
                 return;
             } catch (Throwable e) {
+                // Exceptions.throwIfFatal(e); TODO decide
                 if (error == null) {
                     error = new NullPointerException();
                 }
@@ -541,6 +542,7 @@ public final class RxJavaPlugins {
         try {
             return f.apply(t);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
     }
@@ -560,6 +562,7 @@ public final class RxJavaPlugins {
         try {
             return f.apply(t, u);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             throw Exceptions.propagate(ex);
         }
     }

--- a/src/main/java/io/reactivex/plugins/package-info.java
+++ b/src/main/java/io/reactivex/plugins/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Callback types and a central plugin handler class to hook into the lifecycle
+ * of the base reactive types and schedulers.
+ */
+package io.reactivex.plugins;

--- a/src/main/java/io/reactivex/processors/package-info.java
+++ b/src/main/java/io/reactivex/processors/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes extending the Flowable base reactive class and implementing
+ * the Subscriber interface at the same time (aka hot Flowables).
+ */
+package io.reactivex.processors;

--- a/src/main/java/io/reactivex/schedulers/package-info.java
+++ b/src/main/java/io/reactivex/schedulers/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Scheduler implementations, value+time record class and the standard factory class to 
+ * return standard RxJava schedulers or wrap any Executor-based (thread pool) instances.
+ */
+package io.reactivex.schedulers;

--- a/src/main/java/io/reactivex/subjects/package-info.java
+++ b/src/main/java/io/reactivex/subjects/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes extending the Observable base reactive class and implementing
+ * the Observer interface at the same time (aka hot Observables).
+ */
+package io.reactivex.subjects;

--- a/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
@@ -78,6 +78,6 @@ public abstract class DisposableSubscriber<T> implements Subscriber<T>, Disposab
     
     @Override
     public final void dispose() {
-        SubscriptionHelper.dispose(s);
+        SubscriptionHelper.cancel(s);
     }
 }

--- a/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
@@ -111,7 +111,7 @@ public abstract class ResourceSubscriber<T> implements Subscriber<T>, Disposable
      * case the Subscription will be immediately cancelled.
      */
     protected final void cancel() {
-        if (SubscriptionHelper.dispose(s)) {
+        if (SubscriptionHelper.cancel(s)) {
             resources.dispose();
         }
     }

--- a/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
@@ -14,7 +14,7 @@ package io.reactivex.subscribers;
 
 import org.reactivestreams.*;
 
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -46,6 +46,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
             try {
                 s.cancel();
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 ise.initCause(e);
             }
             onError(ise);
@@ -60,11 +61,13 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
         try {
             actual.onSubscribe(s);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             done = true;
             // can't call onError because the actual's state may be corrupt at this point
             try {
                 s.cancel();
             } catch (Throwable e1) {
+                Exceptions.throwIfFatal(e1);
                 CompositeException ce = new CompositeException(); // NOPMD
                 ce.suppress(e1);
                 ce.suppress(e);
@@ -90,6 +93,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
         try {
             actual.onNext(t);
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             onError(e);
         }
     }
@@ -107,6 +111,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
             try {
                 actual.onSubscribe(EmptySubscription.INSTANCE);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 // can't call onError because the actual's state may be corrupt at this point
                 t2.suppress(e);
                 
@@ -116,6 +121,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
             try {
                 actual.onError(t2);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 // if onError failed, all that's left is to report the error to plugins
                 t2.suppress(e);
                 
@@ -132,6 +138,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
         try {
             subscription.cancel();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             t2 = new CompositeException(e, t);
         }
 
@@ -142,6 +149,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
                 actual.onError(t);
             }
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             t2.suppress(e);
             
             RxJavaPlugins.onError(t2);
@@ -163,9 +171,11 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
         try {
             subscription.cancel();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             try {
                 actual.onError(e);
             } catch (Throwable e1) {
+                Exceptions.throwIfFatal(e1);
                 RxJavaPlugins.onError(new CompositeException(e1, e));
             }
             return;
@@ -174,6 +184,7 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
         try {
             actual.onComplete();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);
         }
     }

--- a/src/main/java/io/reactivex/subscribers/Subscribers.java
+++ b/src/main/java/io/reactivex/subscribers/Subscribers.java
@@ -15,6 +15,7 @@ package io.reactivex.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -87,11 +88,13 @@ public final class Subscribers {
                 try {
                     onStart.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -105,11 +108,13 @@ public final class Subscribers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -126,6 +131,7 @@ public final class Subscribers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -140,6 +146,7 @@ public final class Subscribers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }
@@ -197,11 +204,13 @@ public final class Subscribers {
                 try {
                     onStart.accept(s);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     s.cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -215,11 +224,13 @@ public final class Subscribers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     s.cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -236,6 +247,7 @@ public final class Subscribers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -250,6 +262,7 @@ public final class Subscribers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }
@@ -291,11 +304,13 @@ public final class Subscribers {
                 try {
                     onStart.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(e);
                         RxJavaPlugins.onError(ex);
                     }
@@ -309,11 +324,13 @@ public final class Subscribers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(e);
                         RxJavaPlugins.onError(ex);
                     }
@@ -330,6 +347,7 @@ public final class Subscribers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -344,6 +362,7 @@ public final class Subscribers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }
@@ -381,11 +400,13 @@ public final class Subscribers {
                 try {
                     onStart.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -399,11 +420,13 @@ public final class Subscribers {
                 try {
                     onNext.accept(t);
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     done = true;
                     cancel();
                     try {
                         onError.accept(e);
                     } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
                         RxJavaPlugins.onError(ex);
                         RxJavaPlugins.onError(e);
                     }
@@ -420,6 +443,7 @@ public final class Subscribers {
                 try {
                     onError.accept(t);
                 } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                     RxJavaPlugins.onError(t);
                 }
@@ -434,6 +458,7 @@ public final class Subscribers {
                 try {
                     onComplete.run();
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     RxJavaPlugins.onError(e);
                 }
             }

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Notification;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.*;
 import io.reactivex.internal.functions.Objects;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -169,6 +169,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
                         }
                         completions++;
                     } catch (Throwable ex) {
+                        // Exceptions.throwIfFatal(e); TODO add fatals?
                         errors.add(ex);
                     }
                     return;
@@ -218,6 +219,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
                     values.add(t);
                 }
             } catch (Throwable ex) {
+                // Exceptions.throwIfFatal(e); TODO add fatals?
                 errors.add(ex);
             }
             return;
@@ -296,7 +298,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
     public final void cancel() {
         if (!cancelled) {
             cancelled = true;
-            SubscriptionHelper.dispose(subscription);
+            SubscriptionHelper.cancel(subscription);
         }
     }
     

--- a/src/main/java/io/reactivex/subscribers/package-info.java
+++ b/src/main/java/io/reactivex/subscribers/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default wrappers and implementations for Subscriber-based consumer classes and interfaces;
+ * utility classes for creating them from callbacks.
+ */
+package io.reactivex.subscribers;

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -27,10 +27,10 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observers.TestObserver;
@@ -1175,7 +1175,7 @@ public class CompletableTest {
     public void timerCancel() throws InterruptedException {
         Completable c = Completable.timer(250, TimeUnit.MILLISECONDS);
         
-        final SerialDisposable sd = new SerialDisposable();
+        final SequentialDisposable sd = new SequentialDisposable();
         final AtomicInteger calls = new AtomicInteger();
         
         c.subscribe(new CompletableObserver() {

--- a/src/test/java/io/reactivex/disposables/SequentialDisposableTest.java
+++ b/src/test/java/io/reactivex/disposables/SequentialDisposableTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.disposables;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.reactivex.internal.disposables.SequentialDisposable;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SequentialDisposableTest {
+    private SequentialDisposable serialDisposable;
+
+    @Before
+    public void setUp() {
+        serialDisposable = new SequentialDisposable();
+    }
+
+    @Test
+    public void unsubscribingWithoutUnderlyingDoesNothing() {
+        serialDisposable.dispose();
+    }
+
+    @Test
+    public void getDisposableShouldReturnset() {
+        final Disposable underlying = mock(Disposable.class);
+        serialDisposable.update(underlying);
+        assertSame(underlying, serialDisposable.get());
+
+        final Disposable another = mock(Disposable.class);
+        serialDisposable.update(another);
+        assertSame(another, serialDisposable.get());
+    }
+
+    @Test
+    public void notDisposedWhenReplaced() {
+        final Disposable underlying = mock(Disposable.class);
+        serialDisposable.update(underlying);
+
+        serialDisposable.replace(Disposables.empty());
+        serialDisposable.dispose();
+
+        verify(underlying, never()).dispose();
+    }
+
+    @Test
+    public void unsubscribingTwiceDoesUnsubscribeOnce() {
+        Disposable underlying = mock(Disposable.class);
+        serialDisposable.update(underlying);
+
+        serialDisposable.dispose();
+        verify(underlying).dispose();
+
+        serialDisposable.dispose();
+        verifyNoMoreInteractions(underlying);
+    }
+
+    @Test
+    public void settingSameDisposableTwiceDoesUnsubscribeIt() {
+        Disposable underlying = mock(Disposable.class);
+        serialDisposable.update(underlying);
+        verifyZeroInteractions(underlying);
+        serialDisposable.update(underlying);
+        verify(underlying).dispose();
+    }
+
+    @Test
+    public void unsubscribingWithSingleUnderlyingUnsubscribes() {
+        Disposable underlying = mock(Disposable.class);
+        serialDisposable.update(underlying);
+        underlying.dispose();
+        verify(underlying).dispose();
+    }
+
+    @Test
+    public void replacingFirstUnderlyingCausesUnsubscription() {
+        Disposable first = mock(Disposable.class);
+        serialDisposable.update(first);
+        Disposable second = mock(Disposable.class);
+        serialDisposable.update(second);
+        verify(first).dispose();
+    }
+
+    @Test
+    public void whenUnsubscribingSecondUnderlyingUnsubscribed() {
+        Disposable first = mock(Disposable.class);
+        serialDisposable.update(first);
+        Disposable second = mock(Disposable.class);
+        serialDisposable.update(second);
+        serialDisposable.dispose();
+        verify(second).dispose();
+    }
+
+    @Test
+    public void settingUnderlyingWhenUnsubscribedCausesImmediateUnsubscription() {
+        serialDisposable.dispose();
+        Disposable underlying = mock(Disposable.class);
+        serialDisposable.update(underlying);
+        verify(underlying).dispose();
+    }
+
+    @Test(timeout = 1000)
+    public void settingUnderlyingWhenUnsubscribedCausesImmediateUnsubscriptionConcurrently()
+            throws InterruptedException {
+        final Disposable firstSet = mock(Disposable.class);
+        serialDisposable.update(firstSet);
+
+        final CountDownLatch start = new CountDownLatch(1);
+
+        final int count = 10;
+        final CountDownLatch end = new CountDownLatch(count);
+
+        final List<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < count; i++) {
+            final Thread t = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        start.await();
+                        serialDisposable.dispose();
+                    } catch (InterruptedException e) {
+                        fail(e.getMessage());
+                    } finally {
+                        end.countDown();
+                    }
+                }
+            };
+            t.start();
+            threads.add(t);
+        }
+
+        final Disposable underlying = mock(Disposable.class);
+        start.countDown();
+        serialDisposable.update(underlying);
+        end.await();
+        verify(firstSet).dispose();
+        verify(underlying).dispose();
+
+        for (final Thread t : threads) {
+            t.join();
+        }
+    }
+
+    @Test
+    public void concurrentSetDisposableShouldNotInterleave()
+            throws InterruptedException {
+        final int count = 10;
+        final List<Disposable> subscriptions = new ArrayList<Disposable>();
+
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch end = new CountDownLatch(count);
+
+        final List<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < count; i++) {
+            final Disposable subscription = mock(Disposable.class);
+            subscriptions.add(subscription);
+
+            final Thread t = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        start.await();
+                        serialDisposable.update(subscription);
+                    } catch (InterruptedException e) {
+                        fail(e.getMessage());
+                    } finally {
+                        end.countDown();
+                    }
+                }
+            };
+            t.start();
+            threads.add(t);
+        }
+
+        start.countDown();
+        end.await();
+        serialDisposable.dispose();
+
+        for (final Disposable subscription : subscriptions) {
+            verify(subscription).dispose();
+        }
+
+        for (final Thread t : threads) {
+            t.join();
+        }
+    }
+}


### PR DESCRIPTION
Notable changes:
- implemented `withLatestFrom` with multiple other sources (both `Flowable` and `Observable`)
- added missing `Exceptions.throwIfFatal()` after catching throwables
- added `SequentialDisposable` and replaced internal use of `SerialDisposable` with it
- added `package-info.java` to public packages
- added javadoc to some interfaces and methods
- removed `@Experimental` tags and set those methods to `@since 2.0`
- added `HalfSerializer` to deal with single onNext and multiple onError/onComplete callers
