### PR TITLE
2.x: Remove test scheduler factory.

### DIFF
--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -80,16 +80,6 @@ public final class Schedulers {
     public static Scheduler io() {
         return RxJavaPlugins.onIoScheduler(IO);
     }
-    
-    /**
-     * Creates and returns a {@code TestScheduler}, which is useful for debugging. It allows you to test
-     * schedules of events by manually advancing the clock at whatever pace you choose.
-     *
-     * @return a {@code TestScheduler} meant for debugging
-     */
-    public static TestScheduler test() { // NOPMD
-        return new TestScheduler();
-    }
 
     /**
      * Creates and returns a {@link Scheduler} that queues work on the current thread to be executed after the

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -1139,7 +1139,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000)
     public void timerTestScheduler() {
-        TestScheduler scheduler = Schedulers.test();
+        TestScheduler scheduler = new TestScheduler();
         
         Completable c = Completable.timer(250, TimeUnit.MILLISECONDS, scheduler);
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -765,7 +765,7 @@ public class FlowableDelayTest {
     
     @Test
     public void testErrorRunsBeforeOnNext() {
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         
         PublishProcessor<Integer> ps = PublishProcessor.create();
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -427,11 +427,11 @@ public class FlowableMergeTest {
 
     @Test
     public void testUnsubscribeAsFlowablesComplete() {
-        TestScheduler scheduler1 = Schedulers.test();
+        TestScheduler scheduler1 = new TestScheduler();
         AtomicBoolean os1 = new AtomicBoolean(false);
         Flowable<Long> o1 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
 
-        TestScheduler scheduler2 = Schedulers.test();
+        TestScheduler scheduler2 = new TestScheduler();
         AtomicBoolean os2 = new AtomicBoolean(false);
         Flowable<Long> o2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
@@ -469,11 +469,11 @@ public class FlowableMergeTest {
     @Test
     public void testEarlyUnsubscribe() {
         for (int i = 0; i < 10; i++) {
-            TestScheduler scheduler1 = Schedulers.test();
+            TestScheduler scheduler1 = new TestScheduler();
             AtomicBoolean os1 = new AtomicBoolean(false);
             Flowable<Long> o1 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
 
-            TestScheduler scheduler2 = Schedulers.test();
+            TestScheduler scheduler2 = new TestScheduler();
             AtomicBoolean os2 = new AtomicBoolean(false);
             Flowable<Long> o2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
@@ -1121,7 +1121,7 @@ public class FlowableMergeTest {
 
     @Test
     public void shouldNotCompleteIfThereArePendingScalarSynchronousEmissionsWhenTheLastInnerSubscriberCompletes() {
-        TestScheduler scheduler = Schedulers.test();
+        TestScheduler scheduler = new TestScheduler();
         Flowable<Long> source = Flowable.mergeDelayError(Flowable.just(1L), Flowable.timer(1, TimeUnit.SECONDS, scheduler).skip(1));
         TestSubscriber<Long> subscriber = new TestSubscriber<Long>(0L);
         source.subscribe(subscriber);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -793,7 +793,7 @@ public class FlowableObserveOnTest {
     
     @Test
     public void testErrorDelayed() {
-        TestScheduler s = Schedulers.test();
+        TestScheduler s = new TestScheduler();
         
         Flowable<Integer> source = Flowable.just(1, 2 ,3)
                 .concatWith(Flowable.<Integer>error(new TestException()));
@@ -845,8 +845,8 @@ public class FlowableObserveOnTest {
     @Test
     public void requestExactCompletesImmediately() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
-        
-        TestScheduler test = Schedulers.test();
+
+        TestScheduler test = new TestScheduler();
 
         Flowable.range(1, 10).observeOn(test).subscribe(ts);
 
@@ -869,7 +869,7 @@ public class FlowableObserveOnTest {
     public void fixedReplenishPattern() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         
         final List<Long> requests = new ArrayList<Long>();
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -760,7 +760,7 @@ public class FlowableReplayTest {
     
     @Test
     public void testTimedAndSizedTruncation() {
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test);
         List<Integer> values = new ArrayList<Integer>();
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -268,7 +268,7 @@ public class FlowableSubscribeOnTest {
     
     @Test
     public void cancelBeforeActualSubscribe() {
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         
         TestSubscriber<Integer> ts = Flowable.just(1).hide()
                 .subscribeOn(test).test(Long.MAX_VALUE, 0, true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -204,7 +204,7 @@ public class FlowableTakeLastTimedTest {
     
     @Test
     public void testContinuousDelivery() {
-        TestScheduler scheduler = Schedulers.test();
+        TestScheduler scheduler = new TestScheduler();
         
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
         

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -766,7 +766,7 @@ public class ObservableDelayTest {
     
     @Test
     public void testErrorRunsBeforeOnNext() {
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         
         PublishSubject<Integer> ps = PublishSubject.create();
         

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -417,11 +417,11 @@ public class ObservableMergeTest {
 
     @Test
     public void testUnsubscribeAsObservablesComplete() {
-        TestScheduler scheduler1 = Schedulers.test();
+        TestScheduler scheduler1 = new TestScheduler();
         AtomicBoolean os1 = new AtomicBoolean(false);
         Observable<Long> o1 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
 
-        TestScheduler scheduler2 = Schedulers.test();
+        TestScheduler scheduler2 = new TestScheduler();
         AtomicBoolean os2 = new AtomicBoolean(false);
         Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
@@ -459,11 +459,11 @@ public class ObservableMergeTest {
     @Test
     public void testEarlyUnsubscribe() {
         for (int i = 0; i < 10; i++) {
-            TestScheduler scheduler1 = Schedulers.test();
+            TestScheduler scheduler1 = new TestScheduler();
             AtomicBoolean os1 = new AtomicBoolean(false);
             Observable<Long> o1 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
 
-            TestScheduler scheduler2 = Schedulers.test();
+            TestScheduler scheduler2 = new TestScheduler();
             AtomicBoolean os2 = new AtomicBoolean(false);
             Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -564,7 +564,7 @@ public class ObservableReplayTest {
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
         Action sourceUnsubscribed = mock(Action.class);
-        final TestScheduler mockScheduler = Schedulers.test();
+        final TestScheduler mockScheduler = new TestScheduler();
         
         Observer<Integer> mockObserverBeforeConnect = TestHelper.mockObserver();
         Observer<Integer> mockObserverAfterConnect = TestHelper.mockObserver();
@@ -742,7 +742,7 @@ public class ObservableReplayTest {
     
     @Test
     public void testTimedAndSizedTruncation() {
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test);
         List<Integer> values = new ArrayList<Integer>();
         

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -184,7 +184,7 @@ public class ObservableSubscribeOnTest {
     
     @Test
     public void cancelBeforeActualSubscribe() {
-        TestScheduler test = Schedulers.test();
+        TestScheduler test = new TestScheduler();
         
         TestObserver<Integer> to = new TestObserver<Integer>();
         


### PR DESCRIPTION
This method is misleading in that it's a factory next to a bunch of accessor methods to shared resources. The TestScheduler constructor is public and can be used directly.
