### PR TITLE
2.x: Remove double dash on RxThreadFactory thread names.

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -30,7 +30,7 @@ public final class ComputationScheduler extends Scheduler {
     /** This will indicate no pool is active. */
     static final FixedSchedulerPool NONE = new FixedSchedulerPool(0);
     /** Manages a fixed number of workers. */
-    private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool-";
+    private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
     /** 
      * Key to setting the maximum number of computation scheduler threads.
@@ -55,7 +55,7 @@ public final class ComputationScheduler extends Scheduler {
         }
         MAX_THREADS = max;
 
-        SHUTDOWN_WORKER = new PoolWorker(new RxThreadFactory("RxComputationShutdown-"));
+        SHUTDOWN_WORKER = new PoolWorker(new RxThreadFactory("RxComputationShutdown"));
         SHUTDOWN_WORKER.dispose();
     }
 

--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -28,11 +28,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Scheduler that creates and caches a set of thread pools and reuses them if possible.
  */
 public final class IoScheduler extends Scheduler {
-    private static final String WORKER_THREAD_NAME_PREFIX = "RxCachedThreadScheduler-";
+    private static final String WORKER_THREAD_NAME_PREFIX = "RxCachedThreadScheduler";
     private static final RxThreadFactory WORKER_THREAD_FACTORY =
             new RxThreadFactory(WORKER_THREAD_NAME_PREFIX);
 
-    private static final String EVICTOR_THREAD_NAME_PREFIX = "RxCachedWorkerPoolEvictor-";
+    private static final String EVICTOR_THREAD_NAME_PREFIX = "RxCachedWorkerPoolEvictor";
     private static final RxThreadFactory EVICTOR_THREAD_FACTORY =
             new RxThreadFactory(EVICTOR_THREAD_NAME_PREFIX);
 
@@ -47,7 +47,7 @@ public final class IoScheduler extends Scheduler {
         NONE = new CachedWorkerPool(0, null);
         NONE.shutdown();
 
-        SHUTDOWN_THREADWORKER = new ThreadWorker(new RxThreadFactory("RxCachedThreadSchedulerShutdown-"));
+        SHUTDOWN_THREADWORKER = new ThreadWorker(new RxThreadFactory("RxCachedThreadSchedulerShutdown"));
         SHUTDOWN_THREADWORKER.dispose();
     }
     

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
@@ -23,7 +23,7 @@ import io.reactivex.Scheduler;
  */
 public final class NewThreadScheduler extends Scheduler {
 
-    private static final String THREAD_NAME_PREFIX = "RxNewThreadScheduler-";
+    private static final String THREAD_NAME_PREFIX = "RxNewThreadScheduler";
     private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
     private static final NewThreadScheduler INSTANCE = new NewThreadScheduler();
 

--- a/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
@@ -30,10 +30,7 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     
     @Override
     public Thread newThread(Runnable r) {
-        StringBuilder nameBuilder = new StringBuilder();
-        nameBuilder.append(prefix)
-        .append('-')
-        .append(incrementAndGet());
+        StringBuilder nameBuilder = new StringBuilder(prefix).append('-').append(incrementAndGet());
         
         if (CREATE_TRACE) {
             nameBuilder.append("\r\n");

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
@@ -58,7 +58,7 @@ public enum SchedulerPoolFactory {
             if (curr != null && !curr.isShutdown()) {
                 return;
             }
-            ScheduledExecutorService next = Executors.newScheduledThreadPool(1, new RxThreadFactory("RxSchedulerPurge-"));
+            ScheduledExecutorService next = Executors.newScheduledThreadPool(1, new RxThreadFactory("RxSchedulerPurge"));
             if (PURGE_THREAD.compareAndSet(curr, next)) {
                 
                 next.scheduleAtFixedRate(new Runnable() {

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -35,7 +35,7 @@ public final class SingleScheduler extends Scheduler {
     }
 
     static ScheduledExecutorService createExecutor() {
-        return SchedulerPoolFactory.create(new RxThreadFactory("RxSingleScheduler-"));
+        return SchedulerPoolFactory.create(new RxThreadFactory("RxSingleScheduler"));
     }
     
     @Override

--- a/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.fail;
 
 public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
-    final static Executor executor = Executors.newFixedThreadPool(2, new RxThreadFactory("TestCustomPool-"));
+    final static Executor executor = Executors.newFixedThreadPool(2, new RxThreadFactory("TestCustomPool"));
     
     @Override
     protected Scheduler getScheduler() {


### PR DESCRIPTION
Also optimize name creation to avoid `StringBuilder` having to expand its underlying `char[]`.
