### PR TITLE
1.x: Remove explicit StackOverflow check as its a VirtualMachineError.

### DIFF
--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -65,7 +65,6 @@ public final class Exceptions {
      * <li>{@link OnErrorNotImplementedException}</li>
      * <li>{@link OnErrorFailedException}</li>
      * <li>{@link OnCompletedFailedException}</li>
-     * <li>{@code StackOverflowError}</li>
      * <li>{@code VirtualMachineError}</li>
      * <li>{@code ThreadDeath}</li>
      * <li>{@code LinkageError}</li>
@@ -88,9 +87,7 @@ public final class Exceptions {
             throw (OnCompletedFailedException) t;
         }
         // values here derived from https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495
-        else if (t instanceof StackOverflowError) {
-            throw (StackOverflowError) t;
-        } else if (t instanceof VirtualMachineError) {
+        else if (t instanceof VirtualMachineError) {
             throw (VirtualMachineError) t;
         } else if (t instanceof ThreadDeath) {
             throw (ThreadDeath) t;


### PR DESCRIPTION
Looks like [the linked comment](https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495) was misinterpreted (but not in a way that affected the implementation) as Scala considered StackOverflowError as non-fatal but RxJava always considered it fatal. As such, its explicit check was redundant.
