### PR TITLE
1.x: Fix multiple values produced by throttleFirst with TestScheduler

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
+++ b/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
@@ -38,7 +38,7 @@ public final class OperatorThrottleFirst<T> implements Operator<T, T> {
     public Subscriber<? super T> call(final Subscriber<? super T> subscriber) {
         return new Subscriber<T>(subscriber) {
 
-            private long lastOnNext;
+            private long lastOnNext = -1;
 
             @Override
             public void onStart() {
@@ -48,7 +48,7 @@ public final class OperatorThrottleFirst<T> implements Operator<T, T> {
             @Override
             public void onNext(T v) {
                 long now = scheduler.now();
-                if (lastOnNext == 0 || now - lastOnNext >= timeInMilliseconds) {
+                if (lastOnNext == -1 || now - lastOnNext >= timeInMilliseconds) {
                     lastOnNext = now;
                     subscriber.onNext(v);
                 } 


### PR DESCRIPTION
When throttleFirst was operating on a TestScheduler, it delivered all items passed to it untill TestScheduler's time would change to a non-zero value.
