### PR TITLE
2.x: Avoid potential NPE when onError throws.

### DIFF
--- a/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
@@ -154,8 +154,11 @@ public final class SafeSubscriber<T> implements Subscriber<T> {
             }
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            t2.suppress(e);
-            
+            if (t2 == null) {
+                t2 = new CompositeException(t, e);
+            } else {
+                t2.suppress(e);
+            }
             RxJavaPlugins.onError(t2);
         }
     }


### PR DESCRIPTION
t2 was only initialized if canceling threw an exception. In the happy path it would have never been initialized so when onError threw the call to suppress() would NPE.
