### PR TITLE
2.x: add missing ops, cleanup, fusion fixes

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -49,7 +49,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable amb(final CompletableSource... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
         }
@@ -73,7 +73,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable amb(final Iterable<? extends CompletableSource> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         
         return new CompletableAmbIterable(sources);
     }
@@ -103,7 +103,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable concat(CompletableSource... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
         } else
@@ -125,7 +125,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable concat(Iterable<? extends CompletableSource> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         
         return new CompletableConcatIterable(sources);
     }
@@ -158,7 +158,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable concat(Publisher<? extends CompletableSource> sources, int prefetch) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         if (prefetch < 1) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
         }
@@ -202,7 +202,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable create(CompletableOnSubscribe source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new CompletableCreate(source));
     }
     
@@ -221,7 +221,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable unsafeCreate(CompletableSource source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Completable) {
             throw new IllegalArgumentException("Use of unsafeCreate(Completable)!");
         }
@@ -247,7 +247,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable defer(final Callable<? extends CompletableSource> completableSupplier) {
-        Objects.requireNonNull(completableSupplier, "completableSupplier");
+        ObjectHelper.requireNonNull(completableSupplier, "completableSupplier");
         return new CompletableDefer(completableSupplier);
     }
 
@@ -267,7 +267,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable error(final Callable<? extends Throwable> errorSupplier) {
-        Objects.requireNonNull(errorSupplier, "errorSupplier is null");
+        ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return new CompletableErrorSupplier(errorSupplier);
     }
     
@@ -283,7 +283,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable error(final Throwable error) {
-        Objects.requireNonNull(error, "error is null");
+        ObjectHelper.requireNonNull(error, "error is null");
         return new CompletableError(error);
     }
     
@@ -301,7 +301,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromAction(final Action run) {
-        Objects.requireNonNull(run, "run is null");
+        ObjectHelper.requireNonNull(run, "run is null");
         return new CompletableFromAction(run);
     }
 
@@ -317,7 +317,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromCallable(final Callable<?> callable) {
-        Objects.requireNonNull(callable, "callable is null");
+        ObjectHelper.requireNonNull(callable, "callable is null");
         return new CompletableFromCallable(callable);
     }
     
@@ -334,7 +334,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromFuture(final Future<?> future) {
-        Objects.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(future, "future is null");
         return fromAction(Functions.futureAction(future));
     }
     
@@ -352,7 +352,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromObservable(final ObservableSource<T> observable) {
-        Objects.requireNonNull(observable, "observable is null");
+        ObjectHelper.requireNonNull(observable, "observable is null");
         return new CompletableFromObservable<T>(observable);
     }
     
@@ -370,7 +370,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromPublisher(final Publisher<T> publisher) {
-        Objects.requireNonNull(publisher, "publisher is null");
+        ObjectHelper.requireNonNull(publisher, "publisher is null");
         return new CompletableFromPublisher<T>(publisher);
     }
 
@@ -388,7 +388,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromSingle(final SingleSource<T> single) {
-        Objects.requireNonNull(single, "single is null");
+        ObjectHelper.requireNonNull(single, "single is null");
         return new CompletableFromSingle<T>(single);
     }
     
@@ -405,7 +405,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(CompletableSource... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
         } else
@@ -428,7 +428,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(Iterable<? extends CompletableSource> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new CompletableMergeIterable(sources);
     }
     
@@ -483,7 +483,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     private static Completable merge0(Publisher<? extends CompletableSource> sources, int maxConcurrency, boolean delayErrors) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         if (maxConcurrency < 1) {
             throw new IllegalArgumentException("maxConcurrency > 0 required but it was " + maxConcurrency);
         }
@@ -504,7 +504,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(CompletableSource... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new CompletableMergeDelayErrorArray(sources);
     }
 
@@ -522,7 +522,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(Iterable<? extends CompletableSource> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new CompletableMergeDelayErrorIterable(sources);
     }
 
@@ -605,8 +605,8 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static Completable timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new CompletableTimer(delay, unit, scheduler);
     }
     
@@ -669,9 +669,9 @@ public abstract class Completable implements CompletableSource {
             final Function<? super R, ? extends CompletableSource> completableFunction,
             final Consumer<? super R> disposer, 
             final boolean eager) {
-        Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
-        Objects.requireNonNull(completableFunction, "completableFunction is null");
-        Objects.requireNonNull(disposer, "disposer is null");
+        ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
+        ObjectHelper.requireNonNull(completableFunction, "completableFunction is null");
+        ObjectHelper.requireNonNull(disposer, "disposer is null");
         
         return new CompletableUsing<R>(resourceSupplier, completableFunction, disposer, eager);
     }
@@ -689,7 +689,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable wrap(CompletableSource source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Completable) {
             return (Completable)source;
         }
@@ -709,7 +709,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable ambWith(CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return amb(this, other);
     }
 
@@ -729,7 +729,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> andThen(ObservableSource<T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return new ObservableDelaySubscriptionOther<T, Object>(next, toObservable());
     }
 
@@ -749,7 +749,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> andThen(Publisher<T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return new FlowableDelaySubscriptionOther<T, Object>(next, toFlowable());
     }
 
@@ -769,7 +769,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<T> andThen(SingleSource<T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return new SingleDelayWithCompletable<T>(next, this);
     }
 
@@ -880,7 +880,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable concatWith(CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return concat(this, other);
     }
 
@@ -934,8 +934,8 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable delay(final long delay, final TimeUnit unit, final Scheduler scheduler, final boolean delayError) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new CompletableDelay(this, delay, unit, scheduler, delayError);
     }
 
@@ -1013,12 +1013,12 @@ public abstract class Completable implements CompletableSource {
             final Action onTerminate,
             final Action onAfterTerminate,
             final Action onDisposed) {
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
-        Objects.requireNonNull(onTerminate, "onTerminate is null");
-        Objects.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        Objects.requireNonNull(onDisposed, "onDisposed is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onTerminate, "onTerminate is null");
+        ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
+        ObjectHelper.requireNonNull(onDisposed, "onDisposed is null");
         return new CompletablePeek(this, onSubscribe, onError, onComplete, onTerminate, onAfterTerminate, onDisposed);
     }
     
@@ -1087,7 +1087,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable lift(final CompletableOperator onLift) {
-        Objects.requireNonNull(onLift, "onLift is null");
+        ObjectHelper.requireNonNull(onLift, "onLift is null");
         return new CompletableLift(this, onLift);
     }
 
@@ -1104,7 +1104,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable mergeWith(CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return merge(this, other);
     }
     
@@ -1120,7 +1120,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable observeOn(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new CompletableObserveOn(this, scheduler);
     }
     
@@ -1151,7 +1151,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable onErrorComplete(final Predicate<? super Throwable> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         
         return new CompletableOnErrorComplete(this, predicate);
     }
@@ -1170,7 +1170,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable onErrorResumeNext(final Function<? super Throwable, ? extends CompletableSource> errorMapper) {
-        Objects.requireNonNull(errorMapper, "errorMapper is null");
+        ObjectHelper.requireNonNull(errorMapper, "errorMapper is null");
         return new CompletableResumeNext(this, errorMapper);
     }
     
@@ -1329,7 +1329,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable startWith(CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return concat(other, this);
     }
 
@@ -1347,7 +1347,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> startWith(Observable<T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return other.concatWith(this.<T>toObservable());
     }
     /**
@@ -1364,7 +1364,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> startWith(Publisher<T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return this.<T>toFlowable().startWith(other);
     }
     
@@ -1387,7 +1387,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
     public final void subscribe(CompletableObserver s) {
-        Objects.requireNonNull(s, "s is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         try {
             
             s = RxJavaPlugins.onSubscribe(this, s);
@@ -1422,8 +1422,8 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(final Action onComplete, final Consumer<? super Throwable> onError) {
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         
         CallbackCompletableObserver s = new CallbackCompletableObserver(onError, onComplete);
         subscribe(s);
@@ -1444,7 +1444,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(final Action onComplete) {
-        Objects.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         
         CallbackCompletableObserver s = new CallbackCompletableObserver(onComplete);
         subscribe(s);
@@ -1464,7 +1464,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable subscribeOn(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         
         return new CompletableSubscribeOn(this, scheduler);
     }
@@ -1502,7 +1502,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Completable timeout(long timeout, TimeUnit unit, CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, Schedulers.computation(), other);
     }
     
@@ -1543,7 +1543,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable timeout(long timeout, TimeUnit unit, Scheduler scheduler, CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, scheduler, other);
     }
     
@@ -1561,8 +1561,8 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     private Completable timeout0(long timeout, TimeUnit unit, Scheduler scheduler, CompletableSource other) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new CompletableTimeout(this, timeout, unit, scheduler, other);
     }
     
@@ -1631,7 +1631,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<T> toSingle(final Callable<? extends T> completionValueSupplier) {
-        Objects.requireNonNull(completionValueSupplier, "completionValueSupplier is null");
+        ObjectHelper.requireNonNull(completionValueSupplier, "completionValueSupplier is null");
         return new CompletableToSingle<T>(this, completionValueSupplier, null);
     }
     
@@ -1649,7 +1649,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<T> toSingleDefault(final T completionValue) {
-        Objects.requireNonNull(completionValue, "completionValue is null");
+        ObjectHelper.requireNonNull(completionValue, "completionValue is null");
         return new CompletableToSingle<T>(this, null, completionValue);
     }
     
@@ -1666,7 +1666,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable unsubscribeOn(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new CompletableUnsubscribeOn(this, scheduler);
     }
     // -------------------------------------------------------------------------

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -6441,7 +6441,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             if (v == null) {
                 return empty();
             }
-            return ScalarXMap.scalarXMap(v, mapper);
+            return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(prefetch, "prefetch");
         return new FlowableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE);
@@ -6511,7 +6511,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             if (v == null) {
                 return empty();
             }
-            return ScalarXMap.scalarXMap(v, mapper);
+            return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(prefetch, "prefetch");
         return new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.IMMEDIATE);
@@ -8023,7 +8023,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             if (v == null) {
                 return empty();
             }
-            return ScalarXMap.scalarXMap(v, mapper);
+            return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(maxConcurrency, "maxConcurrency");
         verifyPositive(bufferSize, "bufferSize");
@@ -12207,7 +12207,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             if (v == null) {
                 return empty();
             }
-            return ScalarXMap.scalarXMap(v, mapper);
+            return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableSwitchMap<T, R>(this, mapper, bufferSize, delayError);

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -23,7 +23,7 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.completable.CompletableFromPublisher;
 import io.reactivex.internal.operators.flowable.*;
@@ -88,7 +88,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> amb(Iterable<? extends Publisher<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new FlowableAmb<T>(null, sources);
     }
 
@@ -115,7 +115,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> amb(Publisher<? extends T>... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
             return empty();
@@ -228,8 +228,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
     public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<Object[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         if (sources.length == 0) {
             return empty();
@@ -300,8 +300,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources, 
             Function<Object[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false);
     }
@@ -405,8 +405,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public static <T, R> Flowable<R> combineLatestDelayError(Publisher<? extends T>[] sources, 
             Function<Object[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         if (sources.length == 0) {
             return empty();
@@ -481,8 +481,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public static <T, R> Flowable<R> combineLatestDelayError(Iterable<? extends Publisher<? extends T>> sources, 
             Function<Object[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true);
     }
@@ -906,7 +906,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concat(Iterable<? extends Publisher<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         // unlike general sources, fromIterable can only throw on a boundary because it is consumed only there
         return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), 2, false);
     }
@@ -1443,7 +1443,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concatDelayError(Iterable<? extends Publisher<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMapDelayError((Function)Functions.identity());
     }
 
@@ -1677,7 +1677,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> defer(Callable<? extends Publisher<? extends T>> supplier) {
-        Objects.requireNonNull(supplier, "supplier is null");
+        ObjectHelper.requireNonNull(supplier, "supplier is null");
         return new FlowableDefer<T>(supplier);
     }
 
@@ -1729,7 +1729,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> error(Callable<? extends Throwable> errorSupplier) {
-        Objects.requireNonNull(errorSupplier, "errorSupplier is null");
+        ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return new FlowableError<T>(errorSupplier);
     }
 
@@ -1756,7 +1756,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> error(final Throwable exception) {
-        Objects.requireNonNull(exception, "e is null");
+        ObjectHelper.requireNonNull(exception, "e is null");
         return error(Functions.justCallable(exception));
     }
 
@@ -1782,7 +1782,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromArray(T... values) {
-        Objects.requireNonNull(values, "values is null");
+        ObjectHelper.requireNonNull(values, "values is null");
         if (values.length == 0) {
             return empty();
         } else
@@ -1819,7 +1819,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromCallable(Callable<? extends T> supplier) {
-        Objects.requireNonNull(supplier, "supplier is null");
+        ObjectHelper.requireNonNull(supplier, "supplier is null");
         return new FlowableFromCallable<T>(supplier);
     }
 
@@ -1854,7 +1854,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future) {
-        Objects.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(future, "future is null");
         return new FlowableFromFuture<T>(future, 0L, null);
     }
 
@@ -1893,8 +1893,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
-        Objects.requireNonNull(future, "future is null");
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         return new FlowableFromFuture<T>(future, timeout, unit);
     }
 
@@ -1936,7 +1936,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return fromFuture(future, timeout, unit).subscribeOn(scheduler);
     }
 
@@ -1972,7 +1972,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return fromFuture(future).subscribeOn(scheduler);
     }
 
@@ -1999,7 +1999,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromIterable(Iterable<? extends T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         return new FlowableFromIterable<T>(source);
     }
     
@@ -2025,7 +2025,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (publisher instanceof Flowable) {
             return (Flowable<T>)publisher;
         }
-        Objects.requireNonNull(publisher, "publisher is null");
+        ObjectHelper.requireNonNull(publisher, "publisher is null");
 
         return new FlowableFromPublisher<T>(publisher);
     }
@@ -2050,7 +2050,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> generate(final Consumer<Subscriber<T>> generator) {
-        Objects.requireNonNull(generator, "generator is null");
+        ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(Functions.nullSupplier(), 
                 FlowableInternalHelper.<T, Object>simpleGenerator(generator), 
                 Functions.emptyConsumer());
@@ -2078,7 +2078,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Subscriber<T>> generator) {
-        Objects.requireNonNull(generator, "generator is null");
+        ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), 
                 Functions.emptyConsumer());
     }
@@ -2108,7 +2108,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Subscriber<T>> generator, 
             Consumer<? super S> disposeState) {
-        Objects.requireNonNull(generator, "generator is null");
+        ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), 
                 disposeState);
     }
@@ -2164,9 +2164,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Subscriber<T>, S> generator, Consumer<? super S> disposeState) {
-        Objects.requireNonNull(initialState, "initialState is null");
-        Objects.requireNonNull(generator, "generator is null");
-        Objects.requireNonNull(disposeState, "disposeState is null");
+        ObjectHelper.requireNonNull(initialState, "initialState is null");
+        ObjectHelper.requireNonNull(generator, "generator is null");
+        ObjectHelper.requireNonNull(disposeState, "disposeState is null");
         return new FlowableGenerate<T, S>(initialState, generator, disposeState);
     }
 
@@ -2237,8 +2237,8 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (period < 0) {
             period = 0L;
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
         return new FlowableInterval(initialDelay, period, unit, scheduler);
     }
@@ -2353,8 +2353,8 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (period < 0) {
             period = 0L;
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
         return new FlowableIntervalRange(start, end, initialDelay, period, unit, scheduler);
     }
@@ -2388,7 +2388,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> just(T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return new FlowableJust<T>(value);
     }
 
@@ -2416,8 +2416,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
         
         return fromArray(v1, v2);
     }
@@ -2448,9 +2448,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
         
         return fromArray(v1, v2, v3);
     }
@@ -2483,10 +2483,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
         
         return fromArray(v1, v2, v3, v4);
     }
@@ -2521,11 +2521,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
         
         return fromArray(v1, v2, v3, v4, v5);
     }
@@ -2562,12 +2562,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5, T v6) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6);
     }
@@ -2606,13 +2606,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7);
     }
@@ -2653,14 +2653,14 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
-        Objects.requireNonNull(v8, "The eighth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v8, "The eighth value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -2703,15 +2703,15 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
-        Objects.requireNonNull(v8, "The eighth value is null");
-        Objects.requireNonNull(v9, "The ninth is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v8, "The eighth value is null");
+        ObjectHelper.requireNonNull(v9, "The ninth is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8, v9);
     }
@@ -2756,16 +2756,16 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Flowable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
-        Objects.requireNonNull(v8, "The eighth value is null");
-        Objects.requireNonNull(v9, "The ninth is null");
-        Objects.requireNonNull(v10, "The tenth is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v8, "The eighth value is null");
+        ObjectHelper.requireNonNull(v9, "The ninth is null");
+        ObjectHelper.requireNonNull(v10, "The tenth is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
     }
@@ -3060,8 +3060,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> merge(Publisher<? extends T> p1, Publisher<? extends T> p2) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), false, 2);
     }
 
@@ -3094,9 +3094,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> merge(Publisher<? extends T> p1, Publisher<? extends T> p2, Publisher<? extends T> p3) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
         return fromArray(p1, p2, p3).flatMap((Function)Functions.identity(), false, 3);
     }
 
@@ -3133,10 +3133,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T> Flowable<T> merge(
             Publisher<? extends T> p1, Publisher<? extends T> p2, 
             Publisher<? extends T> p3, Publisher<? extends T> p4) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
-        Objects.requireNonNull(p4, "p4 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p4, "p4 is null");
         return fromArray(p1, p2, p3, p4).flatMap((Function)Functions.identity(), false, 4);
     }
 
@@ -3452,8 +3452,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> mergeDelayError(Publisher<? extends T> p1, Publisher<? extends T> p2) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), true, 2);
     }
 
@@ -3493,9 +3493,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> mergeDelayError(Publisher<? extends T> p1, Publisher<? extends T> p2, Publisher<? extends T> p3) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
         return fromArray(p1, p2, p3).flatMap((Function)Functions.identity(), true, 3);
     }
 
@@ -3540,10 +3540,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T> Flowable<T> mergeDelayError(
             Publisher<? extends T> p1, Publisher<? extends T> p2, 
             Publisher<? extends T> p3, Publisher<? extends T> p4) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
-        Objects.requireNonNull(p4, "p4 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p4, "p4 is null");
         return fromArray(p1, p2, p3, p4).flatMap((Function)Functions.identity(), true, 4);
     }
 
@@ -3633,7 +3633,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<Boolean> sequenceEqual(Publisher<? extends T> p1, Publisher<? extends T> p2) {
-        return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize());
+        return sequenceEqual(p1, p2, ObjectHelper.equalsPredicate(), bufferSize());
     }
 
     /**
@@ -3701,9 +3701,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<Boolean> sequenceEqual(Publisher<? extends T> p1, Publisher<? extends T> p2, 
             BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(isEqual, "isEqual is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(isEqual, "isEqual is null");
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableSequenceEqual<T>(p1, p2, isEqual, bufferSize);
     }
@@ -3732,7 +3732,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<Boolean> sequenceEqual(Publisher<? extends T> p1, Publisher<? extends T> p2, int bufferSize) {
-        return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize);
+        return sequenceEqual(p1, p2, ObjectHelper.equalsPredicate(), bufferSize);
     }
 
     /**
@@ -3943,8 +3943,8 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (delay < 0) {
             delay = 0L;
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
         return new FlowableTimer(delay, unit, scheduler);
     }
@@ -3967,7 +3967,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> unsafeCreate(Publisher<T> onSubscribe) {
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         if (onSubscribe instanceof Flowable) {
             throw new IllegalArgumentException("unsafeCreate(Flowable) should be upgraded");
         }
@@ -4040,9 +4040,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, D> Flowable<T> using(Callable<? extends D> resourceSupplier, 
             Function<? super D, ? extends Publisher<? extends T>> sourceSupplier, 
                     Consumer<? super D> disposer, boolean eager) {
-        Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
-        Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
-        Objects.requireNonNull(disposer, "disposer is null");
+        ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
+        ObjectHelper.requireNonNull(sourceSupplier, "sourceSupplier is null");
+        ObjectHelper.requireNonNull(disposer, "disposer is null");
         return new FlowableUsing<T, D>(resourceSupplier, sourceSupplier, disposer, eager);
     }
 
@@ -4119,8 +4119,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Flowable<R> zip(Iterable<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
-        Objects.requireNonNull(zipper, "zipper is null");
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new FlowableZip<T, R>(null, sources, zipper, bufferSize(), false);
     }
 
@@ -4172,7 +4172,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Flowable<R> zip(Publisher<? extends Publisher<? extends T>> sources, 
             final Function<? super Object[], ? extends R> zipper) {
-        Objects.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
         return fromPublisher(sources).toList().flatMap(FlowableInternalHelper.<T, R>zipIterable(zipper));
     }
 
@@ -4902,7 +4902,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (sources.length == 0) {
             return empty();
         }
-        Objects.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableZip<T, R>(sources, null, zipper, bufferSize, delayError);
     }
@@ -4961,8 +4961,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, R> Flowable<R> zipIterable(Iterable<? extends Publisher<? extends T>> sources,
             Function<? super Object[], ? extends R> zipper, boolean delayError, 
             int bufferSize) {
-        Objects.requireNonNull(zipper, "zipper is null");
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableZip<T, R>(null, sources, zipper, bufferSize, delayError);
     }
@@ -4993,7 +4993,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Boolean> all(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new FlowableAll<T>(this, predicate);
     }
 
@@ -5020,7 +5020,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> ambWith(Publisher<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return amb(this, other);
     }
 
@@ -5050,7 +5050,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Boolean> any(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new FlowableAny<T>(this, predicate);
     }
 
@@ -5698,9 +5698,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <U extends Collection<? super T>> Flowable<U> buffer(long timespan, long timeskip, TimeUnit unit, 
             Scheduler scheduler, Callable<U> bufferSupplier) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new FlowableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false);
     }
     
@@ -5849,9 +5849,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             int count, Scheduler scheduler, 
             Callable<U> bufferSupplier, 
             boolean restartTimerOnMaxSize) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         verifyPositive(count, "count");
         return new FlowableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize);
     }
@@ -5957,9 +5957,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             Flowable<? extends TOpening> bufferOpenings, 
             Function<? super TOpening, ? extends Publisher<? extends TClosing>> bufferClosingSelector,
             Callable<U> bufferSupplier) {
-        Objects.requireNonNull(bufferOpenings, "bufferOpenings is null");
-        Objects.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(bufferOpenings, "bufferOpenings is null");
+        ObjectHelper.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new FlowableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier);
     }
 
@@ -6062,8 +6062,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B, U extends Collection<? super T>> Flowable<U> buffer(Publisher<B> boundary, Callable<U> bufferSupplier) {
-        Objects.requireNonNull(boundary, "boundary is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(boundary, "boundary is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new FlowableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier);
     }
 
@@ -6128,8 +6128,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B, U extends Collection<? super T>> Flowable<U> buffer(Callable<? extends Publisher<B>> boundarySupplier, 
             Callable<U> bufferSupplier) {
-        Objects.requireNonNull(boundarySupplier, "boundarySupplier is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(boundarySupplier, "boundarySupplier is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new FlowableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier);
     }
 
@@ -6276,7 +6276,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> cast(final Class<U> clazz) {
-        Objects.requireNonNull(clazz, "clazz is null");
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
 
@@ -6308,8 +6308,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> collect(Callable<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
-        Objects.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
-        Objects.requireNonNull(collector, "collectior is null");
+        ObjectHelper.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
+        ObjectHelper.requireNonNull(collector, "collectior is null");
         return new FlowableCollect<T, U>(this, initialValueSupplier, collector);
     }
 
@@ -6341,7 +6341,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> collectInto(final U initialValue, BiConsumer<? super U, ? super T> collector) {
-        Objects.requireNonNull(initialValue, "initialValue is null");
+        ObjectHelper.requireNonNull(initialValue, "initialValue is null");
         return collect(Functions.justCallable(initialValue), collector);
     }
 
@@ -6434,7 +6434,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> concatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarCallable<T>)this).call();
@@ -6504,7 +6504,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> concatMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper, 
             int prefetch, boolean tillTheEnd) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarCallable<T>)this).call();
@@ -6696,7 +6696,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return new FlowableFlattenIterable<T, U>(this, mapper, prefetch);
     }
 
@@ -6723,7 +6723,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> concatWith(Publisher<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return concat(this, other);
     }
 
@@ -6749,7 +6749,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Boolean> contains(final Object element) {
-        Objects.requireNonNull(element, "o is null");
+        ObjectHelper.requireNonNull(element, "o is null");
         return any(Functions.equalsWith(element));
     }
 
@@ -6802,7 +6802,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> debounce(Function<? super T, ? extends Publisher<U>> debounceSelector) {
-        Objects.requireNonNull(debounceSelector, "debounceSelector is null");
+        ObjectHelper.requireNonNull(debounceSelector, "debounceSelector is null");
         return new FlowableDebounce<T, U>(this, debounceSelector);
     }
 
@@ -6888,8 +6888,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableDebounceTimed<T>(this, timeout, unit, scheduler);
     }
 
@@ -6917,7 +6917,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> defaultIfEmpty(T defaultValue) {
-        Objects.requireNonNull(defaultValue, "value is null");
+        ObjectHelper.requireNonNull(defaultValue, "value is null");
         return switchIfEmpty(just(defaultValue));
     }
 
@@ -6951,7 +6951,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> delay(final Function<? super T, ? extends Publisher<U>> itemDelay) {
-        Objects.requireNonNull(itemDelay, "itemDelay is null");
+        ObjectHelper.requireNonNull(itemDelay, "itemDelay is null");
         return flatMap(FlowableInternalHelper.itemDelay(itemDelay));
     }
 
@@ -7062,8 +7062,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> delay(long delay, TimeUnit unit, Scheduler scheduler, boolean delayError) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         
         return new FlowableDelay<T>(this, delay, unit, scheduler, delayError);
     }
@@ -7127,7 +7127,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @since 2.0
      */
     public final <U> Flowable<T> delaySubscription(Publisher<U> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new FlowableDelaySubscriptionOther<T, U>(this, other);
     }
 
@@ -7286,8 +7286,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<T> distinct(Function<? super T, K> keySelector, 
             Callable<? extends Collection<? super K>> collectionSupplier) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return FlowableDistinct.withCollection(this, keySelector, collectionSupplier);
     }
 
@@ -7338,7 +7338,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         return FlowableDistinct.untilChanged(this, keySelector);
     }
     
@@ -7366,7 +7366,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
-        Objects.requireNonNull(comparer, "comparer is null");
+        ObjectHelper.requireNonNull(comparer, "comparer is null");
         return new FlowableDistinctUntilChanged<T>(this, comparer);
     }
     
@@ -7472,10 +7472,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     private Flowable<T> doOnEach(Consumer<? super T> onNext, Consumer<? super Throwable> onError, 
             Action onComplete, Action onAfterTerminate) {
-        Objects.requireNonNull(onNext, "onNext is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
-        Objects.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
         return new FlowableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate);
     }
     
@@ -7499,7 +7499,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> doOnEach(final Consumer<? super Notification<T>> onNotification) {
-        Objects.requireNonNull(onNotification, "consumer is null");
+        ObjectHelper.requireNonNull(onNotification, "consumer is null");
         return doOnEach(
                 Functions.notificationOnNext(onNotification),
                 Functions.notificationOnError(onNotification),
@@ -7534,7 +7534,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> doOnEach(final Subscriber<? super T> observer) {
-        Objects.requireNonNull(observer, "observer is null");
+        ObjectHelper.requireNonNull(observer, "observer is null");
         return doOnEach(
                 FlowableInternalHelper.subscriberOnNext(observer),
                 FlowableInternalHelper.subscriberOnError(observer),
@@ -7595,9 +7595,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> doOnLifecycle(final Consumer<? super Subscription> onSubscribe, 
             final LongConsumer onRequest, final Action onCancel) {
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        Objects.requireNonNull(onRequest, "onRequest is null");
-        Objects.requireNonNull(onCancel, "onCancel is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onRequest, "onRequest is null");
+        ObjectHelper.requireNonNull(onCancel, "onCancel is null");
         return new FlowableDoOnLifecycle<T>(this, onSubscribe, onRequest, onCancel);
     }
 
@@ -7770,7 +7770,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        Objects.requireNonNull(defaultValue, "defaultValue is null");
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         return new FlowableElementAt<T>(this, index, defaultValue);
     }
 
@@ -7796,7 +7796,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> filter(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new FlowableFilter<T>(this, predicate);
     }
 
@@ -8016,7 +8016,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, 
             boolean delayErrors, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarCallable<T>)this).call();
@@ -8064,9 +8064,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<? super T, ? extends Publisher<? extends R>> onNextMapper, 
             Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper, 
             Callable<? extends Publisher<? extends R>> onCompleteSupplier) {
-        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
-        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
-        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
+        ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
+        ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(new FlowableMapNotification<T, Publisher<? extends R>>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
 
@@ -8108,9 +8108,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<Throwable, ? extends Publisher<? extends R>> onErrorMapper, 
             Callable<? extends Publisher<? extends R>> onCompleteSupplier, 
             int maxConcurrency) {
-        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
-        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
-        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
+        ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
+        ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(new FlowableMapNotification<T, Publisher<? extends R>>(
                 this, onNextMapper, onErrorMapper, onCompleteSupplier), maxConcurrency);
     }
@@ -8263,8 +8263,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Flowable<R> flatMap(final Function<? super T, ? extends Publisher<? extends U>> mapper, 
             final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         return flatMap(FlowableInternalHelper.flatMapWithCombiner(mapper, combiner), delayErrors, maxConcurrency, bufferSize);
     }
 
@@ -8396,8 +8396,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Flowable<V> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, 
             final BiFunction<? super T, ? super U, ? extends V> resultSelector) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        Objects.requireNonNull(resultSelector, "resultSelector is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(FlowableInternalHelper.flatMapIntoIterable(mapper), resultSelector, false, bufferSize(), bufferSize());
     }
 
@@ -8439,8 +8439,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Flowable<V> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, 
             final BiFunction<? super T, ? super U, ? extends V> resultSelector, int prefetch) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        Objects.requireNonNull(resultSelector, "resultSelector is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(FlowableInternalHelper.flatMapIntoIterable(mapper), resultSelector, false, bufferSize(), prefetch);
     }
 
@@ -8556,9 +8556,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable forEachWhile(final Predicate<? super T> onNext, final Consumer<? super Throwable> onError,
             final Action onComplete) {
-        Objects.requireNonNull(onNext, "onNext is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
 
         ForEachWhileSubscriber<T> s = new ForEachWhileSubscriber<T>(onNext, onError, onComplete);
         subscribe(s);
@@ -8784,8 +8784,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector, 
             Function<? super T, ? extends V> valueSelector, 
             boolean delayError, int bufferSize) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         verifyPositive(bufferSize, "bufferSize");
 
         return new FlowableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError);
@@ -9031,7 +9031,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> lift(FlowableOperator<? extends R, ? super T> lifter) {
-        Objects.requireNonNull(lifter, "lifter is null");
+        ObjectHelper.requireNonNull(lifter, "lifter is null");
         // using onSubscribe so the fusing has access to the underlying raw Publisher
         return new FlowableLift<R, T>(this, lifter);
     }
@@ -9059,7 +9059,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> map(Function<? super T, ? extends R> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return new FlowableMap<T, R>(this, mapper);
     }
 
@@ -9109,7 +9109,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> mergeWith(Publisher<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return merge(this, other);
     }
 
@@ -9218,7 +9218,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
         return new FlowableObserveOn<T>(this, scheduler, delayError, bufferSize);
     }
@@ -9244,7 +9244,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> ofType(final Class<U> clazz) {
-        Objects.requireNonNull(clazz, "clazz is null");
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
         return filter(Functions.isInstanceOf(clazz)).cast(clazz);
     }
 
@@ -9415,7 +9415,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureBuffer(int capacity, boolean delayError, boolean unbounded, 
             Action onOverflow) {
-        Objects.requireNonNull(onOverflow, "onOverflow is null");
+        ObjectHelper.requireNonNull(onOverflow, "onOverflow is null");
         return new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, onOverflow);
     }
 
@@ -9480,7 +9480,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @since 2.0
      */
     public final Publisher<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
-        Objects.requireNonNull(overflowStrategy, "strategy is null");
+        ObjectHelper.requireNonNull(overflowStrategy, "strategy is null");
         verifyPositive(capacity, "capacity");
         return new FlowableOnBackpressureBufferStrategy<T>(this, capacity, onOverflow, overflowStrategy);
     }
@@ -9534,7 +9534,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureDrop(Consumer<? super T> onDrop) {
-        Objects.requireNonNull(onDrop, "onDrop is null");
+        ObjectHelper.requireNonNull(onDrop, "onDrop is null");
         return new FlowableOnBackpressureDrop<T>(this, onDrop);
     }
 
@@ -9608,7 +9608,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onErrorResumeNext(Function<? super Throwable, ? extends Publisher<? extends T>> resumeFunction) {
-        Objects.requireNonNull(resumeFunction, "resumeFunction is null");
+        ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
         return new FlowableOnErrorNext<T>(this, resumeFunction, false);
     }
 
@@ -9650,7 +9650,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onErrorResumeNext(final Publisher<? extends T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }
 
@@ -9688,7 +9688,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
-        Objects.requireNonNull(valueSupplier, "valueSupplier is null");
+        ObjectHelper.requireNonNull(valueSupplier, "valueSupplier is null");
         return new FlowableOnErrorReturn<T>(this, valueSupplier);
     }
 
@@ -9726,7 +9726,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onErrorReturnValue(final T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return onErrorReturn(Functions.justFunction(value));
     }
 
@@ -9771,7 +9771,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onExceptionResumeNext(final Publisher<? extends T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return new FlowableOnErrorNext<T>(this, Functions.justFunction(next), true);
     }
 
@@ -9881,7 +9881,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> publish(Function<? super Flowable<T>, ? extends Publisher<? extends R>> selector, int prefetch) {
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         verifyPositive(prefetch, "prefetch");
         return new FlowablePublishMulticast<T, R>(this, selector, prefetch, false);
     }
@@ -10152,7 +10152,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeatUntil(BooleanSupplier stop) {
-        Objects.requireNonNull(stop, "stop is null");
+        ObjectHelper.requireNonNull(stop, "stop is null");
         return new FlowableRepeatUntil<T>(this, stop);
     }
     
@@ -10181,7 +10181,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeatWhen(final Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
-        Objects.requireNonNull(handler, "handler is null");
+        ObjectHelper.requireNonNull(handler, "handler is null");
         return new FlowableRepeatWhen<T>(this, handler);
     }
     
@@ -10237,7 +10237,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector) {
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this), selector);
     }
 
@@ -10271,7 +10271,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize) {
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this, bufferSize), selector);
     }
 
@@ -10355,7 +10355,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return FlowableReplay.multicastSelector(
                 FlowableInternalHelper.replayCallable(this, bufferSize, time, unit, scheduler), selector);
     }
@@ -10466,9 +10466,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(selector, "selector is null");
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this, time, unit, scheduler), selector);
     }
     
@@ -10501,8 +10501,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <R> Flowable<R> replay(final Function<? super Flowable<T>, ? extends Publisher<R>> selector, final Scheduler scheduler) {
-        Objects.requireNonNull(selector, "selector is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this),
                 FlowableInternalHelper.replayFunction(selector, scheduler));
     }
@@ -10602,8 +10602,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final ConnectableFlowable<T> replay(final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
@@ -10637,7 +10637,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final ConnectableFlowable<T> replay(final int bufferSize, final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.observeOn(replay(bufferSize), scheduler);
     }
     
@@ -10700,8 +10700,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final ConnectableFlowable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.create(this, time, unit, scheduler);
     }
 
@@ -10731,7 +10731,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final ConnectableFlowable<T> replay(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.observeOn(replay(), scheduler);
     }
     
@@ -10788,7 +10788,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         
         return new FlowableRetryBiPredicate<T>(this, predicate);
     }
@@ -10846,7 +10846,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (times < 0) {
             throw new IllegalArgumentException("times >= 0 required but it was " + times);
         }
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
 
         return new FlowableRetryPredicate<T>(this, times, predicate);
     }
@@ -10885,7 +10885,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> retryUntil(final BooleanSupplier stop) {
-        Objects.requireNonNull(stop, "stop is null");
+        ObjectHelper.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, Functions.predicateReverseFor(stop));
     }
     
@@ -10944,7 +10944,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> retryWhen(
             final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
-        Objects.requireNonNull(handler, "handler is null");
+        ObjectHelper.requireNonNull(handler, "handler is null");
         
         return new FlowableRetryWhen<T>(this, handler);
     }
@@ -10966,7 +10966,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final void safeSubscribe(Subscriber<? super T> s) {
-        Objects.requireNonNull(s, "s is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         if (s instanceof SafeSubscriber) {
             subscribe(s);
         } else {
@@ -11029,8 +11029,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableSampleTimed<T>(this, period, unit, scheduler);
     }
     
@@ -11059,7 +11059,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> sample(Publisher<U> sampler) {
-        Objects.requireNonNull(sampler, "sampler is null");
+        ObjectHelper.requireNonNull(sampler, "sampler is null");
         return new FlowableSamplePublisher<T>(this, sampler);
     }
     
@@ -11090,7 +11090,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> scan(BiFunction<T, T, T> accumulator) {
-        Objects.requireNonNull(accumulator, "accumulator is null");
+        ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return new FlowableScan<T>(this, accumulator);
     }
 
@@ -11142,7 +11142,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> scan(final R initialValue, BiFunction<R, ? super T, R> accumulator) {
-        Objects.requireNonNull(initialValue, "seed is null");
+        ObjectHelper.requireNonNull(initialValue, "seed is null");
         return scanWith(Functions.justCallable(initialValue), accumulator);
     }
     
@@ -11194,8 +11194,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> scanWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
-        Objects.requireNonNull(seedSupplier, "seedSupplier is null");
-        Objects.requireNonNull(accumulator, "accumulator is null");
+        ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
+        ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return new FlowableScanSeed<T, R>(this, seedSupplier, accumulator);
     }
     
@@ -11307,7 +11307,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> single(T defaultValue) {
-        Objects.requireNonNull(defaultValue, "defaultValue is null");
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         return new FlowableSingle<T>(this, defaultValue);
     }
     
@@ -11594,8 +11594,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
         // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
         int s = bufferSize << 1; 
@@ -11626,7 +11626,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> skipUntil(Publisher<U> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new FlowableSkipUntil<T, U>(this, other);
     }
     
@@ -11652,7 +11652,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> skipWhile(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new FlowableSkipWhile<T>(this, predicate);
     }
     /**
@@ -11755,7 +11755,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> startWith(Publisher<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
 
@@ -11783,7 +11783,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> startWith(T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return concatArray(just(value), this);
     }
 
@@ -11964,10 +11964,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, 
             Action onComplete, Consumer<? super Subscription> onSubscribe) {
-        Objects.requireNonNull(onNext, "onNext is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
 
         LambdaSubscriber<T> ls = new LambdaSubscriber<T>(onNext, onError, onComplete, onSubscribe);
 
@@ -11980,7 +11980,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
     public final void subscribe(Subscriber<? super T> s) {
-        Objects.requireNonNull(s, "s is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         try {
             s = RxJavaPlugins.onSubscribe(this, s);
 
@@ -12035,7 +12035,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> subscribeOn(Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableSubscribeOn<T>(this, scheduler);
     }
 
@@ -12063,7 +12063,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> switchIfEmpty(Publisher<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new FlowableSwitchIfEmpty<T>(this, other);
     }
 
@@ -12200,7 +12200,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     <R> Flowable<R> switchMap0(Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize, boolean delayError) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarCallable<T>)this).call();
@@ -12465,8 +12465,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> takeLast(long count, long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
@@ -12818,7 +12818,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> takeUntil(Predicate<? super T> stopPredicate) {
-        Objects.requireNonNull(stopPredicate, "stopPredicate is null");
+        ObjectHelper.requireNonNull(stopPredicate, "stopPredicate is null");
         return new FlowableTakeUntilPredicate<T>(this, stopPredicate);
     }
     
@@ -12846,7 +12846,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> takeUntil(Publisher<U> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new FlowableTakeUntil<T, U>(this, other);
     }
 
@@ -12873,7 +12873,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> takeWhile(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new FlowableTakeWhile<T>(this, predicate);
     }
 
@@ -12935,8 +12935,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler);
     }
 
@@ -13184,8 +13184,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
     public final Flowable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableTimeInterval<T>(this, unit, scheduler);
     }
 
@@ -13258,7 +13258,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> timeoutSelector, Flowable<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(null, timeoutSelector, other);
     }
 
@@ -13318,7 +13318,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Flowable<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, Schedulers.computation());
     }
     
@@ -13353,7 +13353,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Flowable<? extends T> other, Scheduler scheduler) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
 
@@ -13421,7 +13421,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     public final <U, V> Flowable<T> timeout(Callable<? extends Publisher<U>> firstTimeoutSelector, 
             Function<? super T, ? extends Publisher<V>> timeoutSelector) {
-        Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
+        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, null);
     }
 
@@ -13467,15 +13467,15 @@ public abstract class Flowable<T> implements Publisher<T> {
             Callable<? extends Publisher<U>> firstTimeoutSelector, 
             Function<? super T, ? extends Publisher<V>> timeoutSelector, 
                     Publisher<? extends T> other) {
-        Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, other);
     }
 
     private Flowable<T> timeout0(long timeout, TimeUnit timeUnit, Flowable<? extends T> other, 
             Scheduler scheduler) {
-        Objects.requireNonNull(timeUnit, "timeUnit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(timeUnit, "timeUnit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other);
     }
 
@@ -13483,7 +13483,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Callable<? extends Publisher<U>> firstTimeoutSelector, 
             Function<? super T, ? extends Publisher<V>> timeoutSelector, 
                     Publisher<? extends T> other) {
-        Objects.requireNonNull(timeoutSelector, "timeoutSelector is null");
+        ObjectHelper.requireNonNull(timeoutSelector, "timeoutSelector is null");
         return new FlowableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other);
     }
 
@@ -13584,8 +13584,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
     public final Flowable<Timed<T>> timestamp(final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return map(Functions.<T>timestampWith(unit, scheduler));
     }
 
@@ -13736,7 +13736,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U extends Collection<? super T>> Flowable<U> toList(Callable<U> collectionSupplier) {
-        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
+        ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return new FlowableToList<T, U>(this, collectionSupplier);
     }
 
@@ -13765,7 +13765,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         return collect(HashMapSupplier.<K, T>asCallable(), Functions.toMapKeySelector(keySelector));
     }
     
@@ -13798,8 +13798,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Flowable<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMapSupplier.<K, V>asCallable(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
     
@@ -13833,8 +13833,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <K, V> Flowable<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector, 
             final Function<? super T, ? extends V> valueSelector,
             final Callable<? extends Map<K, V>> mapSupplier) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         return collect(mapSupplier, Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
@@ -13933,10 +13933,10 @@ public abstract class Flowable<T> implements Publisher<T> {
             final Function<? super T, ? extends V> valueSelector, 
             final Callable<? extends Map<K, Collection<V>>> mapSupplier,
             final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
-        Objects.requireNonNull(mapSupplier, "mapSupplier is null");
-        Objects.requireNonNull(collectionFactory, "collectionFactory is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(mapSupplier, "mapSupplier is null");
+        ObjectHelper.requireNonNull(collectionFactory, "collectionFactory is null");
         return collect(mapSupplier, Functions.toMultimapKeyValueSelector(keySelector, valueSelector, collectionFactory));
     }
     
@@ -14072,7 +14072,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<List<T>> toSortedList(final Comparator<? super T> comparator) {
-        Objects.requireNonNull(comparator, "comparator is null");
+        ObjectHelper.requireNonNull(comparator, "comparator is null");
         return toList().map(Functions.listSorter(comparator));
     }
 
@@ -14102,7 +14102,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
-        Objects.requireNonNull(comparator, "comparator is null");
+        ObjectHelper.requireNonNull(comparator, "comparator is null");
         return toList(capacityHint).map(Functions.listSorter(comparator));
     }
 
@@ -14156,7 +14156,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> unsubscribeOn(Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new FlowableUnsubscribeOn<T>(this, scheduler);
     }
     
@@ -14361,8 +14361,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<Flowable<T>> window(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, int bufferSize) {
         verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         return new FlowableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false);
     }
 
@@ -14632,8 +14632,8 @@ public abstract class Flowable<T> implements Publisher<T> {
             long timespan, TimeUnit unit, Scheduler scheduler, 
             long count, boolean restart, int bufferSize) {
         verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         verifyPositive(count, "count");
         return new FlowableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart);
     }
@@ -14695,7 +14695,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Flowable<Flowable<T>> window(Publisher<B> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary, "boundary is null");
+        ObjectHelper.requireNonNull(boundary, "boundary is null");
         return new FlowableWindowBoundary<T, B>(this, boundary, bufferSize);
     }
 
@@ -14770,8 +14770,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <U, V> Flowable<Flowable<T>> window(
             Publisher<U> windowOpen, 
             Function<? super U, ? extends Publisher<V>> windowClose, int bufferSize) {
-        Objects.requireNonNull(windowOpen, "windowOpen is null");
-        Objects.requireNonNull(windowClose, "windowClose is null");
+        ObjectHelper.requireNonNull(windowOpen, "windowOpen is null");
+        ObjectHelper.requireNonNull(windowClose, "windowClose is null");
         return new FlowableWindowBoundarySelector<T, U, V>(this, windowOpen, windowClose, bufferSize);
     }
     
@@ -14838,7 +14838,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Flowable<Flowable<T>> window(Callable<? extends Publisher<B>> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary, "boundary is null");
+        ObjectHelper.requireNonNull(boundary, "boundary is null");
         return new FlowableWindowBoundarySupplier<T, B>(this, boundary, bufferSize);
     }
 
@@ -14874,8 +14874,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Flowable<R> withLatestFrom(Publisher<? extends U> other, 
             BiFunction<? super T, ? super U, ? extends R> combiner) {
-        Objects.requireNonNull(other, "other is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
 
         return new FlowableWithLatestFrom<T, U, R>(this, combiner, other);
     }
@@ -15159,15 +15159,15 @@ public abstract class Flowable<T> implements Publisher<T> {
             Publisher<T1> p5, Publisher<T2> p6, 
             Publisher<T1> p7, Publisher<T2> p8, 
             Function9<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> combiner) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
-        Objects.requireNonNull(p4, "p4 is null");
-        Objects.requireNonNull(p5, "p5 is null");
-        Objects.requireNonNull(p6, "p6 is null");
-        Objects.requireNonNull(p7, "p7 is null");
-        Objects.requireNonNull(p8, "p8 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p4, "p4 is null");
+        ObjectHelper.requireNonNull(p5, "p5 is null");
+        ObjectHelper.requireNonNull(p6, "p6 is null");
+        ObjectHelper.requireNonNull(p7, "p7 is null");
+        ObjectHelper.requireNonNull(p8, "p8 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new Publisher[] { p1, p2, p3, p4, p5, p6, p7, p8 }, f);
     }
@@ -15196,8 +15196,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @since 2.0
      */
     public final <R> Flowable<R> withLatestFrom(Publisher<?>[] others, Function<? super Object[], R> combiner) {
-        Objects.requireNonNull(others, "others is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(others, "others is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         return new FlowableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
@@ -15225,8 +15225,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @since 2.0
      */
     public final <R> Flowable<R> withLatestFrom(Iterable<? extends Publisher<?>> others, Function<? super Object[], R> combiner) {
-        Objects.requireNonNull(others, "others is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(others, "others is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         return new FlowableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
@@ -15263,8 +15263,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Flowable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other, "other is null");
-        Objects.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
         return new FlowableZipIterable<T, U, R>(this, other, zipper);
     }
 
@@ -15311,7 +15311,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Flowable<R> zipWith(Publisher<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 

--- a/src/main/java/io/reactivex/Notification.java
+++ b/src/main/java/io/reactivex/Notification.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.NotificationLite;
 
 /**
@@ -92,7 +92,7 @@ public final class Notification<T> {
     public boolean equals(Object obj) {
         if (obj instanceof Notification) {
             Notification<?> n = (Notification<?>) obj;
-            return Objects.equals(value, n.value);
+            return ObjectHelper.equals(value, n.value);
         }
         return false;
     }
@@ -123,7 +123,7 @@ public final class Notification<T> {
      * @throws NullPointerException if value is null
      */
     public static <T> Notification<T> createOnNext(T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return new Notification<T>(value);
     }
     
@@ -135,7 +135,7 @@ public final class Notification<T> {
      * @throws NullPointerException if error is null
      */
     public static <T> Notification<T> createOnError(Throwable error) {
-        Objects.requireNonNull(error, "error is null");
+        ObjectHelper.requireNonNull(error, "error is null");
         return new Notification<T>(NotificationLite.error(error));
     }
     

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -23,7 +23,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.completable.CompletableFromObservable;
 import io.reactivex.internal.operators.flowable.*;
@@ -78,7 +78,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
     public static <T> Observable<T> amb(Iterable<? extends ObservableSource<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new ObservableAmb<T>(null, sources);
     }
     
@@ -102,7 +102,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> amb(ObservableSource<? extends T>... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
             return empty();
@@ -206,8 +206,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableSource<? extends T>> sources, 
             Function<? super T[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         
         // the queue holds a pair of values so we need to double the capacity
@@ -268,8 +268,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatest(ObservableSource<? extends T>[] sources, 
             Function<? super T[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         
         // the queue holds a pair of values so we need to double the capacity
@@ -720,7 +720,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T, R> Observable<R> combineLatestDelayError(ObservableSource<? extends T>[] sources, 
             Function<? super T[], ? extends R> combiner, int bufferSize) {
         verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
             return empty();
         }
@@ -786,8 +786,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatestDelayError(Iterable<? extends ObservableSource<? extends T>> sources, 
             Function<? super T[], ? extends R> combiner, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
         
         // the queue holds a pair of values so we need to double the capacity
@@ -811,7 +811,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concat(Iterable<? extends ObservableSource<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), bufferSize(), false);
     }
 
@@ -859,7 +859,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> concat(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new ObservableConcatMap(sources, Functions.identity(), prefetch, ErrorMode.IMMEDIATE);
     }
 
@@ -1253,7 +1253,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatDelayError(Iterable<? extends ObservableSource<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return concatDelayError(fromIterable(sources));
     }
 
@@ -1425,7 +1425,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> create(ObservableOnSubscribe<T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         return new ObservableCreate<T>(source);
     }
 
@@ -1455,7 +1455,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> defer(Callable<? extends ObservableSource<? extends T>> supplier) {
-        Objects.requireNonNull(supplier, "supplier is null");
+        ObjectHelper.requireNonNull(supplier, "supplier is null");
         return new ObservableDefer<T>(supplier);
     }
 
@@ -1501,7 +1501,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> error(Callable<? extends Throwable> errorSupplier) {
-        Objects.requireNonNull(errorSupplier, "errorSupplier is null");
+        ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return new ObservableError<T>(errorSupplier);
     }
 
@@ -1525,7 +1525,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> error(final Throwable exception) {
-        Objects.requireNonNull(exception, "e is null");
+        ObjectHelper.requireNonNull(exception, "e is null");
         return error(Functions.justCallable(exception));
     }
 
@@ -1547,7 +1547,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromArray(T... values) {
-        Objects.requireNonNull(values, "values is null");
+        ObjectHelper.requireNonNull(values, "values is null");
         if (values.length == 0) {
             return empty();
         } else
@@ -1581,7 +1581,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromCallable(Callable<? extends T> supplier) {
-        Objects.requireNonNull(supplier, "supplier is null");
+        ObjectHelper.requireNonNull(supplier, "supplier is null");
         return new ObservableFromCallable<T>(supplier);
     }
 
@@ -1613,7 +1613,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromFuture(Future<? extends T> future) {
-        Objects.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(future, "future is null");
         return new ObservableFromFuture<T>(future, 0L, null);
     }
 
@@ -1649,8 +1649,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
-        Objects.requireNonNull(future, "future is null");
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         return new ObservableFromFuture<T>(future, timeout, unit);
     }
 
@@ -1689,7 +1689,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Observable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         Observable<T> o = fromFuture(future, timeout, unit); 
         return o.subscribeOn(scheduler);
     }
@@ -1723,7 +1723,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Observable<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         Observable<T> o = fromFuture(future);
         return o.subscribeOn(scheduler);
     }
@@ -1746,7 +1746,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     public static <T> Observable<T> fromIterable(Iterable<? extends T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         return new ObservableFromIterable<T>(source);
     }
 
@@ -1762,7 +1762,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @throws NullPointerException if publisher is null
      */
     public static <T> Observable<T> fromPublisher(Publisher<? extends T> publisher) {
-        Objects.requireNonNull(publisher, "publisher is null");
+        ObjectHelper.requireNonNull(publisher, "publisher is null");
         return new ObservableFromPublisher<T>(publisher);
     }
 
@@ -1783,7 +1783,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> generate(final Consumer<Observer<T>> generator) {
-        Objects.requireNonNull(generator, "generator  is null");
+        ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(Functions.<Object>nullSupplier(), 
         ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
     }
@@ -1807,7 +1807,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Observable<T> generate(Callable<S> initialState, final BiConsumer<S, Observer<T>> generator) {
-        Objects.requireNonNull(generator, "generator  is null");
+        ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), Functions.emptyConsumer());
     }
 
@@ -1835,7 +1835,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             final Callable<S> initialState, 
             final BiConsumer<S, Observer<T>> generator, 
             Consumer<? super S> disposeState) {
-        Objects.requireNonNull(generator, "generator  is null");
+        ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), disposeState);
     }
 
@@ -1885,9 +1885,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Observer<T>, S> generator, 
             Consumer<? super S> disposeState) {
-        Objects.requireNonNull(initialState, "initialState is null");
-        Objects.requireNonNull(generator, "generator  is null");
-        Objects.requireNonNull(disposeState, "diposeState is null");
+        ObjectHelper.requireNonNull(initialState, "initialState is null");
+        ObjectHelper.requireNonNull(generator, "generator  is null");
+        ObjectHelper.requireNonNull(disposeState, "diposeState is null");
         return new ObservableGenerate<T, S>(initialState, generator, disposeState);
     }
 
@@ -1948,8 +1948,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (period < 0) {
             period = 0L;
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
         return new ObservableInterval(initialDelay, period, unit, scheduler);
     }
@@ -2049,8 +2049,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (period < 0) {
             period = 0L;
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
         return new ObservableIntervalRange(start, end, initialDelay, period, unit, scheduler);
     }
@@ -2081,7 +2081,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> just(T value) {
-        Objects.requireNonNull(value, "The value is null");
+        ObjectHelper.requireNonNull(value, "The value is null");
         return new ObservableJust<T>(value);
     }
 
@@ -2106,8 +2106,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
         
         return fromArray(v1, v2);
     }
@@ -2135,9 +2135,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
         
         return fromArray(v1, v2, v3);
     }
@@ -2167,10 +2167,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
         
         return fromArray(v1, v2, v3, v4);
     }
@@ -2202,11 +2202,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4, T v5) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
         
         return fromArray(v1, v2, v3, v4, v5);
     }
@@ -2240,12 +2240,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4, T v5, T v6) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6);
     }
@@ -2281,13 +2281,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7);
     }
@@ -2325,14 +2325,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
-        Objects.requireNonNull(v8, "The eighth value is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v8, "The eighth value is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8);
     }
@@ -2372,15 +2372,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
-        Objects.requireNonNull(v8, "The eighth value is null");
-        Objects.requireNonNull(v9, "The ninth is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v8, "The eighth value is null");
+        ObjectHelper.requireNonNull(v9, "The ninth is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8, v9);
     }
@@ -2422,16 +2422,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> just(T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10) {
-        Objects.requireNonNull(v1, "The first value is null");
-        Objects.requireNonNull(v2, "The second value is null");
-        Objects.requireNonNull(v3, "The third value is null");
-        Objects.requireNonNull(v4, "The fourth value is null");
-        Objects.requireNonNull(v5, "The fifth value is null");
-        Objects.requireNonNull(v6, "The sixth value is null");
-        Objects.requireNonNull(v7, "The seventh value is null");
-        Objects.requireNonNull(v8, "The eighth value is null");
-        Objects.requireNonNull(v9, "The ninth is null");
-        Objects.requireNonNull(v10, "The tenth is null");
+        ObjectHelper.requireNonNull(v1, "The first value is null");
+        ObjectHelper.requireNonNull(v2, "The second value is null");
+        ObjectHelper.requireNonNull(v3, "The third value is null");
+        ObjectHelper.requireNonNull(v4, "The fourth value is null");
+        ObjectHelper.requireNonNull(v5, "The fifth value is null");
+        ObjectHelper.requireNonNull(v6, "The sixth value is null");
+        ObjectHelper.requireNonNull(v7, "The seventh value is null");
+        ObjectHelper.requireNonNull(v8, "The eighth value is null");
+        ObjectHelper.requireNonNull(v9, "The ninth is null");
+        ObjectHelper.requireNonNull(v10, "The tenth is null");
         
         return fromArray(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
     }
@@ -2665,8 +2665,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), false, 2);
     }
 
@@ -2695,9 +2695,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2, ObservableSource<? extends T> p3) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
         return fromArray(p1, p2, p3).flatMap((Function)Functions.identity(), false, 3);
     }
 
@@ -2730,10 +2730,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> merge(
             ObservableSource<? extends T> p1, ObservableSource<? extends T> p2,
             ObservableSource<? extends T> p3, ObservableSource<? extends T> p4) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
-        Objects.requireNonNull(p4, "p4 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p4, "p4 is null");
         return fromArray(p1, p2, p3, p4).flatMap((Function)Functions.identity(), false, 4);
     }
 
@@ -3022,8 +3022,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
         return fromArray(p1, p2).flatMap((Function)Functions.identity(), true, 2);
     }
 
@@ -3059,9 +3059,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2, ObservableSource<? extends T> p3) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
         return fromArray(p1, p2, p3).flatMap((Function)Functions.identity(), true, 3);
     }
 
@@ -3101,10 +3101,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> mergeDelayError(
             ObservableSource<? extends T> p1, ObservableSource<? extends T> p2,
             ObservableSource<? extends T> p3, ObservableSource<? extends T> p4) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(p3, "p3 is null");
-        Objects.requireNonNull(p4, "p4 is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(p3, "p3 is null");
+        ObjectHelper.requireNonNull(p4, "p4 is null");
         return fromArray(p1, p2, p3, p4).flatMap((Function)Functions.identity(), true, 4);
     }
 
@@ -3218,7 +3218,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2) {
-        return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize());
+        return sequenceEqual(p1, p2, ObjectHelper.equalsPredicate(), bufferSize());
     }
 
     /**
@@ -3278,9 +3278,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2, 
             BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
-        Objects.requireNonNull(p1, "p1 is null");
-        Objects.requireNonNull(p2, "p2 is null");
-        Objects.requireNonNull(isEqual, "isEqual is null");
+        ObjectHelper.requireNonNull(p1, "p1 is null");
+        ObjectHelper.requireNonNull(p2, "p2 is null");
+        ObjectHelper.requireNonNull(isEqual, "isEqual is null");
         verifyPositive(bufferSize, "bufferSize");
         return new ObservableSequenceEqual<T>(p1, p2, isEqual, bufferSize);
     }
@@ -3309,7 +3309,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> p1, ObservableSource<? extends T> p2, 
             int bufferSize) {
-        return sequenceEqual(p1, p2, Objects.equalsPredicate(), bufferSize);
+        return sequenceEqual(p1, p2, ObjectHelper.equalsPredicate(), bufferSize);
     }
 
     /**
@@ -3342,7 +3342,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNext(ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new ObservableSwitchMap(sources, Functions.identity(), bufferSize, false);
     }
 
@@ -3440,7 +3440,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         verifyPositive(prefetch, "prefetch");
         return new ObservableSwitchMap(sources, Functions.identity(), prefetch, true);
     }
@@ -3491,8 +3491,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (delay < 0) {
             delay = 0L;
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
         return new ObservableTimer(delay, unit, scheduler);
     }
@@ -3511,8 +3511,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> unsafeCreate(ObservableSource<T> onSubscribe) {
-        Objects.requireNonNull(onSubscribe, "source is null");
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onSubscribe, "source is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         if (onSubscribe instanceof Observable) {
             throw new IllegalArgumentException("unsafeCreate(Observable) should be upgraded");
         }
@@ -3574,9 +3574,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, D> Observable<T> using(Callable<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
-        Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
-        Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
-        Objects.requireNonNull(disposer, "disposer is null");
+        ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
+        ObjectHelper.requireNonNull(sourceSupplier, "sourceSupplier is null");
+        ObjectHelper.requireNonNull(disposer, "disposer is null");
         return new ObservableUsing<T, D>(resourceSupplier, sourceSupplier, disposer, eager);
     }
 
@@ -3608,7 +3608,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> wrap(ObservableSource<T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Observable) {
             return (Observable<T>)source;
         }
@@ -3657,8 +3657,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> zip(Iterable<? extends ObservableSource<? extends T>> sources, Function<? super T[], ? extends R> zipper) {
-        Objects.requireNonNull(zipper, "zipper is null");
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new ObservableZip<T, R>(null, sources, zipper, bufferSize(), false);
     }
 
@@ -3705,8 +3705,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> zip(ObservableSource<? extends ObservableSource<? extends T>> sources, final Function<? super T[], ? extends R> zipper) {
-        Objects.requireNonNull(zipper, "zipper is null");
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new ObservableToList(sources, 16)
                 .flatMap(ObservableInternalHelper.zipIterable(zipper));
     }
@@ -4381,7 +4381,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (sources.length == 0) {
             return empty();
         }
-        Objects.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
         verifyPositive(bufferSize, "bufferSize");
         return new ObservableZip<T, R>(sources, null, zipper, bufferSize, delayError);
     }
@@ -4435,8 +4435,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T, R> Observable<R> zipIterable(Iterable<? extends ObservableSource<? extends T>> sources,
             Function<? super T[], ? extends R> zipper, boolean delayError, 
             int bufferSize) {
-        Objects.requireNonNull(zipper, "zipper is null");
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         verifyPositive(bufferSize, "bufferSize");
         return new ObservableZip<T, R>(null, sources, zipper, bufferSize, delayError);
     }
@@ -4463,7 +4463,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> all(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new ObservableAll<T>(this, predicate);
     }
 
@@ -4486,7 +4486,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> ambWith(ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return amb(this, other);
     }
 
@@ -4512,7 +4512,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> any(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new ObservableAny<T>(this, predicate);
     }
 
@@ -5014,7 +5014,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (skip <= 0) {
             throw new IllegalArgumentException("skip > 0 required but it was " + count);
         }
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new ObservableBuffer<T, U>(this, count, skip, bufferSupplier);
     }
 
@@ -5134,9 +5134,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, Callable<U> bufferSupplier) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new ObservableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false);
     }
 
@@ -5269,9 +5269,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
             int count, Scheduler scheduler, 
             Callable<U> bufferSupplier, 
             boolean restartTimerOnMaxSize) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         if (count <= 0) {
             throw new IllegalArgumentException("count > 0 required but it was " + count);
         }
@@ -5367,9 +5367,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<? extends TOpening> bufferOpenings,
             Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> bufferClosingSelector,
             Callable<U> bufferSupplier) {
-        Objects.requireNonNull(bufferOpenings, "bufferOpenings is null");
-        Objects.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(bufferOpenings, "bufferOpenings is null");
+        ObjectHelper.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new ObservableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier);
     }
 
@@ -5457,8 +5457,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableSource<B> boundary, Callable<U> bufferSupplier) {
-        Objects.requireNonNull(boundary, "boundary is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(boundary, "boundary is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new ObservableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier);
     }
 
@@ -5514,8 +5514,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B, U extends Collection<? super T>> Observable<U> buffer(Callable<? extends ObservableSource<B>> boundarySupplier, Callable<U> bufferSupplier) {
-        Objects.requireNonNull(boundarySupplier, "boundarySupplier is null");
-        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
+        ObjectHelper.requireNonNull(boundarySupplier, "boundarySupplier is null");
+        ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return new ObservableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier);
     }
 
@@ -5649,7 +5649,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> cast(final Class<U> clazz) {
-        Objects.requireNonNull(clazz, "clazz is null");
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
 
@@ -5677,8 +5677,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> collect(Callable<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
-        Objects.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
-        Objects.requireNonNull(collector, "collector is null");
+        ObjectHelper.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
+        ObjectHelper.requireNonNull(collector, "collector is null");
         return new ObservableCollect<T, U>(this, initialValueSupplier, collector);
     }
 
@@ -5706,7 +5706,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> collectInto(final U initialValue, BiConsumer<? super U, ? super T> collector) {
-        Objects.requireNonNull(initialValue, "initialValue is null");
+        ObjectHelper.requireNonNull(initialValue, "initialValue is null");
         return collect(Functions.justCallable(initialValue), collector);
     }
 
@@ -5781,7 +5781,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int prefetch) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         verifyPositive(prefetch, "prefetch");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
@@ -5893,7 +5893,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEager(Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
             int maxConcurrency, int prefetch) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         verifyPositive(maxConcurrency, "maxConcurrency");
         verifyPositive(prefetch, "prefetch");
         return new ObservableConcatMapEager<T, R>(this, mapper, ErrorMode.IMMEDIATE, maxConcurrency, prefetch);
@@ -5976,7 +5976,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return concatMap(ObservableInternalHelper.flatMapIntoIterable(mapper));
     }
 
@@ -6024,7 +6024,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> concatWith(ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return concat(this, other);
     }
 
@@ -6046,7 +6046,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> contains(final Object element) {
-        Objects.requireNonNull(element, "element is null");
+        ObjectHelper.requireNonNull(element, "element is null");
         return any(Functions.equalsWith(element));
     }
 
@@ -6090,7 +6090,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> debounce(Function<? super T, ? extends ObservableSource<U>> debounceSelector) {
-        Objects.requireNonNull(debounceSelector, "debounceSelector is null");
+        ObjectHelper.requireNonNull(debounceSelector, "debounceSelector is null");
         return new ObservableDebounce<T, U>(this, debounceSelector);
     }
 
@@ -6168,8 +6168,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableDebounceTimed<T>(this, timeout, unit, scheduler);
     }
 
@@ -6191,7 +6191,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> defaultIfEmpty(T defaultValue) {
-        Objects.requireNonNull(defaultValue, "value is null");
+        ObjectHelper.requireNonNull(defaultValue, "value is null");
         return switchIfEmpty(just(defaultValue));
     }
 
@@ -6220,7 +6220,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> delay(final Function<? super T, ? extends ObservableSource<U>> itemDelay) {
-        Objects.requireNonNull(itemDelay, "itemDelay is null");
+        ObjectHelper.requireNonNull(itemDelay, "itemDelay is null");
         return flatMap(ObservableInternalHelper.itemDelay(itemDelay));
     }
 
@@ -6319,8 +6319,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> delay(long delay, TimeUnit unit, Scheduler scheduler, boolean delayError) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         
         return new ObservableDelay<T>(this, delay, unit, scheduler, delayError);
     }
@@ -6376,7 +6376,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @since 2.0
      */
     public final <U> Observable<T> delaySubscription(ObservableSource<U> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new ObservableDelaySubscriptionOther<T, U>(this, other);
     }
 
@@ -6511,8 +6511,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return ObservableDistinct.withCollection(this, keySelector, collectionSupplier);
     }
 
@@ -6555,7 +6555,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         return ObservableDistinct.untilChanged(this, keySelector);
     }
 
@@ -6579,7 +6579,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
-        Objects.requireNonNull(comparer, "comparer is null");
+        ObjectHelper.requireNonNull(comparer, "comparer is null");
         return new ObservableDistinctUntilChanged<T>(this, comparer);
     }
 
@@ -6602,7 +6602,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> doAfterTerminate(Action onFinally) {
-        Objects.requireNonNull(onFinally, "onFinally is null");
+        ObjectHelper.requireNonNull(onFinally, "onFinally is null");
         return doOnEach(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION, onFinally);
     }
     
@@ -6667,10 +6667,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     private Observable<T> doOnEach(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete, Action onAfterTerminate) {
-        Objects.requireNonNull(onNext, "onNext is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
-        Objects.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
         return new ObservableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate);
     }
 
@@ -6690,7 +6690,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> doOnEach(final Consumer<? super Notification<T>> onNotification) {
-        Objects.requireNonNull(onNotification, "consumer is null");
+        ObjectHelper.requireNonNull(onNotification, "consumer is null");
         return doOnEach(
                 Functions.notificationOnNext(onNotification),
                 Functions.notificationOnError(onNotification),
@@ -6721,7 +6721,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> doOnEach(final Observer<? super T> observer) {
-        Objects.requireNonNull(observer, "observer is null");
+        ObjectHelper.requireNonNull(observer, "observer is null");
         return doOnEach(
                 ObservableInternalHelper.observerOnNext(observer),
                 ObservableInternalHelper.observerOnError(observer),
@@ -6770,8 +6770,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> doOnLifecycle(final Consumer<? super Disposable> onSubscribe, final Action onCancel) {
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        Objects.requireNonNull(onCancel, "onCancel is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onCancel, "onCancel is null");
         return new ObservableDoOnLifecycle<T>(this, onSubscribe, onCancel);
     }
 
@@ -6894,7 +6894,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        Objects.requireNonNull(defaultValue, "defaultValue is null");
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         return new ObservableElementAt<T>(this, index, defaultValue);
     }
 
@@ -6916,7 +6916,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> filter(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new ObservableFilter<T>(this, predicate);
     }
 
@@ -7076,7 +7076,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         if (maxConcurrency <= 0) {
             throw new IllegalArgumentException("maxConcurrency > 0 required but it was " + maxConcurrency);
         }
@@ -7121,9 +7121,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
             Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
             Callable<? extends ObservableSource<? extends R>> onCompleteSupplier) {
-        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
-        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
-        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
+        ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
+        ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(new ObservableMapNotification<T, R>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
 
@@ -7161,9 +7161,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
             Callable<? extends ObservableSource<? extends R>> onCompleteSupplier,
             int maxConcurrency) {
-        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
-        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
-        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
+        ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
+        ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(new ObservableMapNotification<T, R>(this, onNextMapper, onErrorMapper, onCompleteSupplier), maxConcurrency);
     }
 
@@ -7334,8 +7334,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends ObservableSource<? extends U>> mapper, 
             final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         return flatMap(ObservableInternalHelper.flatMapWithCombiner(mapper, combiner), delayErrors, maxConcurrency, bufferSize);
     }
 
@@ -7393,7 +7393,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return flatMap(ObservableInternalHelper.flatMapIntoIterable(mapper));
     }
 
@@ -7549,9 +7549,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable forEachWhile(final Predicate<? super T> onNext, Consumer<? super Throwable> onError,
             final Action onComplete) {
-        Objects.requireNonNull(onNext, "onNext is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
 
         ForEachWhileObserver<T> o = new ForEachWhileObserver<T>(onNext, onError, onComplete);
         subscribe(o);
@@ -7744,8 +7744,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector, 
             Function<? super T, ? extends V> valueSelector, 
             boolean delayError, int bufferSize) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         verifyPositive(bufferSize, "bufferSize");
 
         return new ObservableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError);
@@ -7958,7 +7958,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
     public final <R> Observable<R> lift(ObservableOperator<? extends R, ? super T> lifter) {
-        Objects.requireNonNull(lifter, "onLift is null");
+        ObjectHelper.requireNonNull(lifter, "onLift is null");
         return new ObservableLift<R, T>(this, lifter);
     }
 
@@ -7980,7 +7980,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
     public final <R> Observable<R> map(Function<? super T, ? extends R> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return new ObservableMap<T, R>(this, mapper);
     }
 
@@ -8022,7 +8022,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> mergeWith(ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return merge(this, other);
     }
 
@@ -8110,7 +8110,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
         return new ObservableObserveOn<T>(this, scheduler, delayError, bufferSize);
     }
@@ -8132,7 +8132,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> ofType(final Class<U> clazz) {
-        Objects.requireNonNull(clazz, "clazz is null");
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
         return filter(Functions.isInstanceOf(clazz)).cast(clazz);
     }
 
@@ -8167,7 +8167,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends ObservableSource<? extends T>> resumeFunction) {
-        Objects.requireNonNull(resumeFunction, "resumeFunction is null");
+        ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
         return new ObservableOnErrorNext<T>(this, resumeFunction, false);
     }
 
@@ -8202,7 +8202,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorResumeNext(final ObservableSource<? extends T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }
 
@@ -8234,7 +8234,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
-        Objects.requireNonNull(valueSupplier, "valueSupplier is null");
+        ObjectHelper.requireNonNull(valueSupplier, "valueSupplier is null");
         return new ObservableOnErrorReturn<T>(this, valueSupplier);
     }
 
@@ -8266,7 +8266,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorReturnValue(final T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return onErrorReturn(Functions.justFunction(value));
     }
 
@@ -8304,7 +8304,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onExceptionResumeNext(final ObservableSource<? extends T> next) {
-        Objects.requireNonNull(next, "next is null");
+        ObjectHelper.requireNonNull(next, "next is null");
         return new ObservableOnErrorNext<T>(this, Functions.justFunction(next), true);
     }
 
@@ -8392,7 +8392,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize) {
         verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return ObservablePublish.create(this, selector, bufferSize);
     }
 
@@ -8609,7 +8609,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> repeatUntil(BooleanSupplier stop) {
-        Objects.requireNonNull(stop, "stop is null");
+        ObjectHelper.requireNonNull(stop, "stop is null");
         return new ObservableRepeatUntil<T>(this, stop);
     }
 
@@ -8634,7 +8634,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
-        Objects.requireNonNull(handler, "handler is null");
+        ObjectHelper.requireNonNull(handler, "handler is null");
         return new ObservableRedo<T>(this, ObservableInternalHelper.repeatWhenHandler(handler));
     }
 
@@ -8680,7 +8680,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this), selector);
     }
 
@@ -8709,7 +8709,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize) {
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this, bufferSize), selector);
     }
 
@@ -8783,7 +8783,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
-        Objects.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
         return ObservableReplay.multicastSelector(
                 ObservableInternalHelper.replayCallable(this, bufferSize, time, unit, scheduler), selector);
     }
@@ -8878,9 +8878,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(selector, "selector is null");
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this, time, unit, scheduler), selector);
     }
 
@@ -8908,8 +8908,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final Scheduler scheduler) {
-        Objects.requireNonNull(selector, "selector is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(selector, "selector is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this), 
                 ObservableInternalHelper.replayFunction(selector, scheduler));
     }
@@ -8997,8 +8997,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.create(this, time, unit, scheduler, bufferSize);
     }
 
@@ -9076,8 +9076,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final ConnectableObservable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.create(this, time, unit, scheduler);
     }
 
@@ -9102,7 +9102,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final ConnectableObservable<T> replay(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.observeOn(replay(), scheduler);
     }
 
@@ -9151,7 +9151,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         
         return new ObservableRetryBiPredicate<T>(this, predicate);
     }
@@ -9201,7 +9201,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (times < 0) {
             throw new IllegalArgumentException("times >= 0 required but it was " + times);
         }
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
 
         return new ObservableRetryPredicate<T>(this, times, predicate);
     }
@@ -9232,7 +9232,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> retryUntil(final BooleanSupplier stop) {
-        Objects.requireNonNull(stop, "stop is null");
+        ObjectHelper.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, Functions.predicateReverseFor(stop));
     }
 
@@ -9287,7 +9287,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> retryWhen(
             final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
-        Objects.requireNonNull(handler, "handler is null");
+        ObjectHelper.requireNonNull(handler, "handler is null");
         return new ObservableRedo<T>(this, ObservableInternalHelper.retryWhenHandler(handler));
     }
     
@@ -9305,7 +9305,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final void safeSubscribe(Observer<? super T> s) {
-        Objects.requireNonNull(s, "s is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         if (s instanceof SafeObserver) {
             subscribe(s);
         } else {
@@ -9360,8 +9360,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableSampleTimed<T>(this, period, unit, scheduler);
     }
 
@@ -9386,7 +9386,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> sample(ObservableSource<U> sampler) {
-        Objects.requireNonNull(sampler, "sampler is null");
+        ObjectHelper.requireNonNull(sampler, "sampler is null");
         return new ObservableSampleWithObservable<T>(this, sampler);
     }
 
@@ -9413,7 +9413,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> scan(BiFunction<T, T, T> accumulator) {
-        Objects.requireNonNull(accumulator, "accumulator is null");
+        ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return new ObservableScan<T>(this, accumulator);
     }
 
@@ -9461,7 +9461,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> scan(final R initialValue, BiFunction<R, ? super T, R> accumulator) {
-        Objects.requireNonNull(initialValue, "seed is null");
+        ObjectHelper.requireNonNull(initialValue, "seed is null");
         return scanWith(Functions.justCallable(initialValue), accumulator);
     }
     
@@ -9509,8 +9509,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> scanWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
-        Objects.requireNonNull(seedSupplier, "seedSupplier is null");
-        Objects.requireNonNull(accumulator, "accumulator is null");
+        ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
+        ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return new ObservableScanSeed<T, R>(this, seedSupplier, accumulator);
     }
 
@@ -9605,7 +9605,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> single(T defaultValue) {
-        Objects.requireNonNull(defaultValue, "defaultValue is null");
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         return new ObservableSingle<T>(this, defaultValue);
     }
 
@@ -9855,8 +9855,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
      // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
         int s = bufferSize << 1; 
@@ -9883,7 +9883,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> skipUntil(ObservableSource<U> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new ObservableSkipUntil<T, U>(this, other);
     }
 
@@ -9905,7 +9905,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> skipWhile(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new ObservableSkipWhile<T>(this, predicate);
     }
 
@@ -9993,7 +9993,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> startWith(ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
     
@@ -10016,7 +10016,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> startWith(T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return concatArray(just(value), this);
     }
 
@@ -10170,10 +10170,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, 
             Action onComplete, Consumer<? super Disposable> onSubscribe) {
-        Objects.requireNonNull(onNext, "onNext is null");
-        Objects.requireNonNull(onError, "onError is null");
-        Objects.requireNonNull(onComplete, "onComplete is null");
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
 
         LambdaObserver<T> ls = new LambdaObserver<T>(onNext, onError, onComplete, onSubscribe);
 
@@ -10184,7 +10184,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     @Override
     public final void subscribe(Observer<? super T> observer) {
-        Objects.requireNonNull(observer, "observer is null");
+        ObjectHelper.requireNonNull(observer, "observer is null");
         
         observer = RxJavaPlugins.onSubscribe(this, observer);
         
@@ -10219,7 +10219,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> subscribeOn(Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableSubscribeOn<T>(this, scheduler);
     }
 
@@ -10240,7 +10240,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> switchIfEmpty(ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new ObservableSwitchIfEmpty<T>(this, other);
     }
 
@@ -10295,7 +10295,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> switchMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
@@ -10361,7 +10361,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @since 2.0
      */
     public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
@@ -10593,8 +10593,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> takeLast(long count, long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
@@ -10886,7 +10886,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> takeUntil(ObservableSource<U> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return new ObservableTakeUntil<T, U>(this, other);
     }
 
@@ -10914,7 +10914,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> takeUntil(Predicate<? super T> stopPredicate) {
-        Objects.requireNonNull(stopPredicate, "predicate is null");
+        ObjectHelper.requireNonNull(stopPredicate, "predicate is null");
         return new ObservableTakeUntilPredicate<T>(this, stopPredicate);
     }
 
@@ -10937,7 +10937,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> takeWhile(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
         return new ObservableTakeWhile<T>(this, predicate);
     }
 
@@ -10991,8 +10991,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler);
     }
 
@@ -11208,8 +11208,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
     public final Observable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableTimeInterval<T>(this, unit, scheduler);
     }
 
@@ -11271,7 +11271,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> timeoutSelector, 
             ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(null, timeoutSelector, other);
     }
 
@@ -11321,7 +11321,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, Schedulers.computation());
     }
 
@@ -11350,7 +11350,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other, Scheduler scheduler) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
 
@@ -11410,7 +11410,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public final <U, V> Observable<T> timeout(Callable<? extends ObservableSource<U>> firstTimeoutSelector,
             Function<? super T, ? extends ObservableSource<V>> timeoutSelector) {
-        Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
+        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, null);
     }
 
@@ -11450,15 +11450,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Callable<? extends ObservableSource<U>> firstTimeoutSelector,
             Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
                     ObservableSource<? extends T> other) {
-        Objects.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutSelector, timeoutSelector, other);
     }
     
     private Observable<T> timeout0(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other,
             Scheduler scheduler) {
-        Objects.requireNonNull(timeUnit, "timeUnit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(timeUnit, "timeUnit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other);
     }
 
@@ -11466,7 +11466,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Callable<? extends ObservableSource<U>> firstTimeoutSelector,
             Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
                     ObservableSource<? extends T> other) {
-        Objects.requireNonNull(timeoutSelector, "timeoutSelector is null");
+        ObjectHelper.requireNonNull(timeoutSelector, "timeoutSelector is null");
         return new ObservableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other);
     }
 
@@ -11551,8 +11551,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
     public final Observable<Timed<T>> timestamp(final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return map(Functions.<T>timestampWith(unit, scheduler));
     }
 
@@ -11687,7 +11687,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U extends Collection<? super T>> Observable<U> toList(Callable<U> collectionSupplier) {
-        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
+        ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return new ObservableToList<T, U>(this, collectionSupplier);
     }
 
@@ -11742,8 +11742,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K, V> Observable<Map<K, V>> toMap(
             final Function<? super T, ? extends K> keySelector, 
             final Function<? super T, ? extends V> valueSelector) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMapSupplier.<K, V>asCallable(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
@@ -11862,10 +11862,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
             final Function<? super T, ? extends V> valueSelector, 
             final Callable<? extends Map<K, Collection<V>>> mapSupplier,
             final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
-        Objects.requireNonNull(keySelector, "keySelector is null");
-        Objects.requireNonNull(valueSelector, "valueSelector is null");
-        Objects.requireNonNull(mapSupplier, "mapSupplier is null");
-        Objects.requireNonNull(collectionFactory, "collectionFactory is null");
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(mapSupplier, "mapSupplier is null");
+        ObjectHelper.requireNonNull(collectionFactory, "collectionFactory is null");
         return collect(mapSupplier, Functions.toMultimapKeyValueSelector(keySelector, valueSelector, collectionFactory));
     }
 
@@ -11994,7 +11994,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<List<T>> toSortedList(final Comparator<? super T> comparator) {
-        Objects.requireNonNull(comparator, "comparator is null");
+        ObjectHelper.requireNonNull(comparator, "comparator is null");
         return toList().map(Functions.listSorter(comparator));
     }
 
@@ -12020,7 +12020,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
-        Objects.requireNonNull(comparator, "comparator is null");
+        ObjectHelper.requireNonNull(comparator, "comparator is null");
         return toList(capacityHint).map(Functions.listSorter(comparator));
     }
 
@@ -12066,7 +12066,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> unsubscribeOn(Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new ObservableUnsubscribeOn<T>(this, scheduler);
     }
 
@@ -12242,8 +12242,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<Observable<T>> window(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, int bufferSize) {
         verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         return new ObservableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false);
     }
 
@@ -12470,8 +12470,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
             long timespan, TimeUnit unit, Scheduler scheduler, 
             long count, boolean restart, int bufferSize) {
         verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         if (count <= 0) {
             throw new IllegalArgumentException("count > 0 required but it was " + count);
         }
@@ -12527,7 +12527,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Observable<Observable<T>> window(ObservableSource<B> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary, "boundary is null");
+        ObjectHelper.requireNonNull(boundary, "boundary is null");
         return new ObservableWindowBoundary<T, B>(this, boundary, bufferSize);
     }
 
@@ -12590,8 +12590,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U, V> Observable<Observable<T>> window(
             ObservableSource<U> windowOpen,
             Function<? super U, ? extends ObservableSource<V>> windowClose, int bufferSize) {
-        Objects.requireNonNull(windowOpen, "windowOpen is null");
-        Objects.requireNonNull(windowClose, "windowClose is null");
+        ObjectHelper.requireNonNull(windowOpen, "windowOpen is null");
+        ObjectHelper.requireNonNull(windowClose, "windowClose is null");
         return new ObservableWindowBoundarySelector<T, U, V>(this, windowOpen, windowClose, bufferSize);
     }
 
@@ -12645,7 +12645,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Observable<Observable<T>> window(Callable<? extends ObservableSource<B>> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary, "boundary is null");
+        ObjectHelper.requireNonNull(boundary, "boundary is null");
         return new ObservableWindowBoundarySupplier<T, B>(this, boundary, bufferSize);
     }
 
@@ -12675,8 +12675,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> withLatestFrom(ObservableSource<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
-        Objects.requireNonNull(other, "other is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
 
         return new ObservableWithLatestFrom<T, U, R>(this, combiner, other);
     }
@@ -12707,9 +12707,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <T1, T2, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             Function3<? super T, ? super T1, ? super T2, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2 }, f);
     }
@@ -12743,10 +12743,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T3> o3, 
             Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(o3, "o3 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2, o3 }, f);
     }
@@ -12782,11 +12782,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<T1> o1, ObservableSource<T2> o2, 
             ObservableSource<T3> o3, ObservableSource<T4> o4, 
             Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(o4, "o4 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(o3, "o3 is null");
+        ObjectHelper.requireNonNull(o4, "o4 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4 }, f);
     }
@@ -12824,12 +12824,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<T1> o3, ObservableSource<T2> o4, 
             ObservableSource<T1> o5, 
             Function6<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(o4, "o4 is null");
-        Objects.requireNonNull(o5, "o5 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(o3, "o3 is null");
+        ObjectHelper.requireNonNull(o4, "o4 is null");
+        ObjectHelper.requireNonNull(o5, "o5 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5 }, f);
     }
@@ -12870,13 +12870,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<T1> o3, ObservableSource<T2> o4, 
             ObservableSource<T1> o5, ObservableSource<T2> o6, 
             Function7<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(o4, "o4 is null");
-        Objects.requireNonNull(o5, "o5 is null");
-        Objects.requireNonNull(o6, "o6 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(o3, "o3 is null");
+        ObjectHelper.requireNonNull(o4, "o4 is null");
+        ObjectHelper.requireNonNull(o5, "o5 is null");
+        ObjectHelper.requireNonNull(o6, "o6 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5, o6 }, f);
     }
@@ -12920,14 +12920,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<T1> o5, ObservableSource<T2> o6, 
             ObservableSource<T1> o7,
             Function8<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(o4, "o4 is null");
-        Objects.requireNonNull(o5, "o5 is null");
-        Objects.requireNonNull(o6, "o6 is null");
-        Objects.requireNonNull(o7, "o7 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(o3, "o3 is null");
+        ObjectHelper.requireNonNull(o4, "o4 is null");
+        ObjectHelper.requireNonNull(o5, "o5 is null");
+        ObjectHelper.requireNonNull(o6, "o6 is null");
+        ObjectHelper.requireNonNull(o7, "o7 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5, o6, o7 }, f);
     }
@@ -12973,15 +12973,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
             ObservableSource<T1> o5, ObservableSource<T2> o6, 
             ObservableSource<T1> o7, ObservableSource<T2> o8, 
             Function9<? super T, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(o4, "o4 is null");
-        Objects.requireNonNull(o5, "o5 is null");
-        Objects.requireNonNull(o6, "o6 is null");
-        Objects.requireNonNull(o7, "o7 is null");
-        Objects.requireNonNull(o8, "o8 is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(o1, "o1 is null");
+        ObjectHelper.requireNonNull(o2, "o2 is null");
+        ObjectHelper.requireNonNull(o3, "o3 is null");
+        ObjectHelper.requireNonNull(o4, "o4 is null");
+        ObjectHelper.requireNonNull(o5, "o5 is null");
+        ObjectHelper.requireNonNull(o6, "o6 is null");
+        ObjectHelper.requireNonNull(o7, "o7 is null");
+        ObjectHelper.requireNonNull(o8, "o8 is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4, o5, o6, o7, o8 }, f);
     }
@@ -13007,8 +13007,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @since 2.0
      */
     public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<? super Object[], R> combiner) {
-        Objects.requireNonNull(others, "others is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(others, "others is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         return new ObservableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
@@ -13033,8 +13033,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @since 2.0
      */
     public final <R> Observable<R> withLatestFrom(Iterable<? extends ObservableSource<?>> others, Function<? super Object[], R> combiner) {
-        Objects.requireNonNull(others, "others is null");
-        Objects.requireNonNull(combiner, "combiner is null");
+        ObjectHelper.requireNonNull(others, "others is null");
+        ObjectHelper.requireNonNull(combiner, "combiner is null");
         return new ObservableWithLatestFromMany<T, R>(this, others, combiner);
     }
 
@@ -13066,8 +13066,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other, "other is null");
-        Objects.requireNonNull(zipper, "zipper is null");
+        ObjectHelper.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(zipper, "zipper is null");
         return new ObservableZipIterable<T, U, R>(this, other, zipper);
     }
 
@@ -13110,7 +13110,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other, 
             BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -67,7 +67,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public static <T> Single<T> amb(final Iterable<? extends SingleSource<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return new SingleAmbIterable<T>(sources);
     }
     
@@ -148,8 +148,8 @@ public abstract class Single<T> implements SingleSource<T> {
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
         return concat(Flowable.fromArray(s1, s2));
     }
     
@@ -177,9 +177,9 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
             SingleSource<? extends T> s3
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
         return concat(Flowable.fromArray(s1, s2, s3));
     }
     
@@ -209,10 +209,10 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
             SingleSource<? extends T> s3, SingleSource<? extends T> s4
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4));
     }
     
@@ -245,11 +245,11 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s3, SingleSource<? extends T> s4,
             SingleSource<? extends T> s5
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5));
     }
     
@@ -284,12 +284,12 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s3, SingleSource<? extends T> s4,
             SingleSource<? extends T> s5, SingleSource<? extends T> s6
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6));
     }
     
@@ -327,13 +327,13 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s5, SingleSource<? extends T> s6,
             SingleSource<? extends T> s7
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7));
     }
     
@@ -373,14 +373,14 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s5, SingleSource<? extends T> s6,
             SingleSource<? extends T> s7, SingleSource<? extends T> s8
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
-        Objects.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8));
     }
     
@@ -423,15 +423,15 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s7, SingleSource<? extends T> s8,
             SingleSource<? extends T> s9
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
-        Objects.requireNonNull(s8, "s8 is null");
-        Objects.requireNonNull(s9, "s9 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s9, "s9 is null");
         return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
     }
 
@@ -472,7 +472,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see Cancellable
      */
     public static <T> Single<T> create(SingleOnSubscribe<T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new SingleCreate<T>(source));
     }
 
@@ -489,7 +489,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      */
     public static <T> Single<T> defer(final Callable<? extends SingleSource<? extends T>> singleSupplier) {
-        Objects.requireNonNull(singleSupplier, "singleSupplier is null");
+        ObjectHelper.requireNonNull(singleSupplier, "singleSupplier is null");
         return new SingleDefer<T>(singleSupplier);
     }
     
@@ -505,7 +505,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      */
     public static <T> Single<T> error(final Callable<? extends Throwable> errorSupplier) {
-        Objects.requireNonNull(errorSupplier, "errorSupplier is null");
+        ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return new SingleError<T>(errorSupplier);
     }
     
@@ -528,7 +528,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
     public static <T> Single<T> error(final Throwable exception) {
-        Objects.requireNonNull(exception, "error is null");
+        ObjectHelper.requireNonNull(exception, "error is null");
         return error(Functions.justCallable(exception));
     }
     
@@ -550,7 +550,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@link Single} whose {@link Observer}s' subscriptions trigger an invocation of the given function.
      */
     public static <T> Single<T> fromCallable(final Callable<? extends T> callable) {
-        Objects.requireNonNull(callable, "callable is null");
+        ObjectHelper.requireNonNull(callable, "callable is null");
         return new SingleFromCallable<T>(callable);
     }
     
@@ -686,7 +686,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      */
     public static <T> Single<T> fromPublisher(final Publisher<? extends T> publisher) {
-        Objects.requireNonNull(publisher, "publisher is null");
+        ObjectHelper.requireNonNull(publisher, "publisher is null");
         return new SingleFromPublisher<T>(publisher);
     }
 
@@ -710,7 +710,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
     public static <T> Single<T> just(final T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return new SingleJust<T>(value);
     }
 
@@ -767,7 +767,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Single<T> merge(SingleSource<? extends SingleSource<? extends T>> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         return new SingleFlatMap<SingleSource<? extends T>, T>(source, (Function)Functions.identity());
     }
     
@@ -795,8 +795,8 @@ public abstract class Single<T> implements SingleSource<T> {
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> s1, SingleSource<? extends T> s2
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
         return merge(Flowable.fromArray(s1, s2));
     }
     
@@ -827,9 +827,9 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
             SingleSource<? extends T> s3
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
         return merge(Flowable.fromArray(s1, s2, s3));
     }
     
@@ -862,10 +862,10 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s1, SingleSource<? extends T> s2,
             SingleSource<? extends T> s3, SingleSource<? extends T> s4
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
         return merge(Flowable.fromArray(s1, s2, s3, s4));
     }
     
@@ -901,11 +901,11 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s3, SingleSource<? extends T> s4,
             SingleSource<? extends T> s5
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5));
     }
     
@@ -943,12 +943,12 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s3, SingleSource<? extends T> s4,
             SingleSource<? extends T> s5, SingleSource<? extends T> s6
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6));
     }
 
@@ -989,13 +989,13 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s5, SingleSource<? extends T> s6,
             SingleSource<? extends T> s7
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7));
     }
 
@@ -1038,14 +1038,14 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s5, SingleSource<? extends T> s6,
             SingleSource<? extends T> s7, SingleSource<? extends T> s8
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
-        Objects.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8));
     }
 
@@ -1091,15 +1091,15 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T> s7, SingleSource<? extends T> s8,
             SingleSource<? extends T> s9
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
-        Objects.requireNonNull(s8, "s8 is null");
-        Objects.requireNonNull(s9, "s9 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s9, "s9 is null");
         return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
     }
     
@@ -1146,8 +1146,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public static Single<Long> timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new SingleTimer(delay, unit, scheduler);
     }
     
@@ -1164,8 +1164,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public static <T> Single<Boolean> equals(final SingleSource<? extends T> first, final SingleSource<? extends T> second) { // NOPMD
-        Objects.requireNonNull(first, "first is null");
-        Objects.requireNonNull(second, "second is null");
+        ObjectHelper.requireNonNull(first, "first is null");
+        ObjectHelper.requireNonNull(second, "second is null");
         return new SingleEquals<T>(first, second);
     }
 
@@ -1182,7 +1182,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public static <T> Single<T> unsafeCreate(SingleSource<T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Single) {
             throw new IllegalArgumentException("unsafeCreate(Single) should be upgraded");
         }
@@ -1241,9 +1241,9 @@ public abstract class Single<T> implements SingleSource<T> {
             final Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
             final Consumer<? super U> disposer, 
             final boolean eager) {
-        Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
-        Objects.requireNonNull(singleFunction, "singleFunction is null");
-        Objects.requireNonNull(disposer, "disposer is null");
+        ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
+        ObjectHelper.requireNonNull(singleFunction, "singleFunction is null");
+        ObjectHelper.requireNonNull(disposer, "disposer is null");
         
         return new SingleUsing<T, U>(resourceSupplier, singleFunction, disposer, eager);
     }
@@ -1256,7 +1256,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the Single wrapper or the source cast to Single (if possible)
      */
     static <T> Single<T> wrap(SingleSource<T> source) {
-        Objects.requireNonNull(source, "source is null");
+        ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Single) {
             return (Single<T>)source;
         }
@@ -1285,7 +1285,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public static <T, R> Single<R> zip(final Iterable<? extends SingleSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         return Flowable.zipIterable(SingleInternalHelper.iterableToFlowable(sources), zipper, false, 1).toSingle();
     }
 
@@ -1317,8 +1317,8 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T1> s1, SingleSource<? extends T2> s2,
             BiFunction<? super T1, ? super T2, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2);
     }
 
@@ -1354,9 +1354,9 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T3> s3,
             Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3);
     }
 
@@ -1395,10 +1395,10 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T3> s3, SingleSource<? extends T4> s4,
             Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4);
     }
 
@@ -1441,11 +1441,11 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T5> s5,
             Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5);
     }
 
@@ -1491,12 +1491,12 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T5> s5, SingleSource<? extends T6> s6,
             Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6);
     }
 
@@ -1546,13 +1546,13 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T7> s7,
             Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7);
     }
     
@@ -1605,14 +1605,14 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T7> s7, SingleSource<? extends T8> s8,
             Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
-        Objects.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7, s8);
     }
     
@@ -1669,15 +1669,15 @@ public abstract class Single<T> implements SingleSource<T> {
             SingleSource<? extends T9> s9,
             Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper
      ) {
-        Objects.requireNonNull(s1, "s1 is null");
-        Objects.requireNonNull(s2, "s2 is null");
-        Objects.requireNonNull(s3, "s3 is null");
-        Objects.requireNonNull(s4, "s4 is null");
-        Objects.requireNonNull(s5, "s5 is null");
-        Objects.requireNonNull(s6, "s6 is null");
-        Objects.requireNonNull(s7, "s7 is null");
-        Objects.requireNonNull(s8, "s8 is null");
-        Objects.requireNonNull(s9, "s9 is null");
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s9, "s9 is null");
         return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7, s8, s9);
     }
 
@@ -1704,11 +1704,11 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T, R> Single<R> zipArray(Function<? super Object[], ? extends R> zipper, SingleSource<? extends T>... sources) {
-        Objects.requireNonNull(sources, "sources is null");
+        ObjectHelper.requireNonNull(sources, "sources is null");
         Publisher[] sourcePublishers = new Publisher[sources.length];
         int i = 0;
         for (SingleSource<? extends T> s : sources) {
-            Objects.requireNonNull(s, "The " + i + "th source is null");
+            ObjectHelper.requireNonNull(s, "The " + i + "th source is null");
             sourcePublishers[i] = new SingleToFlowable<T>(s);
             i++;
         }
@@ -1727,7 +1727,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SuppressWarnings("unchecked")
     public final Single<T> ambWith(SingleSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return amb(this, other);
     }
     
@@ -1798,7 +1798,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final <U> Single<U> cast(final Class<? extends U> clazz) {
-        Objects.requireNonNull(clazz, "clazz is null");
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
     
@@ -1854,8 +1854,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new SingleDelay<T>(this, time, unit, scheduler);
     }
 
@@ -1982,7 +1982,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> doOnSubscribe(final Consumer<? super Disposable> onSubscribe) {
-        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         return new SingleDoOnSubscribe<T>(this, onSubscribe);
     }
     
@@ -1998,7 +1998,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> doOnSuccess(final Consumer<? super T> onSuccess) {
-        Objects.requireNonNull(onSuccess, "onSuccess is null");
+        ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
         return new SingleDoOnSuccess<T>(this, onSuccess);
     }
     
@@ -2014,7 +2014,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> doOnError(final Consumer<? super Throwable> onError) {
-        Objects.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
         return new SingleDoOnError<T>(this, onError);
     }
     
@@ -2030,7 +2030,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> doOnCancel(final Action onCancel) {
-        Objects.requireNonNull(onCancel, "onCancel is null");
+        ObjectHelper.requireNonNull(onCancel, "onCancel is null");
         return new SingleDoOnCancel<T>(this, onCancel);
     }
 
@@ -2051,7 +2051,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     public final <R> Single<R> flatMap(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return new SingleFlatMap<T, R>(this, mapper);
     }
 
@@ -2094,7 +2094,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Completable flatMapCompletable(final Function<? super T, ? extends Completable> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
         return new SingleFlatMapCompletable<T>(this, mapper);
     }
     
@@ -2135,7 +2135,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
     public final <R> Single<R> lift(final SingleOperator<? extends R, ? super T> lift) {
-        Objects.requireNonNull(lift, "onLift is null");
+        ObjectHelper.requireNonNull(lift, "onLift is null");
         return new SingleLift<T, R>(this, lift);
     }
     
@@ -2171,7 +2171,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<Boolean> contains(Object value) {
-        return contains(value, Objects.equalsPredicate());
+        return contains(value, ObjectHelper.equalsPredicate());
     }
 
     /**
@@ -2188,8 +2188,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<Boolean> contains(final Object value, final BiPredicate<Object, Object> comparer) {
-        Objects.requireNonNull(value, "value is null");
-        Objects.requireNonNull(comparer, "comparer is null");
+        ObjectHelper.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(comparer, "comparer is null");
         return new SingleContains<T>(this, value, comparer);
     }
     
@@ -2233,7 +2233,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see #subscribeOn
      */
     public final Single<T> observeOn(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new SingleObserveOn<T>(this, scheduler);
     }
 
@@ -2264,7 +2264,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     public final Single<T> onErrorReturn(final Function<Throwable, ? extends T> resumeFunction) {
-        Objects.requireNonNull(resumeFunction, "resumeFunction is null");
+        ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
         return new SingleOnErrorReturn<T>(this, resumeFunction, null);
     }
     
@@ -2279,7 +2279,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> onErrorReturnValue(final T value) {
-        Objects.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(value, "value is null");
         return new SingleOnErrorReturn<T>(this, null, value);
     }
 
@@ -2311,7 +2311,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     public final Single<T> onErrorResumeNext(final Single<? extends T> resumeSingleInCaseOfError) {
-        Objects.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
+        ObjectHelper.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
         return onErrorResumeNext(Functions.justFunction(resumeSingleInCaseOfError));
     }
     
@@ -2345,7 +2345,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> onErrorResumeNext(
             final Function<? super Throwable, ? extends SingleSource<? extends T>> resumeFunctionInCaseOfError) {
-        Objects.requireNonNull(resumeFunctionInCaseOfError, "resumeFunctionInCaseOfError is null");
+        ObjectHelper.requireNonNull(resumeFunctionInCaseOfError, "resumeFunctionInCaseOfError is null");
         return new SingleResumeNext<T>(this, resumeFunctionInCaseOfError);
     }
     
@@ -2531,7 +2531,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *             if {@code onCallback} is null
      */
     public final Disposable subscribe(final BiConsumer<? super T, ? super Throwable> onCallback) {
-        Objects.requireNonNull(onCallback, "onCallback is null");
+        ObjectHelper.requireNonNull(onCallback, "onCallback is null");
         
         BiConsumerSingleObserver<T> s = new BiConsumerSingleObserver<T>(onCallback);
         subscribe(s);
@@ -2576,8 +2576,8 @@ public abstract class Single<T> implements SingleSource<T> {
      *             if {@code onError} is null
      */
     public final Disposable subscribe(final Consumer<? super T> onSuccess, final Consumer<? super Throwable> onError) {
-        Objects.requireNonNull(onSuccess, "onSuccess is null");
-        Objects.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
         
         ConsumerSingleObserver<T> s = new ConsumerSingleObserver<T>(onSuccess, onError);
         subscribe(s);
@@ -2586,11 +2586,11 @@ public abstract class Single<T> implements SingleSource<T> {
     
     @Override
     public final void subscribe(SingleObserver<? super T> subscriber) {
-        Objects.requireNonNull(subscriber, "subscriber is null");
+        ObjectHelper.requireNonNull(subscriber, "subscriber is null");
         
         subscriber = RxJavaPlugins.onSubscribe(this, subscriber);
 
-        Objects.requireNonNull(subscriber, "subscriber returned by the RxJavaPlugins hook is null");
+        ObjectHelper.requireNonNull(subscriber, "subscriber returned by the RxJavaPlugins hook is null");
 
         try {
             subscribeActual(subscriber);
@@ -2627,7 +2627,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see #observeOn
      */
     public final Single<T> subscribeOn(final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new SingleSubscribeOn<T>(this, scheduler);
     }
 
@@ -2747,7 +2747,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler, SingleSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, scheduler, other);
     }
 
@@ -2766,13 +2766,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> timeout(long timeout, TimeUnit unit, SingleSource<? extends T> other) {
-        Objects.requireNonNull(other, "other is null");
+        ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, Schedulers.computation(), other);
     }
 
     private Single<T> timeout0(final long timeout, final TimeUnit unit, final Scheduler scheduler, final SingleSource<? extends T> other) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return new SingleTimeout<T>(this, timeout, unit, scheduler, other);
     }
 

--- a/src/main/java/io/reactivex/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/disposables/CompositeDisposable.java
@@ -16,7 +16,7 @@ import java.util.*;
 
 import io.reactivex.exceptions.*;
 import io.reactivex.internal.disposables.DisposableContainer;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.OpenHashSet;
 
 /**
@@ -40,10 +40,10 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * @param resources the array of Disposables to start with
      */
     public CompositeDisposable(Disposable... resources) {
-        Objects.requireNonNull(resources, "resources is null");
+        ObjectHelper.requireNonNull(resources, "resources is null");
         this.resources = new OpenHashSet<Disposable>(resources.length + 1);
         for (Disposable d : resources) {
-            Objects.requireNonNull(d, "Disposable item is null");
+            ObjectHelper.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);
         }
     }
@@ -53,9 +53,9 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * @param resources the Iterable sequence of Disposables to start with
      */
     public CompositeDisposable(Iterable<? extends Disposable> resources) {
-        Objects.requireNonNull(resources, "resources is null");
+        ObjectHelper.requireNonNull(resources, "resources is null");
         for (Disposable d : resources) {
-            Objects.requireNonNull(d, "Disposable item is null");
+            ObjectHelper.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);
         }
     }
@@ -85,7 +85,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     
     @Override
     public boolean add(Disposable d) {
-        Objects.requireNonNull(d, "d is null");
+        ObjectHelper.requireNonNull(d, "d is null");
         if (!disposed) {
             synchronized (this) {
                 if (!disposed) {
@@ -110,7 +110,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * @return true if the operation was successful, false if the container has been disposed
      */
     public boolean addAll(Disposable... ds) {
-        Objects.requireNonNull(ds, "ds is null");
+        ObjectHelper.requireNonNull(ds, "ds is null");
         if (!disposed) {
             synchronized (this) {
                 if (!disposed) {
@@ -120,7 +120,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
                         resources = set;
                     }
                     for (Disposable d : ds) {
-                        Objects.requireNonNull(d, "d is null");
+                        ObjectHelper.requireNonNull(d, "d is null");
                         set.add(d);
                     }
                     return true;
@@ -144,7 +144,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     
     @Override
     public boolean delete(Disposable d) {
-        Objects.requireNonNull(d, "Disposable item is null");
+        ObjectHelper.requireNonNull(d, "Disposable item is null");
         if (disposed) {
             return false;
         }

--- a/src/main/java/io/reactivex/disposables/Disposables.java
+++ b/src/main/java/io/reactivex/disposables/Disposables.java
@@ -39,7 +39,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     public static Disposable from(Runnable run) {
-        Objects.requireNonNull(run, "run is null");
+        ObjectHelper.requireNonNull(run, "run is null");
         return new RunnableDisposable(run);
     }
 
@@ -50,7 +50,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     public static Disposable from(Action run) {
-        Objects.requireNonNull(run, "run is null");
+        ObjectHelper.requireNonNull(run, "run is null");
         return new ActionDisposable(run);
     }
 
@@ -61,7 +61,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     public static Disposable from(Future<?> future) {
-        Objects.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(future, "future is null");
         return from(future, true);
     }
 
@@ -73,7 +73,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     public static Disposable from(Future<?> future, boolean allowInterrupt) {
-        Objects.requireNonNull(future, "future is null");
+        ObjectHelper.requireNonNull(future, "future is null");
         return new FutureDisposable(future, allowInterrupt);
     }
 
@@ -84,7 +84,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     public static Disposable from(Subscription subscription) {
-        Objects.requireNonNull(subscription, "subscription is null");
+        ObjectHelper.requireNonNull(subscription, "subscription is null");
         return new SubscriptionDisposable(subscription);
     }
 

--- a/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
@@ -15,7 +15,7 @@ package io.reactivex.disposables;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Base class for Disposable containers that manage some other type that
@@ -28,7 +28,7 @@ abstract class ReferenceDisposable<T> extends AtomicReference<T> implements Disp
     private static final long serialVersionUID = 6537757548749041217L;
 
     ReferenceDisposable(T value) {
-        super(Objects.requireNonNull(value, "value is null"));
+        super(ObjectHelper.requireNonNull(value, "value is null"));
     }
 
     protected abstract void onDisposed(T value);

--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.disposables;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -54,7 +54,7 @@ public enum DisposableHelper {
     }
     
     public static boolean setOnce(AtomicReference<Disposable> field, Disposable d) {
-        Objects.requireNonNull(d, "d is null");
+        ObjectHelper.requireNonNull(d, "d is null");
         if (!field.compareAndSet(null, d)) {
             d.dispose();
             if (field.get() != DISPOSED) {

--- a/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
@@ -14,9 +14,22 @@
 package io.reactivex.internal.disposables;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.fuseable.QueueDisposable;
 
-public enum EmptyDisposable implements Disposable {
+/**
+ * Represents a stateless empty Disposable that reports being always
+ * empty and disposed.
+ * <p>It is also async-fuseable but empty all the time.
+ * <p>Since EmptyDisposable implements QueueDisposable and is empty,
+ * don't use it in tests and then signal onNext with it;
+ * use Disposables.empty() instead.
+ */
+public enum EmptyDisposable implements QueueDisposable<Object> {
+    /**
+     * Since EmptyDisposable implements QueueDisposable and is empty,
+     * don't use it in tests and then signal onNext with it;
+     * use Disposables.empty() instead.
+     */
     INSTANCE
     ;
     
@@ -27,7 +40,7 @@ public enum EmptyDisposable implements Disposable {
 
     @Override
     public boolean isDisposed() {
-        return true; // TODO is this okay?
+        return true;
     }
 
     public static void complete(Observer<?> s) {
@@ -54,5 +67,36 @@ public enum EmptyDisposable implements Disposable {
         s.onSubscribe(INSTANCE);
         s.onError(e);
     }
+
+    @Override
+    public boolean offer(Object value) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public boolean offer(Object v1, Object v2) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public Object poll() throws Exception {
+        return null; // always empty
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true; // always empty
+    }
+
+    @Override
+    public void clear() {
+        // nothing to do
+    }
+
+    @Override
+    public int requestFusion(int mode) {
+        return mode & ASYNC;
+    }
+    
 
 }

--- a/src/main/java/io/reactivex/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/ListCompositeDisposable.java
@@ -16,7 +16,7 @@ import java.util.*;
 
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * A disposable container that can hold onto multiple other disposables.
@@ -31,18 +31,18 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
     }
     
     public ListCompositeDisposable(Disposable... resources) {
-        Objects.requireNonNull(resources, "resources is null");
+        ObjectHelper.requireNonNull(resources, "resources is null");
         this.resources = new LinkedList<Disposable>();
         for (Disposable d : resources) {
-            Objects.requireNonNull(d, "Disposable item is null");
+            ObjectHelper.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);
         }
     }
     
     public ListCompositeDisposable(Iterable<? extends Disposable> resources) {
-        Objects.requireNonNull(resources, "resources is null");
+        ObjectHelper.requireNonNull(resources, "resources is null");
         for (Disposable d : resources) {
-            Objects.requireNonNull(d, "Disposable item is null");
+            ObjectHelper.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);
         }
     }
@@ -72,7 +72,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
     
     @Override
     public boolean add(Disposable d) {
-        Objects.requireNonNull(d, "d is null");
+        ObjectHelper.requireNonNull(d, "d is null");
         if (!disposed) {
             synchronized (this) {
                 if (!disposed) {
@@ -91,7 +91,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
     }
 
     public boolean addAll(Disposable... ds) {
-        Objects.requireNonNull(ds, "ds is null");
+        ObjectHelper.requireNonNull(ds, "ds is null");
         if (!disposed) {
             synchronized (this) {
                 if (!disposed) {
@@ -101,7 +101,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
                         resources = set;
                     }
                     for (Disposable d : ds) {
-                        Objects.requireNonNull(d, "d is null");
+                        ObjectHelper.requireNonNull(d, "d is null");
                         set.add(d);
                     }
                     return true;
@@ -125,7 +125,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
     
     @Override
     public boolean delete(Disposable d) {
-        Objects.requireNonNull(d, "Disposable item is null");
+        ObjectHelper.requireNonNull(d, "Disposable item is null");
         if (disposed) {
             return false;
         }

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -28,7 +28,7 @@ public enum Functions {
     
     @SuppressWarnings("unchecked")
     public static <T1, T2, R> Function<Object[], R> toFunction(final BiFunction<? super T1, ? super T2, ? extends R> biFunction) {
-        Objects.requireNonNull(biFunction, "biFunction is null");
+        ObjectHelper.requireNonNull(biFunction, "biFunction is null");
         return new Function<Object[], R>() {
             @Override
             public R apply(Object[] a) throws Exception {
@@ -41,7 +41,7 @@ public enum Functions {
     }
     
     public static <T1, T2, T3, R> Function<Object[], R> toFunction(final Function3<T1, T2, T3, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -55,7 +55,7 @@ public enum Functions {
     }
     
     public static <T1, T2, T3, T4, R> Function<Object[], R> toFunction(final Function4<T1, T2, T3, T4, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -69,7 +69,7 @@ public enum Functions {
     }
     
     public static <T1, T2, T3, T4, T5, R> Function<Object[], R> toFunction(final Function5<T1, T2, T3, T4, T5, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -84,7 +84,7 @@ public enum Functions {
     
     public static <T1, T2, T3, T4, T5, T6, R> Function<Object[], R> toFunction(
             final Function6<T1, T2, T3, T4, T5, T6, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -99,7 +99,7 @@ public enum Functions {
     
     public static <T1, T2, T3, T4, T5, T6, T7, R> Function<Object[], R> toFunction(
             final Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -114,7 +114,7 @@ public enum Functions {
     
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function<Object[], R> toFunction(
             final Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -129,7 +129,7 @@ public enum Functions {
     
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Function<Object[], R> toFunction(
             final Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) {
-        Objects.requireNonNull(f, "f is null");
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -362,7 +362,7 @@ public enum Functions {
         
         @Override
         public boolean test(T t) throws Exception {
-            return Objects.equals(t, value);
+            return ObjectHelper.equals(t, value);
         }
     }
     

--- a/src/main/java/io/reactivex/internal/functions/ObjectHelper.java
+++ b/src/main/java/io/reactivex/internal/functions/ObjectHelper.java
@@ -18,7 +18,7 @@ import io.reactivex.functions.BiPredicate;
  * Utility methods containing the backport of Java 7's Objects utility class.
  * <p>Named as such to avoid clash with java.util.Objects.
  */
-public enum Objects {
+public enum ObjectHelper {
     ;
     /**
      * Verifies if the object is not null and returns it or throws a NullPointerException
@@ -78,7 +78,7 @@ public enum Objects {
     static final BiPredicate<Object, Object> EQUALS = new BiPredicate<Object, Object>() {
         @Override
         public boolean test(Object o1, Object o2) {
-            return Objects.equals(o1, o2);
+            return ObjectHelper.equals(o1, o2);
         }
     };
     

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableAwait.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableAwait.java
@@ -18,7 +18,7 @@ import java.util.concurrent.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public enum CompletableAwait {
     ;
@@ -64,7 +64,7 @@ public enum CompletableAwait {
     }
     
     public static boolean await(CompletableSource cc, long timeout, TimeUnit unit) {
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] err = new Throwable[1];
@@ -145,7 +145,7 @@ public enum CompletableAwait {
     }
     
     public static Throwable get(CompletableSource cc, long timeout, TimeUnit unit) {
-        Objects.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
         
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] err = new Throwable[1];

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
@@ -20,7 +20,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class CompletableConcatIterable extends Completable {
     final Iterable<? extends CompletableSource> sources;
@@ -35,7 +35,7 @@ public final class CompletableConcatIterable extends Completable {
         Iterator<? extends CompletableSource> it;
         
         try {
-            it = Objects.requireNonNull(sources.iterator(), "The iterator returned is null");
+            it = ObjectHelper.requireNonNull(sources.iterator(), "The iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
@@ -20,6 +20,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.Objects;
 
 public final class CompletableConcatIterable extends Completable {
     final Iterable<? extends CompletableSource> sources;
@@ -34,16 +35,10 @@ public final class CompletableConcatIterable extends Completable {
         Iterator<? extends CompletableSource> it;
         
         try {
-            it = sources.iterator();
+            it = Objects.requireNonNull(sources.iterator(), "The iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
-            return;
-        }
-        
-        if (it == null) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(new NullPointerException("The iterator returned is null"));
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Callable;
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class CompletableDefer extends Completable {
 
@@ -33,7 +33,7 @@ public final class CompletableDefer extends Completable {
         CompletableSource c;
         
         try {
-            c = Objects.requireNonNull(completableSupplier.call(), "The completableSupplier returned a null CompletableSource");
+            c = ObjectHelper.requireNonNull(completableSupplier.call(), "The completableSupplier returned a null CompletableSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.Objects;
 
 public final class CompletableDefer extends Completable {
 
@@ -32,16 +33,10 @@ public final class CompletableDefer extends Completable {
         CompletableSource c;
         
         try {
-            c = completableSupplier.call();
+            c = Objects.requireNonNull(completableSupplier.call(), "The completableSupplier returned a null CompletableSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
-            return;
-        }
-        
-        if (c == null) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(new NullPointerException("The completable returned is null"));
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableError.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableError.java
@@ -26,7 +26,6 @@ public final class CompletableError extends Completable {
     
     @Override
     protected void subscribeActual(CompletableObserver s) {
-        s.onSubscribe(EmptyDisposable.INSTANCE);
-        s.onError(error);
+        EmptyDisposable.error(error, s);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
@@ -29,7 +29,6 @@ public final class CompletableErrorSupplier extends Completable {
 
     @Override
     protected void subscribeActual(CompletableObserver s) {
-        s.onSubscribe(EmptyDisposable.INSTANCE);
         Throwable error;
         
         try {
@@ -42,7 +41,7 @@ public final class CompletableErrorSupplier extends Completable {
         if (error == null) {
             error = new NullPointerException("The error supplied is null");
         }
-        s.onError(error);
+        EmptyDisposable.error(error, s);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -99,8 +99,7 @@ public final class CompletablePeek extends Completable {
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     d.dispose();
-                    s.onSubscribe(EmptyDisposable.INSTANCE);
-                    s.onError(ex);
+                    EmptyDisposable.error(ex, s);
                     return;
                 }
                 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
@@ -21,7 +21,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableUsing<R> extends Completable {
@@ -57,7 +57,7 @@ public final class CompletableUsing<R> extends Completable {
         CompletableSource cs;
         
         try {
-            cs = Objects.requireNonNull(completableFunction.apply(resource), "The completableFunction returned a null Completable");
+            cs = ObjectHelper.requireNonNull(completableFunction.apply(resource), "The completableFunction returned a null Completable");
         } catch (Throwable e) {
             try {
                 disposer.accept(resource);

--- a/src/main/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstream.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstream.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Abstract base class for operators that take an upstream
@@ -38,7 +38,7 @@ abstract class AbstractFlowableWithUpstream<T, R> extends Flowable<R> implements
      * @param source the source (upstream) Publisher instance, not null (verified)
      */
     public AbstractFlowableWithUpstream(Publisher<T> source) {
-        this.source = Objects.requireNonNull(source, "source is null");
+        this.source = ObjectHelper.requireNonNull(source, "source is null");
     }
     
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BooleanSupplier;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -49,7 +49,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
         this.size = size;
         this.skip = skip;
-        this.bufferSupplier = Objects.requireNonNull(bufferSupplier, "bufferSupplier");
+        this.bufferSupplier = ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier");
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
@@ -53,9 +53,9 @@ extends Flowable<R> {
             throw new IllegalArgumentException("BUFFER_SIZE > 0 required but it was " + bufferSize);
         }
 
-        this.array = Objects.requireNonNull(array, "array");
+        this.array = ObjectHelper.requireNonNull(array, "array");
         this.iterable = null;
-        this.combiner = Objects.requireNonNull(combiner, "combiner");
+        this.combiner = ObjectHelper.requireNonNull(combiner, "combiner");
         this.bufferSize = bufferSize;
         this.delayErrors = delayErrors;
     }
@@ -68,8 +68,8 @@ extends Flowable<R> {
         }
         
         this.array = null;
-        this.iterable = Objects.requireNonNull(iterable, "iterable");
-        this.combiner = Objects.requireNonNull(combiner, "combiner");
+        this.iterable = ObjectHelper.requireNonNull(iterable, "iterable");
+        this.combiner = ObjectHelper.requireNonNull(combiner, "combiner");
         this.bufferSize = bufferSize;
         this.delayErrors = delayErrors;
     }
@@ -381,7 +381,7 @@ extends Flowable<R> {
                     R w;
                     
                     try {
-                        w = Objects.requireNonNull(combiner.apply(va), "The combiner returned a null value");
+                        w = ObjectHelper.requireNonNull(combiner.apply(va), "The combiner returned a null value");
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -59,9 +59,9 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
     }
     
     @Override
-    public void subscribeActual(Subscriber<? super R> s) {
+    protected void subscribeActual(Subscriber<? super R> s) {
         
-        if (ScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+        if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
@@ -41,9 +41,9 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
         if (prefetch <= 0) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
         }
-        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.mapper = ObjectHelper.requireNonNull(mapper, "mapper");
         this.prefetch = prefetch;
-        this.errorMode = Objects.requireNonNull(errorMode, "errorMode");
+        this.errorMode = ObjectHelper.requireNonNull(errorMode, "errorMode");
     }
     
     public static <T, R> Subscriber<T> subscribe(Subscriber<? super R> s, Function<? super T, ? extends Publisher<? extends R>> mapper, 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscribers.flowable.*;
@@ -116,7 +116,7 @@ public class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpstream<T
             Publisher<? extends R> p;
             
             try {
-                p = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+                p = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 s.cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -70,7 +70,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
                         }
                         Object o = last;
                         last = t;
-                        return !Objects.equals(o, t);
+                        return !ObjectHelper.equals(o, t);
                     }
                 };
             }
@@ -93,7 +93,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
                         }
                         Object o = last;
                         last = t;
-                        return !Objects.equals(o, t);
+                        return !ObjectHelper.equals(o, t);
                     }
                 };
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -44,7 +44,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
     
     @Override
     protected void subscribeActual(Subscriber<? super U> s) {
-        if (ScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+        if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
             return;
         }
         source.subscribe(new MergeSubscriber<T, U>(s, mapper, delayErrors, maxConcurrency, bufferSize));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -136,8 +136,8 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     u  = ((Callable<U>)p).call();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    s.cancel();
-                    onError(ex);
+                    getErrorQueue().offer(ex);
+                    drain();
                     return;
                 }
                 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
@@ -40,7 +40,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
         if (prefetch <= 0) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
         }
-        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.mapper = ObjectHelper.requireNonNull(mapper, "mapper");
         this.prefetch = prefetch;
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -68,7 +68,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
             }
             
             index = i + 1;
-            return Objects.requireNonNull(arr[i], "array element is null");
+            return ObjectHelper.requireNonNull(arr[i], "array element is null");
         }
         
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java
@@ -19,7 +19,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.DeferredScalarSubscription;
 
 public final class FlowableFromCallable<T> extends Flowable<T> implements Callable<T> {
@@ -34,7 +34,7 @@ public final class FlowableFromCallable<T> extends Flowable<T> implements Callab
         
         T t;
         try {
-            t = Objects.requireNonNull(callable.call(), "The callable returned a null value");
+            t = ObjectHelper.requireNonNull(callable.call(), "The callable returned a null value");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             s.onError(ex);
@@ -46,6 +46,6 @@ public final class FlowableFromCallable<T> extends Flowable<T> implements Callab
     
     @Override
     public T call() throws Exception {
-        return Objects.requireNonNull(callable.call(), "The callable returned a null value");
+        return ObjectHelper.requireNonNull(callable.call(), "The callable returned a null value");
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -19,7 +19,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -97,7 +97,7 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                     return null;
                 }
             }
-            return Objects.requireNonNull(it.next(), "Iterator.next() returned a null value");
+            return ObjectHelper.requireNonNull(it.next(), "Iterator.next() returned a null value");
         }
 
         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -22,7 +22,7 @@ import org.reactivestreams.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -133,7 +133,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             
             V v;
             try {
-                v = Objects.requireNonNull(valueSelector.apply(t), "The valueSelector returned null");
+                v = ObjectHelper.requireNonNull(valueSelector.apply(t), "The valueSelector returned null");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 s.cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -25,7 +25,7 @@ import io.reactivex.Flowable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -248,7 +248,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
                         Publisher<TLeftEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -270,7 +270,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
                         R w;
                         
                         try {
-                            w = Objects.requireNonNull(resultSelector.apply(left, up), "The resultSelector returned a null value");
+                            w = ObjectHelper.requireNonNull(resultSelector.apply(left, up), "The resultSelector returned a null value");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -300,7 +300,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
                         Publisher<TRightEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.operators.flowable.FlowableGroupJoin.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -223,7 +223,7 @@ public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstrac
                         Publisher<TLeftEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -250,7 +250,7 @@ public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstrac
                             R w;
                             
                             try {
-                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                                w = ObjectHelper.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
                             } catch (Throwable exc) {
                                 fail(exc, a, q);
                                 return;
@@ -284,7 +284,7 @@ public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstrac
                         Publisher<TRightEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -311,7 +311,7 @@ public class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstrac
                             R w;
                             
                             try {
-                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                                w = ObjectHelper.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
                             } catch (Throwable exc) {
                                 fail(exc, a, q);
                                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.exceptions.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
@@ -42,7 +42,7 @@ final Scheduler scheduler;
         if (prefetch <= 0) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
         }
-        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+        this.scheduler = ObjectHelper.requireNonNull(scheduler, "scheduler");
         this.delayError = delayError;
         this.prefetch = prefetch;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
@@ -24,7 +24,7 @@ import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
@@ -60,7 +60,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
         Publisher<? extends R> other;
         
         try {
-            other = Objects.requireNonNull(selector.apply(mp), "selector returned a null Publisher");
+            other = ObjectHelper.requireNonNull(selector.apply(mp), "selector returned a null Publisher");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptySubscription.error(ex, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.processors.*;
 import io.reactivex.subscribers.SerializedSubscriber;
@@ -44,7 +44,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         Publisher<?> when;
         
         try {
-            when = Objects.requireNonNull(handler.apply(processor), "handler returned a null Publisher");
+            when = ObjectHelper.requireNonNull(handler.apply(processor), "handler returned a null Publisher");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptySubscription.error(ex, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.operators.flowable.FlowableRepeatWhen.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.*;
@@ -42,7 +42,7 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
         Publisher<?> when;
         
         try {
-            when = Objects.requireNonNull(handler.apply(processor), "handler returned a null Publisher");
+            when = ObjectHelper.requireNonNull(handler.apply(processor), "handler returned a null Publisher");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptySubscription.error(ex, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 
 /**
@@ -61,7 +61,7 @@ public enum FlowableScalarXMap {
             Publisher<? extends R> r;
             
             try {
-                r = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+                r = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 EmptySubscription.error(ex, subscriber);
@@ -130,7 +130,7 @@ public enum FlowableScalarXMap {
         public void subscribeActual(Subscriber<? super R> s) {
             Publisher<? extends R> other;
             try {
-                other = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null Publisher");
+                other = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null Publisher");
             } catch (Throwable e) {
                 EmptySubscription.error(e, s);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.subscriptions.*;
 /**
  * Utility classes to work with scalar-sourced XMap operators (where X == { flat, concat, switch }).
  */
-public enum ScalarXMap {
+public enum FlowableScalarXMap {
     ;
 
     /**
@@ -40,7 +40,8 @@ public enum ScalarXMap {
      */
     @SuppressWarnings("unchecked")
     public static <T, R> boolean tryScalarXMapSubscribe(Publisher<T> source, 
-            Subscriber<? super R> subscriber, Function<? super T, ? extends Publisher<? extends R>> mapper) {
+            Subscriber<? super R> subscriber, 
+            Function<? super T, ? extends Publisher<? extends R>> mapper) {
         if (source instanceof Callable) {
             T t;
             
@@ -103,7 +104,7 @@ public enum ScalarXMap {
      * @return the new Flowable instance
      */
     public static <T, U> Flowable<U> scalarXMap(final T value, final Function<? super T, ? extends Publisher<? extends U>> mapper) {
-        return new FlowableScalarXMap<T, U>(value, mapper);
+        return new ScalarXMapFlowable<T, U>(value, mapper);
     }
     
     /**
@@ -112,13 +113,13 @@ public enum ScalarXMap {
      * @param <T> the scalar value type
      * @param <R> the mapped Publisher's element type.
      */
-    static final class FlowableScalarXMap<T, R> extends Flowable<R> {
+    static final class ScalarXMapFlowable<T, R> extends Flowable<R> {
         
         final T value;
         
         final Function<? super T, ? extends Publisher<? extends R>> mapper;
         
-        public FlowableScalarXMap(T value,
+        public ScalarXMapFlowable(T value,
                 Function<? super T, ? extends Publisher<? extends R>> mapper) {
             this.value = value;
             this.mapper = mapper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -40,7 +40,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
     
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        if (ScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+        if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
             return;
         }
         source.subscribe(new SwitchMapSubscriber<T, R>(s, mapper, bufferSize, delayErrors));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -170,7 +170,7 @@ public class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWithUpstre
             R v;
             
             try {
-                v = Objects.requireNonNull(combiner.apply(objects), "combiner returned a null value");
+                v = ObjectHelper.requireNonNull(combiner.apply(objects), "combiner returned a null value");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 cancel();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.*;
@@ -212,7 +212,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                         ObservableSource<? extends U> o;
                         
                         try {
-                            o = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null ObservableConsumable");
+                            o = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null ObservableConsumable");
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             dispose();
@@ -439,7 +439,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                         ObservableSource<? extends R> o;
                         
                         try {
-                            o = Objects.requireNonNull(mapper.apply(v), "The mapper returned a null ObservableSource");
+                            o = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null ObservableSource");
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             this.d.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -42,6 +42,11 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
     }
     @Override
     public void subscribeActual(Observer<? super U> s) {
+        
+        if (ObservableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+            return;
+        }
+        
         if (delayErrors == ErrorMode.IMMEDIATE) {
             SerializedObserver<U> ssub = new SerializedObserver<U>(s);
             source.subscribe(new SourceSubscriber<T, U>(ssub, mapper, bufferSize));

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
@@ -1,0 +1,428 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.subscribers.observable.*;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableConcatMapEager<T, R> extends AbstractObservableWithUpstream<T, R> {
+
+    final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+
+    final ErrorMode errorMode;
+    
+    final int maxConcurrency;
+    
+    final int prefetch;
+    
+    public ObservableConcatMapEager(ObservableSource<T> source,
+            Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
+            ErrorMode errorMode,
+            int maxConcurrency, int prefetch) {
+        super(source);
+        this.mapper = mapper;
+        this.errorMode = errorMode;
+        this.maxConcurrency = maxConcurrency;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> observer) {
+        source.subscribe(new ConcatMapEagerMainObserver<T, R>(observer, mapper, maxConcurrency, prefetch, errorMode));
+    }
+    
+    static final class ConcatMapEagerMainObserver<T, R> 
+    extends AtomicInteger
+    implements Observer<T>, Disposable, InnerQueuedObserverSupport<R> {
+        /** */
+        private static final long serialVersionUID = 8080567949447303262L;
+
+        final Observer<? super R> actual;
+        
+        final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+        
+        final int maxConcurrency;
+        
+        final int prefetch;
+
+        final ErrorMode errorMode;
+
+        final AtomicThrowable error;
+        
+        final ArrayDeque<InnerQueuedObserver<R>> observers;
+        
+        SimpleQueue<T> queue;
+        
+        Disposable d;
+        
+        volatile boolean done;
+        
+        int sourceMode;
+        
+        volatile boolean cancelled;
+        
+        InnerQueuedObserver<R> current;
+        
+        int activeCount;
+
+        public ConcatMapEagerMainObserver(Observer<? super R> actual,
+                Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
+                int maxConcurrency, int prefetch, ErrorMode errorMode) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.maxConcurrency = maxConcurrency;
+            this.prefetch = prefetch;
+            this.errorMode = errorMode;
+            this.error = new AtomicThrowable();
+            this.observers = new ArrayDeque<InnerQueuedObserver<R>>();
+        }
+        
+        @SuppressWarnings("unchecked")
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                
+                if (d instanceof QueueDisposable) {
+                    QueueDisposable<T> qd = (QueueDisposable<T>) d;
+                    
+                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    if (m == QueueDisposable.SYNC) {
+                        sourceMode = m;
+                        queue = qd;
+                        done = true;
+                        
+                        actual.onSubscribe(this);
+                        
+                        drain();
+                        return;
+                    }
+                    if (m == QueueDisposable.ASYNC) {
+                        sourceMode = m;
+                        queue = qd;
+                        
+                        actual.onSubscribe(this);
+                        
+                        return;
+                    }
+                }
+                
+                queue = QueueDrainHelper.createQueue(prefetch);
+                
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onNext(T value) {
+            if (sourceMode == QueueSubscription.NONE) {
+                queue.offer(value);
+            }
+            drain();
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            if (error.addThrowable(e)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+        
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+        
+        @Override
+        public void dispose() {
+            cancelled = true;
+            if (getAndIncrement() == 0) {
+                queue.clear();
+                disposeAll();
+            }
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return cancelled;
+        }
+        
+        void disposeAll() {
+            InnerQueuedObserver<R> inner = current;
+            
+            if (inner != null) {
+                inner.dispose();
+            }
+            
+            for (;;) {
+                
+                try {
+                    inner = observers.poll();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    throw Exceptions.propagate(ex);
+                }
+                if (inner == null) {
+                    return;
+                }
+                
+                inner.dispose();
+            }
+        }
+        
+        @Override
+        public void innerNext(InnerQueuedObserver<R> inner, R value) {
+            inner.queue().offer(value);
+            drain();
+        }
+        
+        @Override
+        public void innerError(InnerQueuedObserver<R> inner, Throwable e) {
+            if (error.addThrowable(e)) {
+                if (errorMode == ErrorMode.IMMEDIATE) {
+                    d.dispose();
+                }
+                inner.setDone();
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+        
+        @Override
+        public void innerComplete(InnerQueuedObserver<R> inner) {
+            inner.setDone();
+            drain();
+        }
+        
+        @SuppressWarnings("unchecked")
+        @Override
+        public void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            
+            int missed = 1;
+            
+            SimpleQueue<T> q = queue;
+            ArrayDeque<InnerQueuedObserver<R>> observers = this.observers;
+            Observer<? super R> a = this.actual;
+            ErrorMode errorMode = this.errorMode;
+            
+            outer:
+            for (;;) {
+                
+                int ac = activeCount;
+                
+                while (ac != maxConcurrency) {
+                    if (cancelled) {
+                        q.clear();
+                        disposeAll();
+                        return;
+                    }
+                    
+                    if (errorMode == ErrorMode.IMMEDIATE) {
+                        Throwable ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            disposeAll();
+                            
+                            a.onError(error.terminate());
+                            return;
+                        }
+                    }
+                    
+                    T v;
+                    ObservableSource<? extends R> source;
+                    
+                    try {
+                        v = q.poll();
+                        
+                        if (v == null) {
+                            break;
+                        }
+                        
+                        source = Objects.requireNonNull(mapper.apply(v), "The mapper returned a null ObservableSource");
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        d.dispose();
+                        q.clear();
+                        disposeAll();
+                        error.addThrowable(ex);
+                        a.onError(error.terminate());
+                        return;
+                    }
+                    
+                    if (source instanceof Callable) {
+                        R w;
+                        
+                        try {
+                            w = ((Callable<R>)source).call();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            error.addThrowable(ex);
+                            continue;
+                        }
+                        
+                        if (w != null) {
+                            a.onNext(w);
+                        }
+                        continue;
+                    }
+                    
+                    InnerQueuedObserver<R> inner = new InnerQueuedObserver<R>(this, prefetch);
+                    
+                    observers.offer(inner);
+                    
+                    source.subscribe(inner);
+                    
+                    ac++;
+                }
+                
+                activeCount = ac;
+
+                if (cancelled) {
+                    q.clear();
+                    disposeAll();
+                    return;
+                }
+                
+                if (errorMode == ErrorMode.IMMEDIATE) {
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        q.clear();
+                        disposeAll();
+                        
+                        a.onError(error.terminate());
+                        return;
+                    }
+                }
+
+                InnerQueuedObserver<R> active = current;
+                
+                if (active == null) {
+                    if (errorMode == ErrorMode.BOUNDARY) {
+                        Throwable ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            disposeAll();
+                            
+                            a.onError(error.terminate());
+                            return;
+                        }
+                    }
+                    boolean d = done;
+                    
+                    active = observers.poll();
+                    
+                    boolean empty = active == null;
+                    
+                    if (d && empty) {
+                        Throwable ex = error.get();
+                        if (ex != null) {
+                            q.clear();
+                            disposeAll();
+                            
+                            a.onError(error.terminate());
+                        } else {
+                            a.onComplete();
+                        }
+                        return;
+                    }
+                    
+                    if (!empty) {
+                        current = active;
+                    }
+                    
+                }
+
+                if (active != null) {
+                    SimpleQueue<R> aq = active.queue();
+                    
+                    for (;;) {
+                        if (cancelled) {
+                            q.clear();
+                            disposeAll();
+                            return;
+                        }
+                        
+                        boolean d = active.isDone();
+                        
+                        if (errorMode == ErrorMode.IMMEDIATE) {
+                            Throwable ex = error.get();
+                            if (ex != null) {
+                                q.clear();
+                                disposeAll();
+                                
+                                a.onError(error.terminate());
+                                return;
+                            }
+                        }
+                        
+                        R w;
+                        
+                        try {
+                            w = aq.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            error.addThrowable(ex);
+                            
+                            current = null;
+                            active = null;
+                            activeCount--;
+                            continue outer;
+                        }
+                        
+                        boolean empty = w == null;
+                        
+                        if (d && empty) {
+                            current = null;
+                            active = null;
+                            activeCount--;
+                            continue outer;
+                        }
+                        
+                        if (empty) {
+                            break;
+                        }
+                        
+                        a.onNext(w);
+                    }
+                }
+                
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
@@ -22,7 +22,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscribers.observable.*;
 import io.reactivex.internal.util.*;
@@ -269,7 +269,7 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
                             break;
                         }
                         
-                        source = Objects.requireNonNull(mapper.apply(v), "The mapper returned a null ObservableSource");
+                        source = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null ObservableSource");
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         d.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscribers.flowable.EmptyComponent;
+
+/**
+ * Breaks the links between the upstream and the downstream (the Disposable and
+ * the Observer references) when the sequence terminates or gets disposed.
+ *
+ * @param <T> the value type
+ */
+public final class ObservableDetach<T> extends AbstractObservableWithUpstream<T, T> {
+
+    public ObservableDetach(ObservableSource<T> source) {
+        super(source);
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        source.subscribe(new DetachObserver<T>(s));
+    }
+    
+    static final class DetachObserver<T> implements Observer<T>, Disposable {
+        
+        Observer<? super T> actual;
+        
+        Disposable s;
+        
+        public DetachObserver(Observer<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            Disposable s = this.s;
+            this.s = EmptyComponent.INSTANCE;
+            this.actual = EmptyComponent.asObserver();
+            s.dispose();
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            Disposable s = this.s;
+            return s == null || s.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            Observer<? super T> a = actual;
+            this.s = EmptyComponent.INSTANCE;
+            this.actual = EmptyComponent.asObserver();
+            a.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            Observer<? super T> a = actual;
+            this.s = EmptyComponent.INSTANCE;
+            this.actual = EmptyComponent.asObserver();
+            a.onComplete();
+        }
+    }
+}
+

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -70,7 +70,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
                         }
                         Object o = last[0];
                         last[0] = t;
-                        return !Objects.equals(o, t);
+                        return !ObjectHelper.equals(o, t);
                     }
                 };
             }
@@ -93,7 +93,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
                         }
                         Object o = last[0];
                         last[0] = t;
-                        return !Objects.equals(o, t);
+                        return !ObjectHelper.equals(o, t);
                     }
                 };
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.functions.BiPredicate;
+import io.reactivex.internal.subscribers.observable.BasicFuseableObserver;
+
+public final class ObservableDistinctUntilChanged<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final BiPredicate<? super T, ? super T> comparer;
+
+    public ObservableDistinctUntilChanged(ObservableSource<T> source, BiPredicate<? super T, ? super T> comparer) {
+        super(source);
+        this.comparer = comparer;
+    }
+    
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        source.subscribe(new DistinctUntilChangedObserver<T>(s, comparer));
+    }
+
+    static final class DistinctUntilChangedObserver<T> extends BasicFuseableObserver<T, T> {
+
+        final BiPredicate<? super T, ? super T> comparer;
+        
+        T last;
+        
+        boolean hasValue;
+        
+        public DistinctUntilChangedObserver(Observer<? super T> actual, 
+                BiPredicate<? super T, ? super T> comparer) {
+            super(actual);
+            this.comparer = comparer;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            if (sourceMode != NONE) {
+                actual.onNext(t);
+                return;
+            }
+            
+            if (hasValue) {
+                boolean equal;
+                try {
+                    equal = comparer.test(last, t);
+                } catch (Throwable ex) {
+                    fail(ex);
+                    return;
+                }
+                last = t;
+                if (equal) {
+                    return;
+                }
+                actual.onNext(t);
+                return;
+            }
+            hasValue = true;
+            last = t;
+            actual.onNext(t);
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public T poll() throws Exception {
+            for (;;) {
+                T v = qs.poll();
+                if (v == null) {
+                    return null;
+                }
+                if (!hasValue) {
+                    hasValue = true;
+                    last = v;
+                    return v;
+                }
+                
+                if (!comparer.test(last, v)) {
+                    last = v;
+                    return v;
+                }
+                last = v;
+            }
+        }
+        
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableEmpty.java
@@ -25,8 +25,7 @@ public final class ObservableEmpty extends Observable<Object> implements ScalarC
 
     @Override
     protected void subscribeActual(Observer<? super Object> o) {
-        o.onSubscribe(EmptyDisposable.INSTANCE);
-        o.onComplete();
+        EmptyDisposable.complete(o);
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -43,6 +43,11 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
     
     @Override
     public void subscribeActual(Observer<? super U> t) {
+        
+        if (ObservableScalarXMap.tryScalarXMapSubscribe(source, t, mapper)) {
+            return;
+        }
+        
         source.subscribe(new MergeSubscriber<T, U>(t, mapper, delayErrors, maxConcurrency, bufferSize));
     }
     
@@ -103,6 +108,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             }
         }
         
+        @SuppressWarnings("unchecked")
         @Override
         public void onNext(T t) {
             // safeguard against misbehaving sources
@@ -117,8 +123,8 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 onError(e);
                 return;
             }
-            if (p instanceof ObservableJust) {
-                tryEmitScalar(((ObservableJust<? extends U>)p).value());
+            if (p instanceof ScalarCallable) {
+                tryEmitScalar(((ScalarCallable<? extends U>)p).call());
             } else {
                 if (maxConcurrency == Integer.MAX_VALUE) {
                     subscribeInner(p);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscribers.observable.BaseQueueDisposable;
 
 public final class ObservableFromArray<T> extends Observable<T> {
@@ -70,7 +70,7 @@ public final class ObservableFromArray<T> extends Observable<T> {
             T[] a = array;
             if (i != a.length) {
                 index = i + 1;
-                return Objects.requireNonNull(a[i], "The array element is null");
+                return ObjectHelper.requireNonNull(a[i], "The array element is null");
             }
             return null;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
@@ -18,7 +18,7 @@ import java.util.Iterator;
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscribers.observable.BaseQueueDisposable;
 
 public final class ObservableFromIterable<T> extends Observable<T> {
@@ -87,7 +87,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
                 T v;
                 
                 try {
-                    v = Objects.requireNonNull(it.next(), "The iterator returned a null value");
+                    v = ObjectHelper.requireNonNull(it.next(), "The iterator returned a null value");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     actual.onError(e);
@@ -136,7 +136,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
                 checkNext = true;
             }
             
-            return Objects.requireNonNull(it.next(), "The iterator returned a null value");
+            return ObjectHelper.requireNonNull(it.next(), "The iterator returned a null value");
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -16,8 +16,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static io.reactivex.Flowable.bufferSize;
-
 import java.util.*;
 import java.util.concurrent.atomic.*;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -26,7 +26,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -244,7 +244,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
                         ObservableSource<TLeftEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -266,7 +266,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
                         R w;
                         
                         try {
-                            w = Objects.requireNonNull(resultSelector.apply(left, up), "The resultSelector returned a null value");
+                            w = ObjectHelper.requireNonNull(resultSelector.apply(left, up), "The resultSelector returned a null value");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -289,7 +289,7 @@ public class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends 
                         ObservableSource<TRightEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
@@ -16,8 +16,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static io.reactivex.Flowable.bufferSize;
-
 import java.util.*;
 import java.util.concurrent.atomic.*;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
@@ -24,7 +24,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.operators.observable.ObservableGroupJoin.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.ExceptionHelper;
@@ -221,7 +221,7 @@ public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstr
                         ObservableSource<TLeftEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(leftEnd.apply(left), "The leftEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -245,7 +245,7 @@ public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstr
                             R w;
                             
                             try {
-                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                                w = ObjectHelper.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
                             } catch (Throwable exc) {
                                 fail(exc, a, q);
                                 return;
@@ -265,7 +265,7 @@ public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstr
                         ObservableSource<TRightEnd> p;
                         
                         try {
-                            p = Objects.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
+                            p = ObjectHelper.requireNonNull(rightEnd.apply(right), "The rightEnd returned a null Publisher");
                         } catch (Throwable exc) {
                             fail(exc, a, q);
                             return;
@@ -289,7 +289,7 @@ public class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Abstr
                             R w;
                             
                             try {
-                                w = Objects.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
+                                w = ObjectHelper.requireNonNull(resultSelector.apply(left, right), "The resultSelector returned a null value");
                             } catch (Throwable exc) {
                                 fail(exc, a, q);
                                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -20,7 +20,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueDisposable;
 
 /**
@@ -61,7 +61,7 @@ public enum ObservableScalarXMap {
             ObservableSource<? extends R> r;
             
             try {
-                r = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+                r = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 EmptyDisposable.error(ex, observer);
@@ -131,7 +131,7 @@ public enum ObservableScalarXMap {
         public void subscribeActual(Observer<? super R> s) {
             ObservableSource<? extends R> other;
             try {
-                other = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null Publisher");
+                other = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null Publisher");
             } catch (Throwable e) {
                 EmptyDisposable.error(e, s);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.QueueDisposable;
+
+/**
+ * Utility classes to work with scalar-sourced XMap operators (where X == { flat, concat, switch }).
+ */
+public enum ObservableScalarXMap {
+    ;
+
+    /**
+     * Tries to subscribe to a possibly Callable source's mapped ObservableSource.
+     * @param <T> the input value type
+     * @param <R> the output value type
+     * @param source the source ObservableSource
+     * @param observer the subscriber
+     * @param mapper the function mapping a scalar value into a Publisher
+     * @return true if successful, false if the caller should continue with the regular path.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T, R> boolean tryScalarXMapSubscribe(ObservableSource<T> source, 
+            Observer<? super R> observer, 
+            Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+        if (source instanceof Callable) {
+            T t;
+            
+            try {
+                t = ((Callable<T>)source).call();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptyDisposable.error(ex, observer);
+                return true;
+            }
+            
+            if (t == null) {
+                EmptyDisposable.complete(observer);
+                return true;
+            }
+            
+            ObservableSource<? extends R> r;
+            
+            try {
+                r = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptyDisposable.error(ex, observer);
+                return true;
+            }
+            
+            if (r instanceof Callable) {
+                R u;
+                
+                try {
+                    u = ((Callable<R>)r).call();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    EmptyDisposable.error(ex, observer);
+                    return true;
+                }
+                
+                if (u == null) {
+                    EmptyDisposable.complete(observer);
+                    return true;
+                }
+                observer.onSubscribe(new ScalarDisposable<R>(observer, u));
+            } else {
+                r.subscribe(observer);
+            }
+            
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * Maps a scalar value into a Publisher and emits its values.
+     * 
+     * @param <T> the scalar value type
+     * @param <U> the output value type
+     * @param value the scalar value to map
+     * @param mapper the function that gets the scalar value and should return
+     * a Publisher that gets streamed
+     * @return the new Flowable instance
+     */
+    public static <T, U> Observable<U> scalarXMap(T value, 
+            Function<? super T, ? extends ObservableSource<? extends U>> mapper) {
+        return new ScalarXMapObservable<T, U>(value, mapper);
+    }
+    
+    /**
+     * Maps a scalar value to a ObservableSource and subscribes to it.
+     *
+     * @param <T> the scalar value type
+     * @param <R> the mapped Publisher's element type.
+     */
+    static final class ScalarXMapObservable<T, R> extends Observable<R> {
+        
+        final T value;
+        
+        final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+        
+        public ScalarXMapObservable(T value,
+                Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+            this.value = value;
+            this.mapper = mapper;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void subscribeActual(Observer<? super R> s) {
+            ObservableSource<? extends R> other;
+            try {
+                other = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null Publisher");
+            } catch (Throwable e) {
+                EmptyDisposable.error(e, s);
+                return;
+            }
+            if (other instanceof Callable) {
+                R u;
+                
+                try {
+                    u = ((Callable<R>)other).call();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    EmptyDisposable.error(ex, s);
+                    return;
+                }
+                
+                if (u == null) {
+                    EmptyDisposable.complete(s);
+                    return;
+                }
+                ScalarDisposable<R> sd = new ScalarDisposable<R>(s, u);
+                s.onSubscribe(sd);
+                sd.run();
+            } else {
+                other.subscribe(s);
+            }
+        }
+    }
+    
+    /**
+     * Represents a Disposable that signals one onNext followed by an onComplete.
+     *
+     * @param <T> the value type
+     */
+    public static final class ScalarDisposable<T> 
+    extends AtomicInteger
+    implements QueueDisposable<T>, Runnable {
+        /** */
+        private static final long serialVersionUID = 3880992722410194083L;
+
+        final Observer<? super T> observer;
+        
+        final T value;
+        
+        static final int START = 0;
+        static final int ON_NEXT = 1;
+        static final int ON_COMPLETE = 2;
+        
+        public ScalarDisposable(Observer<? super T> observer, T value) {
+            this.observer = observer;
+            this.value = value;
+        }
+
+        @Override
+        public boolean offer(T value) {
+            throw new UnsupportedOperationException("Should not be called!");
+        }
+
+        @Override
+        public boolean offer(T v1, T v2) {
+            throw new UnsupportedOperationException("Should not be called!");
+        }
+
+        @Override
+        public T poll() throws Exception {
+            if (get() == START) {
+                lazySet(ON_COMPLETE);
+                return value;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return get() != START;
+        }
+
+        @Override
+        public void clear() {
+            lazySet(ON_COMPLETE);
+        }
+
+        @Override
+        public void dispose() {
+            set(ON_COMPLETE);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get() == ON_COMPLETE;
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return mode & SYNC;
+        }
+
+        @Override
+        public void run() {
+            if (get() == START && compareAndSet(START, ON_NEXT)) {
+                observer.onNext(value);
+                if (get() == ON_NEXT) {
+                    lazySet(ON_COMPLETE);
+                    observer.onComplete();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -165,7 +165,7 @@ public class ObservableWithLatestFromMany<T, R> extends AbstractObservableWithUp
             R v;
             
             try {
-                v = Objects.requireNonNull(combiner.apply(objects), "combiner returned a null value");
+                v = ObjectHelper.requireNonNull(combiner.apply(objects), "combiner returned a null value");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 dispose();

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -32,16 +33,10 @@ public final class SingleDefer<T> extends Single<T> {
         SingleSource<? extends T> next;
         
         try {
-            next = singleSupplier.call();
+            next = Objects.requireNonNull(singleSupplier.call(), "The singleSupplier returned a null SingleSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);
-            return;
-        }
-        
-        if (next == null) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(new NullPointerException("The Single supplied was null"));
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
@@ -13,12 +13,12 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class SingleDefer<T> extends Single<T> {
 
@@ -33,7 +33,7 @@ public final class SingleDefer<T> extends Single<T> {
         SingleSource<? extends T> next;
         
         try {
-            next = Objects.requireNonNull(singleSupplier.call(), "The singleSupplier returned a null SingleSource");
+            next = ObjectHelper.requireNonNull(singleSupplier.call(), "The singleSupplier returned a null SingleSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSubscribe.java
@@ -44,8 +44,7 @@ public final class SingleDoOnSubscribe<T> extends Single<T> {
                     Exceptions.throwIfFatal(ex);
                     done = true;
                     d.dispose();
-                    s.onSubscribe(EmptyDisposable.INSTANCE);
-                    s.onError(ex);
+                    EmptyDisposable.error(ex, s);
                     return;
                 }
                 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleEquals.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleEquals.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SingleEquals<T> extends Single<Boolean> {
@@ -54,7 +54,7 @@ public final class SingleEquals<T> extends Single<Boolean> {
                 values[index] = value;
                 
                 if (count.incrementAndGet() == 2) {
-                    s.onSuccess(Objects.equals(values[0], values[1]));
+                    s.onSuccess(ObjectHelper.equals(values[0], values[1]));
                 }
             }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleError.java
@@ -42,8 +42,7 @@ public final class SingleError<T> extends Single<T> {
             error = new NullPointerException();
         }
         
-        s.onSubscribe(EmptyDisposable.INSTANCE);
-        s.onError(error);
+        EmptyDisposable.error(error, s);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapCompletable.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Maps the success value of the source SingleSource into a Completable. 
@@ -82,7 +82,7 @@ public final class SingleFlatMapCompletable<T> extends Completable {
             CompletableSource cs;
             
             try {
-                cs = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null CompletableSource");
+                cs = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null CompletableSource");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -56,16 +57,10 @@ public final class SingleUsing<T, U> extends Single<T> {
         SingleSource<? extends T> s1;
         
         try {
-            s1 = singleFunction.apply(resource);
+            s1 = Objects.requireNonNull(singleFunction.apply(resource), "The singleFunction returned a null SingleSource");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, s);
-            return;
-        }
-        
-        if (s1 == null) {
-            s.onSubscribe(EmptyDisposable.INSTANCE);
-            s.onError(new NullPointerException("The Single supplied by the function was null"));
             return;
         }
         

--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -21,6 +20,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SingleUsing<T, U> extends Single<T> {
@@ -57,7 +57,7 @@ public final class SingleUsing<T, U> extends Single<T> {
         SingleSource<? extends T> s1;
         
         try {
-            s1 = Objects.requireNonNull(singleFunction.apply(resource), "The singleFunction returned a null SingleSource");
+            s1 = ObjectHelper.requireNonNull(singleFunction.apply(resource), "The singleFunction returned a null SingleSource");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, s);

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -82,7 +82,7 @@ public final class TrampolineScheduler extends Scheduler {
             return enqueue(new SleepingRunnable(action, this, execTime), execTime);
         }
         
-        private Disposable enqueue(Runnable action, long execTime) {
+        Disposable enqueue(Runnable action, long execTime) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -146,9 +146,9 @@ public final class TrampolineScheduler extends Scheduler {
 
         @Override
         public int compareTo(TimedRunnable that) {
-            int result = Objects.compare(execTime, that.execTime);
+            int result = ObjectHelper.compare(execTime, that.execTime);
             if (result == 0) {
-                return Objects.compare(count, that.count);
+                return ObjectHelper.compare(count, that.count);
             }
             return result;
         }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableConditionalSubscriber.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.subscribers.flowable;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -153,7 +153,7 @@ public abstract class BasicFuseableConditionalSubscriber<T, R> implements Condit
      * @return the value if not null
      */
     protected final <V> V nullCheck(V value, String message) {
-        return Objects.requireNonNull(value, message);
+        return ObjectHelper.requireNonNull(value, message);
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BasicFuseableSubscriber.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.subscribers.flowable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -138,7 +138,7 @@ public abstract class BasicFuseableSubscriber<T, R> implements Subscriber<T>, Qu
      * @return the value if not null
      */
     protected final <V> V nullCheck(V value, String message) {
-        return Objects.requireNonNull(value, message);
+        return ObjectHelper.requireNonNull(value, message);
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BasicFuseableObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BasicFuseableObserver.java
@@ -17,7 +17,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -138,7 +138,7 @@ public abstract class BasicFuseableObserver<T, R> implements Observer<T>, QueueD
      * @return the value if not null
      */
     protected final <V> V nullCheck(V value, String message) {
-        return Objects.requireNonNull(value, message);
+        return ObjectHelper.requireNonNull(value, message);
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BasicFuseableObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BasicFuseableObserver.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.observable;
+
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Base class for a fuseable intermediate observer.
+ * @param <T> the upstream value type
+ * @param <R> the downstream value type
+ */
+public abstract class BasicFuseableObserver<T, R> implements Observer<T>, QueueDisposable<R> {
+
+    /** The downstream subscriber. */
+    protected final Observer<? super R> actual;
+    
+    /** The upstream subscription. */
+    protected Disposable s;
+    
+    /** The upstream's QueueDisposable if not null. */
+    protected QueueDisposable<T> qs;
+    
+    /** Flag indicating no further onXXX event should be accepted. */
+    protected boolean done;
+    
+    /** Holds the established fusion mode of the upstream. */
+    protected int sourceMode;
+    
+    /**
+     * Construct a BasicFuseableObserver by wrapping the given subscriber.
+     * @param actual the subscriber, not null (not verified)
+     */
+    public BasicFuseableObserver(Observer<? super R> actual) {
+        this.actual = actual;
+    }
+    
+    // final: fixed protocol steps to support fuseable and non-fuseable upstream
+    @SuppressWarnings("unchecked")
+    @Override
+    public final void onSubscribe(Disposable s) {
+        if (DisposableHelper.validate(this.s, s)) {
+            
+            this.s = s;
+            if (s instanceof QueueDisposable) {
+                this.qs = (QueueDisposable<T>)s;
+            }
+            
+            if (beforeDownstream()) {
+                
+                actual.onSubscribe(this);
+                
+                afterDownstream();
+            }
+            
+        }
+    }
+    
+    /**
+     * Override this to perform actions before the call {@code actual.onSubscribe(this)} happens.
+     * @return true if onSubscribe should continue with the call
+     */
+    protected boolean beforeDownstream() {
+        return true;
+    }
+    
+    /**
+     * Override this to perform actions after the call to {@code actual.onSubscribe(this)} happened.
+     */
+    protected void afterDownstream() {
+        // default no-op
+    }
+
+    // -----------------------------------
+    // Convenience and state-aware methods
+    // -----------------------------------
+
+    /**
+     * Emits the value to the actual subscriber if {@link #done} is false. 
+     * @param value the value to signal
+     */
+    protected final void next(R value) {
+        if (done) {
+            return;
+        }
+        actual.onNext(value);
+    }
+    
+    @Override
+    public void onError(Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        done = true;
+        actual.onError(t);
+    }
+    
+    /**
+     * Rethrows the throwable if it is a fatal exception or calls {@link #onError(Throwable)}.
+     * @param t the throwable to rethrow or signal to the actual subscriber
+     */
+    protected final void fail(Throwable t) {
+        Exceptions.throwIfFatal(t);
+        s.dispose();
+        onError(t);
+    }
+    
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        done = true;
+        actual.onComplete();
+    }
+    
+    /**
+     * Checks if the value is null and if so, throws a NullPointerException.
+     * @param value the value to check
+     * @param message the message to indicate the source of the value
+     * @return the value if not null
+     */
+    protected final <V> V nullCheck(V value, String message) {
+        return Objects.requireNonNull(value, message);
+    }
+    
+    /**
+     * Calls the upstream's QueueDisposable.requestFusion with the mode and
+     * saves the established mode in {@link #sourceMode}.
+     * <p>
+     * If the upstream doesn't support fusion ({@link #qs} is null), the method
+     * returns {@link QueueDisposable#NONE}.
+     * @param mode the fusion mode requested
+     * @return the established fusion mode
+     */
+    protected final int transitiveFusion(int mode) {
+        QueueDisposable<T> qs = this.qs;
+        if (qs != null) {
+            int m = qs.requestFusion(mode);
+            if (m != NONE) {
+                sourceMode = m;
+            }
+            return m;
+        }
+        return NONE;
+    }
+
+    /**
+     * Calls the upstream's QueueDisposable.requestFusion with the mode and
+     * saves the established mode in {@link #sourceMode} if that mode doesn't
+     * have the {@link QueueDisposable#BOUNDARY} flag set.
+     * <p>
+     * If the upstream doesn't support fusion ({@link #qs} is null), the method
+     * returns {@link QueueDisposable#NONE}.
+     * @param mode the fusion mode requested
+     * @return the established fusion mode
+     */
+    protected final int transitiveBoundaryFusion(int mode) {
+        QueueDisposable<T> qs = this.qs;
+        if (qs != null) {
+            if ((mode & BOUNDARY) == 0) {
+                int m = qs.requestFusion(mode);
+                if (m != NONE) {
+                    sourceMode = m;
+                }
+                return m;
+            }
+        }
+        return NONE;
+    }
+
+    // --------------------------------------------------------------
+    // Default implementation of the RS and QS protocol (overridable)
+    // --------------------------------------------------------------
+    
+    @Override
+    public void dispose() {
+        s.dispose();
+    }
+    
+    @Override
+    public boolean isDisposed() {
+        return s.isDisposed();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        return qs.isEmpty();
+    }
+    
+    @Override
+    public void clear() {
+        qs.clear();
+    }
+    
+    // -----------------------------------------------------------
+    // The rest of the Queue interface methods shouldn't be called
+    // -----------------------------------------------------------
+    
+    @Override
+    public final boolean offer(R e) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+    
+    @Override
+    public final boolean offer(R v1, R v2) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+}

--- a/src/main/java/io/reactivex/internal/subscribers/observable/InnerQueuedObserverSupport.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/InnerQueuedObserverSupport.java
@@ -11,19 +11,21 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.completable;
+package io.reactivex.internal.subscribers.observable;
 
-import io.reactivex.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
+/**
+ * Interface to allow the InnerQueuedSubscriber to call back a parent
+ * with signals.
+ *
+ * @param <T> the value type
+ */
+public interface InnerQueuedObserverSupport<T> {
 
-public final class CompletableEmpty extends Completable {
-    public static final Completable INSTANCE = new CompletableEmpty();
-
-    private CompletableEmpty() {
-    }
-
-    @Override
-    public void subscribeActual(CompletableObserver s) {
-        EmptyDisposable.complete(s);
-    }
+    void innerNext(InnerQueuedObserver<T> inner, T value);
+    
+    void innerError(InnerQueuedObserver<T> inner, Throwable e);
+    
+    void innerComplete(InnerQueuedObserver<T> inner);
+    
+    void drain();
 }

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.Subscription;
 
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
 /**
@@ -84,7 +84,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
             return;
         }
 
-        Objects.requireNonNull(s, "s is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         
         if (get() == 0 && compareAndSet(0, 1)) {
             Subscription a = actual;

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.Subscription;
 
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -120,7 +120,7 @@ public enum SubscriptionHelper {
      * @return true if the operation succeeded, false if the target field was not null.
      */
     public static boolean setOnce(AtomicReference<Subscription> field, Subscription d) {
-        Objects.requireNonNull(d, "d is null");
+        ObjectHelper.requireNonNull(d, "d is null");
         if (!field.compareAndSet(null, d)) {
             d.cancel();
             if (field.get() != CANCELLED) {

--- a/src/main/java/io/reactivex/internal/util/NotificationLite.java
+++ b/src/main/java/io/reactivex/internal/util/NotificationLite.java
@@ -18,7 +18,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Lightweight notification handling utility class.
@@ -63,7 +63,7 @@ public enum NotificationLite {
         public boolean equals(Object obj) {
             if (obj instanceof ErrorNotification) {
                 ErrorNotification n = (ErrorNotification) obj;
-                return Objects.equals(e, n.e);
+                return ObjectHelper.equals(e, n.e);
             }
             return false;
         }

--- a/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
@@ -395,7 +395,7 @@ public enum QueueDrainHelper {
      * spsc-linked-array if capacityHint is negative; in both cases, the
      * capacity is the absolute value of prefetch.
      * @param <T> the value type of the queue
-     * @param capacityHint the capacity hint
+     * @param capacityHint the capacity hint, negative value will create an array-based SPSC queue
      * @return the queue instance
      */
     public static <T> SimpleQueue<T> createQueue(int capacityHint) {

--- a/src/main/java/io/reactivex/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceObserver.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * An abstract Observer that allows asynchronous cancellation of its subscription and associated resources.
@@ -42,7 +42,7 @@ public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
      * @throws NullPointerException if resource is null
      */
     public final void add(Disposable resource) {
-        Objects.requireNonNull(resource, "resource is null");
+        ObjectHelper.requireNonNull(resource, "resource is null");
         resources.add(resource);
     }
     

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -22,22 +22,20 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.fuseable.QueueDisposable;
 
 /**
- * A subscriber that records events and allows making assertions about them.
+ * An Observer that records events and allows making assertions about them.
  *
- * <p>You can override the onSubscribe, onNext, onError, onComplete, request and
+ * <p>You can override the onSubscribe, onNext, onError, onComplete and
  * cancel methods but not the others (this is by desing).
  * 
  * <p>The TestSubscriber implements Disposable for convenience where dispose calls cancel.
  * 
- * <p>When calling the default request method, you are requesting on behalf of the
- * wrapped actual subscriber.
- * 
  * @param <T> the value type
  */
 public class TestObserver<T> implements Observer<T>, Disposable {
-    /** The actual subscriber to forward events to. */
+    /** The actual observer to forward events to. */
     private final Observer<? super T> actual;
     /** The latch that indicates an onError or onCompleted has been called. */
     private final CountDownLatch done;
@@ -47,10 +45,10 @@ public class TestObserver<T> implements Observer<T>, Disposable {
     private final List<Throwable> errors;
     /** The number of completions. */
     private long completions;
-    /** The last thread seen by the subscriber. */
+    /** The last thread seen by the observer. */
     private Thread lastThread;
     
-    /** Makes sure the incoming Subscriptions get cancelled immediately. */
+    /** Makes sure the incoming Disposables get cancelled immediately. */
     private volatile boolean cancelled;
 
     /** Holds the current subscription if any. */
@@ -58,16 +56,41 @@ public class TestObserver<T> implements Observer<T>, Disposable {
 
     private boolean checkSubscriptionOnce;
 
+    private int initialFusionMode;
+    
+    private int establishedFusionMode;
+    
+    private QueueDisposable<T> qs;
+    
     /**
-     * Constructs a non-forwarding TestSubscriber with an initial request value of Long.MAX_VALUE.
+     * Constructs a non-forwarding TestObserver.
+     * @param <T> the value type received
+     * @return the new TestObserver instance
+     */
+    public static <T> TestObserver<T> create() {
+        return new TestObserver<T>();
+    }
+    
+    /**
+     * Constructs a forwarding TestObserver.
+     * @param <T> the value type received
+     * @param delegate the actual Observer to forward events to
+     * @return the new TestObserver instance
+     */
+    public static <T> TestObserver<T> create(Observer<? super T> delegate) {
+        return new TestObserver<T>(delegate);
+    }
+
+    /**
+     * Constructs a non-forwarding TestObserver.
      */
     public TestObserver() {
         this(EmptyObserver.INSTANCE);
     }
 
     /**
-     * Constructs a forwarding TestSubscriber but leaves the requesting to the wrapped subscriber.
-     * @param actual the actual Subscriber to forward events to
+     * Constructs a forwarding TestObserver.
+     * @param actual the actual Observer to forward events to
      */
     public TestObserver(Observer<? super T> actual) {
         this.actual = actual;
@@ -76,6 +99,7 @@ public class TestObserver<T> implements Observer<T>, Disposable {
         this.done = new CountDownLatch(1);
     }
     
+    @SuppressWarnings("unchecked")
     @Override
     public void onSubscribe(Disposable s) {
         lastThread = Thread.currentThread();
@@ -96,6 +120,31 @@ public class TestObserver<T> implements Observer<T>, Disposable {
             s.dispose();
         }
         
+        if (initialFusionMode != 0) {
+            if (s instanceof QueueDisposable) {
+                qs = (QueueDisposable<T>)s;
+                
+                int m = qs.requestFusion(initialFusionMode);
+                establishedFusionMode = m;
+                
+                if (m == QueueDisposable.SYNC) {
+                    checkSubscriptionOnce = true;
+                    lastThread = Thread.currentThread();
+                    try {
+                        T t;
+                        while ((t = qs.poll()) != null) {
+                            values.add(t);
+                        }
+                        completions++;
+                    } catch (Throwable ex) {
+                        // Exceptions.throwIfFatal(e); TODO add fatals?
+                        errors.add(ex);
+                    }
+                    return;
+                }
+            }
+        }
+        
         actual.onSubscribe(s);
         
         if (cancelled) {
@@ -113,6 +162,19 @@ public class TestObserver<T> implements Observer<T>, Disposable {
         }
 
         lastThread = Thread.currentThread();
+
+        if (establishedFusionMode == QueueDisposable.ASYNC) {
+            try {
+                while ((t = qs.poll()) != null) {
+                    values.add(t);
+                }
+            } catch (Throwable ex) {
+                // Exceptions.throwIfFatal(e); TODO add fatals?
+                errors.add(ex);
+            }
+            return;
+        }
+
         values.add(t);
         
         if (t == null) {
@@ -170,6 +232,15 @@ public class TestObserver<T> implements Observer<T>, Disposable {
      */
     public final boolean isCancelled() {
         return cancelled;
+    }
+    
+    /**
+     * Cancels the TestObserver (before or after the subscription happened).
+     * <p>This operation is threadsafe.
+     * <p>This method is provided as a convenience when converting Flowable tests that cancel.
+     */
+    public final void cancel() {
+        dispose();
     }
     
     @Override
@@ -253,15 +324,17 @@ public class TestObserver<T> implements Observer<T>, Disposable {
     
     /**
      * Awaits until this TestSubscriber receives an onError or onComplete events.
+     * @return this
      * @throws InterruptedException if the current thread is interrupted while waiting
      * @see #awaitTerminalEvent()
      */
-    public final void await() throws InterruptedException {
+    public final TestObserver<T> await() throws InterruptedException {
         if (done.getCount() == 0) {
-            return;
+            return this;
         }
         
         done.await();
+        return this;
     }
     
     /**
@@ -675,6 +748,65 @@ public class TestObserver<T> implements Observer<T>, Disposable {
         result.add(completeList);
         
         return result;
+    }
+
+    /**
+     * Sets the initial fusion mode if the upstream supports fusion.
+     * @param mode the mode to establish, see the {@link QueueDisposable} constants
+     * @return this
+     */
+    public final TestObserver<T> setInitialFusionMode(int mode) {
+        this.initialFusionMode = mode;
+        return this;
+    }
+    
+    /**
+     * Asserts that the given fusion mode has been established
+     * @param mode the expected mode
+     * @return this
+     */
+    public final TestObserver<T> assertFusionMode(int mode) {
+        int m = establishedFusionMode;
+        if (m != mode) {
+            if (qs != null) {
+                throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
+                + ", actual: " + fusionModeToString(m));
+            } else {
+                throw new AssertionError("Upstream is not fuseable");
+            }
+        }
+        return this;
+    }
+    
+    private String fusionModeToString(int mode) {
+        switch (mode) {
+        case QueueDisposable.NONE : return "NONE";
+        case QueueDisposable.SYNC : return "SYNC";
+        case QueueDisposable.ASYNC : return "ASYNC";
+        default: return "Unknown(" + mode + ")";
+        }
+    }
+    
+    /**
+     * Assert that the upstream is a fuseable source.
+     * @return this
+     */
+    public final TestObserver<T> assertFuseable() {
+        if (qs == null) {
+            throw new AssertionError("Upstream is not fuseable.");
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the upstream is not a fuseable source.
+     * @return this
+     */
+    public final TestObserver<T> assertNotFuseable() {
+        if (qs != null) {
+            throw new AssertionError("Upstream is fuseable.");
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -21,7 +21,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueDisposable;
 
 /**
@@ -500,7 +500,7 @@ public class TestObserver<T> implements Observer<T>, Disposable {
             fail("Expected: " + valueAndClass(value) + ", Actual: " + values);
         }
         T v = values.get(0);
-        if (!Objects.equals(value, v)) {
+        if (!ObjectHelper.equals(value, v)) {
             fail("Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v));
         }
         return this;
@@ -550,7 +550,7 @@ public class TestObserver<T> implements Observer<T>, Disposable {
         for (int i = 0; i < s; i++) {
             T v = this.values.get(i);
             T u = values[i];
-            if (!Objects.equals(u, v)) {
+            if (!ObjectHelper.equals(u, v)) {
                 fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
         }
@@ -596,7 +596,7 @@ public class TestObserver<T> implements Observer<T>, Disposable {
             T v = it.next();
             T u = vit.next();
             
-            if (!Objects.equals(u, v)) {
+            if (!ObjectHelper.equals(u, v)) {
                 fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
             i++;
@@ -717,7 +717,7 @@ public class TestObserver<T> implements Observer<T>, Disposable {
                 fail("Error is null");
             }
             String errorMessage = e.getMessage();
-            if (!Objects.equals(message, errorMessage)) {
+            if (!ObjectHelper.equals(message, errorMessage)) {
                 fail("Error message differs; Expected: " + message + ", Actual: " + errorMessage);
             }
         } else {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -95,7 +95,7 @@ public final class BehaviorProcessor<T> extends FlowProcessor<T> {
      * @return the constructed {@link BehaviorProcessor}
      */
     public static <T> BehaviorProcessor<T> createDefault(T defaultValue) {
-        Objects.requireNonNull(defaultValue, "defaultValue is null");
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         State<T> state = new State<T>();
         state.lazySet(defaultValue);
         return new BehaviorProcessor<T>(state);

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.Scheduler;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -211,8 +211,8 @@ public final class ReplayProcessor<T> extends FlowProcessor<T> {
      * @return the created subject
      */
     public static <T> ReplayProcessor<T> createWithTimeAndSize(long maxAge, TimeUnit unit, Scheduler scheduler, int size) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         if (size <= 0) {
             throw new IllegalArgumentException("size > 0 required but it was " + size);
         }

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
@@ -84,7 +84,7 @@ public final class UnicastProcessor<T> extends FlowProcessor<T> {
      */
     public UnicastProcessor(int capacityHint, Runnable onTerminate) {
         this.queue = new SpscLinkedArrayQueue<T>(capacityHint);
-        this.onTerminate = new AtomicReference<Runnable>(Objects.requireNonNull(onTerminate, "onTerminate"));
+        this.onTerminate = new AtomicReference<Runnable>(ObjectHelper.requireNonNull(onTerminate, "onTerminate"));
         this.actual = new AtomicReference<Subscriber<? super T>>();
         this.once = new AtomicBoolean();
         this.wip = new UnicastQueueSubscription();

--- a/src/main/java/io/reactivex/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/schedulers/TestScheduler.java
@@ -19,7 +19,7 @@ import java.util.concurrent.*;
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * A special, non thread-safe scheduler for testing operators that require
@@ -56,9 +56,9 @@ public final class TestScheduler extends Scheduler {
         @Override
         public int compareTo(TimedRunnable o) {
             if (time == o.time) {
-                return Objects.compare(count, o.count);
+                return ObjectHelper.compare(count, o.count);
             }
-            return Objects.compare(time, o.time);
+            return ObjectHelper.compare(time, o.time);
         }
     }
 

--- a/src/main/java/io/reactivex/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/schedulers/Timed.java
@@ -15,7 +15,7 @@ package io.reactivex.schedulers;
 
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Holds onto a value along with time information.
@@ -37,7 +37,7 @@ public final class Timed<T> {
     public Timed(T value, long time, TimeUnit unit) {
         this.value = value;
         this.time = time;
-        this.unit = Objects.requireNonNull(unit, "unit is null");
+        this.unit = ObjectHelper.requireNonNull(unit, "unit is null");
     }
     
     /**
@@ -77,9 +77,9 @@ public final class Timed<T> {
     public boolean equals(Object other) {
         if (other instanceof Timed) {
             Timed<?> o = (Timed<?>) other;
-            return Objects.equals(value, o.value)
+            return ObjectHelper.equals(value, o.value)
                     && time == o.time
-                    && Objects.equals(unit, o.unit);
+                    && ObjectHelper.equals(unit, o.unit);
         }
         return false;
     }

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -21,7 +21,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -95,7 +95,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
      * @return the constructed {@link BehaviorSubject}
      */
     public static <T> BehaviorSubject<T> createDefault(T defaultValue) {
-        Objects.requireNonNull(defaultValue, "defaultValue is null");
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         State<T> state = new State<T>();
         state.lazySet(defaultValue);
         return new BehaviorSubject<T>(state);

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.*;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -208,8 +208,8 @@ public final class ReplaySubject<T> extends Subject<T> {
      * @return the created subject
      */
     public static <T> ReplaySubject<T> createWithTimeAndSize(long maxAge, TimeUnit unit, Scheduler scheduler, int size) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         if (size <= 0) {
             throw new IllegalArgumentException("size > 0 required but it was " + size);
         }

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -148,8 +148,7 @@ public final class UnicastSubject<T> extends Subject<T> {
                 subscriber.lazySet(s); // full barrier in drain
                 drain();
             } else {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
-                s.onError(new IllegalStateException("Only a single subscriber allowed."));
+                EmptyDisposable.error(new IllegalStateException("Only a single subscriber allowed."), s);
             }
         }
         

--- a/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
@@ -51,7 +51,7 @@ public abstract class ResourceSubscriber<T> implements Subscriber<T>, Disposable
      * @throws NullPointerException if resource is null
      */
     public final void add(Disposable resource) {
-        Objects.requireNonNull(resource, "resource is null");
+        ObjectHelper.requireNonNull(resource, "resource is null");
         resources.add(resource);
     }
     

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.Notification;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
-import io.reactivex.internal.functions.Objects;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -564,7 +564,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
             fail("Expected: " + valueAndClass(value) + ", Actual: " + values);
         }
         T v = values.get(0);
-        if (!Objects.equals(value, v)) {
+        if (!ObjectHelper.equals(value, v)) {
             fail("Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v));
         }
         return this;
@@ -614,7 +614,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
         for (int i = 0; i < s; i++) {
             T v = this.values.get(i);
             T u = values[i];
-            if (!Objects.equals(u, v)) {
+            if (!ObjectHelper.equals(u, v)) {
                 fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
         }
@@ -660,7 +660,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
             T v = it.next();
             T u = vit.next();
             
-            if (!Objects.equals(u, v)) {
+            if (!ObjectHelper.equals(u, v)) {
                 fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
             i++;
@@ -781,7 +781,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
                 fail("Error is null");
             }
             String errorMessage = e.getMessage();
-            if (!Objects.equals(message, errorMessage)) {
+            if (!ObjectHelper.equals(message, errorMessage)) {
                 fail("Error message differs; Expected: " + message + ", Actual: " + errorMessage);
             }
         } else {

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -107,8 +107,7 @@ public class CompletableTest {
             @Override
             public void subscribe(CompletableObserver s) {
                 getAndIncrement();
-                s.onSubscribe(EmptyDisposable.INSTANCE);
-                s.onComplete();
+                EmptyDisposable.complete(s);
             }
         });
         
@@ -133,8 +132,7 @@ public class CompletableTest {
             @Override
             public void subscribe(CompletableObserver s) {
                 getAndIncrement();
-                s.onSubscribe(EmptyDisposable.INSTANCE);
-                s.onError(new TestException());
+                EmptyDisposable.error(new TestException(), s);
             }
         });
         
@@ -2690,8 +2688,7 @@ public class CompletableTest {
             @Override
             public void subscribe(CompletableObserver s) {
                 name.set(Thread.currentThread().getName());
-                s.onSubscribe(EmptyDisposable.INSTANCE);
-                s.onComplete();
+                EmptyDisposable.complete(s);
             }
         }).subscribeOn(Schedulers.computation());
         
@@ -2708,8 +2705,7 @@ public class CompletableTest {
             @Override
             public void subscribe(CompletableObserver s) {
                 name.set(Thread.currentThread().getName());
-                s.onSubscribe(EmptyDisposable.INSTANCE);
-                s.onError(new TestException());
+                EmptyDisposable.error(new TestException(), s);
             }
         }).subscribeOn(Schedulers.computation());
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -577,7 +578,7 @@ public class FlowableConcatMapEagerTest {
             }
         }).observeOn(Schedulers.newThread()).subscribe(ts);
         
-        ts.awaitTerminalEvent();
+        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
         ts.assertValueCount(2000);
     }
@@ -714,7 +715,7 @@ public class FlowableConcatMapEagerTest {
     }
 
     @Test
-    public void Flowable() {
+    public void flowable() {
         Flowable<Integer> source = Flowable.just(1);
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
@@ -726,7 +727,7 @@ public class FlowableConcatMapEagerTest {
     }
     
     @Test
-    public void FlowableCapacityHint() {
+    public void flowableCapacityHint() {
         Flowable<Integer> source = Flowable.just(1);
         TestSubscriber<Integer> ts = TestSubscriber.create();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
@@ -25,8 +25,8 @@ import org.junit.*;
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.processors.BehaviorProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
@@ -238,7 +238,7 @@ public class BlockingObservableNextTest {
 
             @Override
             public void subscribe(final Observer<? super Integer> o) {
-                o.onSubscribe(EmptyDisposable.INSTANCE);
+                o.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
 
                     @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -20,8 +20,8 @@ import java.util.Iterator;
 import org.junit.*;
 
 import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.disposables.EmptyDisposable;
 
 public class BlockingObservableToIteratorTest {
 
@@ -50,7 +50,7 @@ public class BlockingObservableToIteratorTest {
 
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 NbpObserver.onNext("one");
                 NbpObserver.onError(new TestException());
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -26,9 +26,9 @@ import org.mockito.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
@@ -63,7 +63,7 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 NbpObserver.onNext("one");
                 NbpObserver.onNext("two");
                 NbpObserver.onNext("three");
@@ -119,7 +119,7 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 10);
                 push(NbpObserver, "two", 90);
                 push(NbpObserver, "three", 110);
@@ -151,7 +151,7 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 97);
                 push(NbpObserver, "two", 98);
                 /**
@@ -185,7 +185,7 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 10);
                 push(NbpObserver, "two", 60);
                 push(NbpObserver, "three", 110);
@@ -198,7 +198,7 @@ public class ObservableBufferTest {
         Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
             public void subscribe(Observer<Object> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, new Object(), 50);
                 push(NbpObserver, new Object(), 200);
                 complete(NbpObserver, 250);
@@ -211,7 +211,7 @@ public class ObservableBufferTest {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         push(NbpObserver, new Object(), 100);
                         complete(NbpObserver, 101);
                     }
@@ -236,7 +236,7 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 10);
                 push(NbpObserver, "two", 60);
                 push(NbpObserver, "three", 110);
@@ -252,7 +252,7 @@ public class ObservableBufferTest {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         push(NbpObserver, new Object(), 100);
                         push(NbpObserver, new Object(), 200);
                         push(NbpObserver, new Object(), 300);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -25,9 +25,9 @@ import org.junit.*;
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
@@ -61,16 +61,16 @@ public class ObservableCacheTest {
         Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(final Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            public void subscribe(final Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         counter.incrementAndGet();
                         System.out.println("published NbpObservable being executed");
-                        NbpObserver.onNext("one");
-                        NbpObserver.onComplete();
+                        observer.onNext("one");
+                        observer.onComplete();
                     }
                 }).start();
             }
@@ -195,7 +195,7 @@ public class ObservableCacheTest {
         Observable<Integer> firehose = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t) {
-                t.onSubscribe(EmptyDisposable.INSTANCE);
+                t.onSubscribe(Disposables.empty());
                 for (int i = 0; i < m; i++) {
                     t.onNext(i);
                 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -1,0 +1,734 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
+
+import org.junit.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+
+public class ObservableConcatMapEagerTest {
+
+    @Test
+    public void normal() {
+        Observable.range(1, 5)
+        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer t) {
+                return Observable.range(t, 2);
+            }
+        })
+        .test()
+        .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    @Ignore("Observable doesn't do backpressure")
+    public void normalBackpressured() {
+//        TestObserver<Integer> ts = Observable.range(1, 5)
+//        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+//            @Override
+//            public ObservableSource<Integer> apply(Integer t) {
+//                return Observable.range(t, 2);
+//            }
+//        })
+//        .test(3);
+//        
+//        ts.assertValues(1, 2, 2);
+//        
+//        ts.request(1);
+//        
+//        ts.assertValues(1, 2, 2, 3);
+//        
+//        ts.request(1);
+//
+//        ts.assertValues(1, 2, 2, 3, 3);
+//
+//        ts.request(5);
+//
+//        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalDelayBoundary() {
+        Observable.range(1, 5)
+        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer t) {
+                return Observable.range(t, 2);
+            }
+        }, false)
+        .test()
+        .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    @Ignore("Observable doesn't do backpressure")
+    public void normalDelayBoundaryBackpressured() {
+//        TestObserver<Integer> ts = Observable.range(1, 5)
+//        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
+//            @Override
+//            public ObservableSource<Integer> apply(Integer t) {
+//                return Observable.range(t, 2);
+//            }
+//        }, false)
+//        .test(3);
+//        
+//        ts.assertValues(1, 2, 2);
+//        
+//        ts.request(1);
+//        
+//        ts.assertValues(1, 2, 2, 3);
+//        
+//        ts.request(1);
+//
+//        ts.assertValues(1, 2, 2, 3, 3);
+//
+//        ts.request(5);
+//
+//        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void normalDelayEnd() {
+        Observable.range(1, 5)
+        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer t) {
+                return Observable.range(t, 2);
+            }
+        }, true)
+        .test()
+        .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    @Ignore("Observable doesn't do backpressure")
+    public void normalDelayEndBackpressured() {
+//        TestObserver<Integer> ts = Observable.range(1, 5)
+//        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
+//            @Override
+//            public ObservableSource<Integer> apply(Integer t) {
+//                return Observable.range(t, 2);
+//            }
+//        }, true)
+//        .test(3);
+//        
+//        ts.assertValues(1, 2, 2);
+//        
+//        ts.request(1);
+//        
+//        ts.assertValues(1, 2, 2, 3);
+//        
+//        ts.request(1);
+//
+//        ts.assertValues(1, 2, 2, 3, 3);
+//
+//        ts.request(5);
+//
+//        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+    }
+    
+    @Test
+    public void mainErrorsDelayBoundary() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        final PublishSubject<Integer> inner = PublishSubject.create();
+        
+        TestObserver<Integer> ts = main.concatMapEagerDelayError(
+                new Function<Integer, ObservableSource<Integer>>() {
+                    @Override
+                    public ObservableSource<Integer> apply(Integer t) {
+                        return inner;
+                    }
+                }, false).test();
+        
+        main.onNext(1);
+        
+        inner.onNext(2);
+        
+        ts.assertValue(2);
+        
+        main.onError(new TestException("Forced failure"));
+        
+        ts.assertNoErrors();
+        
+        inner.onNext(3);
+        inner.onComplete();
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3);
+    }
+
+    @Test
+    public void mainErrorsDelayEnd() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        final PublishSubject<Integer> inner = PublishSubject.create();
+        
+        TestObserver<Integer> ts = main.concatMapEagerDelayError(
+                new Function<Integer, ObservableSource<Integer>>() {
+                    @Override
+                    public ObservableSource<Integer> apply(Integer t) {
+                        return inner;
+                    }
+                }, true).test();
+        
+        main.onNext(1);
+        main.onNext(2);
+        
+        inner.onNext(2);
+        
+        ts.assertValue(2);
+        
+        main.onError(new TestException("Forced failure"));
+        
+        ts.assertNoErrors();
+        
+        inner.onNext(3);
+        inner.onComplete();
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3, 2, 3);
+    }
+    
+    @Test
+    public void mainErrorsImmediate() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        final PublishSubject<Integer> inner = PublishSubject.create();
+        
+        TestObserver<Integer> ts = main.concatMapEager(
+                new Function<Integer, ObservableSource<Integer>>() {
+                    @Override
+                    public ObservableSource<Integer> apply(Integer t) {
+                        return inner;
+                    }
+                }).test();
+        
+        main.onNext(1);
+        main.onNext(2);
+        
+        inner.onNext(2);
+        
+        ts.assertValue(2);
+        
+        main.onError(new TestException("Forced failure"));
+
+        assertFalse("inner has subscribers?", inner.hasObservers());
+        
+        inner.onNext(3);
+        inner.onComplete();
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2);
+    }
+    
+    @Test
+    public void longEager() {
+        
+        Observable.range(1, 2 * Observable.bufferSize())
+        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) {
+                return Observable.just(1);
+            }
+        })
+        .test()
+        .assertValueCount(2 * Observable.bufferSize())
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    TestObserver<Object> ts;
+    
+    Function<Integer, Observable<Integer>> toJust = new Function<Integer, Observable<Integer>>() {
+        @Override
+        public Observable<Integer> apply(Integer t) {
+            return Observable.just(t);
+        }
+    };
+
+    Function<Integer, Observable<Integer>> toRange = new Function<Integer, Observable<Integer>>() {
+        @Override
+        public Observable<Integer> apply(Integer t) {
+            return Observable.range(t, 2);
+        }
+    };
+
+    @Before
+    public void before() {
+        ts = new TestObserver<Object>();
+    }
+    
+    @Test
+    public void testSimple() {
+        Observable.range(1, 100).concatMapEager(toJust).subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(100);
+        ts.assertComplete();
+    }
+
+    @Test
+    public void testSimple2() {
+        Observable.range(1, 100).concatMapEager(toRange).subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertValueCount(200);
+        ts.assertComplete();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness2() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source).subscribe(ts);
+        
+        Assert.assertEquals(2, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness3() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(3, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness4() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(4, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness5() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(5, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness6() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source, source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(6, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness7() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source, source, source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(7, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness8() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source, source, source, source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(8, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEagerness9() {
+        final AtomicInteger count = new AtomicInteger();
+        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                count.getAndIncrement();
+            }
+        }).hide();
+        
+        Observable.concatArrayEager(source, source, source, source, source, source, source, source, source).subscribe(ts);
+        
+        Assert.assertEquals(9, count.get());
+        
+        ts.assertValueCount(count.get());
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void testMainError() {
+        Observable.<Integer>error(new TestException()).concatMapEager(toJust).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testInnerError() {
+        // TODO verify: concatMapEager subscribes first then consumes the sources is okay
+        
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        Observable.concatArrayEager(Observable.just(1), ps)
+        .subscribe(ts);
+        
+        ps.onError(new TestException());
+        
+        ts.assertValue(1);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testInnerEmpty() {
+        Observable.concatArrayEager(Observable.empty(), Observable.empty()).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void testMapperThrows() {
+        Observable.just(1).concatMapEager(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                throw new TestException();
+            } 
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(TestException.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCapacityHint() {
+        Observable.just(1).concatMapEager(toJust, 0, Observable.bufferSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidMaxConcurrent() {
+        Observable.just(1).concatMapEager(toJust, Observable.bufferSize(), 0);
+    }
+    
+    @Test
+//    @SuppressWarnings("unchecked")
+    @Ignore("Observable doesn't do backpressure")
+    public void testBackpressure() {
+//        Observable.concatArrayEager(Observable.just(1), Observable.just(1)).subscribe(ts);
+//
+//        ts.assertNoErrors();
+//        ts.assertNoValues();
+//        ts.assertNotComplete();
+//        
+//        ts.request(1);
+//        ts.assertValue(1);
+//        ts.assertNoErrors();
+//        ts.assertNotComplete();
+//        
+//        ts.request(1);
+//        ts.assertValues(1, 1);
+//        ts.assertNoErrors();
+//        ts.assertComplete();
+    }
+    
+    @Test
+    public void testAsynchronousRun() {
+        Observable.range(1, 2).concatMapEager(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                return Observable.range(1, 1000).subscribeOn(Schedulers.computation());
+            }
+        }).observeOn(Schedulers.newThread()).subscribe(ts);
+        
+        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        ts.assertNoErrors();
+        ts.assertValueCount(2000);
+    }
+    
+    @Test
+    public void testReentrantWork() {
+        final PublishSubject<Integer> subject = PublishSubject.create();
+        
+        final AtomicBoolean once = new AtomicBoolean();
+        
+        subject.concatMapEager(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                return Observable.just(t);
+            }
+        })
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer t) {
+                if (once.compareAndSet(false, true)) {
+                    subject.onNext(2);
+                }
+            }
+        })
+        .subscribe(ts);
+        
+        subject.onNext(1);
+        
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+        ts.assertValues(1, 2);
+    }
+    
+    @Test
+    @Ignore("Observable doesn't do backpressure so it can't bound its input count")
+    public void testPrefetchIsBounded() {
+        final AtomicInteger count = new AtomicInteger();
+        
+        TestObserver<Object> ts = TestObserver.create();
+        
+        Observable.just(1).concatMapEager(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                return Observable.range(1, Observable.bufferSize() * 2)
+                        .doOnNext(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer t) {
+                                count.getAndIncrement();
+                            }
+                        }).hide();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoErrors();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        Assert.assertEquals(Observable.bufferSize(), count.get());
+    }
+    
+    @Test
+    @Ignore("Null values are not allowed in RS")
+    public void testInnerNull() {
+        Observable.just(1).concatMapEager(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                return Observable.just(null);
+            }
+        }).subscribe(ts);
+
+        ts.assertNoErrors();
+        ts.assertComplete();
+        ts.assertValue(null);
+    }
+
+
+    @Test
+    @Ignore("Observable doesn't do backpressure")
+    public void testMaxConcurrent5() {
+//        final List<Long> requests = new ArrayList<Long>();
+//        Observable.range(1, 100).doOnRequest(new LongConsumer() {
+//            @Override
+//            public void accept(long reqCount) {
+//                requests.add(reqCount);
+//            }
+//        }).concatMapEager(toJust, 5, Observable.bufferSize()).subscribe(ts);
+//
+//        ts.assertNoErrors();
+//        ts.assertValueCount(100);
+//        ts.assertComplete();
+//
+//        Assert.assertEquals(5, (long) requests.get(0));
+//        Assert.assertEquals(1, (long) requests.get(1));
+//        Assert.assertEquals(1, (long) requests.get(2));
+//        Assert.assertEquals(1, (long) requests.get(3));
+//        Assert.assertEquals(1, (long) requests.get(4));
+//        Assert.assertEquals(1, (long) requests.get(5));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    @Ignore("Currently there are no 2-9 argument variants, use concatArrayEager()")
+    public void many() throws Exception {
+        for (int i = 2; i < 10; i++) {
+            Class<?>[] clazz = new Class[i];
+            Arrays.fill(clazz, Observable.class);
+            
+            Observable<Integer>[] obs = new Observable[i];
+            Arrays.fill(obs, Observable.just(1));
+            
+            Integer[] expected = new Integer[i];
+            Arrays.fill(expected, 1);
+            
+            Method m = Observable.class.getMethod("concatEager", clazz);
+            
+            TestObserver<Integer> ts = TestObserver.create();
+            
+            ((Observable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
+            
+            ts.assertValues(expected);
+            ts.assertNoErrors();
+            ts.assertComplete();
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void capacityHint() {
+        Observable<Integer> source = Observable.just(1);
+        TestObserver<Integer> ts = TestObserver.create();
+
+        Observable.concatEager(Arrays.asList(source, source, source), 1, 1).subscribe(ts);
+        
+        ts.assertValues(1, 1, 1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void Observable() {
+        Observable<Integer> source = Observable.just(1);
+        TestObserver<Integer> ts = TestObserver.create();
+
+        Observable.concatEager(Observable.just(source, source, source)).subscribe(ts);
+        
+        ts.assertValues(1, 1, 1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void ObservableCapacityHint() {
+        Observable<Integer> source = Observable.just(1);
+        TestObserver<Integer> ts = TestObserver.create();
+
+        Observable.concatEager(Observable.just(source, source, source), 1, 1).subscribe(ts);
+        
+        ts.assertValues(1, 1, 1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void badCapacityHint() throws Exception {
+        Observable<Integer> source = Observable.just(1);
+        try {
+            Observable.concatEager(Arrays.asList(source, source, source), 1, -99);
+        } catch (IllegalArgumentException ex) {
+            assertEquals("prefetch > 0 required but it was -99", ex.getMessage());
+        }
+        
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void mappingBadCapacityHint() throws Exception {
+        Observable<Integer> source = Observable.just(1);
+        try {
+            Observable.just(source, source, source).concatMapEager((Function)Functions.identity(), 10, -99);
+        } catch (IllegalArgumentException ex) {
+            assertEquals("prefetch > 0 required but it was -99", ex.getMessage());
+        }
+        
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -29,7 +29,6 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.*;
 import io.reactivex.subjects.*;
@@ -84,7 +83,7 @@ public class ObservableConcatTest {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 // simulate what would happen in an NbpObservable
                 NbpObserver.onNext(odds);
                 NbpObserver.onNext(even);
@@ -347,7 +346,7 @@ public class ObservableConcatTest {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 // simulate what would happen in an NbpObservable
                 NbpObserver.onNext(Observable.unsafeCreate(w1));
                 NbpObserver.onNext(Observable.unsafeCreate(w2));
@@ -662,7 +661,7 @@ public class ObservableConcatTest {
 
             @Override
             public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 s.onNext("hello");
                 s.onComplete();
                 s.onComplete();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -13,7 +13,8 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 import io.reactivex.*;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -22,9 +22,9 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
@@ -47,7 +47,7 @@ public class ObservableDebounceTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
                 publishNext(NbpObserver, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
                 publishNext(NbpObserver, 900, "three");   // Should be skipped since onCompleted will arrive before the timeout expires.
@@ -73,7 +73,7 @@ public class ObservableDebounceTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 // all should be skipped since they are happening faster than the 200ms timeout
                 publishNext(NbpObserver, 100, "a");    // Should be skipped
                 publishNext(NbpObserver, 200, "b");    // Should be skipped
@@ -103,7 +103,7 @@ public class ObservableDebounceTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 Exception error = new TestException();
                 publishNext(NbpObserver, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
                 publishNext(NbpObserver, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import java.lang.ref.WeakReference;
+
+import org.junit.*;
+
+import io.reactivex.Observable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+
+
+public class ObservableDetachTest {
+
+    Object o;
+    
+    @Test
+    public void just() throws Exception {
+        o = new Object();
+        
+        WeakReference<Object> wr = new WeakReference<Object>(o);
+        
+        TestObserver<Object> ts = new TestObserver<Object>();
+        
+        Observable.just(o).count().onTerminateDetach().subscribe(ts);
+        
+        ts.assertValue(1L);
+        ts.assertComplete();
+        ts.assertNoErrors();
+        
+        o = null;
+        
+        System.gc();
+        Thread.sleep(200);
+        
+        Assert.assertNull("Object retained!", wr.get());
+        
+    }
+    
+    @Test
+    public void error() {
+        TestObserver<Object> ts = new TestObserver<Object>();
+        
+        Observable.error(new TestException()).onTerminateDetach().subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+    
+    @Test
+    public void empty() {
+        TestObserver<Object> ts = new TestObserver<Object>();
+        
+        Observable.empty().onTerminateDetach().subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void range() {
+        TestObserver<Object> ts = new TestObserver<Object>();
+        
+        Observable.range(1, 1000).onTerminateDetach().subscribe(ts);
+        
+        ts.assertValueCount(1000);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    
+    @Test
+    @Ignore("Observable doesn't do backpressure")
+    public void backpressured() throws Exception {
+//        o = new Object();
+//        
+//        WeakReference<Object> wr = new WeakReference<Object>(o);
+//        
+//        TestObserver<Object> ts = new TestObserver<Object>(0L);
+//        
+//        Observable.just(o).count().onTerminateDetach().subscribe(ts);
+//
+//        ts.assertNoValues();
+//
+//        ts.request(1);
+//        
+//        ts.assertValue(1L);
+//        ts.assertComplete();
+//        ts.assertNoErrors();
+//        
+//        o = null;
+//        
+//        System.gc();
+//        Thread.sleep(200);
+//        
+//        Assert.assertNull("Object retained!", wr.get());
+    }
+
+    @Test
+    public void justUnsubscribed() throws Exception {
+        o = new Object();
+        
+        WeakReference<Object> wr = new WeakReference<Object>(o);
+        
+        TestObserver<Long> ts = Observable.just(o).count().onTerminateDetach().test();
+
+        o = null;
+        ts.cancel();
+        
+        System.gc();
+        Thread.sleep(200);
+        
+        Assert.assertNull("Object retained!", wr.get());
+        
+    }
+
+    @Test
+    @Ignore("Observable doesn't do backpressure")
+    public void deferredUpstreamProducer() {
+//        final AtomicReference<Subscriber<? super Object>> subscriber = new AtomicReference<Subscriber<? super Object>>();
+//        
+//        TestObserver<Object> ts = new TestObserver<Object>(0);
+//        
+//        Observable.unsafeCreate(new ObservableSource<Object>() {
+//            @Override
+//            public void subscribe(Subscriber<? super Object> t) {
+//                subscriber.set(t);
+//            }
+//        }).onTerminateDetach().subscribe(ts);
+//        
+//        ts.request(2);
+//        
+//        new ObservableRange(1, 3).subscribe(subscriber.get());
+//        
+//        ts.assertValues(1, 2);
+//        
+//        ts.request(1);
+//        
+//        ts.assertValues(1, 2, 3);
+//        ts.assertComplete();
+//        ts.assertNoErrors();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnSubscribeTest.java
@@ -20,9 +20,8 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.disposables.EmptyDisposable;
 
 public class ObservableDoOnSubscribeTest {
 
@@ -71,7 +70,7 @@ public class ObservableDoOnSubscribeTest {
 
             @Override
             public void subscribe(Observer<? super Integer> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 onSubscribed.incrementAndGet();
                 sref.set(s);
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -30,7 +30,6 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observables.GroupedObservable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
@@ -186,7 +185,7 @@ public class ObservableGroupByTest {
 
             @Override
             public void subscribe(final Observer<? super Event> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 System.out.println("*** Subscribing to EventStream ***");
                 subscribeCounter.incrementAndGet();
                 new Thread(new Runnable() {
@@ -598,7 +597,7 @@ public class ObservableGroupByTest {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
-                sub.onSubscribe(EmptyDisposable.INSTANCE);
+                sub.onSubscribe(Disposables.empty());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -677,7 +676,7 @@ public class ObservableGroupByTest {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
-                sub.onSubscribe(EmptyDisposable.INSTANCE);
+                sub.onSubscribe(Disposables.empty());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -769,7 +768,7 @@ public class ObservableGroupByTest {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
-                sub.onSubscribe(EmptyDisposable.INSTANCE);
+                sub.onSubscribe(Disposables.empty());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -846,7 +845,7 @@ public class ObservableGroupByTest {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
-                sub.onSubscribe(EmptyDisposable.INSTANCE);
+                sub.onSubscribe(Disposables.empty());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -903,7 +902,7 @@ public class ObservableGroupByTest {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
-                sub.onSubscribe(EmptyDisposable.INSTANCE);
+                sub.onSubscribe(Disposables.empty());
                 sub.onNext(1);
                 sub.onNext(2);
                 sub.onNext(1);
@@ -1426,7 +1425,7 @@ public class ObservableGroupByTest {
                 new ObservableSource<Integer>() {
                     @Override
                     public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                        NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpSubscriber.onSubscribe(Disposables.empty());
                         NbpSubscriber.onNext(0);
                         NbpSubscriber.onNext(1);
                         NbpSubscriber.onError(e);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 
 public class ObservableMaterializeTest {
@@ -149,7 +149,7 @@ public class ObservableMaterializeTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -26,8 +26,8 @@ import org.mockito.InOrder;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 
 public class ObservableMergeDelayErrorTest {
@@ -219,7 +219,7 @@ public class ObservableMergeDelayErrorTest {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 // simulate what would happen in an NbpObservable
                 NbpObserver.onNext(o1);
                 NbpObserver.onNext(o2);
@@ -317,7 +317,7 @@ public class ObservableMergeDelayErrorTest {
 
         @Override
         public void subscribe(Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             NbpObserver.onNext("hello");
             NbpObserver.onComplete();
         }
@@ -328,7 +328,7 @@ public class ObservableMergeDelayErrorTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -352,7 +352,7 @@ public class ObservableMergeDelayErrorTest {
 
         @Override
         public void subscribe(Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             boolean errorThrown = false;
             for (String s : valuesToReturn) {
                 if (s == null) {
@@ -383,7 +383,7 @@ public class ObservableMergeDelayErrorTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -436,7 +436,7 @@ public class ObservableMergeDelayErrorTest {
         Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t1) {
-                t1.onSubscribe(EmptyDisposable.INSTANCE);
+                t1.onSubscribe(Disposables.empty());
                 try {
                     t1.onNext(0);
                 } catch (Throwable swallow) {
@@ -508,7 +508,7 @@ public class ObservableMergeDelayErrorTest {
             Observable<Observable<String>> parentObservable = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
                 @Override
                 public void subscribe(Observer<? super Observable<String>> op) {
-                    op.onSubscribe(EmptyDisposable.INSTANCE);
+                    op.onSubscribe(Disposables.empty());
                     op.onNext(Observable.unsafeCreate(o1));
                     op.onNext(Observable.unsafeCreate(o2));
                     op.onError(new NullPointerException("throwing exception in parent"));
@@ -535,7 +535,7 @@ public class ObservableMergeDelayErrorTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -24,7 +24,7 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.internal.schedulers.IoScheduler;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
@@ -98,7 +98,7 @@ public class ObservableMergeMaxConcurrentTest {
 
         @Override
         public void subscribe(final Observer<? super String> t1) {
-            t1.onSubscribe(EmptyDisposable.INSTANCE);
+            t1.onSubscribe(Disposables.empty());
             new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -29,7 +29,6 @@ import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.*;
 
@@ -77,7 +76,7 @@ public class ObservableMergeTest {
 
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 // simulate what would happen in an NbpObservable
                 NbpObserver.onNext(o1);
                 NbpObserver.onNext(o2);
@@ -359,7 +358,7 @@ public class ObservableMergeTest {
 
         @Override
         public void subscribe(Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             NbpObserver.onNext("hello");
             NbpObserver.onComplete();
         }
@@ -371,7 +370,7 @@ public class ObservableMergeTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -402,7 +401,7 @@ public class ObservableMergeTest {
 
         @Override
         public void subscribe(Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             for (String s : valuesToReturn) {
                 if (s == null) {
                     System.out.println("throwing exception");
@@ -562,7 +561,7 @@ public class ObservableMergeTest {
             public void subscribe(final Observer<? super Integer> s) {
                 Worker inner = Schedulers.newThread().createWorker();
                 final CompositeDisposable as = new CompositeDisposable();
-                as.add(EmptyDisposable.INSTANCE);
+                as.add(Disposables.empty());
                 as.add(inner);
                 
                 s.onSubscribe(as);
@@ -612,7 +611,7 @@ public class ObservableMergeTest {
             public void subscribe(final Observer<? super Integer> s) {
                 Worker inner = Schedulers.newThread().createWorker();
                 final CompositeDisposable as = new CompositeDisposable();
-                as.add(EmptyDisposable.INSTANCE);
+                as.add(Disposables.empty());
                 as.add(inner);
                 
                 s.onSubscribe(as);
@@ -1022,7 +1021,7 @@ public class ObservableMergeTest {
 
                     @Override
                     public void subscribe(Observer<? super Integer> s) {
-                        s.onSubscribe(EmptyDisposable.INSTANCE);
+                        s.onSubscribe(Disposables.empty());
                         if (i < 500) {
                             try {
                                 Thread.sleep(1);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.*;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
@@ -24,10 +24,8 @@ import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
-import io.reactivex.ObservableOperator;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 
@@ -40,7 +38,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
 
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 NbpObserver.onNext("one");
                 NbpObserver.onError(new Throwable("injected failure"));
                 NbpObserver.onNext("two");
@@ -286,7 +284,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
             System.out.println("TestObservable subscribed to ...");
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 
@@ -187,7 +187,7 @@ public class ObservableOnErrorReturnTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpSubscriber) {
-            NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpSubscriber.onSubscribe(Disposables.empty());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
@@ -21,9 +21,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
@@ -225,7 +224,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -24,9 +24,8 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.*;
@@ -40,7 +39,7 @@ public class ObservablePublishTest {
 
             @Override
             public void subscribe(final Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
 
                     @Override
@@ -347,7 +346,7 @@ public class ObservablePublishTest {
         Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t) {
-                t.onSubscribe(EmptyDisposable.INSTANCE);
+                t.onSubscribe(Disposables.empty());
                 calls.getAndIncrement();
             }
         });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
@@ -26,9 +26,9 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
@@ -71,7 +71,7 @@ public class ObservableRepeatTest {
 
             @Override
             public void subscribe(Observer<? super Integer> sub) {
-                sub.onSubscribe(EmptyDisposable.INSTANCE);
+                sub.onSubscribe(Disposables.empty());
                 counter.incrementAndGet();
                 sub.onNext(1);
                 sub.onNext(2);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -28,10 +28,9 @@ import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.operators.observable.ObservableReplay.*;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.observers.TestObserver;
@@ -802,7 +801,7 @@ public class ObservableReplayTest {
 
             @Override
             public void subscribe(final Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
 
                     @Override
@@ -937,7 +936,7 @@ public class ObservableReplayTest {
         Observable<Integer> firehose = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t) {
-                t.onSubscribe(EmptyDisposable.INSTANCE);
+                t.onSubscribe(Disposables.empty());
                 for (int i = 0; i < m; i++) {
                     t.onNext(i);
                 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -29,7 +29,6 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observables.GroupedObservable;
 import io.reactivex.observers.*;
@@ -49,7 +48,7 @@ public class ObservableRetryTest {
 
             @Override
             public void subscribe(Observer<? super String> t1) {
-                t1.onSubscribe(EmptyDisposable.INSTANCE);
+                t1.onSubscribe(Disposables.empty());
                 System.out.println(count.get() + " @ " + String.valueOf(last - System.currentTimeMillis()));
                 last = System.currentTimeMillis();
                 if (count.getAndDecrement() == 0) {
@@ -245,7 +244,7 @@ public class ObservableRetryTest {
         ObservableSource<Integer> onSubscribe = new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpSubscriber.onSubscribe(Disposables.empty());
                 final int emit = inc.incrementAndGet();
                 NbpSubscriber.onNext(emit);
                 NbpSubscriber.onComplete();
@@ -394,7 +393,7 @@ public class ObservableRetryTest {
 
         @Override
         public void subscribe(final Observer<? super String> o) {
-            o.onSubscribe(EmptyDisposable.INSTANCE);
+            o.onSubscribe(Disposables.empty());
             o.onNext("beginningEveryTime");
             int i = count.getAndIncrement();
             if (i < numFailures) {
@@ -488,7 +487,7 @@ public class ObservableRetryTest {
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 subsCount.incrementAndGet();
                 s.onError(new RuntimeException("failed"));
             }
@@ -507,7 +506,7 @@ public class ObservableRetryTest {
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 subsCount.incrementAndGet();
                 s.onError(new RuntimeException("failed"));
             }
@@ -831,7 +830,7 @@ public class ObservableRetryTest {
 
             @Override
             public void subscribe(Observer<? super String> o) {
-                o.onSubscribe(EmptyDisposable.INSTANCE);
+                o.onSubscribe(Disposables.empty());
                 for(int i=0; i<NUM_MSG; i++) {
                     o.onNext("msg:" + count.incrementAndGet());
                 }   

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -28,10 +28,9 @@ import org.mockito.InOrder;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.subjects.PublishSubject;
 
@@ -75,7 +74,7 @@ public class ObservableRetryWithPredicateTest {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
-                t1.onSubscribe(EmptyDisposable.INSTANCE);
+                t1.onSubscribe(Disposables.empty());
                 count++;
                 t1.onNext(0);
                 t1.onNext(1);
@@ -110,7 +109,7 @@ public class ObservableRetryWithPredicateTest {
         Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(Observer<? super Integer> t1) {
-                t1.onSubscribe(EmptyDisposable.INSTANCE);
+                t1.onSubscribe(Disposables.empty());
                 t1.onNext(0);
                 t1.onNext(1);
                 t1.onError(new TestException());
@@ -139,7 +138,7 @@ public class ObservableRetryWithPredicateTest {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
-                t1.onSubscribe(EmptyDisposable.INSTANCE);
+                t1.onSubscribe(Disposables.empty());
                 count++;
                 t1.onNext(0);
                 t1.onNext(1);
@@ -176,7 +175,7 @@ public class ObservableRetryWithPredicateTest {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
-                t1.onSubscribe(EmptyDisposable.INSTANCE);
+                t1.onSubscribe(Disposables.empty());
                 count++;
                 t1.onNext(0);
                 t1.onNext(1);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
@@ -22,8 +22,7 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.disposables.*;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
 
@@ -47,7 +46,7 @@ public class ObservableSampleTest {
         Observable<Long> source = Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
             public void subscribe(final Observer<? super Long> observer1) {
-                observer1.onSubscribe(EmptyDisposable.INSTANCE);
+                observer1.onSubscribe(Disposables.empty());
                 innerScheduler.schedule(new Runnable() {
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSerializeTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.*;
 
 import io.reactivex.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.observers.DefaultObserver;
 
 public class ObservableSerializeTest {
@@ -219,7 +219,7 @@ public class ObservableSerializeTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             System.out.println("TestSingleThreadedObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -270,7 +270,7 @@ public class ObservableSerializeTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             System.out.println("TestMultiThreadedObservable subscribed to ...");
             final NullPointerException npe = new NullPointerException();
             t = new Thread(new Runnable() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -22,7 +22,6 @@ import org.junit.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.*;
 
@@ -42,7 +41,7 @@ public class ObservableSubscribeOnTest {
             @Override
             public void subscribe(
                     final Observer<? super Integer> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpSubscriber.onSubscribe(Disposables.empty());
                 scheduled.countDown();
                 try {
                     try {
@@ -94,7 +93,7 @@ public class ObservableSubscribeOnTest {
 
             @Override
             public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 s.onError(new RuntimeException("fail"));
             }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -25,23 +26,25 @@ import org.mockito.InOrder;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
 
 public class ObservableSwitchTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
-    private Observer<String> NbpObserver;
+    private Observer<String> observer;
 
     @Before
     public void before() {
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
     }
 
     @Test
@@ -49,11 +52,11 @@ public class ObservableSwitchTest {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 70, "one");
                         publishNext(NbpObserver, 100, "two");
                         publishCompleted(NbpObserver, 200);
@@ -64,13 +67,13 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(350, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(2)).onNext(anyString());
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(2)).onNext(anyString());
+        inOrder.verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -78,11 +81,11 @@ public class ObservableSwitchTest {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 10, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 0, "one");
                         publishNext(NbpObserver, 10, "two");
                         publishCompleted(NbpObserver, 20);
@@ -92,7 +95,7 @@ public class ObservableSwitchTest {
                 publishNext(NbpObserver, 100, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 0, "three");
                         publishNext(NbpObserver, 10, "four");
                         publishCompleted(NbpObserver, 20);
@@ -103,20 +106,20 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(150, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, times(1)).onNext("one");
-        inOrder.verify(NbpObserver, times(1)).onNext("two");
-        inOrder.verify(NbpObserver, times(1)).onNext("three");
-        inOrder.verify(NbpObserver, times(1)).onNext("four");
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, times(1)).onNext("one");
+        inOrder.verify(observer, times(1)).onNext("two");
+        inOrder.verify(observer, times(1)).onNext("three");
+        inOrder.verify(observer, times(1)).onNext("four");
 
         scheduler.advanceTimeTo(250, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, never()).onNext(anyString());
+        inOrder.verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -124,11 +127,11 @@ public class ObservableSwitchTest {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(final Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 60, "one");
                         publishNext(NbpObserver, 100, "two");
                     }
@@ -137,7 +140,7 @@ public class ObservableSwitchTest {
                 publishNext(NbpObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(final Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 0, "three");
                         publishNext(NbpObserver, 100, "four");
                     }
@@ -148,34 +151,34 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyString());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(175, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("two");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(225, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(350, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("four");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("four");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -183,11 +186,11 @@ public class ObservableSwitchTest {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(final Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 50, "one");
                         publishNext(NbpObserver, 100, "two");
                     }
@@ -196,7 +199,7 @@ public class ObservableSwitchTest {
                 publishNext(NbpObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 0, "three");
                         publishNext(NbpObserver, 100, "four");
                     }
@@ -207,34 +210,34 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyString());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(175, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("two");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(225, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(350, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onError(any(TestException.class));
+        inOrder.verify(observer, never()).onNext(anyString());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
     }
 
     @Test
@@ -242,11 +245,11 @@ public class ObservableSwitchTest {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 50, "one");
                         publishNext(NbpObserver, 100, "two");
                     }
@@ -255,7 +258,7 @@ public class ObservableSwitchTest {
                 publishNext(NbpObserver, 130, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishCompleted(NbpObserver, 0);
                     }
                 }));
@@ -263,7 +266,7 @@ public class ObservableSwitchTest {
                 publishNext(NbpObserver, 150, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 50, "three");
                     }
                 }));
@@ -271,54 +274,54 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyString());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(250, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testSwitchWithSubsequenceError() {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> observer) {
+                observer.onSubscribe(Disposables.empty());
+                publishNext(observer, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                        publishNext(NbpObserver, 50, "one");
-                        publishNext(NbpObserver, 100, "two");
+                    public void subscribe(Observer<? super String> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        publishNext(observer, 50, "one");
+                        publishNext(observer, 100, "two");
                     }
                 }));
 
-                publishNext(NbpObserver, 130, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(observer, 130, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                        publishError(NbpObserver, 0, new TestException());
+                    public void subscribe(Observer<? super String> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        publishError(observer, 0, new TestException());
                     }
                 }));
 
-                publishNext(NbpObserver, 150, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(observer, 150, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-                        publishNext(NbpObserver, 50, "three");
+                    public void subscribe(Observer<? super String> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        publishNext(observer, 50, "three");
                     }
                 }));
 
@@ -326,24 +329,24 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyString());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(250, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onError(any(TestException.class));
+        inOrder.verify(observer, never()).onNext("three");
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
     }
 
     private <T> void publishCompleted(final Observer<T> NbpObserver, long delay) {
@@ -364,11 +367,11 @@ public class ObservableSwitchTest {
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private <T> void publishNext(final Observer<T> NbpObserver, long delay, final T value) {
+    private <T> void publishNext(final Observer<T> observer, long delay, final T value) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onNext(value);
+                observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
@@ -379,11 +382,11 @@ public class ObservableSwitchTest {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
             public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 0, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 10, "1-one");
                         publishNext(NbpObserver, 20, "1-two");
                         // The following events will be ignored
@@ -394,7 +397,7 @@ public class ObservableSwitchTest {
                 publishNext(NbpObserver, 25, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
                     public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         publishNext(NbpObserver, 10, "2-one");
                         publishNext(NbpObserver, 20, "2-two");
                         publishNext(NbpObserver, 30, "2-three");
@@ -406,17 +409,17 @@ public class ObservableSwitchTest {
         });
 
         Observable<String> sampled = Observable.switchOnNext(source);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
         scheduler.advanceTimeTo(1000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("1-one");
-        inOrder.verify(NbpObserver, times(1)).onNext("1-two");
-        inOrder.verify(NbpObserver, times(1)).onNext("2-one");
-        inOrder.verify(NbpObserver, times(1)).onNext("2-two");
-        inOrder.verify(NbpObserver, times(1)).onNext("2-three");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("1-one");
+        inOrder.verify(observer, times(1)).onNext("1-two");
+        inOrder.verify(observer, times(1)).onNext("2-one");
+        inOrder.verify(observer, times(1)).onNext("2-two");
+        inOrder.verify(observer, times(1)).onNext("2-three");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -477,5 +480,40 @@ public class ObservableSwitchTest {
         ts.assertNoErrors();
         
         Assert.assertEquals(250, ts.valueCount());
+    }
+    
+
+    @Test
+    public void delayErrors() {
+        PublishSubject<ObservableSource<Integer>> source = PublishSubject.create();
+        
+        TestObserver<Integer> ts = source.switchMapDelayError(Functions.<ObservableSource<Integer>>identity())
+        .test();
+        
+        ts.assertNoValues()
+        .assertNoErrors()
+        .assertNotComplete();
+        
+        source.onNext(Observable.just(1));
+        
+        source.onNext(Observable.<Integer>error(new TestException("Forced failure 1")));
+        
+        source.onNext(Observable.just(2, 3, 4));
+        
+        source.onNext(Observable.<Integer>error(new TestException("Forced failure 2")));
+        
+        source.onNext(Observable.just(5));
+        
+        source.onError(new TestException("Forced failure 3"));
+        
+        ts.assertValues(1, 2, 3, 4, 5)
+        .assertNotComplete()
+        .assertError(CompositeException.class);
+        
+        List<Throwable> errors = ExceptionHelper.flatten(ts.errors().get(0));
+        
+        TestHelper.assertError(errors, 0, TestException.class, "Forced failure 1");
+        TestHelper.assertError(errors, 1, TestException.class, "Forced failure 2");
+        TestHelper.assertError(errors, 2, TestException.class, "Forced failure 3");
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -28,7 +28,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
@@ -112,7 +111,7 @@ public class ObservableTakeTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 NbpObserver.onNext("one");
                 NbpObserver.onError(new Throwable("test failed"));
             }
@@ -240,7 +239,7 @@ public class ObservableTakeTest {
 
         @Override
         public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
@@ -20,10 +20,9 @@ import static org.mockito.Mockito.*;
 import org.junit.*;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Predicate;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.*;
 
@@ -103,7 +102,7 @@ public class ObservableTakeWhileTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 NbpObserver.onNext("one");
                 NbpObserver.onError(new Throwable("test failed"));
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
@@ -22,8 +22,8 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
 
@@ -45,7 +45,7 @@ public class ObservableThrottleFirstTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 publishNext(NbpObserver, 100, "one");    // publish as it's first
                 publishNext(NbpObserver, 300, "two");    // skip as it's last within the first 400
                 publishNext(NbpObserver, 900, "three");   // publish
@@ -73,7 +73,7 @@ public class ObservableThrottleFirstTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 Exception error = new TestException();
                 publishNext(NbpObserver, 100, "one");    // Should be published since it is first
                 publishNext(NbpObserver, 200, "two");    // Should be skipped since onError will arrive before the timeout expires

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -23,8 +23,7 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.disposables.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
@@ -241,16 +240,16 @@ public class ObservableTimeoutTests {
                 Observable.unsafeCreate(new ObservableSource<String>() {
 
                     @Override
-                    public void subscribe(Observer<? super String> NbpSubscriber) {
-                        NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);
+                    public void subscribe(Observer<? super String> observer) {
+                        observer.onSubscribe(Disposables.empty());
                         try {
                             timeoutSetuped.countDown();
                             exit.await();
                         } catch (InterruptedException e) {
                             e.printStackTrace();
                         }
-                        NbpSubscriber.onNext("a");
-                        NbpSubscriber.onComplete();
+                        observer.onNext("a");
+                        observer.onComplete();
                     }
 
                 }).timeout(1, TimeUnit.SECONDS, testScheduler)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -27,10 +27,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
@@ -328,7 +327,7 @@ public class ObservableTimeoutWithSelectorTest {
                     return Observable.unsafeCreate(new ObservableSource<Integer>() {
                         @Override
                         public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                            NbpSubscriber.onSubscribe(EmptyDisposable.INSTANCE);
+                            NbpSubscriber.onSubscribe(Disposables.empty());
                             enteredTimeoutOne.countDown();
                             // force the timeout message be sent after NbpObserver.onNext(2)
                             while (true) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -23,8 +23,8 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
@@ -48,7 +48,7 @@ public class ObservableWindowWithStartEndObservableTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 10);
                 push(NbpObserver, "two", 60);
                 push(NbpObserver, "three", 110);
@@ -61,7 +61,7 @@ public class ObservableWindowWithStartEndObservableTest {
         Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
             public void subscribe(Observer<? super Object> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, new Object(), 50);
                 push(NbpObserver, new Object(), 200);
                 complete(NbpObserver, 250);
@@ -74,7 +74,7 @@ public class ObservableWindowWithStartEndObservableTest {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         push(NbpObserver, new Object(), 100);
                         complete(NbpObserver, 101);
                     }
@@ -99,7 +99,7 @@ public class ObservableWindowWithStartEndObservableTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 10);
                 push(NbpObserver, "two", 60);
                 push(NbpObserver, "three", 110);
@@ -116,7 +116,7 @@ public class ObservableWindowWithStartEndObservableTest {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                        NbpObserver.onSubscribe(Disposables.empty());
                         int c = calls++;
                         if (c == 0) {
                             push(NbpObserver, new Object(), 100);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -24,8 +24,8 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.TestScheduler;
 
@@ -49,7 +49,7 @@ public class ObservableWindowWithTimeTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 10);
                 push(NbpObserver, "two", 90);
                 push(NbpObserver, "three", 110);
@@ -83,7 +83,7 @@ public class ObservableWindowWithTimeTest {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+                NbpObserver.onSubscribe(Disposables.empty());
                 push(NbpObserver, "one", 98);
                 push(NbpObserver, "two", 99);
                 push(NbpObserver, "three", 99); // FIXME happens after the window is open

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -29,7 +29,6 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
@@ -623,7 +622,7 @@ public class ObservableZipTest {
         public void subscribe(Observer<? super String> NbpObserver) {
             // just store the variable where it can be accessed so we can manually trigger it
             this.NbpObserver = NbpObserver;
-            NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
+            NbpObserver.onSubscribe(Disposables.empty());
         }
 
     }

--- a/src/test/java/io/reactivex/observable/ObservableTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableTests.java
@@ -27,9 +27,8 @@ import org.mockito.InOrder;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.*;
@@ -446,7 +445,7 @@ public class ObservableTests {
         ConnectableObservable<String> connectable = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
-                observer.onSubscribe(EmptyDisposable.INSTANCE);
+                observer.onSubscribe(Disposables.empty());
                 count.incrementAndGet();
                 new Thread(new Runnable() {
                     @Override
@@ -484,7 +483,7 @@ public class ObservableTests {
         ConnectableObservable<String> o = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
-                    observer.onSubscribe(EmptyDisposable.INSTANCE);
+                    observer.onSubscribe(Disposables.empty());
                     new Thread(new Runnable() {
 
                         @Override
@@ -537,7 +536,7 @@ public class ObservableTests {
         Observable<String> o = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
-                    observer.onSubscribe(EmptyDisposable.INSTANCE);
+                    observer.onSubscribe(Disposables.empty());
                     new Thread(new Runnable() {
                         @Override
                         public void run() {
@@ -582,7 +581,7 @@ public class ObservableTests {
         Observable<String> o = Observable.<String>unsafeCreate(new ObservableSource<String>() {
             @Override
             public void subscribe(final Observer<? super String> observer) {
-                observer.onSubscribe(EmptyDisposable.INSTANCE);
+                observer.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -24,7 +24,6 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -130,7 +129,7 @@ public class SingleTest {
         Single.unsafeCreate(new SingleSource<Object>() {
             @Override
             public void subscribe(SingleObserver<? super Object> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 s.onSuccess("Hello");
             }
         }).toFlowable().subscribe(ts);
@@ -144,7 +143,7 @@ public class SingleTest {
         Single.unsafeCreate(new SingleSource<Object>() {
             @Override
             public void subscribe(SingleObserver<? super Object> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 s.onError(new RuntimeException("fail"));
             }
         }).toFlowable().subscribe(ts);
@@ -201,7 +200,7 @@ public class SingleTest {
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                 try {
                     Thread.sleep(5000);
                 } catch (InterruptedException e) {
@@ -223,7 +222,7 @@ public class SingleTest {
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> s) {
-                s.onSubscribe(EmptyDisposable.INSTANCE);
+                s.onSubscribe(Disposables.empty());
                     try {
                         Thread.sleep(5000);
                     } catch (InterruptedException e) {
@@ -428,7 +427,7 @@ public class SingleTest {
         Single<String> s = Single.unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> t) {
-                t.onSubscribe(EmptyDisposable.INSTANCE);
+                t.onSubscribe(Disposables.empty());
                 t.onSuccess("hello");
             }
         });

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -24,8 +24,8 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 
@@ -42,7 +42,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(EmptyDisposable.INSTANCE);
+                        o.onSubscribe(Disposables.empty());
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
                             o.onNext(l);
@@ -152,7 +152,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(EmptyDisposable.INSTANCE);
+                        o.onSubscribe(Disposables.empty());
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
                             o.onNext(l);

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
@@ -24,8 +24,8 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 
@@ -42,7 +42,7 @@ public class ReplaySubjectConcurrencyTest {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(EmptyDisposable.INSTANCE);
+                        o.onSubscribe(Disposables.empty());
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
                             o.onNext(l);
@@ -152,7 +152,7 @@ public class ReplaySubjectConcurrencyTest {
 
                     @Override
                     public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(EmptyDisposable.INSTANCE);
+                        o.onSubscribe(Disposables.empty());
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
                             o.onNext(l);


### PR DESCRIPTION
Notable changes:
- Implement `concatEager` and its variants
- Implement `onTerminateDetach`
- Implement `distinctUntilChanged(BiPredicate)`
- Replace `EmptyDisposable.INSTANCE` with `Disposables.empty()` due to clash with fusion (sending an INSTANCE tells a fusion-enabled source to not expect onNext values yet the test still send those - this was a problem with EmptySubscription.INSTANCE a while back too). Also added javadoc warning about its use
- add `ObservableScalarXMap` optimization to `Observable.xMap(Function)` and their operator's `subscribeActual`
- Make `ObservableJust` `ScalarCallable` and sync-fuseable with `ScalarDisposable` (similar to `Flowable.just()`)
- Make `Observable.bufferSize()` public for convenience.
- Fix `flatMap` fused `Callable` handling
- Renamed `Objects` to `ObjectHelper` to avoid accidental bad imports of `java.util.Objects` of Java 8.
