### PR TITLE
2.x: cleanup, enhancements 8/23-1

### DIFF
--- a/src/main/java/io/reactivex/Emitter.java
+++ b/src/main/java/io/reactivex/Emitter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex;
+
+/**
+ * Base interface for emitting signals in a push-fashion in various generator-like source
+ * operators (create, generate).
+ *
+ * @param <T> the value type emitted
+ */
+public interface Emitter<T> {
+
+    /**
+     * Signal a normal value.
+     * @param value the value to signal, not null
+     */
+    void onNext(T value);
+    
+    /**
+     * Signal a Throwable exception.
+     * @param error the Throwable to signal, not null
+     */
+    void onError(Throwable error);
+    
+    /**
+     * Signal a completion.
+     */
+    void onComplete();
+}

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -2049,7 +2049,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> generate(final Consumer<Subscriber<T>> generator) {
+    public static <T> Flowable<T> generate(final Consumer<Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(Functions.nullSupplier(), 
                 FlowableInternalHelper.<T, Object>simpleGenerator(generator), 
@@ -2077,7 +2077,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Subscriber<T>> generator) {
+    public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), 
                 Functions.emptyConsumer());
@@ -2106,7 +2106,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Subscriber<T>> generator, 
+    public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Emitter<T>> generator, 
             Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), 
@@ -2135,7 +2135,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Subscriber<T>, S> generator) {
+    public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
         return generate(initialState, generator, Functions.emptyConsumer());
     }
 
@@ -2163,7 +2163,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Subscriber<T>, S> generator, Consumer<? super S> disposeState) {
+    public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator, Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator is null");
         ObjectHelper.requireNonNull(disposeState, "disposeState is null");
@@ -15446,22 +15446,21 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Creates a TestSubscriber with the given initial request amount, fusion mode
-     * and optionally in cancelled state, then subscribes it to this Flowable.
+     * Creates a TestSubscriber with the given initial request amount,
+     * optionally cancels it before the subscription and subscribes
+     * it to this Flowable.
      * @param initialRequest the initial request amount, positive
-     * @param fusionMode the requested fusion mode, see {@link QueueSubscription} constants.
-     * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
-     * Flowable.
+     * @param cancel should the TestSubscriber be cancelled before the subscription?
      * @return the new TestSubscriber instance
      * @since 2.0
      */
-    public final TestSubscriber<T> test(long initialRequest, int fusionMode, boolean cancelled) { // NoPMD
+    public final TestSubscriber<T> test(long initialRequest, boolean cancel) { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
-        ts.setInitialFusionMode(fusionMode);
-        if (cancelled) {
+        if (cancel) {
             ts.cancel();
         }
         subscribe(ts);
         return ts;
     }
+
 }

--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -28,25 +28,8 @@ import io.reactivex.functions.Cancellable;
  *
  * @param <T> the value type to emit
  */
-public interface FlowableEmitter<T> {
+public interface FlowableEmitter<T> extends Emitter<T> {
 
-    /**
-     * Signal a value.
-     * @param t the value, not null
-     */
-    void onNext(T t);
-    
-    /**
-     * Signal an exception.
-     * @param t the exception, not null
-     */
-    void onError(Throwable t);
-    
-    /**
-     * Signal the completion.
-     */
-    void onComplete();
-    
     /**
      * Sets a Disposable on this emitter; any previous Disposable
      * or Cancellation will be unsubscribed/cancelled.

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1782,7 +1782,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> generate(final Consumer<Observer<T>> generator) {
+    public static <T> Observable<T> generate(final Consumer<Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(Functions.<Object>nullSupplier(), 
         ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
@@ -1806,7 +1806,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Callable<S> initialState, final BiConsumer<S, Observer<T>> generator) {
+    public static <T, S> Observable<T> generate(Callable<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), Functions.emptyConsumer());
     }
@@ -1833,7 +1833,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Observable<T> generate(
             final Callable<S> initialState, 
-            final BiConsumer<S, Observer<T>> generator, 
+            final BiConsumer<S, Emitter<T>> generator, 
             Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), disposeState);
@@ -1858,7 +1858,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Observer<T>, S> generator) {
+    public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
         return generate(initialState, generator, Functions.emptyConsumer());
     }
 
@@ -1883,7 +1883,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Observer<T>, S> generator, 
+    public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator, 
             Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator  is null");
@@ -13217,25 +13217,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public final TestObserver<T> test() { // NoPMD
         TestObserver<T> ts = new TestObserver<T>();
-        subscribe(ts);
-        return ts;
-    }
-    
-    /**
-     * Creates a TestObserver with the given fusion mode
-     * and optionally in cancelled state, then subscribes it to this Observable.
-     * @param fusionMode the requested fusion mode, see {@link QueueDisposable} constants.
-     * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
-     * Observable.
-     * @return the new TestObserver instance
-     * @since 2.0
-     */
-    public final TestObserver<T> test(int fusionMode, boolean cancelled) { // NoPMD
-        TestObserver<T> ts = new TestObserver<T>();
-        ts.setInitialFusionMode(fusionMode);
-        if (cancelled) {
-            ts.dispose();
-        }
         subscribe(ts);
         return ts;
     }

--- a/src/main/java/io/reactivex/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/ObservableEmitter.java
@@ -27,25 +27,8 @@ import io.reactivex.functions.Cancellable;
  *
  * @param <T> the value type to emit
  */
-public interface ObservableEmitter<T> {
+public interface ObservableEmitter<T> extends Emitter<T> {
 
-    /**
-     * Signal a value.
-     * @param t the value, not null
-     */
-    void onNext(T t);
-    
-    /**
-     * Signal an exception.
-     * @param t the exception, not null
-     */
-    void onError(Throwable t);
-    
-    /**
-     * Signal the completion.
-     */
-    void onComplete();
-    
     /**
      * Sets a Disposable on this emitter; any previous Disposable
      * or Cancellation will be unsubscribed/cancelled.

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
@@ -28,39 +28,39 @@ import io.reactivex.internal.functions.Functions;
 public enum FlowableInternalHelper {
     ;
 
-    static final class SimpleGenerator<T, S> implements BiFunction<S, Subscriber<T>, S> {
-        final Consumer<Subscriber<T>> consumer;
+    static final class SimpleGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
+        final Consumer<Emitter<T>> consumer;
         
-        public SimpleGenerator(Consumer<Subscriber<T>> consumer) {
+        public SimpleGenerator(Consumer<Emitter<T>> consumer) {
             this.consumer = consumer;
         }
         
         @Override
-        public S apply(S t1, Subscriber<T> t2) throws Exception {
+        public S apply(S t1, Emitter<T> t2) throws Exception {
             consumer.accept(t2);
             return t1;
         }
     }
     
-    public static <T, S> BiFunction<S, Subscriber<T>, S> simpleGenerator(Consumer<Subscriber<T>> consumer) {
+    public static <T, S> BiFunction<S, Emitter<T>, S> simpleGenerator(Consumer<Emitter<T>> consumer) {
         return new SimpleGenerator<T, S>(consumer);
     }
     
-    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Subscriber<T>, S> {
-        final BiConsumer<S, Subscriber<T>> consumer;
+    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
+        final BiConsumer<S, Emitter<T>> consumer;
         
-        public SimpleBiGenerator(BiConsumer<S, Subscriber<T>> consumer) {
+        public SimpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
             this.consumer = consumer;
         }
         
         @Override
-        public S apply(S t1, Subscriber<T> t2) throws Exception {
+        public S apply(S t1, Emitter<T> t2) throws Exception {
             consumer.accept(t1, t2);
             return t1;
         }
     }
     
-    public static <T, S> BiFunction<S, Subscriber<T>, S> simpleBiGenerator(BiConsumer<S, Subscriber<T>> consumer) {
+    public static <T, S> BiFunction<S, Emitter<T>, S> simpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
         return new SimpleBiGenerator<T, S>(consumer);
     }
     

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -26,39 +26,39 @@ import io.reactivex.observables.ConnectableObservable;
 public enum ObservableInternalHelper {
     ;
 
-    static final class SimpleGenerator<T, S> implements BiFunction<S, Observer<T>, S> {
-        final Consumer<Observer<T>> consumer;
+    static final class SimpleGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
+        final Consumer<Emitter<T>> consumer;
         
-        public SimpleGenerator(Consumer<Observer<T>> consumer) {
+        public SimpleGenerator(Consumer<Emitter<T>> consumer) {
             this.consumer = consumer;
         }
         
         @Override
-        public S apply(S t1, Observer<T> t2) throws Exception {
+        public S apply(S t1, Emitter<T> t2) throws Exception {
             consumer.accept(t2);
             return t1;
         }
     }
     
-    public static <T, S> BiFunction<S, Observer<T>, S> simpleGenerator(Consumer<Observer<T>> consumer) {
+    public static <T, S> BiFunction<S, Emitter<T>, S> simpleGenerator(Consumer<Emitter<T>> consumer) {
         return new SimpleGenerator<T, S>(consumer);
     }
     
-    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Observer<T>, S> {
-        final BiConsumer<S, Observer<T>> consumer;
+    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
+        final BiConsumer<S, Emitter<T>> consumer;
         
-        public SimpleBiGenerator(BiConsumer<S, Observer<T>> consumer) {
+        public SimpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
             this.consumer = consumer;
         }
         
         @Override
-        public S apply(S t1, Observer<T> t2) throws Exception {
+        public S apply(S t1, Emitter<T> t2) throws Exception {
             consumer.accept(t1, t2);
             return t1;
         }
     }
     
-    public static <T, S> BiFunction<S, Observer<T>, S> simpleBiGenerator(BiConsumer<S, Observer<T>> consumer) {
+    public static <T, S> BiFunction<S, Emitter<T>, S> simpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
         return new SimpleBiGenerator<T, S>(consumer);
     }
     

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -21,6 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.Notification;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
+import io.reactivex.functions.Consumer;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -816,20 +817,24 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
 
     /**
      * Sets the initial fusion mode if the upstream supports fusion.
+     * <p>Package-private: avoid leaking the now internal fusion properties into the public API.
+     * Use SubscriberFusion to work with such tests.
      * @param mode the mode to establish, see the {@link QueueSubscription} constants
      * @return this
      */
-    public final TestSubscriber<T> setInitialFusionMode(int mode) {
+    final TestSubscriber<T> setInitialFusionMode(int mode) {
         this.initialFusionMode = mode;
         return this;
     }
     
     /**
      * Asserts that the given fusion mode has been established
+     * <p>Package-private: avoid leaking the now internal fusion properties into the public API.
+     * Use SubscriberFusion to work with such tests.
      * @param mode the expected mode
      * @return this
      */
-    public final TestSubscriber<T> assertFusionMode(int mode) {
+    final TestSubscriber<T> assertFusionMode(int mode) {
         int m = establishedFusionMode;
         if (m != mode) {
             if (qs != null) {
@@ -853,9 +858,11 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
     
     /**
      * Assert that the upstream is a fuseable source.
+     * <p>Package-private: avoid leaking the now internal fusion properties into the public API.
+     * Use SubscriberFusion to work with such tests.
      * @return this
      */
-    public final TestSubscriber<T> assertFuseable() {
+    final TestSubscriber<T> assertFuseable() {
         if (qs == null) {
             throw new AssertionError("Upstream is not fuseable.");
         }
@@ -864,11 +871,27 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
 
     /**
      * Assert that the upstream is not a fuseable source.
+     * <p>Package-private: avoid leaking the now internal fusion properties into the public API.
+     * Use SubscriberFusion to work with such tests.
      * @return this
      */
-    public final TestSubscriber<T> assertNotFuseable() {
+    final TestSubscriber<T> assertNotFuseable() {
         if (qs != null) {
             throw new AssertionError("Upstream is fuseable.");
+        }
+        return this;
+    }
+    
+    /**
+     * Run a check consumer with this TestSubscriber instance.
+     * @param check the check consumer to run
+     * @return this
+     */
+    public final TestSubscriber<T> assertOf(Consumer<? super TestSubscriber<T>> check) {
+        try {
+            check.accept(this);
+        } catch (Throwable ex) {
+            throw Exceptions.propagate(ex);
         }
         return this;
     }

--- a/src/test/java/io/reactivex/flowable/FlowableEventStream.java
+++ b/src/test/java/io/reactivex/flowable/FlowableEventStream.java
@@ -15,9 +15,7 @@ package io.reactivex.flowable;
 
 import java.util.*;
 
-import org.reactivestreams.Subscriber;
-
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.functions.Consumer;
 import io.reactivex.schedulers.Schedulers;
 
@@ -30,9 +28,9 @@ public final class FlowableEventStream {
     }
     public static Flowable<Event> getEventStream(final String type, final int numInstances) {
         
-        return Flowable.<Event>generate(new Consumer<Subscriber<Event>>() {
+        return Flowable.<Event>generate(new Consumer<Emitter<Event>>() {
             @Override
-            public void accept(Subscriber<Event> s) {
+            public void accept(Emitter<Event> s) {
                 s.onNext(randomEvent(type, numInstances));
                 try {
                     // slow it down somewhat

--- a/src/test/java/io/reactivex/flowable/FlowableFuseableTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableFuseableTest.java
@@ -18,19 +18,16 @@ import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.internal.fuseable.QueueSubscription;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.subscribers.*;
 
 public class FlowableFuseableTest {
 
     @Test
     public void syncRange() {
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.setInitialFusionMode(QueueSubscription.SYNC);
-        
-        Flowable.range(1, 10).subscribe(ts);
-        
-        ts.assertFusionMode(QueueSubscription.SYNC)
+        Flowable.range(1, 10)
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -39,12 +36,9 @@ public class FlowableFuseableTest {
     @Test
     public void syncArray() {
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.setInitialFusionMode(QueueSubscription.SYNC);
-        
-        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).subscribe(ts);
-        
-        ts.assertFusionMode(QueueSubscription.SYNC)
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -53,12 +47,9 @@ public class FlowableFuseableTest {
     @Test
     public void syncIterable() {
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.setInitialFusionMode(QueueSubscription.SYNC);
-        
-        Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).subscribe(ts);
-        
-        ts.assertFusionMode(QueueSubscription.SYNC)
+        Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -67,12 +58,10 @@ public class FlowableFuseableTest {
     @Test
     public void syncRangeHidden() {
         
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.setInitialFusionMode(QueueSubscription.SYNC);
-        
-        Flowable.range(1, 10).hide().subscribe(ts);
-        
-        ts.assertNotFuseable()
+        Flowable.range(1, 10).hide()
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertNotFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -80,14 +69,11 @@ public class FlowableFuseableTest {
     
     @Test
     public void syncArrayHidden() {
-        
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.setInitialFusionMode(QueueSubscription.SYNC);
-        
         Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
-        .hide().subscribe(ts);
-        
-        ts.assertNotFuseable()
+        .hide()
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertNotFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -95,14 +81,11 @@ public class FlowableFuseableTest {
 
     @Test
     public void syncIterableHidden() {
-        
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.setInitialFusionMode(QueueSubscription.SYNC);
-        
         Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-        .hide().subscribe(ts);
-        
-        ts.assertNotFuseable()
+        .hide()
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertNotFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -341,9 +341,9 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void generateConsumerEmitsNull() {
-        Flowable.generate(new Consumer<Subscriber<Object>>() {
+        Flowable.generate(new Consumer<Emitter<Object>>() {
             @Override
-            public void accept(Subscriber<Object> s) {
+            public void accept(Emitter<Object> s) {
                 s.onNext(null);
             }
         }).blockingLast();
@@ -351,9 +351,9 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerInitialStateNull() {
-        BiConsumer<Integer, Subscriber<Integer>> generator = new BiConsumer<Integer, Subscriber<Integer>>() {
+        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
             @Override
-            public void accept(Integer s, Subscriber<Integer> o) {
+            public void accept(Integer s, Emitter<Integer> o) {
                 o.onNext(1);
             }
         };
@@ -362,9 +362,11 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void generateStateFunctionInitialStateNull() {
-        Flowable.generate(null, new BiFunction<Object, Subscriber<Object>, Object>() {
+        Flowable.generate(null, new BiFunction<Object, Emitter<Object>, Object>() {
             @Override
-            public Object apply(Object s, Subscriber<Object> o) { o.onNext(1); return s; }
+            public Object apply(Object s, Emitter<Object> o) { 
+                o.onNext(1); return s; 
+            }
         });
     }
 
@@ -375,14 +377,14 @@ public class FlowableNullTests {
             public Integer call() {
                 return 1;
             }
-        }, (BiConsumer<Integer, Subscriber<Object>>)null);
+        }, (BiConsumer<Integer, Emitter<Object>>)null);
     }
     
     @Test
     public void generateConsumerStateNullAllowed() {
-        BiConsumer<Integer, Subscriber<Integer>> generator = new BiConsumer<Integer, Subscriber<Integer>>() {
+        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
             @Override
-            public void accept(Integer s, Subscriber<Integer> o) {
+            public void accept(Integer s, Emitter<Integer> o) {
                 o.onComplete();
             }
         };
@@ -401,17 +403,19 @@ public class FlowableNullTests {
             public Object call() {
                 return null;
             }
-        }, new BiFunction<Object, Subscriber<Object>, Object>() {
+        }, new BiFunction<Object, Emitter<Object>, Object>() {
             @Override
-            public Object apply(Object s, Subscriber<Object> o) { o.onComplete(); return s; }
+            public Object apply(Object s, Emitter<Object> o) { 
+                o.onComplete(); return s; 
+            }
         }).blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void generateConsumerDisposeNull() {
-        BiConsumer<Integer, Subscriber<Integer>> generator = new BiConsumer<Integer, Subscriber<Integer>>() {
+        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
             @Override
-            public void accept(Integer s, Subscriber<Integer> o) {
+            public void accept(Integer s, Emitter<Integer> o) {
                 o.onNext(1);
             }
         };
@@ -430,9 +434,11 @@ public class FlowableNullTests {
             public Object call() {
                 return 1;
             }
-        }, new BiFunction<Object, Subscriber<Object>, Object>() {
+        }, new BiFunction<Object, Emitter<Object>, Object>() {
             @Override
-            public Object apply(Object s, Subscriber<Object> o) { o.onNext(1); return s; }
+            public Object apply(Object s, Emitter<Object> o) { 
+                o.onNext(1); return s; 
+            }
         }, null);
     }
     

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -26,7 +26,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.QueueSubscription;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.subscribers.*;
 
 public class FlowableDistinctUntilChangedTest {
 
@@ -176,8 +176,9 @@ public class FlowableDistinctUntilChangedTest {
                 return a.equals(b);
             }
         })
-        .test(Long.MAX_VALUE, QueueSubscription.ANY, false)
-        .assertFusionMode(QueueSubscription.SYNC)
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
     
@@ -196,8 +197,9 @@ public class FlowableDistinctUntilChangedTest {
                 return true;
             }
         })
-        .test(Long.MAX_VALUE, QueueSubscription.ANY, false)
-        .assertFusionMode(QueueSubscription.SYNC)
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
     

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1596,11 +1596,9 @@ public class FlowableGroupByTest {
     
     @Test
     public void outerInnerFusion() {
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-        ts1.setInitialFusionMode(QueueSubscription.ANY);
+        final TestSubscriber<Integer> ts1 = SubscriberFusion.newTest(QueueSubscription.ANY);
 
-        final TestSubscriber<GroupedFlowable<Integer, Integer>> ts2 = new TestSubscriber<GroupedFlowable<Integer, Integer>>();
-        ts2.setInitialFusionMode(QueueSubscription.ANY);
+        final TestSubscriber<GroupedFlowable<Integer, Integer>> ts2 = SubscriberFusion.newTest(QueueSubscription.ANY);
 
         Flowable.range(1, 10).groupBy(new Function<Integer, Integer>() {
             @Override
@@ -1622,13 +1620,13 @@ public class FlowableGroupByTest {
         .subscribe(ts2);
         
         ts1
-        .assertFusionMode(QueueSubscription.ASYNC)
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
         .assertValues(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
         .assertNoErrors()
         .assertComplete();
 
         ts2
-        .assertFusionMode(QueueSubscription.ASYNC)
+        .assertOf(SubscriberFusion.<GroupedFlowable<Integer, Integer>>assertFusionMode(QueueSubscription.ASYNC))
         .assertValueCount(1)
         .assertNoErrors()
         .assertComplete();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -271,7 +271,7 @@ public class FlowableSubscribeOnTest {
         TestScheduler test = new TestScheduler();
         
         TestSubscriber<Integer> ts = Flowable.just(1).hide()
-                .subscribeOn(test).test(Long.MAX_VALUE, 0, true);
+                .subscribeOn(test).test(Long.MAX_VALUE, true);
         
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         

--- a/src/test/java/io/reactivex/observable/ObservableEventStream.java
+++ b/src/test/java/io/reactivex/observable/ObservableEventStream.java
@@ -15,8 +15,8 @@ package io.reactivex.observable;
 
 import java.util.*;
 
+import io.reactivex.Emitter;
 import io.reactivex.Observable;
-import io.reactivex.Observer;
 import io.reactivex.functions.Consumer;
 import io.reactivex.schedulers.Schedulers;
 
@@ -29,9 +29,9 @@ public final class ObservableEventStream {
     }
     public static Observable<Event> getEventStream(final String type, final int numInstances) {
         
-        return Observable.<Event>generate(new Consumer<Observer<Event>>() {
+        return Observable.<Event>generate(new Consumer<Emitter<Event>>() {
             @Override
-            public void accept(Observer<Event> s) {
+            public void accept(Emitter<Event> s) {
                 s.onNext(randomEvent(type, numInstances));
                 try {
                     // slow it down somewhat

--- a/src/test/java/io/reactivex/observable/ObservableFuseableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableFuseableTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.observable;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.observers.ObserverFusion;
+
+public class ObservableFuseableTest {
+
+    @Test
+    public void syncRange() {
+        
+        Observable.range(1, 10)
+        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    @Test
+    public void syncArray() {
+        
+        Observable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void syncIterable() {
+        
+        Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    @Test
+    public void syncRangeHidden() {
+        
+        Observable.range(1, 10).hide()
+        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertNotFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+    
+    @Test
+    public void syncArrayHidden() {
+        Observable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        .hide()
+        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertNotFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void syncIterableHidden() {
+        Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        .hide()
+        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertNotFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .assertNoErrors()
+        .assertComplete();
+    }
+}

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -429,9 +429,9 @@ public class ObservableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void generateConsumerEmitsNull() {
-        Observable.generate(new Consumer<Observer<Object>>() {
+        Observable.generate(new Consumer<Emitter<Object>>() {
             @Override
-            public void accept(Observer<Object> s) {
+            public void accept(Emitter<Object> s) {
                 s.onNext(null);
             }
         }).blockingLast();
@@ -439,9 +439,9 @@ public class ObservableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerInitialStateNull() {
-        BiConsumer<Integer, Observer<Integer>> generator = new BiConsumer<Integer, Observer<Integer>>() {
+        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
             @Override
-            public void accept(Integer s, Observer<Integer> o) {
+            public void accept(Integer s, Emitter<Integer> o) {
                 o.onNext(1);
             }
         };
@@ -450,9 +450,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void generateStateFunctionInitialStateNull() {
-        Observable.generate(null, new BiFunction<Object, Observer<Object>, Object>() {
+        Observable.generate(null, new BiFunction<Object, Emitter<Object>, Object>() {
             @Override
-            public Object apply(Object s, Observer<Object> o) { o.onNext(1); return s; }
+            public Object apply(Object s, Emitter<Object> o) { o.onNext(1); return s; }
         });
     }
 
@@ -463,14 +463,14 @@ public class ObservableNullTests {
             public Integer call() {
                 return 1;
             }
-        }, (BiConsumer<Integer, Observer<Object>>)null);
+        }, (BiConsumer<Integer, Emitter<Object>>)null);
     }
     
     @Test
     public void generateConsumerStateNullAllowed() {
-        BiConsumer<Integer, Observer<Integer>> generator = new BiConsumer<Integer, Observer<Integer>>() {
+        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
             @Override
-            public void accept(Integer s, Observer<Integer> o) {
+            public void accept(Integer s, Emitter<Integer> o) {
                 o.onComplete();
             }
         };
@@ -489,17 +489,17 @@ public class ObservableNullTests {
             public Object call() {
                 return null;
             }
-        }, new BiFunction<Object, Observer<Object>, Object>() {
+        }, new BiFunction<Object, Emitter<Object>, Object>() {
             @Override
-            public Object apply(Object s, Observer<Object> o) { o.onComplete(); return s; }
+            public Object apply(Object s, Emitter<Object> o) { o.onComplete(); return s; }
         }).blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void generateConsumerDisposeNull() {
-        BiConsumer<Integer, Observer<Integer>> generator = new BiConsumer<Integer, Observer<Integer>>() {
+        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
             @Override
-            public void accept(Integer s, Observer<Integer> o) {
+            public void accept(Integer s, Emitter<Integer> o) {
                 o.onNext(1);
             }
         };
@@ -518,9 +518,9 @@ public class ObservableNullTests {
             public Object call() {
                 return 1;
             }
-        }, new BiFunction<Object, Observer<Object>, Object>() {
+        }, new BiFunction<Object, Emitter<Object>, Object>() {
             @Override
-            public Object apply(Object s, Observer<Object> o) { o.onNext(1); return s; }
+            public Object apply(Object s, Emitter<Object> o) { o.onNext(1); return s; }
         }, null);
     }
     

--- a/src/test/java/io/reactivex/observers/ObserverFusion.java
+++ b/src/test/java/io/reactivex/observers/ObserverFusion.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.observers;
+
+import io.reactivex.Observable;
+import io.reactivex.functions.*;
+import io.reactivex.internal.fuseable.*;
+
+/**
+ * Utility methods that return functional interfaces to support assertions regarding fusion
+ * in a TestObserver.
+ * <p>Don't move this class as it needs package-private access to TestObserver's internals.
+ */
+public enum ObserverFusion {
+    ;
+    
+    /**
+     * Returns a function that takes a Flowable and returns a TestObserver that
+     * is set up according to the parameters and is subscribed to the Flowable.
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .assertResult(0);
+     * </pre>
+     * @param <T> the value type
+     * @param mode the fusion mode to request, see {@link QueueDisposable} constants.
+     * @param cancelled should the TestObserver cancelled before the subscription even happens?
+     * @return the new Function instance
+     */
+    public static <T> Function<Observable<T>, TestObserver<T>> test(
+            final int mode, final boolean cancelled) {
+        return new Function<Observable<T>, TestObserver<T>>() {
+            @Override
+            public TestObserver<T> apply(Observable<T> t) throws Exception {
+                TestObserver<T> ts = new TestObserver<T>();
+                ts.setInitialFusionMode(mode);
+                if (cancelled) {
+                    ts.cancel();
+                }
+                t.subscribe(ts);
+                return ts;
+            }
+        };
+    }
+    
+    /**
+     * Returns a Consumer that asserts on its TestObserver parameter that
+     * the upstream is Fuseable (sent a QueueDisposable subclass in onSubscribe).
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .assertOf(ObserverFusion.assertFuseable());
+     * </pre>
+     * @param <T> the value type
+     * @return the new Consumer instance
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Consumer<TestObserver<T>> assertFuseable() {
+        return (Consumer)AssertFuseable.INSTANCE;
+    }
+    
+    enum AssertFuseable implements Consumer<TestObserver<Object>> {
+        INSTANCE;
+        @Override
+        public void accept(TestObserver<Object> ts) throws Exception {
+            ts.assertFuseable();
+        }
+    }
+
+    /**
+     * Returns a Consumer that asserts on its TestObserver parameter that
+     * the upstream is not Fuseable (didn't sent a QueueDisposable subclass in onSubscribe).
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .assertOf(ObserverFusion.assertNotFuseable());
+     * </pre>
+     * @param <T> the value type
+     * @return the new Consumer instance
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Consumer<TestObserver<T>> assertNotFuseable() {
+        return (Consumer)AssertNotFuseable.INSTANCE;
+    }
+
+    enum AssertNotFuseable implements Consumer<TestObserver<Object>> {
+        INSTANCE;
+        @Override
+        public void accept(TestObserver<Object> ts) throws Exception {
+            ts.assertNotFuseable();
+        }
+    }
+
+    /**
+     * Returns a Consumer that asserts on its TestObserver parameter that
+     * the upstream is Fuseable (sent a QueueDisposable subclass in onSubscribe)
+     * and the established the given fusion mode.
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .assertOf(ObserverFusion.assertFusionMode(QueueDisposable.SYNC));
+     * </pre>
+     * @param <T> the value type
+     * @param mode the expected established fusion mode, see {@link QueueDisposable} constants.
+     * @return the new Consumer instance
+     */
+    public static <T> Consumer<TestObserver<T>> assertFusionMode(final int mode) {
+        return new Consumer<TestObserver<T>>() {
+            @Override
+            public void accept(TestObserver<T> ts) throws Exception {
+                ts.assertFusionMode(mode);
+            }
+        };
+    }
+
+
+    /**
+     * Constructs a TestObserver with the given required fusion mode.
+     * @param <T> the value type
+     * @param mode the requested fusion mode, see {@link QueueSubscription} constants
+     * @return the new TestSubscriber
+     */
+    public static <T> TestObserver<T> newTest(int mode) {
+        TestObserver<T> ts = new TestObserver<T>();
+        ts.setInitialFusionMode(mode);
+        return ts;
+    }}

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.subscribers;
+package io.reactivex.observers;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -28,6 +28,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.*;
 
 public class SerializedObserverTest {
 

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.subscribers;
+package io.reactivex.observers;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -27,6 +27,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
 
 public class TestObserverTest {
 

--- a/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
+++ b/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subscribers;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.*;
+import io.reactivex.internal.fuseable.*;
+
+/**
+ * Utility methods that return functional interfaces to support assertions regarding fusion
+ * in a TestSubscriber.
+ * <p>Don't move this class as it needs package-private access to TestSubscriber's internals.
+ */
+public enum SubscriberFusion {
+    ;
+    
+    /**
+     * Returns a function that takes a Flowable and returns a TestSubscriber that
+     * is set up according to the parameters and is subscribed to the Flowable.
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(SubscriberFusion.test(0, QueueSubscription.ANY, false))
+     * .assertResult(0);
+     * </pre>
+     * @param <T> the value type
+     * @param initialRequest the initial request amount, non-negative
+     * @param mode the fusion mode to request, see {@link QueueSubscription} constants.
+     * @param cancelled should the TestSubscriber cancelled before the subscription even happens?
+     * @return the new Function instance
+     */
+    public static <T> Function<Flowable<T>, TestSubscriber<T>> test(
+            final long initialRequest, final int mode, final boolean cancelled) {
+        return new Function<Flowable<T>, TestSubscriber<T>>() {
+            @Override
+            public TestSubscriber<T> apply(Flowable<T> t) throws Exception {
+                TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
+                ts.setInitialFusionMode(mode);
+                if (cancelled) {
+                    ts.cancel();
+                }
+                t.subscribe(ts);
+                return ts;
+            }
+        };
+    }
+    /**
+     * Returns a Consumer that asserts on its TestSubscriber parameter that
+     * the upstream is Fuseable (sent a QueueDisposable subclass in onSubscribe).
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .assertOf(ObserverFusion.assertFuseable());
+     * </pre>
+     * @param <T> the value type
+     * @return the new Consumer instance
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Consumer<TestSubscriber<T>> assertFuseable() {
+        return (Consumer)AssertFuseable.INSTANCE;
+    }
+    
+    enum AssertFuseable implements Consumer<TestSubscriber<Object>> {
+        INSTANCE;
+        @Override
+        public void accept(TestSubscriber<Object> ts) throws Exception {
+            ts.assertFuseable();
+        }
+    }
+
+    /**
+     * Returns a Consumer that asserts on its TestSubscriber parameter that
+     * the upstream is not Fuseable (didn't sent a QueueDisposable subclass in onSubscribe).
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .assertOf(ObserverFusion.assertNotFuseable());
+     * </pre>
+     * @param <T> the value type
+     * @return the new Consumer instance
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Consumer<TestSubscriber<T>> assertNotFuseable() {
+        return (Consumer)AssertNotFuseable.INSTANCE;
+    }
+
+    enum AssertNotFuseable implements Consumer<TestSubscriber<Object>> {
+        INSTANCE;
+        @Override
+        public void accept(TestSubscriber<Object> ts) throws Exception {
+            ts.assertNotFuseable();
+        }
+    }
+
+    /**
+     * Returns a Consumer that asserts on its TestSubscriber parameter that
+     * the upstream is Fuseable (sent a QueueSubscription subclass in onSubscribe)
+     * and the established the given fusion mode.
+     * <p>
+     * Use this as follows:
+     * <pre>
+     * source
+     * .to(SubscriberFusion.test(0, QueueSubscription.ANY, false))
+     * .assertOf(SubscriberFusion.assertFusionMode(QueueSubscription.SYNC));
+     * </pre>
+     * @param <T> the value type
+     * @param mode the expected established fusion mode, see {@link QueueSubscription} constants.
+     * @return the new Consumer instance
+     */
+    public static <T> Consumer<TestSubscriber<T>> assertFusionMode(final int mode) {
+        return new Consumer<TestSubscriber<T>>() {
+            @Override
+            public void accept(TestSubscriber<T> ts) throws Exception {
+                ts.assertFusionMode(mode);
+            }
+        };
+    }
+    
+    /**
+     * Constructs a TestSubscriber with the given initial request and required fusion mode.
+     * @param <T> the value type
+     * @param initialRequest the initial request, non-negative
+     * @param mode the requested fusion mode, see {@link QueueSubscription} constants
+     * @return the new TestSubscriber
+     */
+    public static <T> TestSubscriber<T> newTest(long initialRequest, int mode) {
+        TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
+        ts.setInitialFusionMode(mode);
+        return ts;
+    }
+
+    /**
+     * Constructs a TestSubscriber with the given required fusion mode.
+     * @param <T> the value type
+     * @param mode the requested fusion mode, see {@link QueueSubscription} constants
+     * @return the new TestSubscriber
+     */
+    public static <T> TestSubscriber<T> newTest(int mode) {
+        TestSubscriber<T> ts = new TestSubscriber<T>();
+        ts.setInitialFusionMode(mode);
+        return ts;
+    }
+}


### PR DESCRIPTION
Notable changes:
- Introduce `Emitter<T>` as a base interface for `FlowableEmitter` and `ObservableEmitter`, use it for the `generate()` operators to be the push surface.
- Hide fusion-related methods in `TestSubscriber` and `TestObserver`, remove `test()` method overload from the base reactive classes, introduce `SubscriberFusion` and `ObserverFusion` helper in the test source set
- Enable fusion on `Observable.range()`.
- Move `Observer`-related tests into the `observers` test package.
