### PR TITLE
2.x: add assembly tracking, minor fixes and cleanup

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -48,7 +48,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable amb(final CompletableSource... sources) {
+    public static Completable ambArray(final CompletableSource... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
@@ -57,7 +57,7 @@ public abstract class Completable implements CompletableSource {
             return wrap(sources[0]);
         }
         
-        return new CompletableAmbArray(sources);
+        return RxJavaPlugins.onAssembly(new CompletableAmbArray(sources));
     }
     
     /**
@@ -75,7 +75,7 @@ public abstract class Completable implements CompletableSource {
     public static Completable amb(final Iterable<? extends CompletableSource> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         
-        return new CompletableAmbIterable(sources);
+        return RxJavaPlugins.onAssembly(new CompletableAmbIterable(sources));
     }
     
     /**
@@ -88,7 +88,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable complete() {
-        return CompletableEmpty.INSTANCE;
+        return RxJavaPlugins.onAssembly(CompletableEmpty.INSTANCE);
     }
     
     /**
@@ -102,7 +102,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable concat(CompletableSource... sources) {
+    public static Completable concatArray(CompletableSource... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
@@ -110,7 +110,7 @@ public abstract class Completable implements CompletableSource {
         if (sources.length == 1) {
             return wrap(sources[0]);
         }
-        return new CompletableConcatArray(sources);
+        return RxJavaPlugins.onAssembly(new CompletableConcatArray(sources));
     }
     
     /**
@@ -127,7 +127,7 @@ public abstract class Completable implements CompletableSource {
     public static Completable concat(Iterable<? extends CompletableSource> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         
-        return new CompletableConcatIterable(sources);
+        return RxJavaPlugins.onAssembly(new CompletableConcatIterable(sources));
     }
     
     /**
@@ -162,7 +162,7 @@ public abstract class Completable implements CompletableSource {
         if (prefetch < 1) {
             throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
         }
-        return new CompletableConcat(sources, prefetch);
+        return RxJavaPlugins.onAssembly(new CompletableConcat(sources, prefetch));
     }
 
     /**
@@ -248,7 +248,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable defer(final Callable<? extends CompletableSource> completableSupplier) {
         ObjectHelper.requireNonNull(completableSupplier, "completableSupplier");
-        return new CompletableDefer(completableSupplier);
+        return RxJavaPlugins.onAssembly(new CompletableDefer(completableSupplier));
     }
 
     /**
@@ -268,7 +268,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable error(final Callable<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
-        return new CompletableErrorSupplier(errorSupplier);
+        return RxJavaPlugins.onAssembly(new CompletableErrorSupplier(errorSupplier));
     }
     
     /**
@@ -284,7 +284,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable error(final Throwable error) {
         ObjectHelper.requireNonNull(error, "error is null");
-        return new CompletableError(error);
+        return RxJavaPlugins.onAssembly(new CompletableError(error));
     }
     
     
@@ -302,7 +302,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromAction(final Action run) {
         ObjectHelper.requireNonNull(run, "run is null");
-        return new CompletableFromAction(run);
+        return RxJavaPlugins.onAssembly(new CompletableFromAction(run));
     }
 
     /**
@@ -318,7 +318,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable fromCallable(final Callable<?> callable) {
         ObjectHelper.requireNonNull(callable, "callable is null");
-        return new CompletableFromCallable(callable);
+        return RxJavaPlugins.onAssembly(new CompletableFromCallable(callable));
     }
     
     /**
@@ -353,7 +353,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromObservable(final ObservableSource<T> observable) {
         ObjectHelper.requireNonNull(observable, "observable is null");
-        return new CompletableFromObservable<T>(observable);
+        return RxJavaPlugins.onAssembly(new CompletableFromObservable<T>(observable));
     }
     
     /**
@@ -371,7 +371,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromPublisher(final Publisher<T> publisher) {
         ObjectHelper.requireNonNull(publisher, "publisher is null");
-        return new CompletableFromPublisher<T>(publisher);
+        return RxJavaPlugins.onAssembly(new CompletableFromPublisher<T>(publisher));
     }
 
     /**
@@ -389,7 +389,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromSingle(final SingleSource<T> single) {
         ObjectHelper.requireNonNull(single, "single is null");
-        return new CompletableFromSingle<T>(single);
+        return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(single));
     }
     
     /**
@@ -404,7 +404,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable merge(CompletableSource... sources) {
+    public static Completable mergeArray(CompletableSource... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
@@ -412,7 +412,7 @@ public abstract class Completable implements CompletableSource {
         if (sources.length == 1) {
             return wrap(sources[0]);
         }
-        return new CompletableMergeArray(sources);
+        return RxJavaPlugins.onAssembly(new CompletableMergeArray(sources));
     }
 
     /**
@@ -429,7 +429,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(Iterable<? extends CompletableSource> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new CompletableMergeIterable(sources);
+        return RxJavaPlugins.onAssembly(new CompletableMergeIterable(sources));
     }
     
     /**
@@ -487,7 +487,7 @@ public abstract class Completable implements CompletableSource {
         if (maxConcurrency < 1) {
             throw new IllegalArgumentException("maxConcurrency > 0 required but it was " + maxConcurrency);
         }
-        return new CompletableMerge(sources, maxConcurrency, delayErrors);
+        return RxJavaPlugins.onAssembly(new CompletableMerge(sources, maxConcurrency, delayErrors));
     }
 
     /**
@@ -503,9 +503,9 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable mergeDelayError(CompletableSource... sources) {
+    public static Completable mergeArrayDelayError(CompletableSource... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new CompletableMergeDelayErrorArray(sources);
+        return RxJavaPlugins.onAssembly(new CompletableMergeDelayErrorArray(sources));
     }
 
     /**
@@ -523,7 +523,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable mergeDelayError(Iterable<? extends CompletableSource> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new CompletableMergeDelayErrorIterable(sources);
+        return RxJavaPlugins.onAssembly(new CompletableMergeDelayErrorIterable(sources));
     }
 
     
@@ -573,7 +573,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable never() {
-        return CompletableNever.INSTANCE;
+        return RxJavaPlugins.onAssembly(CompletableNever.INSTANCE);
     }
     
     /**
@@ -607,7 +607,7 @@ public abstract class Completable implements CompletableSource {
     public static Completable timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new CompletableTimer(delay, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new CompletableTimer(delay, unit, scheduler));
     }
     
     /**
@@ -673,7 +673,7 @@ public abstract class Completable implements CompletableSource {
         ObjectHelper.requireNonNull(completableFunction, "completableFunction is null");
         ObjectHelper.requireNonNull(disposer, "disposer is null");
         
-        return new CompletableUsing<R>(resourceSupplier, completableFunction, disposer, eager);
+        return RxJavaPlugins.onAssembly(new CompletableUsing<R>(resourceSupplier, completableFunction, disposer, eager));
     }
 
     /**
@@ -691,9 +691,9 @@ public abstract class Completable implements CompletableSource {
     public static Completable wrap(CompletableSource source) {
         ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Completable) {
-            return (Completable)source;
+            return RxJavaPlugins.onAssembly((Completable)source);
         }
-        return new CompletableFromUnsafeSource(source);
+        return RxJavaPlugins.onAssembly(new CompletableFromUnsafeSource(source));
     }
     
     /**
@@ -710,7 +710,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable ambWith(CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return amb(this, other);
+        return ambArray(this, other);
     }
 
     /**
@@ -730,7 +730,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> andThen(ObservableSource<T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return new ObservableDelaySubscriptionOther<T, Object>(next, toObservable());
+        return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<T, Object>(next, toObservable()));
     }
 
     /**
@@ -750,7 +750,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> andThen(Publisher<T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return new FlowableDelaySubscriptionOther<T, Object>(next, toFlowable());
+        return RxJavaPlugins.onAssembly(new FlowableDelaySubscriptionOther<T, Object>(next, toFlowable()));
     }
 
     /**
@@ -770,7 +770,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<T> andThen(SingleSource<T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return new SingleDelayWithCompletable<T>(next, this);
+        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<T>(next, this));
     }
 
     /**
@@ -881,7 +881,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable concatWith(CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return concat(this, other);
+        return concatArray(this, other);
     }
 
     /**
@@ -936,7 +936,7 @@ public abstract class Completable implements CompletableSource {
     public final Completable delay(final long delay, final TimeUnit unit, final Scheduler scheduler, final boolean delayError) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new CompletableDelay(this, delay, unit, scheduler, delayError);
+        return RxJavaPlugins.onAssembly(new CompletableDelay(this, delay, unit, scheduler, delayError));
     }
 
     /**
@@ -1019,7 +1019,7 @@ public abstract class Completable implements CompletableSource {
         ObjectHelper.requireNonNull(onTerminate, "onTerminate is null");
         ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
         ObjectHelper.requireNonNull(onDisposed, "onDisposed is null");
-        return new CompletablePeek(this, onSubscribe, onError, onComplete, onTerminate, onAfterTerminate, onDisposed);
+        return RxJavaPlugins.onAssembly(new CompletablePeek(this, onSubscribe, onError, onComplete, onTerminate, onAfterTerminate, onDisposed));
     }
     
     /**
@@ -1088,7 +1088,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable lift(final CompletableOperator onLift) {
         ObjectHelper.requireNonNull(onLift, "onLift is null");
-        return new CompletableLift(this, onLift);
+        return RxJavaPlugins.onAssembly(new CompletableLift(this, onLift));
     }
 
     /**
@@ -1105,7 +1105,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable mergeWith(CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return merge(this, other);
+        return mergeArray(this, other);
     }
     
     /**
@@ -1121,7 +1121,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable observeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new CompletableObserveOn(this, scheduler);
+        return RxJavaPlugins.onAssembly(new CompletableObserveOn(this, scheduler));
     }
     
     /**
@@ -1153,7 +1153,7 @@ public abstract class Completable implements CompletableSource {
     public final Completable onErrorComplete(final Predicate<? super Throwable> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
         
-        return new CompletableOnErrorComplete(this, predicate);
+        return RxJavaPlugins.onAssembly(new CompletableOnErrorComplete(this, predicate));
     }
     
     /**
@@ -1171,7 +1171,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable onErrorResumeNext(final Function<? super Throwable, ? extends CompletableSource> errorMapper) {
         ObjectHelper.requireNonNull(errorMapper, "errorMapper is null");
-        return new CompletableResumeNext(this, errorMapper);
+        return RxJavaPlugins.onAssembly(new CompletableResumeNext(this, errorMapper));
     }
     
     /**
@@ -1330,7 +1330,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable startWith(CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return concat(other, this);
+        return concatArray(other, this);
     }
 
     /**
@@ -1466,7 +1466,7 @@ public abstract class Completable implements CompletableSource {
     public final Completable subscribeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         
-        return new CompletableSubscribeOn(this, scheduler);
+        return RxJavaPlugins.onAssembly(new CompletableSubscribeOn(this, scheduler));
     }
 
     /**
@@ -1563,7 +1563,7 @@ public abstract class Completable implements CompletableSource {
     private Completable timeout0(long timeout, TimeUnit unit, Scheduler scheduler, CompletableSource other) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new CompletableTimeout(this, timeout, unit, scheduler, other);
+        return RxJavaPlugins.onAssembly(new CompletableTimeout(this, timeout, unit, scheduler, other));
     }
     
     /**
@@ -1599,7 +1599,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> toFlowable() {
-        return new CompletableToFlowable<T>(this);
+        return RxJavaPlugins.onAssembly(new CompletableToFlowable<T>(this));
     }
     
     /**
@@ -1614,7 +1614,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> toObservable() {
-        return new CompletableToObservable<T>(this);
+        return RxJavaPlugins.onAssembly(new CompletableToObservable<T>(this));
     }
     
     /**
@@ -1632,7 +1632,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<T> toSingle(final Callable<? extends T> completionValueSupplier) {
         ObjectHelper.requireNonNull(completionValueSupplier, "completionValueSupplier is null");
-        return new CompletableToSingle<T>(this, completionValueSupplier, null);
+        return RxJavaPlugins.onAssembly(new CompletableToSingle<T>(this, completionValueSupplier, null));
     }
     
     /**
@@ -1650,7 +1650,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<T> toSingleDefault(final T completionValue) {
         ObjectHelper.requireNonNull(completionValue, "completionValue is null");
-        return new CompletableToSingle<T>(this, null, completionValue);
+        return RxJavaPlugins.onAssembly(new CompletableToSingle<T>(this, null, completionValue));
     }
     
     /**
@@ -1667,7 +1667,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable unsubscribeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new CompletableUnsubscribeOn(this, scheduler);
+        return RxJavaPlugins.onAssembly(new CompletableUnsubscribeOn(this, scheduler));
     }
     // -------------------------------------------------------------------------
     // Fluent test support, super handy and reduces test preparation boilerplate

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -89,7 +89,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> amb(Iterable<? extends Publisher<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new FlowableAmb<T>(null, sources);
+        return RxJavaPlugins.onAssembly(new FlowableAmb<T>(null, sources));
     }
 
     /**
@@ -114,7 +114,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> amb(Publisher<? extends T>... sources) {
+    public static <T> Flowable<T> ambArray(Publisher<? extends T>... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
@@ -123,7 +123,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (len == 1) {
             return fromPublisher(sources[0]);
         }
-        return new FlowableAmb<T>(sources, null);
+        return RxJavaPlugins.onAssembly(new FlowableAmb<T>(sources, null));
     }
 
     /**
@@ -234,7 +234,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (sources.length == 0) {
             return empty();
         }
-        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false);
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false));
     }
 
     /**
@@ -303,7 +303,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false);
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false));
     }
 
     /**
@@ -411,7 +411,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (sources.length == 0) {
             return empty();
         }
-        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true);
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true));
     }
 
     /**
@@ -484,7 +484,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true);
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true));
     }
 
     /**
@@ -1102,7 +1102,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (sources.length == 1) {
             return fromPublisher(sources[0]);
         }
-        return new FlowableConcatArray<T>(sources, false);
+        return RxJavaPlugins.onAssembly(new FlowableConcatArray<T>(sources, false));
     }
 
     /**
@@ -1133,7 +1133,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (sources.length == 1) {
             return fromPublisher(sources[0]);
         }
-        return new FlowableConcatArray<T>(sources, true);
+        return RxJavaPlugins.onAssembly(new FlowableConcatArray<T>(sources, true));
     }
 
     /**
@@ -1189,7 +1189,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> Flowable<T> concatArrayEager(int maxConcurrency, int prefetch, Publisher<? extends T>... sources) {
-        return new FlowableConcatMapEager(new FlowableFromArray(sources), Functions.identity(), maxConcurrency, prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager(new FlowableFromArray(sources), Functions.identity(), maxConcurrency, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -1315,7 +1315,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> Flowable<T> concatEager(Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency, int prefetch) {
-        return new FlowableConcatMapEager(sources, Functions.identity(), maxConcurrency, prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager(sources, Functions.identity(), maxConcurrency, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -1369,7 +1369,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> Flowable<T> concatEager(Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int prefetch) {
-        return new FlowableConcatMapEager(new FlowableFromIterable(sources), Functions.identity(), maxConcurrency, prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager(new FlowableFromIterable(sources), Functions.identity(), maxConcurrency, prefetch, ErrorMode.IMMEDIATE));
     }
     
     /**
@@ -1415,7 +1415,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> create(FlowableOnSubscribe<T> source, FlowableEmitter.BackpressureMode mode) {
-        return new FlowableCreate<T>(source, mode);
+        return RxJavaPlugins.onAssembly(new FlowableCreate<T>(source, mode));
     }
 
     /**
@@ -1449,7 +1449,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> defer(Callable<? extends Publisher<? extends T>> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
-        return new FlowableDefer<T>(supplier);
+        return RxJavaPlugins.onAssembly(new FlowableDefer<T>(supplier));
     }
 
     /**
@@ -1474,7 +1474,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> empty() {
-        return (Flowable<T>) FlowableEmpty.INSTANCE;
+        return RxJavaPlugins.onAssembly((Flowable<T>) FlowableEmpty.INSTANCE);
     }
 
     /**
@@ -1501,7 +1501,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> error(Callable<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
-        return new FlowableError<T>(errorSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableError<T>(errorSupplier));
     }
 
     /**
@@ -1556,11 +1556,11 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(values, "values is null");
         if (values.length == 0) {
             return empty();
-        } else
-            if (values.length == 1) {
-                return just(values[0]);
-            }
-        return new FlowableFromArray<T>(values);
+        }
+        if (values.length == 1) {
+            return just(values[0]);
+        }
+        return RxJavaPlugins.onAssembly(new FlowableFromArray<T>(values));
     }
 
     /**
@@ -1591,7 +1591,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromCallable(Callable<? extends T> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
-        return new FlowableFromCallable<T>(supplier);
+        return RxJavaPlugins.onAssembly(new FlowableFromCallable<T>(supplier));
     }
 
     /**
@@ -1626,7 +1626,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future) {
         ObjectHelper.requireNonNull(future, "future is null");
-        return new FlowableFromFuture<T>(future, 0L, null);
+        return RxJavaPlugins.onAssembly(new FlowableFromFuture<T>(future, 0L, null));
     }
 
     /**
@@ -1666,7 +1666,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
         ObjectHelper.requireNonNull(future, "future is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
-        return new FlowableFromFuture<T>(future, timeout, unit);
+        return RxJavaPlugins.onAssembly(new FlowableFromFuture<T>(future, timeout, unit));
     }
 
     /**
@@ -1771,7 +1771,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> fromIterable(Iterable<? extends T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
-        return new FlowableFromIterable<T>(source);
+        return RxJavaPlugins.onAssembly(new FlowableFromIterable<T>(source));
     }
     
     /**
@@ -1794,11 +1794,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> fromPublisher(final Publisher<? extends T> publisher) {
         if (publisher instanceof Flowable) {
-            return (Flowable<T>)publisher;
+            return RxJavaPlugins.onAssembly((Flowable<T>)publisher);
         }
         ObjectHelper.requireNonNull(publisher, "publisher is null");
 
-        return new FlowableFromPublisher<T>(publisher);
+        return RxJavaPlugins.onAssembly(new FlowableFromPublisher<T>(publisher));
     }
 
     /**
@@ -1938,7 +1938,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator is null");
         ObjectHelper.requireNonNull(disposeState, "disposeState is null");
-        return new FlowableGenerate<T, S>(initialState, generator, disposeState);
+        return RxJavaPlugins.onAssembly(new FlowableGenerate<T, S>(initialState, generator, disposeState));
     }
 
     /**
@@ -2011,7 +2011,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
-        return new FlowableInterval(initialDelay, period, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableInterval(initialDelay, period, unit, scheduler));
     }
 
     /**
@@ -2109,8 +2109,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static Flowable<Long> intervalRange(long start, long count, long initialDelay, long period, TimeUnit unit, Scheduler scheduler) {
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         if (count == 0L) {
-            return Flowable.<Long>empty().delay(initialDelay, unit);
+            return RxJavaPlugins.onAssembly(Flowable.<Long>empty().delay(initialDelay, unit, scheduler));
         }
         
         long end = start + (count - 1);
@@ -2124,10 +2126,8 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (period < 0) {
             period = 0L;
         }
-        ObjectHelper.requireNonNull(unit, "unit is null");
-        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
-        return new FlowableIntervalRange(start, end, initialDelay, period, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableIntervalRange(start, end, initialDelay, period, unit, scheduler));
     }
 
     /**
@@ -2160,7 +2160,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> just(T value) {
         ObjectHelper.requireNonNull(value, "value is null");
-        return new FlowableJust<T>(value);
+        return RxJavaPlugins.onAssembly(new FlowableJust<T>(value));
     }
 
     /**
@@ -3272,7 +3272,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> never() {
-        return (Flowable<T>) FlowableNever.INSTANCE;
+        return RxJavaPlugins.onAssembly((Flowable<T>) FlowableNever.INSTANCE);
     }
 
     /**
@@ -3311,7 +3311,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if ((long)start + (count - 1) > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Integer overflow");
         }
-        return new FlowableRange(start, count);
+        return RxJavaPlugins.onAssembly(new FlowableRange(start, count));
     }
 
     /**
@@ -3408,7 +3408,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(p2, "p2 is null");
         ObjectHelper.requireNonNull(isEqual, "isEqual is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableSequenceEqual<T>(p1, p2, isEqual, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableSequenceEqual<T>(p1, p2, isEqual, bufferSize));
     }
 
     /**
@@ -3649,7 +3649,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
-        return new FlowableTimer(delay, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableTimer(delay, unit, scheduler));
     }
 
     /**
@@ -3666,6 +3666,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T> the value type emitted
      * @param onSubscribe the Publisher instance to wrap
      * @return the new Flowable instance
+     * @throws IllegalArgumentException if {@code onSubscribe} is a subclass of {@code Flowable}; such
+     * instances don't need conversion and is possibly a port remnant from 1.x or one should use {@link #hide()}
+     * instead.
      */
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3674,7 +3677,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (onSubscribe instanceof Flowable) {
             throw new IllegalArgumentException("unsafeCreate(Flowable) should be upgraded");
         }
-        return new FlowableFromPublisher<T>(onSubscribe);
+        return RxJavaPlugins.onAssembly(new FlowableFromPublisher<T>(onSubscribe));
     }
 
     /**
@@ -3746,7 +3749,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
         ObjectHelper.requireNonNull(sourceSupplier, "sourceSupplier is null");
         ObjectHelper.requireNonNull(disposer, "disposer is null");
-        return new FlowableUsing<T, D>(resourceSupplier, sourceSupplier, disposer, eager);
+        return RxJavaPlugins.onAssembly(new FlowableUsing<T, D>(resourceSupplier, sourceSupplier, disposer, eager));
     }
 
     /**
@@ -3824,7 +3827,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, R> Flowable<R> zip(Iterable<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new FlowableZip<T, R>(null, sources, zipper, bufferSize(), false);
+        return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(null, sources, zipper, bufferSize(), false));
     }
 
     /**
@@ -4607,7 +4610,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableZip<T, R>(sources, null, zipper, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(sources, null, zipper, bufferSize, delayError));
     }
 
     /**
@@ -4667,7 +4670,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableZip<T, R>(null, sources, zipper, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(null, sources, zipper, bufferSize, delayError));
     }
 
     // ***************************************************************************************************
@@ -4697,7 +4700,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Boolean> all(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new FlowableAll<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableAll<T>(this, predicate));
     }
 
     /**
@@ -4724,7 +4727,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> ambWith(Publisher<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return amb(this, other);
+        return ambArray(this, other);
     }
 
     /**
@@ -4754,11 +4757,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Boolean> any(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new FlowableAny<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableAny<T>(this, predicate));
     }
 
     /**
-     * Returns the first item emitted by this {@code BlockingObservable}, or throws
+     * Returns the first item emitted by this {@code Flowable}, or throws
      * {@code NoSuchElementException} if it emits no items.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -4768,9 +4771,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code blockingFirst} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the first item emitted by this {@code BlockingObservable}
+     * @return the first item emitted by this {@code Flowable}
      * @throws NoSuchElementException
-     *             if this {@code BlockingObservable} emits no items
+     *             if this {@code Flowable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public final T blockingFirst() {
@@ -4784,7 +4787,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns the first item emitted by this {@code BlockingObservable}, or a default value if it emits no
+     * Returns the first item emitted by this {@code Flowable}, or a default value if it emits no
      * items.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -4795,8 +4798,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param defaultValue
-     *            a default value to return if this {@code BlockingObservable} emits no items
-     * @return the first item emitted by this {@code BlockingObservable}, or the default value if it emits no
+     *            a default value to return if this {@code Flowable} emits no items
+     * @return the first item emitted by this {@code Flowable}, or the default value if it emits no
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
@@ -4808,7 +4811,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Invokes a method on each item emitted by this {@code BlockingObservable} and blocks until the Observable
+     * Invokes a method on each item emitted by this {@code Flowable} and blocks until the Observable
      * completes.
      * <p>
      * <em>Note:</em> This will block even if the underlying Observable is asynchronous.
@@ -4831,7 +4834,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * 
      * @param onNext
-     *            the {@link Consumer} to invoke for each item emitted by the {@code BlockingObservable}
+     *            the {@link Consumer} to invoke for each item emitted by the {@code Flowable}
      * @throws RuntimeException
      *             if an error occurs
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX documentation: Subscribe</a>
@@ -4851,7 +4854,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * Converts this {@code BlockingObservable} into an {@link Iterable}.
+     * Converts this {@code Flowable} into an {@link Iterable}.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toIterable.png" alt="">
      * <dl>
@@ -4862,7 +4865,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code blockingITerable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Iterable} version of this {@code BlockingObservable}
+     * @return an {@link Iterable} version of this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public final Iterable<T> blockingIterable() {
@@ -4870,7 +4873,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * Converts this {@code BlockingObservable} into an {@link Iterable}.
+     * Converts this {@code Flowable} into an {@link Iterable}.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toIterable.png" alt="">
      * <dl>
@@ -4878,11 +4881,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
      *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code blockingFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code blockingIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param bufferSize the number of items to prefetch from the current Flowable
-     * @return an {@link Iterable} version of this {@code BlockingObservable}
+     * @return an {@link Iterable} version of this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public final Iterable<T> blockingIterable(int bufferSize) {
@@ -4891,8 +4894,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * Returns the last item emitted by this {@code BlockingObservable}, or throws
-     * {@code NoSuchElementException} if this {@code BlockingObservable} emits no items.
+     * Returns the last item emitted by this {@code Flowable}, or throws
+     * {@code NoSuchElementException} if this {@code Flowable} emits no items.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.last.png" alt="">
      * <dl>
@@ -4903,9 +4906,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code blockingLast} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the last item emitted by this {@code BlockingObservable}
+     * @return the last item emitted by this {@code Flowable}
      * @throws NoSuchElementException
-     *             if this {@code BlockingObservable} emits no items
+     *             if this {@code Flowable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
     public final T blockingLast() {
@@ -4919,7 +4922,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns the last item emitted by this {@code BlockingObservable}, or a default value if it emits no
+     * Returns the last item emitted by this {@code Flowable}, or a default value if it emits no
      * items.
      * <p>
      * <img width="640" height="310" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.lastOrDefault.png" alt="">
@@ -4932,8 +4935,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param defaultValue
-     *            a default value to return if this {@code BlockingObservable} emits no items
-     * @return the last item emitted by the {@code BlockingObservable}, or the default value if it emits no
+     *            a default value to return if this {@code Flowable} emits no items
+     * @return the last item emitted by the {@code Flowable}, or the default value if it emits no
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
@@ -4948,10 +4951,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * Returns an {@link Iterable} that returns the latest item emitted by this {@code BlockingObservable},
+     * Returns an {@link Iterable} that returns the latest item emitted by this {@code Flowable},
      * waiting if necessary for one to become available.
      * <p>
-     * If this {@code BlockingObservable} produces items faster than {@code Iterator.next} takes them,
+     * If this {@code Flowable} produces items faster than {@code Iterator.next} takes them,
      * {@code onNext} events might be skipped, but {@code onError} or {@code onCompleted} events are not.
      * <p>
      * Note also that an {@code onNext} directly followed by {@code onCompleted} might hide the {@code onNext}
@@ -4964,7 +4967,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code blockingLatest} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an Iterable that always returns the latest item emitted by this {@code BlockingObservable}
+     * @return an Iterable that always returns the latest item emitted by this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public final Iterable<T> blockingLatest() {
@@ -4973,7 +4976,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     
     /**
      * Returns an {@link Iterable} that always returns the item most recently emitted by this
-     * {@code BlockingObservable}.
+     * {@code Flowable}.
      * <p>
      * <img width="640" height="490" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.mostRecent.png" alt="">
      * <dl>
@@ -4986,8 +4989,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param initialValue
      *            the initial value that the {@link Iterable} sequence will yield if this
-     *            {@code BlockingObservable} has not yet emitted an item
-     * @return an {@link Iterable} that on each iteration returns the item that this {@code BlockingObservable}
+     *            {@code Flowable} has not yet emitted an item
+     * @return an {@link Iterable} that on each iteration returns the item that this {@code Flowable}
      *         has most recently emitted
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
@@ -4996,7 +4999,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * Returns an {@link Iterable} that blocks until this {@code BlockingObservable} emits another item, then
+     * Returns an {@link Iterable} that blocks until this {@code Flowable} emits another item, then
      * returns that item.
      * <p>
      * <img width="640" height="490" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.next.png" alt="">
@@ -5008,7 +5011,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code blockingNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Iterable} that blocks upon each iteration until this {@code BlockingObservable} emits
+     * @return an {@link Iterable} that blocks upon each iteration until this {@code Flowable} emits
      *         a new item, whereupon the Iterable returns that item
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX documentation: TakeLast</a>
      */
@@ -5017,7 +5020,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * If this {@code BlockingObservable} completes after emitting a single item, return that item, otherwise
+     * If this {@code Flowable} completes after emitting a single item, return that item, otherwise
      * throw a {@code NoSuchElementException}.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.single.png" alt="">
@@ -5029,7 +5032,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code blockingSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the single item emitted by this {@code BlockingObservable}
+     * @return the single item emitted by this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public final T blockingSingle() {
@@ -5037,7 +5040,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * If this {@code BlockingObservable} completes after emitting a single item, return that item; if it emits
+     * If this {@code Flowable} completes after emitting a single item, return that item; if it emits
      * more than one item, throw an {@code IllegalArgumentException}; if it emits no items, return a default
      * value.
      * <p>
@@ -5051,8 +5054,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param defaultValue
-     *            a default value to return if this {@code BlockingObservable} emits no items
-     * @return the single item emitted by this {@code BlockingObservable}, or the default value if it emits no
+     *            a default value to return if this {@code Flowable} emits no items
+     * @return the single item emitted by this {@code Flowable}, or the default value if it emits no
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
@@ -5061,13 +5064,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
     
     /**
-     * Returns a {@link Future} representing the single value emitted by this {@code BlockingObservable}.
+     * Returns a {@link Future} representing the single value emitted by this {@code Flowable}.
      * <p>
      * If the {@link Flowable} emits more than one item, {@link java.util.concurrent.Future} will receive an
      * {@link java.lang.IllegalArgumentException}. If the {@link Flowable} is empty, {@link java.util.concurrent.Future}
      * will receive an {@link java.util.NoSuchElementException}.
      * <p>
-     * If the {@code BlockingObservable} may emit more than one item, use {@code Observable.toList().toBlocking().toFuture()}.
+     * If the {@code Flowable} may emit more than one item, use {@code Observable.toList().toBlocking().toFuture()}.
      * <p>
      * <img width="640" height="395" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toFuture.png" alt="">
      * <dl>
@@ -5078,7 +5081,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a {@link Future} that expects a single item to be emitted by this {@code BlockingObservable}
+     * @return a {@link Future} that expects a single item to be emitted by this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public final Future<T> toFuture() {
@@ -5264,7 +5267,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U extends Collection<? super T>> Flowable<U> buffer(int count, int skip, Callable<U> bufferSupplier) {
-        return new FlowableBuffer<T, U>(this, count, skip, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableBuffer<T, U>(this, count, skip, bufferSupplier));
     }
     
     /**
@@ -5404,7 +5407,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new FlowableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false);
+        return RxJavaPlugins.onAssembly(new FlowableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
     }
     
     /**
@@ -5556,7 +5559,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         verifyPositive(count, "count");
-        return new FlowableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize);
+        return RxJavaPlugins.onAssembly(new FlowableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
     }
 
     /**
@@ -5663,7 +5666,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(bufferOpenings, "bufferOpenings is null");
         ObjectHelper.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new FlowableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier));
     }
 
     /**
@@ -5767,7 +5770,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <B, U extends Collection<? super T>> Flowable<U> buffer(Publisher<B> boundary, Callable<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new FlowableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier));
     }
 
     /**
@@ -5833,7 +5836,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Callable<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundarySupplier, "boundarySupplier is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new FlowableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier));
     }
 
     /**
@@ -6013,7 +6016,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <U> Flowable<U> collect(Callable<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
         ObjectHelper.requireNonNull(collector, "collectior is null");
-        return new FlowableCollect<T, U>(this, initialValueSupplier, collector);
+        return RxJavaPlugins.onAssembly(new FlowableCollect<T, U>(this, initialValueSupplier, collector));
     }
 
     /**
@@ -6147,7 +6150,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(prefetch, "prefetch");
-        return new FlowableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -6217,7 +6220,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(prefetch, "prefetch");
-        return new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.IMMEDIATE));
     }
 
 
@@ -6275,7 +6278,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             int maxConcurrency, int prefetch) {
         verifyPositive(maxConcurrency, "maxConcurrency");
         verifyPositive(prefetch, "prefetch");
-        return new FlowableConcatMapEager<T, R>(this, mapper, maxConcurrency, prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager<T, R>(this, mapper, maxConcurrency, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -6339,7 +6342,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> concatMapEagerDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper, 
             int maxConcurrency, int prefetch, boolean tillTheEnd) {
-        return new FlowableConcatMapEager<T, R>(this, mapper, maxConcurrency, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager<T, R>(this, mapper, maxConcurrency, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
     /**
@@ -6400,7 +6403,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
-        return new FlowableFlattenIterable<T, U>(this, mapper, prefetch);
+        return RxJavaPlugins.onAssembly(new FlowableFlattenIterable<T, U>(this, mapper, prefetch));
     }
 
     /**
@@ -6477,7 +6480,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Long> count() {
-        return new FlowableCount<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableCount<T>(this));
     }
 
     /**
@@ -6506,7 +6509,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> debounce(Function<? super T, ? extends Publisher<U>> debounceSelector) {
         ObjectHelper.requireNonNull(debounceSelector, "debounceSelector is null");
-        return new FlowableDebounce<T, U>(this, debounceSelector);
+        return RxJavaPlugins.onAssembly(new FlowableDebounce<T, U>(this, debounceSelector));
     }
 
     /**
@@ -6593,7 +6596,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableDebounceTimed<T>(this, timeout, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableDebounceTimed<T>(this, timeout, unit, scheduler));
     }
 
     /**
@@ -6768,7 +6771,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         
-        return new FlowableDelay<T>(this, delay, unit, scheduler, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableDelay<T>(this, delay, unit, scheduler, delayError));
     }
 
     /**
@@ -6831,7 +6834,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     public final <U> Flowable<T> delaySubscription(Publisher<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new FlowableDelaySubscriptionOther<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new FlowableDelaySubscriptionOther<T, U>(this, other));
     }
 
     /**
@@ -6910,7 +6913,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <T2> Flowable<T2> dematerialize() {
         @SuppressWarnings("unchecked")
         Flowable<Notification<T2>> m = (Flowable<Notification<T2>>)this;
-        return new FlowableDematerialize<T2>(m);
+        return RxJavaPlugins.onAssembly(new FlowableDematerialize<T2>(m));
     }
 
     /**
@@ -7070,7 +7073,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
         ObjectHelper.requireNonNull(comparer, "comparer is null");
-        return new FlowableDistinctUntilChanged<T>(this, comparer);
+        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<T>(this, comparer));
     }
     
     /**
@@ -7179,7 +7182,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(onError, "onError is null");
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        return new FlowableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate);
+        return RxJavaPlugins.onAssembly(new FlowableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate));
     }
     
     /**
@@ -7301,7 +7304,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         ObjectHelper.requireNonNull(onRequest, "onRequest is null");
         ObjectHelper.requireNonNull(onCancel, "onCancel is null");
-        return new FlowableDoOnLifecycle<T>(this, onSubscribe, onRequest, onCancel);
+        return RxJavaPlugins.onAssembly(new FlowableDoOnLifecycle<T>(this, onSubscribe, onRequest, onCancel));
     }
 
     /**
@@ -7441,7 +7444,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        return new FlowableElementAt<T>(this, index, null);
+        return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(this, index, null));
     }
 
     /**
@@ -7474,7 +7477,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
         ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
-        return new FlowableElementAt<T>(this, index, defaultValue);
+        return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(this, index, defaultValue));
     }
 
     /**
@@ -7500,7 +7503,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> filter(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new FlowableFilter<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableFilter<T>(this, predicate));
     }
 
     /**
@@ -7730,7 +7733,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         verifyPositive(maxConcurrency, "maxConcurrency");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableFlatMap<T, R>(this, mapper, delayErrors, maxConcurrency, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableFlatMap<T, R>(this, mapper, delayErrors, maxConcurrency, bufferSize));
     }
 
     /**
@@ -8065,7 +8068,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<U> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, int bufferSize) {
-        return new FlowableFlattenIterable<T, U>(this, mapper, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableFlattenIterable<T, U>(this, mapper, bufferSize));
     }
 
     /**
@@ -8491,7 +8494,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         verifyPositive(bufferSize, "bufferSize");
 
-        return new FlowableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError));
     }
 
     /**
@@ -8535,8 +8538,8 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<? super T, ? extends Publisher<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super Flowable<TRight>, ? extends R> resultSelector) {
-        return new FlowableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
-                this, other, leftEnd, rightEnd, resultSelector);
+        return RxJavaPlugins.onAssembly(new FlowableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+                this, other, leftEnd, rightEnd, resultSelector));
     }
 
     /**
@@ -8558,7 +8561,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> hide() {
-        return new FlowableHide<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableHide<T>(this));
     }
 
     /**
@@ -8580,7 +8583,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> ignoreElements() {
-        return new FlowableIgnoreElements<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<T>(this));
     }
 
     /**
@@ -8648,8 +8651,8 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<? super T, ? extends Publisher<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super TRight, ? extends R> resultSelector) {
-        return new FlowableJoin<T, TRight, TLeftEnd, TRightEnd, R>(
-                this, other, leftEnd, rightEnd, resultSelector);
+        return RxJavaPlugins.onAssembly(new FlowableJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+                this, other, leftEnd, rightEnd, resultSelector));
     }
     
 
@@ -8735,8 +8738,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> lift(FlowableOperator<? extends R, ? super T> lifter) {
         ObjectHelper.requireNonNull(lifter, "lifter is null");
-        // using onSubscribe so the fusing has access to the underlying raw Publisher
-        return new FlowableLift<R, T>(this, lifter);
+        return RxJavaPlugins.onAssembly(new FlowableLift<R, T>(this, lifter));
     }
 
     /**
@@ -8763,7 +8765,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> map(Function<? super T, ? extends R> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
-        return new FlowableMap<T, R>(this, mapper);
+        return RxJavaPlugins.onAssembly(new FlowableMap<T, R>(this, mapper));
     }
 
     /**
@@ -8786,7 +8788,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<Notification<T>> materialize() {
-        return new FlowableMaterialize<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableMaterialize<T>(this));
     }
 
     /**
@@ -8923,7 +8925,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableObserveOn<T>(this, scheduler, delayError, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableObserveOn<T>(this, scheduler, delayError, bufferSize));
     }
 
     /**
@@ -9084,7 +9086,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureBuffer(int capacity, boolean delayError, boolean unbounded) {
         verifyPositive(capacity, "bufferSize");
-        return new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, Functions.EMPTY_ACTION);
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, Functions.EMPTY_ACTION));
     }
 
     /**
@@ -9119,7 +9121,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> onBackpressureBuffer(int capacity, boolean delayError, boolean unbounded, 
             Action onOverflow) {
         ObjectHelper.requireNonNull(onOverflow, "onOverflow is null");
-        return new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, onOverflow);
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, onOverflow));
     }
 
     /**
@@ -9185,7 +9187,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Publisher<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
         ObjectHelper.requireNonNull(overflowStrategy, "strategy is null");
         verifyPositive(capacity, "capacity");
-        return new FlowableOnBackpressureBufferStrategy<T>(this, capacity, onOverflow, overflowStrategy);
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBufferStrategy<T>(this, capacity, onOverflow, overflowStrategy));
     }
 
     /**
@@ -9210,7 +9212,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureDrop() {
-        return new FlowableOnBackpressureDrop<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureDrop<T>(this));
     }
 
     /**
@@ -9238,7 +9240,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureDrop(Consumer<? super T> onDrop) {
         ObjectHelper.requireNonNull(onDrop, "onDrop is null");
-        return new FlowableOnBackpressureDrop<T>(this, onDrop);
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureDrop<T>(this, onDrop));
     }
 
     /**
@@ -9270,7 +9272,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureLatest() {
-        return new FlowableOnBackpressureLatest<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureLatest<T>(this));
     }
 
     /**
@@ -9312,7 +9314,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onErrorResumeNext(Function<? super Throwable, ? extends Publisher<? extends T>> resumeFunction) {
         ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
-        return new FlowableOnErrorNext<T>(this, resumeFunction, false);
+        return RxJavaPlugins.onAssembly(new FlowableOnErrorNext<T>(this, resumeFunction, false));
     }
 
     /**
@@ -9392,7 +9394,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
         ObjectHelper.requireNonNull(valueSupplier, "valueSupplier is null");
-        return new FlowableOnErrorReturn<T>(this, valueSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableOnErrorReturn<T>(this, valueSupplier));
     }
 
     /**
@@ -9475,7 +9477,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onExceptionResumeNext(final Publisher<? extends T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return new FlowableOnErrorNext<T>(this, Functions.justFunction(next), true);
+        return RxJavaPlugins.onAssembly(new FlowableOnErrorNext<T>(this, Functions.justFunction(next), true));
     }
 
     /**
@@ -9495,7 +9497,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onTerminateDetach() {
-        return new FlowableDetach<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableDetach<T>(this));
     }
     
     /**
@@ -9586,7 +9588,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> publish(Function<? super Flowable<T>, ? extends Publisher<? extends R>> selector, int prefetch) {
         ObjectHelper.requireNonNull(selector, "selector is null");
         verifyPositive(prefetch, "prefetch");
-        return new FlowablePublishMulticast<T, R>(this, selector, prefetch, false);
+        return RxJavaPlugins.onAssembly(new FlowablePublishMulticast<T, R>(this, selector, prefetch, false));
     }
 
     /**
@@ -9828,7 +9830,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (count == 0) {
             return empty();
         }
-        return new FlowableRepeat<T>(this, count);
+        return RxJavaPlugins.onAssembly(new FlowableRepeat<T>(this, count));
     }
 
     /**
@@ -9856,7 +9858,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeatUntil(BooleanSupplier stop) {
         ObjectHelper.requireNonNull(stop, "stop is null");
-        return new FlowableRepeatUntil<T>(this, stop);
+        return RxJavaPlugins.onAssembly(new FlowableRepeatUntil<T>(this, stop));
     }
     
     /**
@@ -9885,7 +9887,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeatWhen(final Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         ObjectHelper.requireNonNull(handler, "handler is null");
-        return new FlowableRepeatWhen<T>(this, handler);
+        return RxJavaPlugins.onAssembly(new FlowableRepeatWhen<T>(this, handler));
     }
     
     /**
@@ -10493,7 +10495,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
         
-        return new FlowableRetryBiPredicate<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableRetryBiPredicate<T>(this, predicate));
     }
     
     /**
@@ -10551,7 +10553,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         ObjectHelper.requireNonNull(predicate, "predicate is null");
 
-        return new FlowableRetryPredicate<T>(this, times, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableRetryPredicate<T>(this, times, predicate));
     }
     
     /**
@@ -10649,7 +10651,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
         ObjectHelper.requireNonNull(handler, "handler is null");
         
-        return new FlowableRetryWhen<T>(this, handler);
+        return RxJavaPlugins.onAssembly(new FlowableRetryWhen<T>(this, handler));
     }
     
     /**
@@ -10734,7 +10736,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableSampleTimed<T>(this, period, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableSampleTimed<T>(this, period, unit, scheduler));
     }
     
     /**
@@ -10763,7 +10765,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> sample(Publisher<U> sampler) {
         ObjectHelper.requireNonNull(sampler, "sampler is null");
-        return new FlowableSamplePublisher<T>(this, sampler);
+        return RxJavaPlugins.onAssembly(new FlowableSamplePublisher<T>(this, sampler));
     }
     
     /**
@@ -10794,7 +10796,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> scan(BiFunction<T, T, T> accumulator) {
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
-        return new FlowableScan<T>(this, accumulator);
+        return RxJavaPlugins.onAssembly(new FlowableScan<T>(this, accumulator));
     }
 
     /**
@@ -10899,7 +10901,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> scanWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
-        return new FlowableScanSeed<T, R>(this, seedSupplier, accumulator);
+        return RxJavaPlugins.onAssembly(new FlowableScanSeed<T, R>(this, seedSupplier, accumulator));
     }
     
     /**
@@ -10928,7 +10930,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> serialize() {
-        return new FlowableSerialized<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableSerialized<T>(this));
     }
 
     /**
@@ -10982,7 +10984,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> single() {
-        return new FlowableSingle<T>(this, null);
+        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(this, null));
     }
     
     /**
@@ -11011,7 +11013,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> single(T defaultValue) {
         ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
-        return new FlowableSingle<T>(this, defaultValue);
+        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(this, defaultValue));
     }
     
     /**
@@ -11037,9 +11039,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> skip(long count) {
         if (count <= 0L) {
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
-        return new FlowableSkip<T>(this, count);
+        return RxJavaPlugins.onAssembly(new FlowableSkip<T>(this, count));
     }
 
     /**
@@ -11131,9 +11133,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         } 
         if (count == 0) {
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
-        return new FlowableSkipLast<T>(this, count);
+        return RxJavaPlugins.onAssembly(new FlowableSkipLast<T>(this, count));
     }
     
     /**
@@ -11302,7 +11304,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         verifyPositive(bufferSize, "bufferSize");
         // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
         int s = bufferSize << 1; 
-        return new FlowableSkipLastTimed<T>(this, time, unit, scheduler, s, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableSkipLastTimed<T>(this, time, unit, scheduler, s, delayError));
     }
     
     /**
@@ -11330,7 +11332,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> skipUntil(Publisher<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new FlowableSkipUntil<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new FlowableSkipUntil<T, U>(this, other));
     }
     
     /**
@@ -11356,7 +11358,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> skipWhile(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new FlowableSkipWhile<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableSkipWhile<T>(this, predicate));
     }
     /**
      * Returns a Flowable that emits the events emitted by source Publisher, in a
@@ -11516,7 +11518,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> startWithArray(T... values) {
         Flowable<T> fromArray = fromArray(values);
         if (fromArray == empty()) {
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
         return concatArray(fromArray, this);
     }
@@ -11739,7 +11741,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> subscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableSubscribeOn<T>(this, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<T>(this, scheduler));
     }
 
     /**
@@ -11767,7 +11769,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> switchIfEmpty(Publisher<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new FlowableSwitchIfEmpty<T>(this, other);
+        return RxJavaPlugins.onAssembly(new FlowableSwitchIfEmpty<T>(this, other));
     }
 
     /**
@@ -11913,7 +11915,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableSwitchMap<T, R>(this, mapper, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMap<T, R>(this, mapper, bufferSize, delayError));
     }
     
     /**
@@ -11946,7 +11948,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (count < 0) {
             throw new IllegalArgumentException("n >= required but it was " + count);
         }
-        return new FlowableTake<T>(this, count);
+        return RxJavaPlugins.onAssembly(new FlowableTake<T>(this, count));
     }
 
     /**
@@ -12061,9 +12063,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             return ignoreElements();
         } else
         if (count == 1) {
-            return new FlowableTakeLastOne<T>(this);
+            return RxJavaPlugins.onAssembly(new FlowableTakeLastOne<T>(this));
         }
-        return new FlowableTakeLast<T>(this, count);
+        return RxJavaPlugins.onAssembly(new FlowableTakeLast<T>(this, count));
     }
 
     /**
@@ -12174,7 +12176,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         }
-        return new FlowableTakeLastTimed<T>(this, count, time, unit, scheduler, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new FlowableTakeLastTimed<T>(this, count, time, unit, scheduler, bufferSize, delayError));
     }
 
     /**
@@ -12376,7 +12378,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> takeUntil(Predicate<? super T> stopPredicate) {
         ObjectHelper.requireNonNull(stopPredicate, "stopPredicate is null");
-        return new FlowableTakeUntilPredicate<T>(this, stopPredicate);
+        return RxJavaPlugins.onAssembly(new FlowableTakeUntilPredicate<T>(this, stopPredicate));
     }
     
     /**
@@ -12404,7 +12406,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> takeUntil(Publisher<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new FlowableTakeUntil<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new FlowableTakeUntil<T, U>(this, other));
     }
 
     /**
@@ -12431,7 +12433,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> takeWhile(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new FlowableTakeWhile<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new FlowableTakeWhile<T>(this, predicate));
     }
 
     /**
@@ -12494,7 +12496,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler));
     }
 
     /**
@@ -12743,7 +12745,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableTimeInterval<T>(this, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableTimeInterval<T>(this, unit, scheduler));
     }
 
     /**
@@ -13033,7 +13035,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Scheduler scheduler) {
         ObjectHelper.requireNonNull(timeUnit, "timeUnit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other);
+        return RxJavaPlugins.onAssembly(new FlowableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other));
     }
 
     private <U, V> Flowable<T> timeout0(
@@ -13041,7 +13043,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<? super T, ? extends Publisher<V>> timeoutSelector, 
                     Publisher<? extends T> other) {
         ObjectHelper.requireNonNull(timeoutSelector, "timeoutSelector is null");
-        return new FlowableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other);
+        return RxJavaPlugins.onAssembly(new FlowableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other));
     }
 
     /**
@@ -13191,7 +13193,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable toCompletable() {
-        return new CompletableFromPublisher<T>(this);
+        return RxJavaPlugins.onAssembly(new CompletableFromPublisher<T>(this));
     }
     
     /**
@@ -13223,7 +13225,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<List<T>> toList() {
-        return new FlowableToList<T, List<T>>(this);
+        return RxJavaPlugins.onAssembly(new FlowableToList<T, List<T>>(this));
     }
 
     /**
@@ -13258,7 +13260,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<List<T>> toList(final int capacityHint) {
         verifyPositive(capacityHint, "capacityHint");
-        return new FlowableToList<T, List<T>>(this, Functions.<T>createArrayList(capacityHint));
+        return RxJavaPlugins.onAssembly(new FlowableToList<T, List<T>>(this, Functions.<T>createArrayList(capacityHint)));
     }
 
     /**
@@ -13294,7 +13296,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U extends Collection<? super T>> Flowable<U> toList(Callable<U> collectionSupplier) {
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return new FlowableToList<T, U>(this, collectionSupplier);
+        return RxJavaPlugins.onAssembly(new FlowableToList<T, U>(this, collectionSupplier));
     }
 
     /**
@@ -13548,7 +13550,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> toObservable() {
-        return new ObservableFromPublisher<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableFromPublisher<T>(this));
     }
     
     /**
@@ -13576,7 +13578,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
-        return new SingleFromPublisher<T>(this);
+        return RxJavaPlugins.onAssembly(new SingleFromPublisher<T>(this));
     }
 
     /**
@@ -13714,7 +13716,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> unsubscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new FlowableUnsubscribeOn<T>(this, scheduler);
+        return RxJavaPlugins.onAssembly(new FlowableUnsubscribeOn<T>(this, scheduler));
     }
     
     /**
@@ -13809,7 +13811,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         verifyPositive(skip, "skip");
         verifyPositive(count, "count");
         verifyPositive(bufferSize, "bufferSize");
-        return new FlowableWindow<T>(this, count, skip, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableWindow<T>(this, count, skip, bufferSize));
     }
     
     /**
@@ -13920,7 +13922,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
-        return new FlowableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false);
+        return RxJavaPlugins.onAssembly(new FlowableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false));
     }
 
     /**
@@ -14192,7 +14194,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
         verifyPositive(count, "count");
-        return new FlowableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart);
+        return RxJavaPlugins.onAssembly(new FlowableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart));
     }
     
     /**
@@ -14253,7 +14255,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Flowable<Flowable<T>> window(Publisher<B> boundary, int bufferSize) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
-        return new FlowableWindowBoundary<T, B>(this, boundary, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableWindowBoundary<T, B>(this, boundary, bufferSize));
     }
 
     /**
@@ -14329,7 +14331,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<? super U, ? extends Publisher<V>> windowClose, int bufferSize) {
         ObjectHelper.requireNonNull(windowOpen, "windowOpen is null");
         ObjectHelper.requireNonNull(windowClose, "windowClose is null");
-        return new FlowableWindowBoundarySelector<T, U, V>(this, windowOpen, windowClose, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableWindowBoundarySelector<T, U, V>(this, windowOpen, windowClose, bufferSize));
     }
     
     /**
@@ -14396,7 +14398,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Flowable<Flowable<T>> window(Callable<? extends Publisher<B>> boundary, int bufferSize) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
-        return new FlowableWindowBoundarySupplier<T, B>(this, boundary, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowableWindowBoundarySupplier<T, B>(this, boundary, bufferSize));
     }
 
     /**
@@ -14434,7 +14436,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
 
-        return new FlowableWithLatestFrom<T, U, R>(this, combiner, other);
+        return RxJavaPlugins.onAssembly(new FlowableWithLatestFrom<T, U, R>(this, combiner, other));
     }
 
     /**
@@ -14569,7 +14571,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> withLatestFrom(Publisher<?>[] others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
-        return new FlowableWithLatestFromMany<T, R>(this, others, combiner);
+        return RxJavaPlugins.onAssembly(new FlowableWithLatestFromMany<T, R>(this, others, combiner));
     }
 
     /**
@@ -14598,7 +14600,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> withLatestFrom(Iterable<? extends Publisher<?>> others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
-        return new FlowableWithLatestFromMany<T, R>(this, others, combiner);
+        return RxJavaPlugins.onAssembly(new FlowableWithLatestFromMany<T, R>(this, others, combiner));
     }
 
     /**
@@ -14636,7 +14638,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <U, R> Flowable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(zipper, "zipper is null");
-        return new FlowableZipIterable<T, U, R>(this, other, zipper);
+        return RxJavaPlugins.onAssembly(new FlowableZipIterable<T, U, R>(this, other, zipper));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -79,7 +79,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public static <T> Observable<T> amb(Iterable<? extends ObservableSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new ObservableAmb<T>(null, sources);
+        return RxJavaPlugins.onAssembly(new ObservableAmb<T>(null, sources));
     }
     
     /**
@@ -101,7 +101,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> amb(ObservableSource<? extends T>... sources) {
+    public static <T> Observable<T> ambArray(ObservableSource<? extends T>... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
@@ -110,7 +110,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (len == 1) {
             return (Observable<T>)wrap(sources[0]);
         }
-        return new ObservableAmb<T>(sources, null);
+        return RxJavaPlugins.onAssembly(new ObservableAmb<T>(sources, null));
     }
     
     /**
@@ -212,7 +212,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return new ObservableCombineLatest<T, R>(null, sources, combiner, s, false);
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(null, sources, combiner, s, false));
     }
 
     /**
@@ -274,7 +274,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return new ObservableCombineLatest<T, R>(sources, null, combiner, s, false);
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(sources, null, combiner, s, false));
     }
 
     /**
@@ -726,7 +726,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         }
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return new ObservableCombineLatest<T, R>(sources, null, combiner, s, true);
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(sources, null, combiner, s, true));
     }
 
     /**
@@ -792,7 +792,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return new ObservableCombineLatest<T, R>(null, sources, combiner, s, true);
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(null, sources, combiner, s, true));
     }
 
     /**
@@ -860,7 +860,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> concat(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new ObservableConcatMap(sources, Functions.identity(), prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, Functions.identity(), prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -966,7 +966,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (sources.length == 1) {
             return wrap((ObservableSource<T>)sources[0]);
         }
-        return new ObservableConcatMap(fromArray(sources), Functions.identity(), bufferSize(), ErrorMode.BOUNDARY);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap(fromArray(sources), Functions.identity(), bufferSize(), ErrorMode.BOUNDARY));
     }
 
     /**
@@ -1095,7 +1095,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static final <T> Observable<T> concatDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch, boolean tillTheEnd) {
-        return new ObservableConcatMap(sources, Functions.identity(), prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, Functions.identity(), prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
     /**
@@ -1227,7 +1227,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> create(ObservableOnSubscribe<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
-        return new ObservableCreate<T>(source);
+        return RxJavaPlugins.onAssembly(new ObservableCreate<T>(source));
     }
 
     /**
@@ -1257,7 +1257,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> defer(Callable<? extends ObservableSource<? extends T>> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
-        return new ObservableDefer<T>(supplier);
+        return RxJavaPlugins.onAssembly(new ObservableDefer<T>(supplier));
     }
 
     /**
@@ -1279,7 +1279,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> empty() {
-        return (Observable<T>) ObservableEmpty.INSTANCE;
+        return RxJavaPlugins.onAssembly((Observable<T>) ObservableEmpty.INSTANCE);
     }
 
     /**
@@ -1303,7 +1303,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> error(Callable<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
-        return new ObservableError<T>(errorSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableError<T>(errorSupplier));
     }
 
     /**
@@ -1355,7 +1355,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (values.length == 1) {
             return just(values[0]);
         }
-        return new ObservableFromArray<T>(values);
+        return RxJavaPlugins.onAssembly(new ObservableFromArray<T>(values));
     }
 
     /**
@@ -1383,7 +1383,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromCallable(Callable<? extends T> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
-        return new ObservableFromCallable<T>(supplier);
+        return RxJavaPlugins.onAssembly(new ObservableFromCallable<T>(supplier));
     }
 
     /**
@@ -1415,7 +1415,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromFuture(Future<? extends T> future) {
         ObjectHelper.requireNonNull(future, "future is null");
-        return new ObservableFromFuture<T>(future, 0L, null);
+        return RxJavaPlugins.onAssembly(new ObservableFromFuture<T>(future, 0L, null));
     }
 
     /**
@@ -1452,7 +1452,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
         ObjectHelper.requireNonNull(future, "future is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
-        return new ObservableFromFuture<T>(future, timeout, unit);
+        return RxJavaPlugins.onAssembly(new ObservableFromFuture<T>(future, timeout, unit));
     }
 
     /**
@@ -1548,7 +1548,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public static <T> Observable<T> fromIterable(Iterable<? extends T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
-        return new ObservableFromIterable<T>(source);
+        return RxJavaPlugins.onAssembly(new ObservableFromIterable<T>(source));
     }
 
     /**
@@ -1564,11 +1564,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public static <T> Observable<T> fromPublisher(Publisher<? extends T> publisher) {
         ObjectHelper.requireNonNull(publisher, "publisher is null");
-        return new ObservableFromPublisher<T>(publisher);
+        return RxJavaPlugins.onAssembly(new ObservableFromPublisher<T>(publisher));
     }
 
     /**
-     * Returns a cold, synchronous, stateless and backpressure-aware generator of values.
+     * Returns a cold, synchronous and stateless generator of values.
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1590,7 +1590,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a cold, synchronous, stateful and backpressure-aware generator of values.
+     * Returns a cold, synchronous and stateful generator of values.
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1613,7 +1613,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a cold, synchronous, stateful and backpressure-aware generator of values.
+     * Returns a cold, synchronous and stateful generator of values.
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1641,7 +1641,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a cold, synchronous, stateful and backpressure-aware generator of values.
+     * Returns a cold, synchronous and stateful generator of values.
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1664,7 +1664,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a cold, synchronous, stateful and backpressure-aware generator of values.
+     * Returns a cold, synchronous and stateful generator of values.
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1689,7 +1689,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator  is null");
         ObjectHelper.requireNonNull(disposeState, "diposeState is null");
-        return new ObservableGenerate<T, S>(initialState, generator, disposeState);
+        return RxJavaPlugins.onAssembly(new ObservableGenerate<T, S>(initialState, generator, disposeState));
     }
 
     /**
@@ -1752,7 +1752,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
-        return new ObservableInterval(initialDelay, period, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableInterval(initialDelay, period, unit, scheduler));
     }
 
     /**
@@ -1853,7 +1853,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
-        return new ObservableIntervalRange(start, end, initialDelay, period, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableIntervalRange(start, end, initialDelay, period, unit, scheduler));
     }
 
     /**
@@ -1883,7 +1883,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> just(T value) {
         ObjectHelper.requireNonNull(value, "The value is null");
-        return new ObservableJust<T>(value);
+        return RxJavaPlugins.onAssembly(new ObservableJust<T>(value));
     }
 
     /**
@@ -2378,7 +2378,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources) {
-        return new ObservableFlatMap(sources, Functions.identity(), false, Integer.MAX_VALUE, bufferSize());
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, Integer.MAX_VALUE, bufferSize()));
     }
 
     /**
@@ -2410,7 +2410,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        return new ObservableFlatMap(sources, Functions.identity(), false, maxConcurrency, bufferSize());
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, maxConcurrency, bufferSize()));
     }
 
     /**
@@ -2693,7 +2693,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
-        return new ObservableFlatMap(sources, Functions.identity(), true, Integer.MAX_VALUE, bufferSize());
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, Integer.MAX_VALUE, bufferSize()));
     }
 
     /**
@@ -2728,7 +2728,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        return new ObservableFlatMap(sources, Functions.identity(), true, maxConcurrency, bufferSize());
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, maxConcurrency, bufferSize()));
     }
 
     /**
@@ -2896,7 +2896,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> never() {
-        return (Observable<T>) ObservableNever.INSTANCE;
+        return RxJavaPlugins.onAssembly((Observable<T>) ObservableNever.INSTANCE);
     }
 
     /**
@@ -2922,17 +2922,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static Observable<Integer> range(final int start, final int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
-        } else
+        }
         if (count == 0) {
             return empty();
-        } else
+        }
         if (count == 1) {
             return just(start);
-        } else
+        }
         if ((long)start + (count - 1) > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Integer overflow");
         }
-        return new ObservableRange(start, count);
+        return RxJavaPlugins.onAssembly(new ObservableRange(start, count));
     }
 
     /**
@@ -3020,7 +3020,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(p2, "p2 is null");
         ObjectHelper.requireNonNull(isEqual, "isEqual is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new ObservableSequenceEqual<T>(p1, p2, isEqual, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableSequenceEqual<T>(p1, p2, isEqual, bufferSize));
     }
 
     /**
@@ -3081,7 +3081,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNext(ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new ObservableSwitchMap(sources, Functions.identity(), bufferSize, false);
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), bufferSize, false));
     }
 
     /**
@@ -3180,7 +3180,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         verifyPositive(prefetch, "prefetch");
-        return new ObservableSwitchMap(sources, Functions.identity(), prefetch, true);
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), prefetch, true));
     }
     
     /**
@@ -3232,12 +3232,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
 
-        return new ObservableTimer(delay, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableTimer(delay, unit, scheduler));
     }
 
     /**
      * Create a Observable by wrapping a ObservableSource <em>which has to be implemented according
-     * to the Reactive-Streams specification by handling backpressure and
+     * to the Reactive-Streams-based Observable specification by handling
      * cancellation correctly; no safeguards are provided by the Observable itself</em>.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -3254,7 +3254,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (onSubscribe instanceof Observable) {
             throw new IllegalArgumentException("unsafeCreate(Observable) should be upgraded");
         }
-        return new ObservableFromUnsafeSource<T>(onSubscribe);
+        return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<T>(onSubscribe));
     }
 
     /**
@@ -3315,19 +3315,32 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
         ObjectHelper.requireNonNull(sourceSupplier, "sourceSupplier is null");
         ObjectHelper.requireNonNull(disposer, "disposer is null");
-        return new ObservableUsing<T, D>(resourceSupplier, sourceSupplier, disposer, eager);
+        return RxJavaPlugins.onAssembly(new ObservableUsing<T, D>(resourceSupplier, sourceSupplier, disposer, eager));
     }
 
     /**
      * Validate that the given value is positive or report an IllegalArgumentException with
      * the parameter name.
-     * @param bufferSize the value to validate
+     * @param value the value to validate
      * @param paramName the parameter name of the value
      * @throws IllegalArgumentException if bufferSize &lt;= 0
      */
-    private static void verifyPositive(int bufferSize, String paramName) {
-        if (bufferSize <= 0) {
-            throw new IllegalArgumentException(paramName + " > 0 required but it was " + bufferSize);
+    private static void verifyPositive(int value, String paramName) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(paramName + " > 0 required but it was " + value);
+        }
+    }
+    
+    /**
+     * Validate that the given value is positive or report an IllegalArgumentException with
+     * the parameter name.
+     * @param value the value to validate
+     * @param paramName the parameter name of the value
+     * @throws IllegalArgumentException if bufferSize &lt;= 0
+     */
+    private static void verifyPositive(long value, String paramName) {
+        if (value <= 0L) {
+            throw new IllegalArgumentException(paramName + " > 0 required but it was " + value);
         }
     }
     
@@ -3348,7 +3361,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> wrap(ObservableSource<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Observable) {
-            return (Observable<T>)source;
+            return RxJavaPlugins.onAssembly((Observable<T>)source);
         }
         return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<T>(source));
     }
@@ -3397,7 +3410,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T, R> Observable<R> zip(Iterable<? extends ObservableSource<? extends T>> sources, Function<? super T[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new ObservableZip<T, R>(null, sources, zipper, bufferSize(), false);
+        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize(), false));
     }
 
     /**
@@ -3445,8 +3458,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T, R> Observable<R> zip(ObservableSource<? extends ObservableSource<? extends T>> sources, final Function<? super T[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new ObservableToList(sources, 16)
-                .flatMap(ObservableInternalHelper.zipIterable(zipper));
+        return RxJavaPlugins.onAssembly(new ObservableToList(sources, 16)
+                .flatMap(ObservableInternalHelper.zipIterable(zipper)));
     }
 
     /**
@@ -4121,7 +4134,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         }
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new ObservableZip<T, R>(sources, null, zipper, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(sources, null, zipper, bufferSize, delayError));
     }
 
     /**
@@ -4176,7 +4189,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new ObservableZip<T, R>(null, sources, zipper, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize, delayError));
     }
 
     // ***************************************************************************************************
@@ -4202,7 +4215,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> all(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new ObservableAll<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableAll<T>(this, predicate));
     }
 
     /**
@@ -4225,7 +4238,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> ambWith(ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return amb(this, other);
+        return ambArray(this, other);
     }
 
     /**
@@ -4251,23 +4264,20 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Boolean> any(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new ObservableAny<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableAny<T>(this, predicate));
     }
 
     /**
-     * Returns the first item emitted by this {@code BlockingObservable}, or throws
+     * Returns the first item emitted by this {@code Observable}, or throws
      * {@code NoSuchElementException} if it emits no items.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingFirst} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the first item emitted by this {@code BlockingObservable}
+     * @return the first item emitted by this {@code Observable}
      * @throws NoSuchElementException
-     *             if this {@code BlockingObservable} emits no items
+     *             if this {@code Observable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public final T blockingFirst() {
@@ -4281,19 +4291,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns the first item emitted by this {@code BlockingObservable}, or a default value if it emits no
+     * Returns the first item emitted by this {@code Observable}, or a default value if it emits no
      * items.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingFirst} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultValue
-     *            a default value to return if this {@code BlockingObservable} emits no items
-     * @return the first item emitted by this {@code BlockingObservable}, or the default value if it emits no
+     *            a default value to return if this {@code Observable} emits no items
+     * @return the first item emitted by this {@code Observable}, or the default value if it emits no
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
@@ -4305,7 +4312,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Invokes a method on each item emitted by this {@code BlockingObservable} and blocks until the Observable
+     * Invokes a method on each item emitted by this {@code Observable} and blocks until the Observable
      * completes.
      * <p>
      * <em>Note:</em> This will block even if the underlying Observable is asynchronous.
@@ -4320,15 +4327,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>The difference between this method and {@link #subscribe(Consumer)} is that the {@code onNext} action
      * is executed on the emission thread instead of the current thread.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingForEach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * 
      * @param onNext
-     *            the {@link Consumer} to invoke for each item emitted by the {@code BlockingObservable}
+     *            the {@link Consumer} to invoke for each item emitted by the {@code Observable}
      * @throws RuntimeException
      *             if an error occurs
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX documentation: Subscribe</a>
@@ -4348,18 +4352,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * Converts this {@code BlockingObservable} into an {@link Iterable}.
+     * Converts this {@code Observable} into an {@link Iterable}.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toIterable.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code blockingITerable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code blockingIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Iterable} version of this {@code BlockingObservable}
+     * @return an {@link Iterable} version of this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public final Iterable<T> blockingIterable() {
@@ -4367,19 +4368,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * Converts this {@code BlockingObservable} into an {@link Iterable}.
+     * Converts this {@code Observable} into an {@link Iterable}.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toIterable.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code blockingFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code blockingIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param bufferSize the number of items to prefetch from the current Flowable
-     * @return an {@link Iterable} version of this {@code BlockingObservable}
+     * @param bufferSize the number of items to prefetch from the current Observable
+     * @return an {@link Iterable} version of this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public final Iterable<T> blockingIterable(int bufferSize) {
@@ -4388,21 +4386,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * Returns the last item emitted by this {@code BlockingObservable}, or throws
-     * {@code NoSuchElementException} if this {@code BlockingObservable} emits no items.
+     * Returns the last item emitted by this {@code Observable}, or throws
+     * {@code NoSuchElementException} if this {@code Observable} emits no items.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.last.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingLast} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the last item emitted by this {@code BlockingObservable}
+     * @return the last item emitted by this {@code Observable}
      * @throws NoSuchElementException
-     *             if this {@code BlockingObservable} emits no items
+     *             if this {@code Observable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
     public final T blockingLast() {
@@ -4416,21 +4411,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns the last item emitted by this {@code BlockingObservable}, or a default value if it emits no
+     * Returns the last item emitted by this {@code Observable}, or a default value if it emits no
      * items.
      * <p>
      * <img width="640" height="310" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.lastOrDefault.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingLast} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultValue
-     *            a default value to return if this {@code BlockingObservable} emits no items
-     * @return the last item emitted by the {@code BlockingObservable}, or the default value if it emits no
+     *            a default value to return if this {@code Observable} emits no items
+     * @return the last item emitted by the {@code Observable}, or the default value if it emits no
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
@@ -4445,23 +4437,20 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * Returns an {@link Iterable} that returns the latest item emitted by this {@code BlockingObservable},
+     * Returns an {@link Iterable} that returns the latest item emitted by this {@code Observable},
      * waiting if necessary for one to become available.
      * <p>
-     * If this {@code BlockingObservable} produces items faster than {@code Iterator.next} takes them,
+     * If this {@code Observable} produces items faster than {@code Iterator.next} takes them,
      * {@code onNext} events might be skipped, but {@code onError} or {@code onCompleted} events are not.
      * <p>
      * Note also that an {@code onNext} directly followed by {@code onCompleted} might hide the {@code onNext}
      * event.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingLatest} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an Iterable that always returns the latest item emitted by this {@code BlockingObservable}
+     * @return an Iterable that always returns the latest item emitted by this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public final Iterable<T> blockingLatest() {
@@ -4470,21 +4459,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
     
     /**
      * Returns an {@link Iterable} that always returns the item most recently emitted by this
-     * {@code BlockingObservable}.
+     * {@code Observable}.
      * <p>
      * <img width="640" height="490" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.mostRecent.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingMostRecent} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param initialValue
      *            the initial value that the {@link Iterable} sequence will yield if this
-     *            {@code BlockingObservable} has not yet emitted an item
-     * @return an {@link Iterable} that on each iteration returns the item that this {@code BlockingObservable}
+     *            {@code Observable} has not yet emitted an item
+     * @return an {@link Iterable} that on each iteration returns the item that this {@code Observable}
      *         has most recently emitted
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
@@ -4493,19 +4479,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * Returns an {@link Iterable} that blocks until this {@code BlockingObservable} emits another item, then
+     * Returns an {@link Iterable} that blocks until this {@code Observable} emits another item, then
      * returns that item.
      * <p>
      * <img width="640" height="490" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.next.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Iterable} that blocks upon each iteration until this {@code BlockingObservable} emits
+     * @return an {@link Iterable} that blocks upon each iteration until this {@code Observable} emits
      *         a new item, whereupon the Iterable returns that item
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX documentation: TakeLast</a>
      */
@@ -4514,19 +4497,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * If this {@code BlockingObservable} completes after emitting a single item, return that item, otherwise
+     * If this {@code Observable} completes after emitting a single item, return that item, otherwise
      * throw a {@code NoSuchElementException}.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.single.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the single item emitted by this {@code BlockingObservable}
+     * @return the single item emitted by this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
     public final T blockingSingle() {
@@ -4534,22 +4514,19 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * If this {@code BlockingObservable} completes after emitting a single item, return that item; if it emits
+     * If this {@code Observable} completes after emitting a single item, return that item; if it emits
      * more than one item, throw an {@code IllegalArgumentException}; if it emits no items, return a default
      * value.
      * <p>
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.singleOrDefault.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultValue
-     *            a default value to return if this {@code BlockingObservable} emits no items
-     * @return the single item emitted by this {@code BlockingObservable}, or the default value if it emits no
+     *            a default value to return if this {@code Observable} emits no items
+     * @return the single item emitted by this {@code Observable}, or the default value if it emits no
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
@@ -4558,24 +4535,21 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
     
     /**
-     * Returns a {@link Future} representing the single value emitted by this {@code BlockingObservable}.
+     * Returns a {@link Future} representing the single value emitted by this {@code Observable}.
      * <p>
      * If the {@link Observable} emits more than one item, {@link java.util.concurrent.Future} will receive an
      * {@link java.lang.IllegalArgumentException}. If the {@link Observable} is empty, {@link java.util.concurrent.Future}
      * will receive an {@link java.util.NoSuchElementException}.
      * <p>
-     * If the {@code BlockingObservable} may emit more than one item, use {@code Observable.toList().toBlocking().toFuture()}.
+     * If the {@code Observable} may emit more than one item, use {@code Observable.toList().toBlocking().toFuture()}.
      * <p>
      * <img width="640" height="395" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toFuture.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a {@link Future} that expects a single item to be emitted by this {@code BlockingObservable}
+     * @return a {@link Future} that expects a single item to be emitted by this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
     public final Future<T> toFuture() {
@@ -4585,9 +4559,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Runs the source observable to a terminal event, ignoring any values and rethrowing any exception.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -4600,9 +4571,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -4616,9 +4584,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -4634,9 +4599,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -4653,14 +4615,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Subscribes to the source and calls the Observer methods <strong>on the current thread</strong>.
      * <p>
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source 
-     *  {@code Observable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * The unsubscription and backpressure is composed through.
+     * The unsubscription is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @since 2.0
      */
@@ -4753,7 +4711,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             throw new IllegalArgumentException("skip > 0 required but it was " + count);
         }
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new ObservableBuffer<T, U>(this, count, skip, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableBuffer<T, U>(this, count, skip, bufferSupplier));
     }
 
     /**
@@ -4875,7 +4833,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new ObservableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false);
+        return RxJavaPlugins.onAssembly(new ObservableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
     }
 
     /**
@@ -5013,7 +4971,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count <= 0) {
             throw new IllegalArgumentException("count > 0 required but it was " + count);
         }
-        return new ObservableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize);
+        return RxJavaPlugins.onAssembly(new ObservableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
     }
 
     /**
@@ -5108,7 +5066,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(bufferOpenings, "bufferOpenings is null");
         ObjectHelper.requireNonNull(bufferClosingSelector, "bufferClosingSelector is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new ObservableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableBufferBoundary<T, U, TOpening, TClosing>(this, bufferOpenings, bufferClosingSelector, bufferSupplier));
     }
 
     /**
@@ -5197,7 +5155,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableSource<B> boundary, Callable<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new ObservableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier));
     }
 
     /**
@@ -5254,7 +5212,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <B, U extends Collection<? super T>> Observable<U> buffer(Callable<? extends ObservableSource<B>> boundarySupplier, Callable<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundarySupplier, "boundarySupplier is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return new ObservableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier));
     }
 
     /**
@@ -5417,7 +5375,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U> Observable<U> collect(Callable<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
         ObjectHelper.requireNonNull(collector, "collector is null");
-        return new ObservableCollect<T, U>(this, initialValueSupplier, collector);
+        return RxJavaPlugins.onAssembly(new ObservableCollect<T, U>(this, initialValueSupplier, collector));
     }
 
     /**
@@ -5529,7 +5487,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return new ObservableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -5584,7 +5542,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return new ObservableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
     /**
@@ -5634,7 +5592,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         verifyPositive(maxConcurrency, "maxConcurrency");
         verifyPositive(prefetch, "prefetch");
-        return new ObservableConcatMapEager<T, R>(this, mapper, ErrorMode.IMMEDIATE, maxConcurrency, prefetch);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<T, R>(this, mapper, ErrorMode.IMMEDIATE, maxConcurrency, prefetch));
     }
     
     /**
@@ -5690,7 +5648,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, 
             int maxConcurrency, int prefetch, boolean tillTheEnd) {
-        return new ObservableConcatMapEager<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, maxConcurrency, prefetch);
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, maxConcurrency, prefetch));
     }
     
     /**
@@ -5805,7 +5763,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Long> count() {
-        return new ObservableCount<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableCount<T>(this));
     }
 
     /**
@@ -5829,7 +5787,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> debounce(Function<? super T, ? extends ObservableSource<U>> debounceSelector) {
         ObjectHelper.requireNonNull(debounceSelector, "debounceSelector is null");
-        return new ObservableDebounce<T, U>(this, debounceSelector);
+        return RxJavaPlugins.onAssembly(new ObservableDebounce<T, U>(this, debounceSelector));
     }
 
     /**
@@ -5908,7 +5866,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableDebounceTimed<T>(this, timeout, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableDebounceTimed<T>(this, timeout, unit, scheduler));
     }
 
     /**
@@ -6060,7 +6018,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         
-        return new ObservableDelay<T>(this, delay, unit, scheduler, delayError);
+        return RxJavaPlugins.onAssembly(new ObservableDelay<T>(this, delay, unit, scheduler, delayError));
     }
 
     /**
@@ -6115,7 +6073,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public final <U> Observable<T> delaySubscription(ObservableSource<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new ObservableDelaySubscriptionOther<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<T, U>(this, other));
     }
 
     /**
@@ -6184,7 +6142,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <T2> Observable<T2> dematerialize() {
         @SuppressWarnings("unchecked")
         Observable<Notification<T2>> m = (Observable<Notification<T2>>)this;
-        return new ObservableDematerialize<T2>(m);
+        return RxJavaPlugins.onAssembly(new ObservableDematerialize<T2>(m));
     }
     
     /**
@@ -6318,7 +6276,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
         ObjectHelper.requireNonNull(comparer, "comparer is null");
-        return new ObservableDistinctUntilChanged<T>(this, comparer);
+        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<T>(this, comparer));
     }
 
     /**
@@ -6409,7 +6367,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(onError, "onError is null");
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        return new ObservableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate);
+        return RxJavaPlugins.onAssembly(new ObservableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate));
     }
 
     /**
@@ -6510,7 +6468,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> doOnLifecycle(final Consumer<? super Disposable> onSubscribe, final Action onCancel) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         ObjectHelper.requireNonNull(onCancel, "onCancel is null");
-        return new ObservableDoOnLifecycle<T>(this, onSubscribe, onCancel);
+        return RxJavaPlugins.onAssembly(new ObservableDoOnLifecycle<T>(this, onSubscribe, onCancel));
     }
 
     /**
@@ -6604,7 +6562,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        return new ObservableElementAt<T>(this, index, null);
+        return RxJavaPlugins.onAssembly(new ObservableElementAt<T>(this, index, null));
     }
 
     /**
@@ -6633,7 +6591,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
         ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
-        return new ObservableElementAt<T>(this, index, defaultValue);
+        return RxJavaPlugins.onAssembly(new ObservableElementAt<T>(this, index, defaultValue));
     }
 
     /**
@@ -6655,7 +6613,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> filter(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new ObservableFilter<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableFilter<T>(this, predicate));
     }
 
     /**
@@ -6827,7 +6785,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return new ObservableFlatMap<T, R>(this, mapper, delayErrors, maxConcurrency, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap<T, R>(this, mapper, delayErrors, maxConcurrency, bufferSize));
     }
 
     /**
@@ -6940,9 +6898,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.png" alt="">
      * <dl>
-     *  <dd>The operator honors backpressure from downstream. The outer {@code ObservableSource} is consumed
-     *  in unbounded mode (i.e., no backpressure is applied to it). The inner {@code ObservableSource}s are expected to honor
-     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -6972,9 +6927,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.png" alt="">
      * <dl>
-     *  <dd>The operator honors backpressure from downstream. The outer {@code ObservableSource} is consumed
-     *  in unbounded mode (i.e., no backpressure is applied to it). The inner {@code ObservableSource}s are expected to honor
-     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -7486,7 +7438,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         verifyPositive(bufferSize, "bufferSize");
 
-        return new ObservableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new ObservableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError));
     }
 
     /**
@@ -7527,8 +7479,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super Observable<TRight>, ? extends R> resultSelector
                     ) {
-        return new ObservableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
-                this, other, leftEnd, rightEnd, resultSelector);
+        return RxJavaPlugins.onAssembly(new ObservableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+                this, other, leftEnd, rightEnd, resultSelector));
     }
     
     /**
@@ -7546,7 +7498,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> hide() {
-        return new ObservableHide<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableHide<T>(this));
     }
 
     /**
@@ -7564,7 +7516,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> ignoreElements() {
-        return new ObservableIgnoreElements<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<T>(this));
     }
 
     /**
@@ -7625,8 +7577,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super TRight, ? extends R> resultSelector
                     ) {
-        return new ObservableJoin<T, TRight, TLeftEnd, TRightEnd, R>(
-                this, other, leftEnd, rightEnd, resultSelector);
+        return RxJavaPlugins.onAssembly(new ObservableJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+                this, other, leftEnd, rightEnd, resultSelector));
     }
     
     /**
@@ -7697,7 +7649,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public final <R> Observable<R> lift(ObservableOperator<? extends R, ? super T> lifter) {
         ObjectHelper.requireNonNull(lifter, "onLift is null");
-        return new ObservableLift<R, T>(this, lifter);
+        return RxJavaPlugins.onAssembly(new ObservableLift<R, T>(this, lifter));
     }
 
     /**
@@ -7719,7 +7671,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public final <R> Observable<R> map(Function<? super T, ? extends R> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
-        return new ObservableMap<T, R>(this, mapper);
+        return RxJavaPlugins.onAssembly(new ObservableMap<T, R>(this, mapper));
     }
 
     /**
@@ -7738,7 +7690,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Notification<T>> materialize() {
-        return new ObservableMaterialize<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableMaterialize<T>(this));
     }
 
     /**
@@ -7850,7 +7802,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
-        return new ObservableObserveOn<T>(this, scheduler, delayError, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableObserveOn<T>(this, scheduler, delayError, bufferSize));
     }
 
     /**
@@ -7906,7 +7858,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends ObservableSource<? extends T>> resumeFunction) {
         ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
-        return new ObservableOnErrorNext<T>(this, resumeFunction, false);
+        return RxJavaPlugins.onAssembly(new ObservableOnErrorNext<T>(this, resumeFunction, false));
     }
 
     /**
@@ -7973,7 +7925,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
         ObjectHelper.requireNonNull(valueSupplier, "valueSupplier is null");
-        return new ObservableOnErrorReturn<T>(this, valueSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableOnErrorReturn<T>(this, valueSupplier));
     }
 
     /**
@@ -8043,7 +7995,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onExceptionResumeNext(final ObservableSource<? extends T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return new ObservableOnErrorNext<T>(this, Functions.justFunction(next), true);
+        return RxJavaPlugins.onAssembly(new ObservableOnErrorNext<T>(this, Functions.justFunction(next), true));
     }
 
     /**
@@ -8059,7 +8011,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onTerminateDetach() {
-        return new ObservableDetach<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableDetach<T>(this));
     }
     
     /**
@@ -8324,7 +8276,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count == 0) {
             return empty();
         }
-        return new ObservableRepeat<T>(this, count);
+        return RxJavaPlugins.onAssembly(new ObservableRepeat<T>(this, count));
     }
 
     /**
@@ -8348,7 +8300,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> repeatUntil(BooleanSupplier stop) {
         ObjectHelper.requireNonNull(stop, "stop is null");
-        return new ObservableRepeatUntil<T>(this, stop);
+        return RxJavaPlugins.onAssembly(new ObservableRepeatUntil<T>(this, stop));
     }
 
     /**
@@ -8373,7 +8325,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
         ObjectHelper.requireNonNull(handler, "handler is null");
-        return new ObservableRedo<T>(this, ObservableInternalHelper.repeatWhenHandler(handler));
+        return RxJavaPlugins.onAssembly(new ObservableRedo<T>(this, ObservableInternalHelper.repeatWhenHandler(handler)));
     }
 
     /**
@@ -8891,7 +8843,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
         
-        return new ObservableRetryBiPredicate<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableRetryBiPredicate<T>(this, predicate));
     }
 
     /**
@@ -8941,7 +8893,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         }
         ObjectHelper.requireNonNull(predicate, "predicate is null");
 
-        return new ObservableRetryPredicate<T>(this, times, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableRetryPredicate<T>(this, times, predicate));
     }
 
     /**
@@ -9026,7 +8978,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> retryWhen(
             final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
         ObjectHelper.requireNonNull(handler, "handler is null");
-        return new ObservableRedo<T>(this, ObservableInternalHelper.retryWhenHandler(handler));
+        return RxJavaPlugins.onAssembly(new ObservableRedo<T>(this, ObservableInternalHelper.retryWhenHandler(handler)));
     }
     
     /**
@@ -9100,7 +9052,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableSampleTimed<T>(this, period, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableSampleTimed<T>(this, period, unit, scheduler));
     }
 
     /**
@@ -9125,7 +9077,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> sample(ObservableSource<U> sampler) {
         ObjectHelper.requireNonNull(sampler, "sampler is null");
-        return new ObservableSampleWithObservable<T>(this, sampler);
+        return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<T>(this, sampler));
     }
 
     /**
@@ -9152,7 +9104,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> scan(BiFunction<T, T, T> accumulator) {
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
-        return new ObservableScan<T>(this, accumulator);
+        return RxJavaPlugins.onAssembly(new ObservableScan<T>(this, accumulator));
     }
 
     /**
@@ -9249,7 +9201,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> scanWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
-        return new ObservableScanSeed<T, R>(this, seedSupplier, accumulator);
+        return RxJavaPlugins.onAssembly(new ObservableScanSeed<T, R>(this, seedSupplier, accumulator));
     }
 
     /**
@@ -9274,7 +9226,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> serialize() {
-        return new ObservableSerialized<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableSerialized<T>(this));
     }
 
     /**
@@ -9319,7 +9271,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> single() {
-        return new ObservableSingle<T>(this, null);
+        return RxJavaPlugins.onAssembly(new ObservableSingle<T>(this, null));
     }
 
     /**
@@ -9344,7 +9296,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> single(T defaultValue) {
         ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
-        return new ObservableSingle<T>(this, defaultValue);
+        return RxJavaPlugins.onAssembly(new ObservableSingle<T>(this, defaultValue));
     }
 
     /**
@@ -9366,9 +9318,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> skip(long count) {
         if (count <= 0) {
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
-        return new ObservableSkip<T>(this, count);
+        return RxJavaPlugins.onAssembly(new ObservableSkip<T>(this, count));
     }
 
     /**
@@ -9445,11 +9397,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> skipLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
-        } else
-            if (count == 0) {
-                return this;
-            }
-        return new ObservableSkipLast<T>(this, count);
+        }
+        if (count == 0) {
+            return RxJavaPlugins.onAssembly(this);
+        }
+        return RxJavaPlugins.onAssembly(new ObservableSkipLast<T>(this, count));
     }
 
     /**
@@ -9596,9 +9548,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         verifyPositive(bufferSize, "bufferSize");
-     // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
+        // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
         int s = bufferSize << 1; 
-        return new ObservableSkipLastTimed<T>(this, time, unit, scheduler, s, delayError);
+        return RxJavaPlugins.onAssembly(new ObservableSkipLastTimed<T>(this, time, unit, scheduler, s, delayError));
     }
 
     /**
@@ -9622,7 +9574,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> skipUntil(ObservableSource<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new ObservableSkipUntil<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new ObservableSkipUntil<T, U>(this, other));
     }
 
     /**
@@ -9644,7 +9596,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> skipWhile(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new ObservableSkipWhile<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableSkipWhile<T>(this, predicate));
     }
 
     /**
@@ -9779,7 +9731,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> startWithArray(T... values) {
         Observable<T> fromArray = fromArray(values);
         if (fromArray == empty()) {
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
         return concatArray(fromArray, this);
     }
@@ -9958,7 +9910,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> subscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableSubscribeOn<T>(this, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableSubscribeOn<T>(this, scheduler));
     }
 
     /**
@@ -9979,7 +9931,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> switchIfEmpty(ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new ObservableSwitchIfEmpty<T>(this, other);
+        return RxJavaPlugins.onAssembly(new ObservableSwitchIfEmpty<T>(this, other));
     }
 
     /**
@@ -10043,7 +9995,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return new ObservableSwitchMap<T, R>(this, mapper, bufferSize, false);
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<T, R>(this, mapper, bufferSize, false));
     }
 
     /**
@@ -10109,7 +10061,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return new ObservableSwitchMap<T, R>(this, mapper, bufferSize, true);
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<T, R>(this, mapper, bufferSize, true));
     }
 
     /**
@@ -10137,7 +10089,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count < 0) {
             throw new IllegalArgumentException("count >= required but it was " + count);
         }
-        return new ObservableTake<T>(this, count);
+        return RxJavaPlugins.onAssembly(new ObservableTake<T>(this, count));
     }
 
     /**
@@ -10236,9 +10188,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
             return ignoreElements();
         } else
         if (count == 1) {
-            return new ObservableTakeLastOne<T>(this);
+            return RxJavaPlugins.onAssembly(new ObservableTakeLastOne<T>(this));
         }
-        return new ObservableTakeLast<T>(this, count);
+        return RxJavaPlugins.onAssembly(new ObservableTakeLast<T>(this, count));
     }
 
     /**
@@ -10337,7 +10289,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         }
-        return new ObservableTakeLastTimed<T>(this, count, time, unit, scheduler, bufferSize, delayError);
+        return RxJavaPlugins.onAssembly(new ObservableTakeLastTimed<T>(this, count, time, unit, scheduler, bufferSize, delayError));
     }
 
     /**
@@ -10499,7 +10451,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> takeUntil(ObservableSource<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return new ObservableTakeUntil<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new ObservableTakeUntil<T, U>(this, other));
     }
 
     /**
@@ -10527,7 +10479,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> takeUntil(Predicate<? super T> stopPredicate) {
         ObjectHelper.requireNonNull(stopPredicate, "predicate is null");
-        return new ObservableTakeUntilPredicate<T>(this, stopPredicate);
+        return RxJavaPlugins.onAssembly(new ObservableTakeUntilPredicate<T>(this, stopPredicate));
     }
 
     /**
@@ -10550,7 +10502,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> takeWhile(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return new ObservableTakeWhile<T>(this, predicate);
+        return RxJavaPlugins.onAssembly(new ObservableTakeWhile<T>(this, predicate));
     }
 
     /**
@@ -10605,7 +10557,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler));
     }
 
     /**
@@ -10822,7 +10774,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableTimeInterval<T>(this, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableTimeInterval<T>(this, unit, scheduler));
     }
 
     /**
@@ -11071,7 +11023,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Scheduler scheduler) {
         ObjectHelper.requireNonNull(timeUnit, "timeUnit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other);
+        return RxJavaPlugins.onAssembly(new ObservableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other));
     }
 
     private <U, V> Observable<T> timeout0(
@@ -11079,7 +11031,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
                     ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(timeoutSelector, "timeoutSelector is null");
-        return new ObservableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other);
+        return RxJavaPlugins.onAssembly(new ObservableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other));
     }
 
     /**
@@ -11207,7 +11159,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable toCompletable() {
-        return new CompletableFromObservable<T>(this);
+        return RxJavaPlugins.onAssembly(new CompletableFromObservable<T>(this));
     }
 
     /**
@@ -11268,7 +11220,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (capacityHint <= 0) {
             throw new IllegalArgumentException("capacityHint > 0 required but it was " + capacityHint);
         }
-        return new ObservableToList<T, List<T>>(this, capacityHint);
+        return RxJavaPlugins.onAssembly(new ObservableToList<T, List<T>>(this, capacityHint));
     }
 
     /**
@@ -11300,7 +11252,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U extends Collection<? super T>> Observable<U> toList(Callable<U> collectionSupplier) {
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return new ObservableToList<T, U>(this, collectionSupplier);
+        return RxJavaPlugins.onAssembly(new ObservableToList<T, U>(this, collectionSupplier));
     }
 
     /**
@@ -11561,7 +11513,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
-        return new SingleFromObservable<T>(this);
+        return RxJavaPlugins.onAssembly(new SingleFromObservable<T>(this));
     }
 
     /**
@@ -11679,7 +11631,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> unsubscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new ObservableUnsubscribeOn<T>(this, scheduler);
+        return RxJavaPlugins.onAssembly(new ObservableUnsubscribeOn<T>(this, scheduler));
     }
 
     /**
@@ -11759,14 +11711,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Observable<T>> window(long count, long skip, int bufferSize) {
-        if (skip <= 0) {
-            throw new IllegalArgumentException("skip > 0 required but it was " + skip);
-        }
-        if (count <= 0) {
-            throw new IllegalArgumentException("count > 0 required but it was " + count);
-        }
+        verifyPositive(count, "count");
+        verifyPositive(skip, "skip");
         verifyPositive(bufferSize, "bufferSize");
-        return new ObservableWindow<T>(this, count, skip, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableWindow<T>(this, count, skip, bufferSize));
     }
 
     /**
@@ -11856,7 +11804,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
-        return new ObservableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false);
+        return RxJavaPlugins.onAssembly(new ObservableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false));
     }
 
     /**
@@ -12087,7 +12035,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count <= 0) {
             throw new IllegalArgumentException("count > 0 required but it was " + count);
         }
-        return new ObservableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart);
+        return RxJavaPlugins.onAssembly(new ObservableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart));
     }
 
     /**
@@ -12140,7 +12088,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Observable<Observable<T>> window(ObservableSource<B> boundary, int bufferSize) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
-        return new ObservableWindowBoundary<T, B>(this, boundary, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableWindowBoundary<T, B>(this, boundary, bufferSize));
     }
 
     /**
@@ -12204,7 +12152,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super U, ? extends ObservableSource<V>> windowClose, int bufferSize) {
         ObjectHelper.requireNonNull(windowOpen, "windowOpen is null");
         ObjectHelper.requireNonNull(windowClose, "windowClose is null");
-        return new ObservableWindowBoundarySelector<T, U, V>(this, windowOpen, windowClose, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableWindowBoundarySelector<T, U, V>(this, windowOpen, windowClose, bufferSize));
     }
 
     /**
@@ -12258,7 +12206,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Observable<Observable<T>> window(Callable<? extends ObservableSource<B>> boundary, int bufferSize) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
-        return new ObservableWindowBoundarySupplier<T, B>(this, boundary, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservableWindowBoundarySupplier<T, B>(this, boundary, bufferSize));
     }
 
     /**
@@ -12290,7 +12238,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
 
-        return new ObservableWithLatestFrom<T, U, R>(this, combiner, other);
+        return RxJavaPlugins.onAssembly(new ObservableWithLatestFrom<T, U, R>(this, combiner, other));
     }
 
     /**
@@ -12426,7 +12374,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
-        return new ObservableWithLatestFromMany<T, R>(this, others, combiner);
+        return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<T, R>(this, others, combiner));
     }
 
     /**
@@ -12452,7 +12400,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> withLatestFrom(Iterable<? extends ObservableSource<?>> others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
-        return new ObservableWithLatestFromMany<T, R>(this, others, combiner);
+        return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<T, R>(this, others, combiner));
     }
 
     /**
@@ -12485,7 +12433,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U, R> Observable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(zipper, "zipper is null");
-        return new ObservableZipIterable<T, U, R>(this, other, zipper);
+        return RxJavaPlugins.onAssembly(new ObservableZipIterable<T, U, R>(this, other, zipper));
     }
 
     /**
@@ -12634,6 +12582,22 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     public final TestObserver<T> test() { // NoPMD
         TestObserver<T> ts = new TestObserver<T>();
+        subscribe(ts);
+        return ts;
+    }
+
+    /**
+     * Creates a TestObserver, optionally disposes it and then subscribes
+     * it to this Observable.
+     * @param dispose dispose the TestObserver before it is subscribed to this Observable?
+     * @return the new TestObserver instance
+     * @since 2.0
+     */
+    public final TestObserver<T> test(boolean dispose) { // NoPMD
+        TestObserver<T> ts = new TestObserver<T>();
+        if (dispose) {
+            ts.dispose();
+        }
         subscribe(ts);
         return ts;
     }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -68,7 +68,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public static <T> Single<T> amb(final Iterable<? extends SingleSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return new SingleAmbIterable<T>(sources);
+        return RxJavaPlugins.onAssembly(new SingleAmbIterable<T>(sources));
     }
     
     /**
@@ -84,14 +84,14 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     @SuppressWarnings("unchecked")
-    public static <T> Single<T> amb(final SingleSource<? extends T>... sources) {
+    public static <T> Single<T> ambArray(final SingleSource<? extends T>... sources) {
         if (sources.length == 0) {
             return error(SingleInternalHelper.<T>emptyThrower());
         }
         if (sources.length == 1) {
             return wrap((SingleSource<T>)sources[0]);
         }
-        return new SingleAmbArray<T>(sources);
+        return RxJavaPlugins.onAssembly(new SingleAmbArray<T>(sources));
     }
 
     /**
@@ -124,7 +124,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources) {
-        return new FlowableConcatMap(sources, SingleInternalHelper.toFlowable(), 2, ErrorMode.IMMEDIATE);
+        return RxJavaPlugins.onAssembly(new FlowableConcatMap(sources, SingleInternalHelper.toFlowable(), 2, ErrorMode.IMMEDIATE));
     }
     
     /**
@@ -271,7 +271,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public static <T> Single<T> defer(final Callable<? extends SingleSource<? extends T>> singleSupplier) {
         ObjectHelper.requireNonNull(singleSupplier, "singleSupplier is null");
-        return new SingleDefer<T>(singleSupplier);
+        return RxJavaPlugins.onAssembly(new SingleDefer<T>(singleSupplier));
     }
     
     /**
@@ -287,7 +287,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public static <T> Single<T> error(final Callable<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
-        return new SingleError<T>(errorSupplier);
+        return RxJavaPlugins.onAssembly(new SingleError<T>(errorSupplier));
     }
     
     /**
@@ -332,7 +332,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public static <T> Single<T> fromCallable(final Callable<? extends T> callable) {
         ObjectHelper.requireNonNull(callable, "callable is null");
-        return new SingleFromCallable<T>(callable);
+        return RxJavaPlugins.onAssembly(new SingleFromCallable<T>(callable));
     }
     
     /**
@@ -468,7 +468,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public static <T> Single<T> fromPublisher(final Publisher<? extends T> publisher) {
         ObjectHelper.requireNonNull(publisher, "publisher is null");
-        return new SingleFromPublisher<T>(publisher);
+        return RxJavaPlugins.onAssembly(new SingleFromPublisher<T>(publisher));
     }
 
     /**
@@ -492,7 +492,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public static <T> Single<T> just(final T value) {
         ObjectHelper.requireNonNull(value, "value is null");
-        return new SingleJust<T>(value);
+        return RxJavaPlugins.onAssembly(new SingleJust<T>(value));
     }
 
     /**
@@ -525,7 +525,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> merge(Publisher<? extends SingleSource<? extends T>> sources) {
-        return new FlowableFlatMap(sources, SingleInternalHelper.toFlowable(), false, Integer.MAX_VALUE, Flowable.bufferSize());
+        return RxJavaPlugins.onAssembly(new FlowableFlatMap(sources, SingleInternalHelper.toFlowable(), false, Integer.MAX_VALUE, Flowable.bufferSize()));
     }
     
     /**
@@ -549,7 +549,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Single<T> merge(SingleSource<? extends SingleSource<? extends T>> source) {
         ObjectHelper.requireNonNull(source, "source is null");
-        return new SingleFlatMap<SingleSource<? extends T>, T>(source, (Function)Functions.identity());
+        return RxJavaPlugins.onAssembly(new SingleFlatMap<SingleSource<? extends T>, T>(source, (Function)Functions.identity()));
     }
     
     /**
@@ -662,7 +662,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T> Single<T> never() {
-        return (Single<T>) SingleNever.INSTANCE;
+        return RxJavaPlugins.onAssembly((Single<T>) SingleNever.INSTANCE);
     }
     
     /**
@@ -695,7 +695,7 @@ public abstract class Single<T> implements SingleSource<T> {
     public static Single<Long> timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new SingleTimer(delay, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new SingleTimer(delay, unit, scheduler));
     }
     
     /**
@@ -713,7 +713,7 @@ public abstract class Single<T> implements SingleSource<T> {
     public static <T> Single<Boolean> equals(final SingleSource<? extends T> first, final SingleSource<? extends T> second) { // NOPMD
         ObjectHelper.requireNonNull(first, "first is null");
         ObjectHelper.requireNonNull(second, "second is null");
-        return new SingleEquals<T>(first, second);
+        return RxJavaPlugins.onAssembly(new SingleEquals<T>(first, second));
     }
 
     /**
@@ -792,7 +792,7 @@ public abstract class Single<T> implements SingleSource<T> {
         ObjectHelper.requireNonNull(singleFunction, "singleFunction is null");
         ObjectHelper.requireNonNull(disposer, "disposer is null");
         
-        return new SingleUsing<T, U>(resourceSupplier, singleFunction, disposer, eager);
+        return RxJavaPlugins.onAssembly(new SingleUsing<T, U>(resourceSupplier, singleFunction, disposer, eager));
     }
 
     /**
@@ -805,9 +805,9 @@ public abstract class Single<T> implements SingleSource<T> {
     static <T> Single<T> wrap(SingleSource<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Single) {
-            return (Single<T>)source;
+            return RxJavaPlugins.onAssembly((Single<T>)source);
         }
-        return new SingleFromUnsafeSource<T>(source);
+        return RxJavaPlugins.onAssembly(new SingleFromUnsafeSource<T>(source));
     }
     
     /**
@@ -1256,7 +1256,7 @@ public abstract class Single<T> implements SingleSource<T> {
         int i = 0;
         for (SingleSource<? extends T> s : sources) {
             ObjectHelper.requireNonNull(s, "The " + i + "th source is null");
-            sourcePublishers[i] = new SingleToFlowable<T>(s);
+            sourcePublishers[i] = RxJavaPlugins.onAssembly(new SingleToFlowable<T>(s));
             i++;
         }
         return Flowable.zipArray(zipper, false, 1, sourcePublishers).toSingle();
@@ -1275,7 +1275,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SuppressWarnings("unchecked")
     public final Single<T> ambWith(SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return amb(this, other);
+        return ambArray(this, other);
     }
     
     /**
@@ -1289,7 +1289,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> hide() {
-        return new SingleHide<T>(this);
+        return RxJavaPlugins.onAssembly(new SingleHide<T>(this));
     }
     
     /**
@@ -1329,7 +1329,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> cache() {
-        return new SingleCache<T>(this);
+        return RxJavaPlugins.onAssembly(new SingleCache<T>(this));
     }
     
     /**
@@ -1403,7 +1403,7 @@ public abstract class Single<T> implements SingleSource<T> {
     public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new SingleDelay<T>(this, time, unit, scheduler);
+        return RxJavaPlugins.onAssembly(new SingleDelay<T>(this, time, unit, scheduler));
     }
 
     /**
@@ -1421,7 +1421,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Single<T> delaySubscription(CompletableSource other) {
-        return new SingleDelayWithCompletable<T>(this, other);
+        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<T>(this, other));
     }
 
     /**
@@ -1440,7 +1440,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final <U> Single<T> delaySubscription(SingleSource<U> other) {
-        return new SingleDelayWithSingle<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new SingleDelayWithSingle<T, U>(this, other));
     }
 
     /**
@@ -1459,7 +1459,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final <U> Single<T> delaySubscription(ObservableSource<U> other) {
-        return new SingleDelayWithObservable<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new SingleDelayWithObservable<T, U>(this, other));
     }
 
     /**
@@ -1479,7 +1479,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final <U> Single<T> delaySubscription(Publisher<U> other) {
-        return new SingleDelayWithPublisher<T, U>(this, other);
+        return RxJavaPlugins.onAssembly(new SingleDelayWithPublisher<T, U>(this, other));
     }
     
     /**
@@ -1530,7 +1530,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> doOnSubscribe(final Consumer<? super Disposable> onSubscribe) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
-        return new SingleDoOnSubscribe<T>(this, onSubscribe);
+        return RxJavaPlugins.onAssembly(new SingleDoOnSubscribe<T>(this, onSubscribe));
     }
     
     /**
@@ -1546,7 +1546,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> doOnSuccess(final Consumer<? super T> onSuccess) {
         ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
-        return new SingleDoOnSuccess<T>(this, onSuccess);
+        return RxJavaPlugins.onAssembly(new SingleDoOnSuccess<T>(this, onSuccess));
     }
     
     /**
@@ -1562,7 +1562,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> doOnError(final Consumer<? super Throwable> onError) {
         ObjectHelper.requireNonNull(onError, "onError is null");
-        return new SingleDoOnError<T>(this, onError);
+        return RxJavaPlugins.onAssembly(new SingleDoOnError<T>(this, onError));
     }
     
     /**
@@ -1578,7 +1578,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> doOnCancel(final Action onCancel) {
         ObjectHelper.requireNonNull(onCancel, "onCancel is null");
-        return new SingleDoOnCancel<T>(this, onCancel);
+        return RxJavaPlugins.onAssembly(new SingleDoOnCancel<T>(this, onCancel));
     }
 
     /**
@@ -1599,7 +1599,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final <R> Single<R> flatMap(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
-        return new SingleFlatMap<T, R>(this, mapper);
+        return RxJavaPlugins.onAssembly(new SingleFlatMap<T, R>(this, mapper));
     }
 
     /**
@@ -1642,7 +1642,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Completable flatMapCompletable(final Function<? super T, ? extends Completable> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
-        return new SingleFlatMapCompletable<T>(this, mapper);
+        return RxJavaPlugins.onAssembly(new SingleFlatMapCompletable<T>(this, mapper));
     }
     
     /**
@@ -1683,7 +1683,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final <R> Single<R> lift(final SingleOperator<? extends R, ? super T> lift) {
         ObjectHelper.requireNonNull(lift, "onLift is null");
-        return new SingleLift<T, R>(this, lift);
+        return RxJavaPlugins.onAssembly(new SingleLift<T, R>(this, lift));
     }
     
     /**
@@ -1703,7 +1703,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
     public final <R> Single<R> map(Function<? super T, ? extends R> mapper) {
-        return new SingleMap<T, R>(this, mapper);
+        return RxJavaPlugins.onAssembly(new SingleMap<T, R>(this, mapper));
     }
 
     /**
@@ -1737,7 +1737,7 @@ public abstract class Single<T> implements SingleSource<T> {
     public final Single<Boolean> contains(final Object value, final BiPredicate<Object, Object> comparer) {
         ObjectHelper.requireNonNull(value, "value is null");
         ObjectHelper.requireNonNull(comparer, "comparer is null");
-        return new SingleContains<T>(this, value, comparer);
+        return RxJavaPlugins.onAssembly(new SingleContains<T>(this, value, comparer));
     }
     
     /**
@@ -1781,7 +1781,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> observeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new SingleObserveOn<T>(this, scheduler);
+        return RxJavaPlugins.onAssembly(new SingleObserveOn<T>(this, scheduler));
     }
 
     /**
@@ -1812,7 +1812,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> onErrorReturn(final Function<Throwable, ? extends T> resumeFunction) {
         ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
-        return new SingleOnErrorReturn<T>(this, resumeFunction, null);
+        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, resumeFunction, null));
     }
     
     /**
@@ -1827,7 +1827,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> onErrorReturnValue(final T value) {
         ObjectHelper.requireNonNull(value, "value is null");
-        return new SingleOnErrorReturn<T>(this, null, value);
+        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, null, value));
     }
 
     /**
@@ -1893,7 +1893,7 @@ public abstract class Single<T> implements SingleSource<T> {
     public final Single<T> onErrorResumeNext(
             final Function<? super Throwable, ? extends SingleSource<? extends T>> resumeFunctionInCaseOfError) {
         ObjectHelper.requireNonNull(resumeFunctionInCaseOfError, "resumeFunctionInCaseOfError is null");
-        return new SingleResumeNext<T>(this, resumeFunctionInCaseOfError);
+        return RxJavaPlugins.onAssembly(new SingleResumeNext<T>(this, resumeFunctionInCaseOfError));
     }
     
     /**
@@ -2175,7 +2175,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> subscribeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new SingleSubscribeOn<T>(this, scheduler);
+        return RxJavaPlugins.onAssembly(new SingleSubscribeOn<T>(this, scheduler));
     }
 
     /**
@@ -2220,7 +2220,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
     public final <E> Single<T> takeUntil(final Publisher<E> other) {
-        return new SingleTakeUntil<T, E>(this, other);
+        return RxJavaPlugins.onAssembly(new SingleTakeUntil<T, E>(this, other));
     }
 
     /**
@@ -2320,7 +2320,7 @@ public abstract class Single<T> implements SingleSource<T> {
     private Single<T> timeout0(final long timeout, final TimeUnit unit, final Scheduler scheduler, final SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return new SingleTimeout<T>(this, timeout, unit, scheduler, other);
+        return RxJavaPlugins.onAssembly(new SingleTimeout<T>(this, timeout, unit, scheduler, other));
     }
 
     /**
@@ -2364,7 +2364,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @since 2.0
      */
     public final Completable toCompletable() {
-        return new CompletableFromSingle<T>(this);
+        return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(this));
     }
     
     /**
@@ -2375,7 +2375,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return an {@link Observable} that emits a single item T.
      */
     public final Flowable<T> toFlowable() {
-        return new SingleToFlowable<T>(this);
+        return RxJavaPlugins.onAssembly(new SingleToFlowable<T>(this));
     }
     
     /**
@@ -2386,7 +2386,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return an {@link Observable} that emits a single item T.
      */
     public final Observable<T> toObservable() {
-        return new SingleToObservable<T>(this);
+        return RxJavaPlugins.onAssembly(new SingleToObservable<T>(this));
     }
     
     /**

--- a/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
@@ -20,6 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * A {@code ConnectableObservable} resembles an ordinary {@link Flowable}, except that it does not begin
@@ -75,7 +76,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
      */
     public Flowable<T> refCount() {
-        return new FlowableRefCount<T>(this);
+        return RxJavaPlugins.onAssembly(new FlowableRefCount<T>(this));
     }
 
     /**
@@ -119,8 +120,8 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     public Flowable<T> autoConnect(int numberOfSubscribers, Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
-        return new FlowableAutoConnect<T>(this, numberOfSubscribers, connection);
+        return RxJavaPlugins.onAssembly(new FlowableAutoConnect<T>(this, numberOfSubscribers, connection));
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -22,6 +22,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * An observable which auto-connects to another observable, caches the elements
@@ -35,28 +36,28 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final AtomicBoolean once;
     /**
-     * Creates a cached Observable with a default capacity hint of 16.
+     * Creates a cached Flowable with a default capacity hint of 16.
      * @param <T> the value type
      * @param source the source Observable to cache
      * @return the CachedObservable instance
      */
-    public static <T> FlowableCache<T> from(Flowable<T> source) {
+    public static <T> Flowable<T> from(Flowable<T> source) {
         return from(source, 16);
     }
     
     /**
-     * Creates a cached Observable with the given capacity hint.
+     * Creates a cached Flowable with the given capacity hint.
      * @param <T> the value type
      * @param source the source Observable to cache
      * @param capacityHint the hint for the internal buffer size
      * @return the CachedObservable instance
      */
-    public static <T> FlowableCache<T> from(Flowable<T> source, int capacityHint) {
+    public static <T> Flowable<T> from(Flowable<T> source, int capacityHint) {
         if (capacityHint < 1) {
             throw new IllegalArgumentException("capacityHint > 0 required");
         }
         CacheState<T> state = new CacheState<T>(source, capacityHint);
-        return new FlowableCache<T>(source, state);
+        return RxJavaPlugins.onAssembly(new FlowableCache<T>(source, state));
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -18,10 +18,12 @@ import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super T, K> keySelector;
@@ -33,7 +35,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
         this.keySelector = keySelector;
     }
     
-    public static <T, K> FlowableDistinct<T, K> withCollection(Publisher<T> source, Function<? super T, K> keySelector, final Callable<? extends Collection<? super K>> collectionSupplier) {
+    public static <T, K> Flowable<T> withCollection(Publisher<T> source, Function<? super T, K> keySelector, final Callable<? extends Collection<? super K>> collectionSupplier) {
         Callable<? extends Predicate<? super K>> p = new Callable<Predicate<K>>() {
             @Override
             public Predicate<K> call() throws Exception {
@@ -52,10 +54,10 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             }
         };
         
-        return new FlowableDistinct<T, K>(source, keySelector, p);
+        return RxJavaPlugins.onAssembly(new FlowableDistinct<T, K>(source, keySelector, p));
     }
     
-    public static <T> FlowableDistinct<T, T> untilChanged(Publisher<T> source) {
+    public static <T> Flowable<T> untilChanged(Publisher<T> source) {
         Callable<? extends Predicate<? super T>> p = new Callable<Predicate<T>>() {
             Object last;
             @Override
@@ -75,10 +77,10 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
                 };
             }
         };
-        return new FlowableDistinct<T, T>(source, Functions.<T>identity(), p);
+        return RxJavaPlugins.onAssembly(new FlowableDistinct<T, T>(source, Functions.<T>identity(), p));
     }
 
-    public static <T, K> FlowableDistinct<T, K> untilChanged(Publisher<T> source, Function<? super T, K> keySelector) {
+    public static <T, K> Flowable<T> untilChanged(Publisher<T> source, Function<? super T, K> keySelector) {
         Callable<? extends Predicate<? super K>> p = new Callable<Predicate<K>>() {
             Object last;
             @Override
@@ -98,7 +100,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
                 };
             }
         };
-        return new FlowableDistinct<T, K>(source, keySelector, p);
+        return RxJavaPlugins.onAssembly(new FlowableDistinct<T, K>(source, keySelector, p));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
@@ -117,7 +117,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
                 }
             }
         };
-        return new FlowablePublish<T>(onSubscribe, source, curr, bufferSize);
+        return RxJavaPlugins.onAssembly(new FlowablePublish<T>(onSubscribe, source, curr, bufferSize));
     }
 
     private FlowablePublish(Publisher<T> onSubscribe, Publisher<T> source,

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
@@ -39,7 +39,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         
         SerializedSubscriber<T> z = new SerializedSubscriber<T>(s);
         
-        FlowProcessor<Object> processor = new UnicastProcessor<Object>(8).toSerialized();
+        FlowableProcessor<Object> processor = new UnicastProcessor<Object>(8).toSerialized();
         
         Publisher<?> when;
         
@@ -137,13 +137,13 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
 
         protected final Subscriber<? super T> actual;
         
-        protected final FlowProcessor<U> processor;
+        protected final FlowableProcessor<U> processor;
         
         protected final Subscription receiver;
         
         private long produced;
         
-        public WhenSourceSubscriber(Subscriber<? super T> actual, FlowProcessor<U> processor,
+        public WhenSourceSubscriber(Subscriber<? super T> actual, FlowableProcessor<U> processor,
                 Subscription receiver) {
             this.actual = actual;
             this.processor = processor;
@@ -183,7 +183,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         /** */
         private static final long serialVersionUID = -2680129890138081029L;
 
-        public RepeatWhenSubscriber(Subscriber<? super T> actual, FlowProcessor<Object> processor,
+        public RepeatWhenSubscriber(Subscriber<? super T> actual, FlowableProcessor<Object> processor,
                 Subscription receiver) {
             super(actual, processor, receiver);
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -113,7 +113,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
      */
     public static <T> ConnectableFlowable<T> observeOn(final ConnectableFlowable<T> co, final Scheduler scheduler) {
         final Flowable<T> observable = co.observeOn(scheduler);
-        return new ConnectableFlowable<T>() {
+        return RxJavaPlugins.onAssembly(new ConnectableFlowable<T>() {
             @Override
             public void connect(Consumer<? super Disposable> connection) {
                 co.connect(connection);
@@ -123,7 +123,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
             protected void subscribeActual(Subscriber<? super T> s) {
                 observable.subscribe(s);
             }
-        };
+        });
     }
     
     /**
@@ -248,7 +248,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements F
                 }
             }
         };
-        return new FlowableReplay<T>(onSubscribe, source, curr, bufferFactory);
+        return RxJavaPlugins.onAssembly(new FlowableReplay<T>(onSubscribe, source, curr, bufferFactory));
     }
     
     private FlowableReplay(Publisher<T> onSubscribe, Flowable<T> source,

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
@@ -37,7 +37,7 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
     public void subscribeActual(Subscriber<? super T> s) {
         SerializedSubscriber<T> z = new SerializedSubscriber<T>(s);
         
-        FlowProcessor<Throwable> processor = new UnicastProcessor<Throwable>(8).toSerialized();
+        FlowableProcessor<Throwable> processor = new UnicastProcessor<Throwable>(8).toSerialized();
         
         Publisher<?> when;
         
@@ -67,7 +67,7 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
         /** */
         private static final long serialVersionUID = -2680129890138081029L;
 
-        public RetryWhenSubscriber(Subscriber<? super T> actual, FlowProcessor<Throwable> processor,
+        public RetryWhenSubscriber(Subscriber<? super T> actual, FlowableProcessor<Throwable> processor,
                 Subscription receiver) {
             super(actual, processor, receiver);
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
@@ -22,6 +22,7 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Utility classes to work with scalar-sourced XMap operators (where X == { flat, concat, switch }).
@@ -104,7 +105,7 @@ public enum FlowableScalarXMap {
      * @return the new Flowable instance
      */
     public static <T, U> Flowable<U> scalarXMap(final T value, final Function<? super T, ? extends Publisher<? extends U>> mapper) {
-        return new ScalarXMapFlowable<T, U>(value, mapper);
+        return RxJavaPlugins.onAssembly(new ScalarXMapFlowable<T, U>(value, mapper));
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCache.java
@@ -20,6 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * An observable which auto-connects to another observable, caches the elements
@@ -39,7 +40,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
      * @param source the source Observable to cache
      * @return the CachedObservable instance
      */
-    public static <T> ObservableCache<T> from(Observable<T> source) {
+    public static <T> Observable<T> from(Observable<T> source) {
         return from(source, 16);
     }
     
@@ -50,12 +51,12 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
      * @param capacityHint the hint for the internal buffer size
      * @return the CachedObservable instance
      */
-    public static <T> ObservableCache<T> from(Observable<T> source, int capacityHint) {
+    public static <T> Observable<T> from(Observable<T> source, int capacityHint) {
         if (capacityHint < 1) {
             throw new IllegalArgumentException("capacityHint > 0 required");
         }
         CacheState<T> state = new CacheState<T>(source, capacityHint);
-        return new ObservableCache<T>(source, state);
+        return RxJavaPlugins.onAssembly(new ObservableCache<T>(source, state));
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservablePublish.java
@@ -23,6 +23,7 @@ import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * A connectable observable which shares an underlying source and dispatches source values to subscribers in a backpressure-aware
@@ -114,12 +115,12 @@ public final class ObservablePublish<T> extends ConnectableObservable<T> impleme
                 }
             }
         };
-        return new ObservablePublish<T>(onSubscribe, source, curr, bufferSize);
+        return RxJavaPlugins.onAssembly(new ObservablePublish<T>(onSubscribe, source, curr, bufferSize));
     }
 
     public static <T, R> Observable<R> create(final ObservableSource<T> source,
                                               final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize) {
-        return new Observable<R>() {
+        return RxJavaPlugins.onAssembly(new Observable<R>() {
             @Override
             protected void subscribeActual(Observer<? super R> o) {
                 ConnectableObservable<T> op = ObservablePublish.create(source, bufferSize);
@@ -145,7 +146,7 @@ public final class ObservablePublish<T> extends ConnectableObservable<T> impleme
                     }
                 });
             }
-        };
+        });
     }
 
     private ObservablePublish(ObservableSource<T> onSubscribe, ObservableSource<T> source,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -26,6 +26,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Timed;
 
 public final class ObservableReplay<T> extends ConnectableObservable<T> implements ObservableWithUpstream<T> {
@@ -58,7 +59,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     public static <U, R> Observable<R> multicastSelector(
             final Callable<? extends ConnectableObservable<U>> connectableFactory,
             final Function<? super Observable<U>, ? extends ObservableSource<R>> selector) {
-        return new Observable<R>() {
+        return RxJavaPlugins.onAssembly(new Observable<R>() {
             @Override
             protected void subscribeActual(Observer<? super R> child) {
                 ConnectableObservable<U> co;
@@ -83,7 +84,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                     }
                 });
             }
-        };
+        });
     }
     
     /**
@@ -96,7 +97,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     public static <T> ConnectableObservable<T> observeOn(final ConnectableObservable<T> co, final Scheduler scheduler) {
         final Observable<T> observable = co.observeOn(scheduler);
-        return new ConnectableObservable<T>() {
+        return RxJavaPlugins.onAssembly(new ConnectableObservable<T>() {
             @Override
             public void connect(Consumer<? super Disposable> connection) {
                 co.connect(connection);
@@ -106,7 +107,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
             protected void subscribeActual(Observer<? super T> observer) {
                 observable.subscribe(observer);
             }
-        };
+        });
     }
     
     /**
@@ -234,7 +235,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                 }
             }
         };
-        return new ObservableReplay<T>(onSubscribe, source, curr, bufferFactory);
+        return RxJavaPlugins.onAssembly(new ObservableReplay<T>(onSubscribe, source, curr, bufferFactory));
     }
     
     private ObservableReplay(ObservableSource<T> onSubscribe, Observable<T> source,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -22,6 +22,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Utility classes to work with scalar-sourced XMap operators (where X == { flat, concat, switch }).
@@ -105,7 +106,7 @@ public enum ObservableScalarXMap {
      */
     public static <T, U> Observable<U> scalarXMap(T value, 
             Function<? super T, ? extends ObservableSource<? extends U>> mapper) {
-        return new ScalarXMapObservable<T, U>(value, mapper);
+        return RxJavaPlugins.onAssembly(new ScalarXMapObservable<T, U>(value, mapper));
     }
     
     /**

--- a/src/main/java/io/reactivex/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/observables/ConnectableObservable.java
@@ -20,6 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * A {@code ConnectableObservable} resembles an ordinary {@link Flowable}, except that it does not begin
@@ -75,7 +76,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
      */
     public Observable<T> refCount() {
-        return new ObservableRefCount<T>(this);
+        return RxJavaPlugins.onAssembly(new ObservableRefCount<T>(this));
     }
 
     /**
@@ -119,8 +120,8 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
     public Observable<T> autoConnect(int numberOfSubscribers, Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);
-            return this;
+            return RxJavaPlugins.onAssembly(this);
         }
-        return new ObservableAutoConnect<T>(this, numberOfSubscribers, connection);
+        return RxJavaPlugins.onAssembly(new ObservableAutoConnect<T>(this, numberOfSubscribers, connection));
     }
 }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -18,7 +18,9 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.observables.ConnectableObservable;
 
 /**
  * Utility class to inject handlers to certain standard RxJava operations.
@@ -47,10 +49,16 @@ public final class RxJavaPlugins {
     
     @SuppressWarnings("rawtypes")
     static volatile Function<Flowable, Flowable> onFlowableAssembly;
-    
+
+    @SuppressWarnings("rawtypes")
+    static volatile Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly;
+
     @SuppressWarnings("rawtypes")
     static volatile Function<Observable, Observable> onObservableAssembly;
-    
+
+    @SuppressWarnings("rawtypes")
+    static volatile Function<ConnectableObservable, ConnectableObservable> onConnectableObservableAssembly;
+
     @SuppressWarnings("rawtypes")
     static volatile Function<Single, Single> onSingleAssembly;
     
@@ -485,7 +493,16 @@ public final class RxJavaPlugins {
     public static Function<Flowable, Flowable> getOnFlowableAssembly() {
         return onFlowableAssembly;
     }
-    
+
+    /**
+     * Returns the current hook function.
+     * @return the hook function, may be null
+     */
+    @SuppressWarnings("rawtypes")
+    public static Function<ConnectableFlowable, ConnectableFlowable> getOnConnectableFlowableAssembly() {
+        return onConnectableFlowableAssembly;
+    }
+
     /**
      * Returns the current hook function.
      * @return the hook function, may be null
@@ -520,6 +537,15 @@ public final class RxJavaPlugins {
     @SuppressWarnings("rawtypes")
     public static Function<Observable, Observable> getOnObservableAssembly() {
         return onObservableAssembly;
+    }
+    
+    /**
+     * Returns the current hook function.
+     * @return the hook function, may be null
+     */
+    @SuppressWarnings("rawtypes")
+    public static Function<ConnectableObservable, ConnectableObservable> getOnConnectableObservableAssembly() {
+        return onConnectableObservableAssembly;
     }
     
     /**
@@ -568,6 +594,18 @@ public final class RxJavaPlugins {
     
     /**
      * Sets the specific hook function.
+     * @param onConnectableFlowableAssembly the hook function to set, null allowed
+     */
+    @SuppressWarnings("rawtypes")
+    public static void setOnConnectableFlowableAssembly(Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        RxJavaPlugins.onConnectableFlowableAssembly = onConnectableFlowableAssembly;
+    }
+    
+    /**
+     * Sets the specific hook function.
      * @param onFlowableSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
@@ -588,6 +626,18 @@ public final class RxJavaPlugins {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
         RxJavaPlugins.onObservableAssembly = onObservableAssembly;
+    }
+    
+    /**
+     * Sets the specific hook function.
+     * @param onObservableAssembly the hook function to set, null allowed
+     */
+    @SuppressWarnings("rawtypes")
+    public static void setOnConnectableObservableAssembly(Function<ConnectableObservable, ConnectableObservable> onObservableAssembly) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        RxJavaPlugins.onConnectableObservableAssembly = onConnectableObservableAssembly;
     }
     
     /**
@@ -711,8 +761,38 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> ConnectableFlowable<T> onAssembly(ConnectableFlowable<T> source) {
+        Function<ConnectableFlowable, ConnectableFlowable> f = onConnectableFlowableAssembly;
+        if (f != null) {
+            return apply(f, source);
+        }
+        return source;
+    }
+
+    /**
+     * Calls the associated hook function.
+     * @param <T> the value type
+     * @param source the hook's input value
+     * @return the value returned by the hook
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> Observable<T> onAssembly(Observable<T> source) {
         Function<Observable, Observable> f = onObservableAssembly;
+        if (f != null) {
+            return apply(f, source);
+        }
+        return source;
+    }
+
+    /**
+     * Calls the associated hook function.
+     * @param <T> the value type
+     * @param source the hook's input value
+     * @return the value returned by the hook
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> ConnectableObservable<T> onAssembly(ConnectableObservable<T> source) {
+        Function<ConnectableObservable, ConnectableObservable> f = onConnectableObservableAssembly;
         if (f != null) {
             return apply(f, source);
         }

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -33,7 +33,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class AsyncProcessor<T> extends FlowProcessor<T> {
+public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     /** The state holding onto the latest value or error and the array of subscribers. */
     final State<T> state;
     /** 
@@ -111,7 +111,11 @@ public final class AsyncProcessor<T> extends FlowProcessor<T> {
         return state.subscribers().length != 0;
     }
     
-    @Override
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
     public boolean hasValue() {
         Object o = state.get();
         return o != null && !NotificationLite.isError(o);
@@ -137,7 +141,11 @@ public final class AsyncProcessor<T> extends FlowProcessor<T> {
         return null;
     }
     
-    @Override
+    /**
+     * Returns a single value the Subject currently has or null if no such value exists.
+     * <p>The method is thread-safe.
+     * @return a single value the Subject currently has or null if no such value exists
+     */
     @SuppressWarnings("unchecked")
     public T getValue() {
         Object o = state.get();
@@ -147,7 +155,33 @@ public final class AsyncProcessor<T> extends FlowProcessor<T> {
         return null;
     }
     
-    @Override
+    /** An empty array to avoid allocation in getValues(). */
+    private static final Object[] EMPTY = new Object[0];
+
+    /**
+     * Returns an Object array containing snapshot all values of the Subject.
+     * <p>The method is thread-safe.
+     * @return the array containing the snapshot of all values of the Subject
+     */
+    public Object[] getValues() {
+        @SuppressWarnings("unchecked")
+        T[] a = (T[])EMPTY;
+        T[] b = getValues(a);
+        if (b == EMPTY) {
+            return new Object[0];
+        }
+        return b;
+            
+    }
+    
+    /**
+     * Returns a typed array containing a snapshot of all values of the Subject.
+     * <p>The method follows the conventions of Collection.toArray by setting the array element
+     * after the last value to null (if the capacity permits).
+     * <p>The method is thread-safe.
+     * @param array the target array to copy values into if it fits
+     * @return the given array if the values fit into it or a new array containing all values
+     */
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
         Object o = state.get();

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -69,7 +69,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <T>
  *          the type of item expected to be observed by the Subject
  */
-public final class BehaviorProcessor<T> extends FlowProcessor<T> {
+public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     final State<T> state;
 
     /**
@@ -156,7 +156,11 @@ public final class BehaviorProcessor<T> extends FlowProcessor<T> {
         return null;
     }
     
-    @Override
+    /**
+     * Returns a single value the Subject currently has or null if no such value exists.
+     * <p>The method is thread-safe.
+     * @return a single value the Subject currently has or null if no such value exists
+     */
     public T getValue() {
         Object o = state.get();
         if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
@@ -165,7 +169,33 @@ public final class BehaviorProcessor<T> extends FlowProcessor<T> {
         return NotificationLite.getValue(o);
     }
     
-    @Override
+    /** An empty array to avoid allocation in getValues(). */
+    private static final Object[] EMPTY = new Object[0];
+
+    /**
+     * Returns an Object array containing snapshot all values of the Subject.
+     * <p>The method is thread-safe.
+     * @return the array containing the snapshot of all values of the Subject
+     */
+    public Object[] getValues() {
+        @SuppressWarnings("unchecked")
+        T[] a = (T[])EMPTY;
+        T[] b = getValues(a);
+        if (b == EMPTY) {
+            return new Object[0];
+        }
+        return b;
+            
+    }
+    
+    /**
+     * Returns a typed array containing a snapshot of all values of the Subject.
+     * <p>The method follows the conventions of Collection.toArray by setting the array element
+     * after the last value to null (if the capacity permits).
+     * <p>The method is thread-safe.
+     * @param array the target array to copy values into if it fits
+     * @return the given array if the values fit into it or a new array containing all values
+     */
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
         Object o = state.get();
@@ -200,7 +230,11 @@ public final class BehaviorProcessor<T> extends FlowProcessor<T> {
         return NotificationLite.isError(o);
     }
     
-    @Override
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
     public boolean hasValue() {
         Object o = state.get();
         return o != null && !NotificationLite.isComplete(o) && !NotificationLite.isError(o);

--- a/src/main/java/io/reactivex/processors/FlowableProcessor.java
+++ b/src/main/java/io/reactivex/processors/FlowableProcessor.java
@@ -25,10 +25,7 @@ import io.reactivex.Flowable;
  *
  * @param <T> the item value type
  */
-public abstract class FlowProcessor<T> extends Flowable<T> implements Processor<T, T> {
-    /** An empty array to avoid allocation in getValues(). */
-    private static final Object[] EMPTY = new Object[0];
-    
+public abstract class FlowableProcessor<T> extends Flowable<T> implements Processor<T, T> {
     
     /**
      * Returns true if the subject has subscribers.
@@ -44,9 +41,7 @@ public abstract class FlowProcessor<T> extends Flowable<T> implements Processor<
      * @see #getThrowable()
      * @see #hasComplete()
      */
-    public boolean hasThrowable() {
-        throw new UnsupportedOperationException();
-    }
+    public abstract boolean hasThrowable();
     
     /**
      * Returns true if the subject has reached a terminal state through a complete event.
@@ -54,18 +49,7 @@ public abstract class FlowProcessor<T> extends Flowable<T> implements Processor<
      * @return true if the subject has reached a terminal state through a complete event
      * @see #hasThrowable()
      */
-    public boolean hasComplete() {
-        throw new UnsupportedOperationException();
-    }
-    
-    /**
-     * Returns true if the subject has any value.
-     * <p>The method is thread-safe.
-     * @return true if the subject has any value
-     */
-    public boolean hasValue() {
-        throw new UnsupportedOperationException();
-    }
+    public abstract boolean hasComplete();
     
     /**
      * Returns the error that caused the Subject to terminate or null if the Subject
@@ -74,57 +58,18 @@ public abstract class FlowProcessor<T> extends Flowable<T> implements Processor<
      * @return the error that caused the Subject to terminate or null if the Subject
      * hasn't terminated yet
      */
-    public Throwable getThrowable() {
-        throw new UnsupportedOperationException();
-    }
-    
-    /**
-     * Returns a single value the Subject currently has or null if no such value exists.
-     * <p>The method is thread-safe.
-     * @return a single value the Subject currently has or null if no such value exists
-     */
-    public T getValue() {
-        throw new UnsupportedOperationException();
-    }
-    
+    public abstract Throwable getThrowable();
+
     /**
      * Wraps this Subject and serializes the calls to the onSubscribe, onNext, onError and
      * onComplete methods, making them thread-safe.
      * <p>The method is thread-safe.
      * @return the wrapped and serialized subject
      */
-    public final FlowProcessor<T> toSerialized() {
+    public final FlowableProcessor<T> toSerialized() {
         if (this instanceof SerializedProcessor) {
             return this;
         }
         return new SerializedProcessor<T>(this);
-    }
-    
-    /**
-     * Returns an Object array containing snapshot all values of the Subject.
-     * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the Subject
-     */
-    public Object[] getValues() {
-        @SuppressWarnings("unchecked")
-        T[] a = (T[])EMPTY;
-        T[] b = getValues(a);
-        if (b == EMPTY) {
-            return new Object[0];
-        }
-        return b;
-            
-    }
-    
-    /**
-     * Returns a typed array containing a snapshot of all values of the Subject.
-     * <p>The method follows the conventions of Collection.toArray by setting the array element
-     * after the last value to null (if the capacity permits).
-     * <p>The method is thread-safe.
-     * @param array the target array to copy values into if it fits
-     * @return the given array if the values fit into it or a new array containing all values
-     */
-    public T[] getValues(T[] array) {
-        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -56,7 +56,7 @@ import io.reactivex.plugins.RxJavaPlugins;
   } </pre>
  * @param <T> the value type multicast to Subscribers.
  */
-public final class PublishProcessor<T> extends FlowProcessor<T> {
+public final class PublishProcessor<T> extends FlowableProcessor<T> {
     
     /** Holds the terminal event and manages the array of subscribers. */
     final State<T> state;
@@ -138,24 +138,6 @@ public final class PublishProcessor<T> extends FlowProcessor<T> {
     @Override
     public boolean hasSubscribers() {
         return state.subscribers().length != 0;
-    }
-    
-    @Override
-    public boolean hasValue() {
-        return false;
-    }
-    
-    @Override
-    public T getValue() {
-        return null;
-    }
-    
-    @Override
-    public T[] getValues(T[] array) {
-        if (array.length != 0) {
-            array[0] = null;
-        }
-        return array;
     }
     
     @Override

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -51,7 +51,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * 
  * @param <T> the value type
  */
-public final class ReplayProcessor<T> extends FlowProcessor<T> {
+public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     final State<T> state;
     
     /**
@@ -280,12 +280,42 @@ public final class ReplayProcessor<T> extends FlowProcessor<T> {
         return null;
     }
     
-    @Override
+    /**
+     * Returns a single value the Subject currently has or null if no such value exists.
+     * <p>The method is thread-safe.
+     * @return a single value the Subject currently has or null if no such value exists
+     */
     public T getValue() {
         return state.buffer.getValue();
     }
     
-    @Override
+    /** An empty array to avoid allocation in getValues(). */
+    private static final Object[] EMPTY = new Object[0];
+
+    /**
+     * Returns an Object array containing snapshot all values of the Subject.
+     * <p>The method is thread-safe.
+     * @return the array containing the snapshot of all values of the Subject
+     */
+    public Object[] getValues() {
+        @SuppressWarnings("unchecked")
+        T[] a = (T[])EMPTY;
+        T[] b = getValues(a);
+        if (b == EMPTY) {
+            return new Object[0];
+        }
+        return b;
+            
+    }
+    
+    /**
+     * Returns a typed array containing a snapshot of all values of the Subject.
+     * <p>The method follows the conventions of Collection.toArray by setting the array element
+     * after the last value to null (if the capacity permits).
+     * <p>The method is thread-safe.
+     * @param array the target array to copy values into if it fits
+     * @return the given array if the values fit into it or a new array containing all values
+     */
     public T[] getValues(T[] array) {
         return state.buffer.getValues(array);
     }
@@ -302,7 +332,11 @@ public final class ReplayProcessor<T> extends FlowProcessor<T> {
         return NotificationLite.isError(o);
     }
     
-    @Override
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
     public boolean hasValue() {
         return state.buffer.size() != 0; // NOPMD
     }

--- a/src/main/java/io/reactivex/processors/SerializedProcessor.java
+++ b/src/main/java/io/reactivex/processors/SerializedProcessor.java
@@ -26,9 +26,9 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the item value type
  */
-/* public */ final class SerializedProcessor<T> extends FlowProcessor<T> {
+/* public */ final class SerializedProcessor<T> extends FlowableProcessor<T> {
     /** The actual subscriber to serialize Subscriber calls to. */
-    final FlowProcessor<T> actual;
+    final FlowableProcessor<T> actual;
     /** Indicates an emission is going on, guarted by this. */
     boolean emitting;
     /** If not null, it holds the missed NotificationLite events. */
@@ -40,7 +40,7 @@ import io.reactivex.plugins.RxJavaPlugins;
      * Constructor that wraps an actual subject.
      * @param actual the subject wrapped
      */
-    public SerializedProcessor(final FlowProcessor<T> actual) {
+    public SerializedProcessor(final FlowableProcessor<T> actual) {
         this.actual = actual;
     }
 
@@ -201,26 +201,6 @@ import io.reactivex.plugins.RxJavaPlugins;
     @Override
     public Throwable getThrowable() {
         return actual.getThrowable();
-    }
-    
-    @Override
-    public boolean hasValue() {
-        return actual.hasValue();
-    }
-    
-    @Override
-    public T getValue() {
-        return actual.getValue();
-    }
-    
-    @Override
-    public Object[] getValues() {
-        return actual.getValues();
-    }
-    
-    @Override
-    public T[] getValues(T[] array) {
-        return actual.getValues(array);
     }
     
     @Override

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -38,7 +38,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * 
  * @param <T> the value type unicasted
  */
-public final class UnicastProcessor<T> extends FlowProcessor<T> {
+public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
     final SpscLinkedArrayQueue<T> queue;
     

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -85,7 +85,11 @@ public final class AsyncSubject<T> extends Subject<T> {
         return null;
     }
     
-    @Override
+    /**
+     * Returns a single value the Subject currently has or null if no such value exists.
+     * <p>The method is thread-safe.
+     * @return a single value the Subject currently has or null if no such value exists
+     */
     public T getValue() {
         Object o = state.get();
         if (o != null) {
@@ -97,8 +101,34 @@ public final class AsyncSubject<T> extends Subject<T> {
         return null;
     }
     
+    /** An empty array to avoid allocation in getValues(). */
+    private static final Object[] EMPTY = new Object[0];
+
+    /**
+     * Returns an Object array containing snapshot all values of the Subject.
+     * <p>The method is thread-safe.
+     * @return the array containing the snapshot of all values of the Subject
+     */
+    public Object[] getValues() {
+        @SuppressWarnings("unchecked")
+        T[] a = (T[])EMPTY;
+        T[] b = getValues(a);
+        if (b == EMPTY) {
+            return new Object[0];
+        }
+        return b;
+            
+    }
+    
+    /**
+     * Returns a typed array containing a snapshot of all values of the Subject.
+     * <p>The method follows the conventions of Collection.toArray by setting the array element
+     * after the last value to null (if the capacity permits).
+     * <p>The method is thread-safe.
+     * @param array the target array to copy values into if it fits
+     * @return the given array if the values fit into it or a new array containing all values
+     */
     @SuppressWarnings("unchecked")
-    @Override
     public T[] getValues(T[] array) {
         Object o = state.get();
         if (o != null) {
@@ -136,7 +166,11 @@ public final class AsyncSubject<T> extends Subject<T> {
         return NotificationLite.isError(state.get());
     }
     
-    @Override
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
     public boolean hasValue() {
         Object o = state.get();
         return o != null && !NotificationLite.isComplete(o) && !NotificationLite.isError(o);

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -156,7 +156,11 @@ public final class BehaviorSubject<T> extends Subject<T> {
         return null;
     }
     
-    @Override
+    /**
+     * Returns a single value the Subject currently has or null if no such value exists.
+     * <p>The method is thread-safe.
+     * @return a single value the Subject currently has or null if no such value exists
+     */
     public T getValue() {
         Object o = state.get();
         if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
@@ -165,7 +169,33 @@ public final class BehaviorSubject<T> extends Subject<T> {
         return NotificationLite.getValue(o);
     }
     
-    @Override
+    /** An empty array to avoid allocation in getValues(). */
+    private static final Object[] EMPTY = new Object[0];
+
+    /**
+     * Returns an Object array containing snapshot all values of the Subject.
+     * <p>The method is thread-safe.
+     * @return the array containing the snapshot of all values of the Subject
+     */
+    public Object[] getValues() {
+        @SuppressWarnings("unchecked")
+        T[] a = (T[])EMPTY;
+        T[] b = getValues(a);
+        if (b == EMPTY) {
+            return new Object[0];
+        }
+        return b;
+            
+    }
+    
+    /**
+     * Returns a typed array containing a snapshot of all values of the Subject.
+     * <p>The method follows the conventions of Collection.toArray by setting the array element
+     * after the last value to null (if the capacity permits).
+     * <p>The method is thread-safe.
+     * @param array the target array to copy values into if it fits
+     * @return the given array if the values fit into it or a new array containing all values
+     */
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
         Object o = state.get();
@@ -200,7 +230,11 @@ public final class BehaviorSubject<T> extends Subject<T> {
         return NotificationLite.isError(o);
     }
     
-    @Override
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
     public boolean hasValue() {
         Object o = state.get();
         return o != null && !NotificationLite.isComplete(o) && !NotificationLite.isError(o);

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -105,19 +105,6 @@ public final class PublishSubject<T> extends Subject<T> {
     }
     
     @Override
-    public T getValue() {
-        return null;
-    }
-    
-    @Override
-    public T[] getValues(T[] array) {
-        if (array.length != 0) {
-            array[0] = null;
-        }
-        return array;
-    }
-    
-    @Override
     public boolean hasComplete() {
         Object o = state.get();
         return o != null && !NotificationLite.isError(o);
@@ -126,11 +113,6 @@ public final class PublishSubject<T> extends Subject<T> {
     @Override
     public boolean hasThrowable() {
         return NotificationLite.isError(state.get());
-    }
-    
-    @Override
-    public boolean hasValue() {
-        return false;
     }
     
     static final class State<T> extends AtomicReference<Object> implements ObservableSource<T>, Observer<T> {

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -277,12 +277,42 @@ public final class ReplaySubject<T> extends Subject<T> {
         return null;
     }
     
-    @Override
+    /**
+     * Returns a single value the Subject currently has or null if no such value exists.
+     * <p>The method is thread-safe.
+     * @return a single value the Subject currently has or null if no such value exists
+     */
     public T getValue() {
         return state.buffer.getValue();
     }
     
-    @Override
+    /** An empty array to avoid allocation in getValues(). */
+    private static final Object[] EMPTY = new Object[0];
+
+    /**
+     * Returns an Object array containing snapshot all values of the Subject.
+     * <p>The method is thread-safe.
+     * @return the array containing the snapshot of all values of the Subject
+     */
+    public Object[] getValues() {
+        @SuppressWarnings("unchecked")
+        T[] a = (T[])EMPTY;
+        T[] b = getValues(a);
+        if (b == EMPTY) {
+            return new Object[0];
+        }
+        return b;
+            
+    }
+    
+    /**
+     * Returns a typed array containing a snapshot of all values of the Subject.
+     * <p>The method follows the conventions of Collection.toArray by setting the array element
+     * after the last value to null (if the capacity permits).
+     * <p>The method is thread-safe.
+     * @param array the target array to copy values into if it fits
+     * @return the given array if the values fit into it or a new array containing all values
+     */
     public T[] getValues(T[] array) {
         return state.buffer.getValues(array);
     }
@@ -299,7 +329,11 @@ public final class ReplaySubject<T> extends Subject<T> {
         return NotificationLite.isError(o);
     }
     
-    @Override
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
     public boolean hasValue() {
         return state.buffer.size() != 0; // NOPMD
     }

--- a/src/main/java/io/reactivex/subjects/SerializedSubject.java
+++ b/src/main/java/io/reactivex/subjects/SerializedSubject.java
@@ -186,26 +186,6 @@ import io.reactivex.plugins.RxJavaPlugins;
     }
     
     @Override
-    public boolean hasValue() {
-        return actual.hasValue();
-    }
-    
-    @Override
-    public T getValue() {
-        return actual.getValue();
-    }
-    
-    @Override
-    public Object[] getValues() {
-        return actual.getValues();
-    }
-    
-    @Override
-    public T[] getValues(T[] array) {
-        return actual.getValues(array);
-    }
-    
-    @Override
     public boolean hasComplete() {
         return actual.hasComplete();
     }

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -24,9 +24,6 @@ import io.reactivex.*;
  * @param <T> the item value type
  */
 public abstract class Subject<T> extends Observable<T> implements Observer<T> {
-    /** An empty array to avoid allocation in getValues(). */
-    private static final Object[] EMPTY = new Object[0];
-    
     /**
      * Returns true if the subject has any Observers.
      * <p>The method is thread-safe.
@@ -41,9 +38,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * @see #getThrowable()
      * &see {@link #hasComplete()}
      */
-    public boolean hasThrowable() {
-        throw new UnsupportedOperationException();
-    }
+    public abstract boolean hasThrowable();
     
     /**
      * Returns true if the subject has reached a terminal state through a complete event.
@@ -51,18 +46,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * @return true if the subject has reached a terminal state through a complete event
      * @see #hasThrowable()
      */
-    public boolean hasComplete() {
-        throw new UnsupportedOperationException();
-    }
-    
-    /**
-     * Returns true if the subject has any value.
-     * <p>The method is thread-safe.
-     * @return true if the subject has any value
-     */
-    public boolean hasValue() {
-        throw new UnsupportedOperationException();
-    }
+    public abstract boolean hasComplete();
     
     /**
      * Returns the error that caused the Subject to terminate or null if the Subject
@@ -71,18 +55,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * @return the error that caused the Subject to terminate or null if the Subject
      * hasn't terminated yet
      */
-    public Throwable getThrowable() {
-        throw new UnsupportedOperationException();
-    }
-    
-    /**
-     * Returns a single value the Subject currently has or null if no such value exists.
-     * <p>The method is thread-safe.
-     * @return a single value the Subject currently has or null if no such value exists
-     */
-    public T getValue() {
-        throw new UnsupportedOperationException();
-    }
+    public abstract Throwable getThrowable();
     
     /**
      * Wraps this Subject and serializes the calls to the onSubscribe, onNext, onError and
@@ -95,33 +68,5 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
             return this;
         }
         return new SerializedSubject<T>(this);
-    }
-    
-    /**
-     * Returns an Object array containing snapshot all values of the Subject.
-     * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the Subject
-     */
-    public Object[] getValues() {
-        @SuppressWarnings("unchecked")
-        T[] a = (T[])EMPTY;
-        T[] b = getValues(a);
-        if (b == EMPTY) {
-            return new Object[0];
-        }
-        return b;
-            
-    }
-    
-    /**
-     * Returns a typed array containing a snapshot of all values of the Subject.
-     * <p>The method follows the conventions of Collection.toArray by setting the array element
-     * after the last value to null (if the capacity permits).
-     * <p>The method is thread-safe.
-     * @param array the target array to copy values into if it fits
-     * @return the given array if the values fit into it or a new array containing all values
-     */
-    public T[] getValues(T[] array) {
-        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -348,22 +348,4 @@ public final class UnicastSubject<T> extends Subject<T> {
         State<T> s = state;
         return s.done && s.error == null;
     }
-    
-    @Override
-    public boolean hasValue() {
-        return false;
-    }
-    
-    @Override
-    public T getValue() {
-        return null;
-    }
-    
-    @Override
-    public T[] getValues(T[] array) {
-        if (array.length != 0) {
-            array[0] = null;
-        }
-        return array;
-    }
 }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -160,19 +160,19 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void concatNull() {
-        Completable.concat((Completable[])null);
+        Completable.concatArray((Completable[])null);
     }
     
     @Test(timeout = 1000)
     public void concatEmpty() {
-        Completable c = Completable.concat();
+        Completable c = Completable.concatArray();
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatSingleSource() {
-        Completable c = Completable.concat(normal.completable);
+        Completable c = Completable.concatArray(normal.completable);
         
         c.blockingAwait();
         
@@ -181,14 +181,14 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void concatSingleSourceThrows() {
-        Completable c = Completable.concat(error.completable);
+        Completable c = Completable.concatArray(error.completable);
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void concatMultipleSources() {
-        Completable c = Completable.concat(normal.completable, normal.completable, normal.completable);
+        Completable c = Completable.concatArray(normal.completable, normal.completable, normal.completable);
         
         c.blockingAwait();
         
@@ -197,14 +197,14 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void concatMultipleOneThrows() {
-        Completable c = Completable.concat(normal.completable, error.completable, normal.completable);
+        Completable c = Completable.concatArray(normal.completable, error.completable, normal.completable);
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void concatMultipleOneIsNull() {
-        Completable c = Completable.concat(normal.completable, null);
+        Completable c = Completable.concatArray(normal.completable, null);
         
         c.blockingAwait();
     }
@@ -666,19 +666,19 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void mergeNull() {
-        Completable.merge((Completable[])null);
+        Completable.mergeArray((Completable[])null);
     }
     
     @Test(timeout = 1000)
     public void mergeEmpty() {
-        Completable c = Completable.merge();
+        Completable c = Completable.mergeArray();
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeSingleSource() {
-        Completable c = Completable.merge(normal.completable);
+        Completable c = Completable.mergeArray(normal.completable);
         
         c.blockingAwait();
         
@@ -687,14 +687,14 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void mergeSingleSourceThrows() {
-        Completable c = Completable.merge(error.completable);
+        Completable c = Completable.mergeArray(error.completable);
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeMultipleSources() {
-        Completable c = Completable.merge(normal.completable, normal.completable, normal.completable);
+        Completable c = Completable.mergeArray(normal.completable, normal.completable, normal.completable);
         
         c.blockingAwait();
         
@@ -703,14 +703,14 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void mergeMultipleOneThrows() {
-        Completable c = Completable.merge(normal.completable, error.completable, normal.completable);
+        Completable c = Completable.mergeArray(normal.completable, error.completable, normal.completable);
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void mergeMultipleOneIsNull() {
-        Completable c = Completable.merge(normal.completable, null);
+        Completable c = Completable.mergeArray(normal.completable, null);
         
         c.blockingAwait();
     }
@@ -878,19 +878,19 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorNull() {
-        Completable.mergeDelayError((Completable[])null);
+        Completable.mergeArrayDelayError((Completable[])null);
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorEmpty() {
-        Completable c = Completable.mergeDelayError();
+        Completable c = Completable.mergeArrayDelayError();
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorSingleSource() {
-        Completable c = Completable.mergeDelayError(normal.completable);
+        Completable c = Completable.mergeArrayDelayError(normal.completable);
         
         c.blockingAwait();
         
@@ -899,14 +899,14 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = TestException.class)
     public void mergeDelayErrorSingleSourceThrows() {
-        Completable c = Completable.mergeDelayError(error.completable);
+        Completable c = Completable.mergeArrayDelayError(error.completable);
         
         c.blockingAwait();
     }
     
     @Test(timeout = 1000)
     public void mergeDelayErrorMultipleSources() {
-        Completable c = Completable.mergeDelayError(normal.completable, normal.completable, normal.completable);
+        Completable c = Completable.mergeArrayDelayError(normal.completable, normal.completable, normal.completable);
         
         c.blockingAwait();
         
@@ -915,7 +915,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000)
     public void mergeDelayErrorMultipleOneThrows() {
-        Completable c = Completable.mergeDelayError(normal.completable, error.completable, normal.completable);
+        Completable c = Completable.mergeArrayDelayError(normal.completable, error.completable, normal.completable);
         
         try {
             c.blockingAwait();
@@ -926,7 +926,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void mergeDelayErrorMultipleOneIsNull() {
-        Completable c = Completable.mergeDelayError(normal.completable, null);
+        Completable c = Completable.mergeArrayDelayError(normal.completable, null);
         
         c.blockingAwait();
     }
@@ -2908,26 +2908,26 @@ public class CompletableTest {
     
     @Test(expected = NullPointerException.class)
     public void ambArrayNull() {
-        Completable.amb((Completable[])null);
+        Completable.ambArray((Completable[])null);
     }
 
     @Test(timeout = 1000)
     public void ambArrayEmpty() {
-        Completable c = Completable.amb();
+        Completable c = Completable.ambArray();
                 
         c.blockingAwait();
     }
 
     @Test(timeout = 1000)
     public void ambArraySingleNormal() {
-        Completable c = Completable.amb(normal.completable);
+        Completable c = Completable.ambArray(normal.completable);
                 
         c.blockingAwait();
     }
 
     @Test(timeout = 1000, expected = TestException.class)
     public void ambArraySingleError() {
-        Completable c = Completable.amb(error.completable);
+        Completable c = Completable.ambArray(error.completable);
                 
         c.blockingAwait();
     }
@@ -2941,7 +2941,7 @@ public class CompletableTest {
 
         Completable c2 = Completable.fromPublisher(ps2);
         
-        Completable c = Completable.amb(c1, c2);
+        Completable c = Completable.ambArray(c1, c2);
         
         final AtomicBoolean complete = new AtomicBoolean();
         
@@ -2972,7 +2972,7 @@ public class CompletableTest {
 
         Completable c2 = Completable.fromPublisher(ps2);
         
-        Completable c = Completable.amb(c1, c2);
+        Completable c = Completable.ambArray(c1, c2);
         
         final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
 
@@ -3003,7 +3003,7 @@ public class CompletableTest {
 
         Completable c2 = Completable.fromPublisher(ps2);
         
-        Completable c = Completable.amb(c1, c2);
+        Completable c = Completable.ambArray(c1, c2);
         
         final AtomicBoolean complete = new AtomicBoolean();
         
@@ -3034,7 +3034,7 @@ public class CompletableTest {
 
         Completable c2 = Completable.fromPublisher(ps2);
         
-        Completable c = Completable.amb(c1, c2);
+        Completable c = Completable.ambArray(c1, c2);
         
         final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
 
@@ -3058,7 +3058,7 @@ public class CompletableTest {
     
     @Test(timeout = 1000, expected = NullPointerException.class)
     public void ambMultipleOneIsNull() {
-        Completable c = Completable.amb(null, normal.completable);
+        Completable c = Completable.ambArray(null, normal.completable);
         
         c.blockingAwait();
     }

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.flowable;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -41,13 +41,13 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void ambVarargsNull() {
-        Flowable.amb((Publisher<Object>[])null);
+        Flowable.ambArray((Publisher<Object>[])null);
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambVarargsOneIsNull() {
-        Flowable.amb(Flowable.never(), null).blockingLast();
+        Flowable.ambArray(Flowable.never(), null).blockingLast();
     }
     
     @Test(expected = NullPointerException.class)
@@ -2736,70 +2736,70 @@ public class FlowableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void asyncSubjectOnNextNull() {
-        FlowProcessor<Integer> subject = AsyncProcessor.create();
+        FlowableProcessor<Integer> subject = AsyncProcessor.create();
         subject.onNext(null);
         subject.blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void asyncSubjectOnErrorNull() {
-        FlowProcessor<Integer> subject = AsyncProcessor.create();
+        FlowableProcessor<Integer> subject = AsyncProcessor.create();
         subject.onError(null);
         subject.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void behaviorSubjectOnNextNull() {
-        FlowProcessor<Integer> subject = BehaviorProcessor.create();
+        FlowableProcessor<Integer> subject = BehaviorProcessor.create();
         subject.onNext(null);
         subject.blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void behaviorSubjectOnErrorNull() {
-        FlowProcessor<Integer> subject = BehaviorProcessor.create();
+        FlowableProcessor<Integer> subject = BehaviorProcessor.create();
         subject.onError(null);
         subject.blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void publishSubjectOnNextNull() {
-        FlowProcessor<Integer> subject = PublishProcessor.create();
+        FlowableProcessor<Integer> subject = PublishProcessor.create();
         subject.onNext(null);
         subject.blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void publishSubjectOnErrorNull() {
-        FlowProcessor<Integer> subject = PublishProcessor.create();
+        FlowableProcessor<Integer> subject = PublishProcessor.create();
         subject.onError(null);
         subject.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void replaycSubjectOnNextNull() {
-        FlowProcessor<Integer> subject = ReplayProcessor.create();
+        FlowableProcessor<Integer> subject = ReplayProcessor.create();
         subject.onNext(null);
         subject.blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void replaySubjectOnErrorNull() {
-        FlowProcessor<Integer> subject = ReplayProcessor.create();
+        FlowableProcessor<Integer> subject = ReplayProcessor.create();
         subject.onError(null);
         subject.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void serializedcSubjectOnNextNull() {
-        FlowProcessor<Integer> subject = PublishProcessor.<Integer>create().toSerialized();
+        FlowableProcessor<Integer> subject = PublishProcessor.<Integer>create().toSerialized();
         subject.onNext(null);
         subject.blockingSubscribe();
     }
     
     @Test(expected = NullPointerException.class)
     public void serializedSubjectOnErrorNull() {
-        FlowProcessor<Integer> subject = PublishProcessor.<Integer>create().toSerialized();
+        FlowableProcessor<Integer> subject = PublishProcessor.<Integer>create().toSerialized();
         subject.onError(null);
         subject.blockingSubscribe();
     }

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -966,7 +966,7 @@ public class FlowableTests {
     
     @Test
     public void testErrorThrownIssue1685() {
-        FlowProcessor<Object> subject = ReplayProcessor.create();
+        FlowableProcessor<Object> subject = ReplayProcessor.create();
 
         Flowable.error(new RuntimeException("oops"))
             .materialize()

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
@@ -33,7 +33,7 @@ public class BlockingFlowableMostRecentTest {
 
     @Test
     public void testMostRecent() {
-        FlowProcessor<String> s = PublishProcessor.create();
+        FlowableProcessor<String> s = PublishProcessor.create();
 
         Iterator<String> it = s.blockingMostRecent("default").iterator();
 
@@ -58,7 +58,7 @@ public class BlockingFlowableMostRecentTest {
 
     @Test(expected = TestException.class)
     public void testMostRecentWithException() {
-        FlowProcessor<String> s = PublishProcessor.create();
+        FlowableProcessor<String> s = PublishProcessor.create();
 
         Iterator<String> it = s.blockingMostRecent("default").iterator();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -291,7 +291,7 @@ public class BlockingFlowableNextTest {
 
     @Test /* (timeout = 8000) */
     public void testSingleSourceManyIterators() throws InterruptedException {
-        Flowable<Long> o = Flowable.interval(100, TimeUnit.MILLISECONDS);
+        Flowable<Long> o = Flowable.interval(250, TimeUnit.MILLISECONDS);
         PublishProcessor<Integer> terminal = PublishProcessor.create();
         Flowable<Long> source = o.takeUntil(terminal);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -30,7 +30,7 @@ import io.reactivex.schedulers.Schedulers;
 
 public class BlockingFlowableNextTest {
 
-    private void fireOnNextInNewThread(final FlowProcessor<String> o, final String value) {
+    private void fireOnNextInNewThread(final FlowableProcessor<String> o, final String value) {
         new Thread() {
             @Override
             public void run() {
@@ -44,7 +44,7 @@ public class BlockingFlowableNextTest {
         }.start();
     }
 
-    private void fireOnErrorInNewThread(final FlowProcessor<String> o) {
+    private void fireOnErrorInNewThread(final FlowableProcessor<String> o) {
         new Thread() {
             @Override
             public void run() {
@@ -60,7 +60,7 @@ public class BlockingFlowableNextTest {
 
     @Test
     public void testNext() {
-        FlowProcessor<String> obs = PublishProcessor.create();
+        FlowableProcessor<String> obs = PublishProcessor.create();
         Iterator<String> it = obs.blockingNext().iterator();
         fireOnNextInNewThread(obs, "one");
         assertTrue(it.hasNext());
@@ -96,7 +96,7 @@ public class BlockingFlowableNextTest {
 
     @Test
     public void testNextWithError() {
-        FlowProcessor<String> obs = PublishProcessor.create();
+        FlowableProcessor<String> obs = PublishProcessor.create();
         Iterator<String> it = obs.blockingNext().iterator();
         fireOnNextInNewThread(obs, "one");
         assertTrue(it.hasNext());
@@ -135,7 +135,7 @@ public class BlockingFlowableNextTest {
 
     @Test
     public void testOnError() throws Throwable {
-        FlowProcessor<String> obs = PublishProcessor.create();
+        FlowableProcessor<String> obs = PublishProcessor.create();
         Iterator<String> it = obs.blockingNext().iterator();
 
         obs.onError(new TestException());
@@ -151,7 +151,7 @@ public class BlockingFlowableNextTest {
 
     @Test
     public void testOnErrorInNewThread() {
-        FlowProcessor<String> obs = PublishProcessor.create();
+        FlowableProcessor<String> obs = PublishProcessor.create();
         Iterator<String> it = obs.blockingNext().iterator();
 
         fireOnErrorInNewThread(obs);
@@ -182,7 +182,7 @@ public class BlockingFlowableNextTest {
 
     @Test
     public void testNextWithOnlyUsingNextMethod() {
-        FlowProcessor<String> obs = PublishProcessor.create();
+        FlowableProcessor<String> obs = PublishProcessor.create();
         Iterator<String> it = obs.blockingNext().iterator();
         fireOnNextInNewThread(obs, "one");
         assertEquals("one", it.next());
@@ -200,7 +200,7 @@ public class BlockingFlowableNextTest {
 
     @Test
     public void testNextWithCallingHasNextMultipleTimes() {
-        FlowProcessor<String> obs = PublishProcessor.create();
+        FlowableProcessor<String> obs = PublishProcessor.create();
         Iterator<String> it = obs.blockingNext().iterator();
         fireOnNextInNewThread(obs, "one");
         assertTrue(it.hasNext());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -100,7 +100,7 @@ public class FlowableAmbTest {
                 "3", "33", "333", "3333" }, 3000, null);
 
         @SuppressWarnings("unchecked")
-        Flowable<String> o = Flowable.amb(Flowable1,
+        Flowable<String> o = Flowable.ambArray(Flowable1,
                 Flowable2, Flowable3);
 
         @SuppressWarnings("unchecked")
@@ -130,7 +130,7 @@ public class FlowableAmbTest {
                 3000, new IOException("fake exception"));
 
         @SuppressWarnings("unchecked")
-        Flowable<String> o = Flowable.amb(Flowable1,
+        Flowable<String> o = Flowable.ambArray(Flowable1,
                 Flowable2, Flowable3);
 
         @SuppressWarnings("unchecked")
@@ -158,7 +158,7 @@ public class FlowableAmbTest {
                 "3" }, 3000, null);
 
         @SuppressWarnings("unchecked")
-        Flowable<String> o = Flowable.amb(Flowable1,
+        Flowable<String> o = Flowable.ambArray(Flowable1,
                 Flowable2, Flowable3);
 
         @SuppressWarnings("unchecked")
@@ -218,7 +218,7 @@ public class FlowableAmbTest {
             }
 
         });
-        Flowable.amb(o1, o2).subscribe(ts);
+        Flowable.ambArray(o1, o2).subscribe(ts);
         assertEquals(3, requested1.get());
         assertEquals(3, requested2.get());
     }
@@ -256,7 +256,7 @@ public class FlowableAmbTest {
         Flowable<Integer> o2 = Flowable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        Flowable.amb(o1, o2).subscribe(ts);
+        Flowable.ambArray(o1, o2).subscribe(ts);
         ts.request(1);
         ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -274,7 +274,7 @@ public class FlowableAmbTest {
                 .delay(200, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L);
         
-        Flowable.amb(o1, o2).subscribe(ts);
+        Flowable.ambArray(o1, o2).subscribe(ts);
         // before first emission request 20 more
         // this request should suffice to emit all
         ts.request(20);
@@ -312,7 +312,7 @@ public class FlowableAmbTest {
         
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         
-        Flowable.amb(source1, source2, source3).subscribe(ts);
+        Flowable.ambArray(source1, source2, source3).subscribe(ts);
         
         assertTrue("Source 1 doesn't have subscribers!", source1.hasSubscribers());
         assertTrue("Source 2 doesn't have subscribers!", source2.hasSubscribers());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -33,7 +33,7 @@ import io.reactivex.subscribers.TestSubscriber;
 public class FlowableCacheTest {
     @Test
     public void testColdReplayNoBackpressure() {
-        FlowableCache<Integer> source = FlowableCache.from(Flowable.range(0, 1000));
+        FlowableCache<Integer> source = (FlowableCache<Integer>)FlowableCache.from(Flowable.range(0, 1000));
         
         assertFalse("Source is connected!", source.isConnected());
         
@@ -55,7 +55,7 @@ public class FlowableCacheTest {
     }
     @Test
     public void testColdReplayBackpressure() {
-        FlowableCache<Integer> source = FlowableCache.from(Flowable.range(0, 1000));
+        FlowableCache<Integer> source = (FlowableCache<Integer>)FlowableCache.from(Flowable.range(0, 1000));
         
         assertFalse("Source is connected!", source.isConnected());
         
@@ -144,7 +144,7 @@ public class FlowableCacheTest {
     public void testTake() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        FlowableCache<Integer> cached = FlowableCache.from(Flowable.range(1, 100));
+        FlowableCache<Integer> cached = (FlowableCache<Integer>)FlowableCache.from(Flowable.range(1, 100));
         cached.take(10).subscribe(ts);
         
         ts.assertNoErrors();
@@ -160,7 +160,7 @@ public class FlowableCacheTest {
         for (int i = 0; i < 100; i++) {
             TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
             
-            FlowableCache<Integer> cached = FlowableCache.from(source);
+            FlowableCache<Integer> cached = (FlowableCache<Integer>)FlowableCache.from(source);
             
             cached.observeOn(Schedulers.computation()).subscribe(ts1);
             
@@ -183,7 +183,7 @@ public class FlowableCacheTest {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
                 .subscribeOn(Schedulers.io());
-        FlowableCache<Long> cached = FlowableCache.from(source);
+        FlowableCache<Long> cached = (FlowableCache<Long>)FlowableCache.from(source);
         
         Flowable<Long> output = cached.observeOn(Schedulers.computation());
         

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -733,7 +733,7 @@ public class FlowableConcatTest {
                 Flowable<Integer> observable = Flowable.just(t)
                         .subscribeOn(sch)
                 ;
-                FlowProcessor<Integer> subject = new UnicastProcessor<Integer>();
+                FlowableProcessor<Integer> subject = new UnicastProcessor<Integer>();
                 observable.subscribe(subject);
                 return subject;
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -50,7 +50,7 @@ public class FlowableTakeWhileTest {
 
     @Test
     public void testTakeWhileOnSubject1() {
-        FlowProcessor<Integer> s = PublishProcessor.create();
+        FlowableProcessor<Integer> s = PublishProcessor.create();
         Flowable<Integer> take = s.takeWhile(new Predicate<Integer>() {
             @Override
             public boolean test(Integer input) {

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
@@ -294,7 +294,7 @@ public class BlockingObservableNextTest {
 
     @Test /* (timeout = 8000) */
     public void testSingleSourceManyIterators() throws InterruptedException {
-        Observable<Long> o = Observable.interval(100, TimeUnit.MILLISECONDS);
+        Observable<Long> o = Observable.interval(250, TimeUnit.MILLISECONDS);
         PublishSubject<Integer> terminal = PublishSubject.create();
         Observable<Long> source = o.takeUntil(terminal);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -86,7 +86,7 @@ public class ObservableAmbTest {
                 "3", "33", "333", "3333" }, 3000, null);
 
         @SuppressWarnings("unchecked")
-        Observable<String> o = Observable.amb(observable1,
+        Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
@@ -115,7 +115,7 @@ public class ObservableAmbTest {
                 3000, new IOException("fake exception"));
 
         @SuppressWarnings("unchecked")
-        Observable<String> o = Observable.amb(observable1,
+        Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
@@ -142,7 +142,7 @@ public class ObservableAmbTest {
                 "3" }, 3000, null);
 
         @SuppressWarnings("unchecked")
-        Observable<String> o = Observable.amb(observable1,
+        Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
@@ -172,7 +172,7 @@ public class ObservableAmbTest {
         Observable<Integer> o2 = Observable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.amb(o1, o2).subscribe(ts);
+        Observable.ambArray(o1, o2).subscribe(ts);
         ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
         assertEquals(2, count.get());
@@ -207,7 +207,7 @@ public class ObservableAmbTest {
         
         TestObserver<Integer> ts = new TestObserver<Integer>();
         
-        Observable.amb(source1, source2, source3).subscribe(ts);
+        Observable.ambArray(source1, source2, source3).subscribe(ts);
         
         assertTrue("Source 1 doesn't have subscribers!", source1.hasObservers());
         assertTrue("Source 2 doesn't have subscribers!", source2.hasObservers());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -34,7 +34,7 @@ import io.reactivex.schedulers.Schedulers;
 public class ObservableCacheTest {
     @Test
     public void testColdReplayNoBackpressure() {
-        ObservableCache<Integer> source = ObservableCache.from(Observable.range(0, 1000));
+        ObservableCache<Integer> source = (ObservableCache<Integer>)ObservableCache.from(Observable.range(0, 1000));
         
         assertFalse("Source is connected!", source.isConnected());
         
@@ -119,7 +119,7 @@ public class ObservableCacheTest {
     public void testTake() {
         TestObserver<Integer> ts = new TestObserver<Integer>();
 
-        ObservableCache<Integer> cached = ObservableCache.from(Observable.range(1, 100));
+        ObservableCache<Integer> cached = (ObservableCache<Integer>)ObservableCache.from(Observable.range(1, 100));
         cached.take(10).subscribe(ts);
         
         ts.assertNoErrors();
@@ -135,7 +135,7 @@ public class ObservableCacheTest {
         for (int i = 0; i < 100; i++) {
             TestObserver<Integer> ts1 = new TestObserver<Integer>();
             
-            ObservableCache<Integer> cached = ObservableCache.from(source);
+            ObservableCache<Integer> cached = (ObservableCache<Integer>)ObservableCache.from(source);
             
             cached.observeOn(Schedulers.computation()).subscribe(ts1);
             
@@ -158,7 +158,7 @@ public class ObservableCacheTest {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
                 .subscribeOn(Schedulers.io());
-        ObservableCache<Long> cached = ObservableCache.from(source);
+        ObservableCache<Long> cached = (ObservableCache<Long>)ObservableCache.from(source);
         
         Observable<Long> output = cached.observeOn(Schedulers.computation());
         

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -42,13 +42,13 @@ public class ObservableNullTests {
     
     @Test(expected = NullPointerException.class)
     public void ambVarargsNull() {
-        Observable.amb((Observable<Object>[])null);
+        Observable.ambArray((Observable<Object>[])null);
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambVarargsOneIsNull() {
-        Observable.amb(Observable.never(), null).blockingLast();
+        Observable.ambArray(Observable.never(), null).blockingLast();
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
@@ -38,108 +38,89 @@ public class SerializedProcessorTest {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
         async.onNext(1);
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testAsyncSubjectValueEmpty() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testAsyncSubjectValueError() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
         TestException te = new TestException();
         async.onError(te);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testPublishSubjectValueRelay() {
         PublishProcessor<Integer> async = PublishProcessor.create();
         async.onNext(1);
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        
-        assertArrayEquals(new Object[0], serial.getValues());
-        assertArrayEquals(new Integer[0], serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
     public void testPublishSubjectValueEmpty() {
         PublishProcessor<Integer> async = PublishProcessor.create();
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testPublishSubjectValueError() {
         PublishProcessor<Integer> async = PublishProcessor.create();
         TestException te = new TestException();
         async.onError(te);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
     }
 
     @Test
@@ -147,86 +128,86 @@ public class SerializedProcessorTest {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
         async.onNext(1);
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectValueRelayIncomplete() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
         async.onNext(1);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectIncompleteEmpty() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectEmpty() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectError() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
         TestException te = new TestException();
         async.onError(te);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
@@ -234,35 +215,35 @@ public class SerializedProcessorTest {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
         async.onNext(1);
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
         async.onNext(1);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayBounded() {
@@ -270,147 +251,147 @@ public class SerializedProcessorTest {
         async.onNext(0);
         async.onNext(1);
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayBoundedIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
         async.onNext(0);
         async.onNext(1);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayBoundedEmptyIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayEmptyIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
     public void testReplaySubjectEmpty() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectError() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
         TestException te = new TestException();
         async.onError(te);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
     public void testReplaySubjectBoundedEmpty() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
         async.onComplete();
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectBoundedError() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
         TestException te = new TestException();
         async.onError(te);
-        FlowProcessor<Integer> serial = async.toSerialized();
+        FlowableProcessor<Integer> serial = async.toSerialized();
         
         assertFalse(serial.hasSubscribers());
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
     public void testDontWrapSerializedSubjectAgain() {
         PublishProcessor<Object> s = PublishProcessor.create();
-        FlowProcessor<Object> s1 = s.toSerialized();
-        FlowProcessor<Object> s2 = s1.toSerialized();
+        FlowableProcessor<Object> s1 = s.toSerialized();
+        FlowableProcessor<Object> s2 = s1.toSerialized();
         assertSame(s1, s2);
     }
 }

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -56,13 +56,13 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void ambArrayNull() {
-        Single.amb((Single<Integer>[])null);
+        Single.ambArray((Single<Integer>[])null);
     }
     
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambArrayOneIsNull() {
-        Single.amb(null, just1).blockingGet();
+        Single.ambArray(null, just1).blockingGet();
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -44,12 +44,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testAsyncSubjectValueEmpty() {
@@ -61,12 +61,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testAsyncSubjectValueError() {
@@ -79,12 +79,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testPublishSubjectValueRelay() {
@@ -97,13 +97,6 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        
-        assertArrayEquals(new Object[0], serial.getValues());
-        assertArrayEquals(new Integer[0], serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
@@ -116,12 +109,6 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testPublishSubjectValueError() {
@@ -134,12 +121,6 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
     }
 
     @Test
@@ -153,12 +134,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectValueRelayIncomplete() {
@@ -170,12 +151,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectIncompleteEmpty() {
@@ -186,12 +167,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectEmpty() {
@@ -203,12 +184,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testBehaviorSubjectError() {
@@ -221,12 +202,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
@@ -240,12 +221,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayIncomplete() {
@@ -257,12 +238,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayBounded() {
@@ -276,12 +257,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayBoundedIncomplete() {
@@ -294,12 +275,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertEquals((Integer)1, serial.getValue());
-        assertTrue(serial.hasValue());
-        assertArrayEquals(new Object[] { 1 }, serial.getValues());
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, serial.getValues(new Integer[] { 0, 0 }));
+        assertEquals((Integer)1, async.getValue());
+        assertTrue(async.hasValue());
+        assertArrayEquals(new Object[] { 1 }, async.getValues());
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayBoundedEmptyIncomplete() {
@@ -310,12 +291,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectValueRelayEmptyIncomplete() {
@@ -326,12 +307,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
@@ -344,12 +325,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectError() {
@@ -362,12 +343,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test
@@ -380,12 +361,12 @@ public class SerializedSubjectTest {
         assertTrue(serial.hasComplete());
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     @Test
     public void testReplaySubjectBoundedError() {
@@ -398,12 +379,12 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasComplete());
         assertTrue(serial.hasThrowable());
         assertSame(te, serial.getThrowable());
-        assertNull(serial.getValue());
-        assertFalse(serial.hasValue());
-        assertArrayEquals(new Object[] { }, serial.getValues());
-        assertArrayEquals(new Integer[] { }, serial.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, serial.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, serial.getValues(new Integer[] { 0, 0 }));
+        assertNull(async.getValue());
+        assertFalse(async.hasValue());
+        assertArrayEquals(new Object[] { }, async.getValues());
+        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
+        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
+        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
     
     @Test


### PR DESCRIPTION
Notable changes:
- renamed `amb(sources...)` to `ambArray(sources...)` to be consistent with the naming of other operators with varargs input
- Renamed some other varargs operators ot `xArray` to be consistent
- Added `RxJavaPlugins.onAssembly()` to operators, note that no other infrastructure (such as `enableAssemblyTracking` was added; companion libraries may later utilize these hooks to inject the necessary wrapper classes.
- Extended `RxJavaPlugins.onAssembly()` to support `ConnectableX` operators
- Renamed `FlowProcessor` into `FlowableProcessor` to avoid future confusion with JDK 9's `Flow.Processor`
- Removed common value extraction methods from `Subject` and `FlowableProcessor` and left them in the implementations
- Made common terminal state checking methods of `Subject` and `FlowableProcessor` as abstract since all subtypes can implement them reasonably
- fixed copy-paste errors in javadocs, such as wrong class named, referencing non-existent backpressure
