### PR TITLE
1.x: Remove 'Completable' prefix from nested interfaces, move its subscription to top-level.

### DIFF
--- a/src/main/java/rx/CompletableSubscriber.java
+++ b/src/main/java/rx/CompletableSubscriber.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx;
+
+import rx.annotations.Experimental;
+
+/**
+ * Represents the subscription API callbacks when subscribing to a Completable instance.
+ */
+@Experimental
+public interface CompletableSubscriber {
+    /**
+     * Called once the deferred computation completes normally.
+     */
+    void onCompleted();
+
+    /**
+     * Called once if the deferred computation 'throws' an exception.
+     * @param e the exception, not null.
+     */
+    void onError(Throwable e);
+
+    /**
+     * Called once by the Completable to set a Subscription on this instance which
+     * then can be used to cancel the subscription at any time.
+     * @param d the Subscription instance to call dispose on for cancellation, not null
+     */
+    void onSubscribe(Subscription d);
+}

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -2021,7 +2021,7 @@ public class Single<T> {
                     }
                 };
 
-                final Completable.CompletableSubscriber so = new Completable.CompletableSubscriber() {
+                final CompletableSubscriber so = new CompletableSubscriber() {
                     @Override
                     public void onCompleted() {
                         onError(new CancellationException("Stream was canceled before emitting a terminal event."));

--- a/src/main/java/rx/internal/operators/CompletableFlatMapSingleToCompletable.java
+++ b/src/main/java/rx/internal/operators/CompletableFlatMapSingleToCompletable.java
@@ -17,15 +17,15 @@
 package rx.internal.operators;
 
 import rx.Completable;
-import rx.Completable.CompletableOnSubscribe;
-import rx.Completable.CompletableSubscriber;
+import rx.Completable.OnSubscribe;
+import rx.CompletableSubscriber;
 import rx.Single;
 import rx.SingleSubscriber;
 import rx.Subscription;
 import rx.exceptions.Exceptions;
 import rx.functions.Func1;
 
-public final class CompletableFlatMapSingleToCompletable<T> implements CompletableOnSubscribe {
+public final class CompletableFlatMapSingleToCompletable<T> implements OnSubscribe {
 
     final Single<T> source;
 

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcat.java
@@ -19,13 +19,13 @@ package rx.internal.operators;
 import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.exceptions.MissingBackpressureException;
 import rx.internal.util.unsafe.SpscArrayQueue;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
-public final class CompletableOnSubscribeConcat implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeConcat implements OnSubscribe {
     final Observable<Completable> sources;
     final int prefetch;
     

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
@@ -19,10 +19,10 @@ package rx.internal.operators;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.subscriptions.SerialSubscription;
 
-public final class CompletableOnSubscribeConcatArray implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeConcatArray implements OnSubscribe {
     final Completable[] sources;
     
     public CompletableOnSubscribeConcatArray(Completable[] sources) {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatIterable.java
@@ -20,10 +20,10 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.subscriptions.*;
 
-public final class CompletableOnSubscribeConcatIterable implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeConcatIterable implements OnSubscribe {
     final Iterable<? extends Completable> sources;
     
     public CompletableOnSubscribeConcatIterable(Iterable<? extends Completable> sources) {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMerge.java
@@ -21,13 +21,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.Observable;
 import rx.exceptions.CompositeException;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
-public final class CompletableOnSubscribeMerge implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeMerge implements OnSubscribe {
     final Observable<Completable> source;
     final int maxConcurrency;
     final boolean delayErrors;

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeArray.java
@@ -19,11 +19,11 @@ package rx.internal.operators;
 import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
-public final class CompletableOnSubscribeMergeArray implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeMergeArray implements OnSubscribe {
     final Completable[] sources;
     
     public CompletableOnSubscribeMergeArray(Completable[] sources) {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorArray.java
@@ -21,10 +21,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.subscriptions.CompositeSubscription;
 
-public final class CompletableOnSubscribeMergeDelayErrorArray implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeMergeDelayErrorArray implements OnSubscribe {
     final Completable[] sources;
     
     public CompletableOnSubscribeMergeDelayErrorArray(Completable[] sources) {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeDelayErrorIterable.java
@@ -20,11 +20,11 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.internal.util.unsafe.MpscLinkedQueue;
 import rx.subscriptions.CompositeSubscription;
 
-public final class CompletableOnSubscribeMergeDelayErrorIterable implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeMergeDelayErrorIterable implements OnSubscribe {
     final Iterable<? extends Completable> sources;
     
     public CompletableOnSubscribeMergeDelayErrorIterable(Iterable<? extends Completable> sources) {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeMergeIterable.java
@@ -20,11 +20,11 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
-public final class CompletableOnSubscribeMergeIterable implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeMergeIterable implements OnSubscribe {
     final Iterable<? extends Completable> sources;
     
     public CompletableOnSubscribeMergeIterable(Iterable<? extends Completable> sources) {

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeTimeout.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeTimeout.java
@@ -20,12 +20,12 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import rx.*;
-import rx.Completable.*;
+import rx.Completable.OnSubscribe;
 import rx.functions.Action0;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.CompositeSubscription;
 
-public final class CompletableOnSubscribeTimeout implements CompletableOnSubscribe {
+public final class CompletableOnSubscribeTimeout implements OnSubscribe {
     
     final Completable source;
     final long timeout;

--- a/src/main/java/rx/internal/operators/OnSubscribeOnAssemblyCompletable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeOnAssemblyCompletable.java
@@ -16,7 +16,7 @@
 package rx.internal.operators;
 
 import rx.*;
-import rx.Completable.CompletableSubscriber;
+import rx.CompletableSubscriber;
 import rx.exceptions.AssemblyStackTraceException;
 
 /**
@@ -26,9 +26,9 @@ import rx.exceptions.AssemblyStackTraceException;
  *
  * @param <T> the value type
  */
-public final class OnSubscribeOnAssemblyCompletable<T> implements Completable.CompletableOnSubscribe {
+public final class OnSubscribeOnAssemblyCompletable<T> implements Completable.OnSubscribe {
 
-    final Completable.CompletableOnSubscribe source;
+    final Completable.OnSubscribe source;
     
     final String stacktrace;
 
@@ -38,13 +38,13 @@ public final class OnSubscribeOnAssemblyCompletable<T> implements Completable.Co
      */
     public static volatile boolean fullStackTrace;
     
-    public OnSubscribeOnAssemblyCompletable(Completable.CompletableOnSubscribe source) {
+    public OnSubscribeOnAssemblyCompletable(Completable.OnSubscribe source) {
         this.source = source;
         this.stacktrace = OnSubscribeOnAssembly.createStacktrace();
     }
     
     @Override
-    public void call(Completable.CompletableSubscriber t) {
+    public void call(CompletableSubscriber t) {
         source.call(new OnAssemblyCompletableSubscriber(t, stacktrace));
     }
     

--- a/src/main/java/rx/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/rx/internal/schedulers/SchedulerWhen.java
@@ -20,9 +20,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import rx.Completable;
-import rx.Completable.CompletableOnSubscribe;
-import rx.Completable.CompletableSubscriber;
-import rx.Scheduler.Worker;
+import rx.Completable.OnSubscribe;
+import rx.CompletableSubscriber;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
@@ -143,7 +142,7 @@ public class SchedulerWhen extends Scheduler implements Subscription {
 		Observable<Completable> actions = actionSubject.map(new Func1<ScheduledAction, Completable>() {
 			@Override
 			public Completable call(final ScheduledAction action) {
-				return Completable.create(new CompletableOnSubscribe() {
+				return Completable.create(new OnSubscribe() {
 					@Override
 					public void call(CompletableSubscriber actionCompletable) {
 						actionCompletable.onSubscribe(action);

--- a/src/main/java/rx/observers/AsyncCompletableSubscriber.java
+++ b/src/main/java/rx/observers/AsyncCompletableSubscriber.java
@@ -17,7 +17,7 @@ package rx.observers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import rx.Completable.CompletableSubscriber;
+import rx.CompletableSubscriber;
 import rx.Subscription;
 import rx.annotations.Experimental;
 import rx.plugins.RxJavaHooks;

--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -15,7 +15,7 @@
  */
 package rx.observers;
 
-import rx.Completable.CompletableSubscriber;
+import rx.CompletableSubscriber;
 import rx.Subscription;
 import rx.annotations.Experimental;
 import rx.exceptions.*;

--- a/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
@@ -40,18 +40,18 @@ import rx.functions.Func1;
 @Experimental
 public abstract class RxJavaCompletableExecutionHook { // NOPMD 
     /**
-     * Invoked during the construction by {@link Completable#create(Completable.CompletableOnSubscribe)}
+     * Invoked during the construction by {@link Completable#create(Completable.OnSubscribe)}
      * <p>
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.
      *
      * @param f
-     *            original {@link rx.Completable.CompletableOnSubscribe}<{@code T}> to be executed
-     * @return {@link rx.Completable.CompletableOnSubscribe} function that can be modified, decorated, replaced or just
+     *            original {@link Completable.OnSubscribe}<{@code T}> to be executed
+     * @return {@link Completable.OnSubscribe} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     @Deprecated
-    public Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe f) {
+    public Completable.OnSubscribe onCreate(Completable.OnSubscribe f) {
         return f;
     }
 
@@ -63,12 +63,12 @@ public abstract class RxJavaCompletableExecutionHook { // NOPMD
      *
      * @param completableInstance the target completable instance
      * @param onSubscribe
-     *            original {@link rx.Completable.CompletableOnSubscribe}<{@code T}> to be executed
-     * @return {@link rx.Completable.CompletableOnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
+     *            original {@link Completable.OnSubscribe}<{@code T}> to be executed
+     * @return {@link Completable.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     @Deprecated
-    public Completable.CompletableOnSubscribe onSubscribeStart(Completable completableInstance, final Completable.CompletableOnSubscribe onSubscribe) {
+    public Completable.OnSubscribe onSubscribeStart(Completable completableInstance, final Completable.OnSubscribe onSubscribe) {
         // pass through by default
         return onSubscribe;
     }
@@ -93,16 +93,16 @@ public abstract class RxJavaCompletableExecutionHook { // NOPMD
      * Invoked just as the operator functions is called to bind two operations together into a new
      * {@link Completable} and the return value is used as the lifted function
      * <p>
-     * This can be used to decorate or replace the {@link rx.Completable.CompletableOperator} instance or just perform extra
+     * This can be used to decorate or replace the {@link Completable.Operator} instance or just perform extra
      * logging, metrics and other such things and pass through the onSubscribe.
      *
      * @param lift
-     *            original {@link rx.Completable.CompletableOperator}{@code <R, T>}
-     * @return {@link rx.Completable.CompletableOperator}{@code <R, T>} function that can be modified, decorated, replaced or just
+     *            original {@link Completable.Operator}{@code <R, T>}
+     * @return {@link Completable.Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     @Deprecated
-    public Completable.CompletableOperator onLift(final Completable.CompletableOperator lift) {
+    public Completable.Operator onLift(final Completable.Operator lift) {
         return lift;
     }
 }

--- a/src/main/java/rx/plugins/RxJavaHooks.java
+++ b/src/main/java/rx/plugins/RxJavaHooks.java
@@ -19,8 +19,6 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 
 import rx.*;
-import rx.Completable.*;
-import rx.Observable.*;
 import rx.annotations.Experimental;
 import rx.functions.*;
 import rx.internal.operators.*;
@@ -47,7 +45,7 @@ public final class RxJavaHooks {
     @SuppressWarnings("rawtypes")
     static volatile Func1<Single.OnSubscribe, Single.OnSubscribe> onSingleCreate;
 
-    static volatile Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableCreate;
+    static volatile Func1<Completable.OnSubscribe, Completable.OnSubscribe> onCompletableCreate;
 
     @SuppressWarnings("rawtypes")
     static volatile Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe> onObservableStart;
@@ -55,7 +53,7 @@ public final class RxJavaHooks {
     @SuppressWarnings("rawtypes")
     static volatile Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> onSingleStart;
 
-    static volatile Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableStart;
+    static volatile Func2<Completable, Completable.OnSubscribe, Completable.OnSubscribe> onCompletableStart;
 
     static volatile Func1<Scheduler, Scheduler> onComputationScheduler;
 
@@ -78,12 +76,12 @@ public final class RxJavaHooks {
     static volatile Func1<Throwable, Throwable> onCompletableSubscribeError;
 
     @SuppressWarnings("rawtypes")
-    static volatile Func1<Operator, Operator> onObservableLift;
+    static volatile Func1<Observable.Operator, Observable.Operator> onObservableLift;
 
     @SuppressWarnings("rawtypes")
-    static volatile Func1<Operator, Operator> onSingleLift;
+    static volatile Func1<Observable.Operator, Observable.Operator> onSingleLift;
 
-    static volatile Func1<CompletableOperator, CompletableOperator> onCompletableLift;
+    static volatile Func1<Completable.Operator, Completable.Operator> onCompletableLift;
 
     /** Initialize with the default delegation to the original RxJavaPlugins. */
     static {
@@ -108,9 +106,9 @@ public final class RxJavaHooks {
             }
         };
         
-        onObservableStart = new Func2<Observable, OnSubscribe, OnSubscribe>() {
+        onObservableStart = new Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe>() {
             @Override
-            public OnSubscribe call(Observable t1, OnSubscribe t2) {
+            public Observable.OnSubscribe call(Observable t1, Observable.OnSubscribe t2) {
                 return RxJavaPlugins.getInstance().getObservableExecutionHook().onSubscribeStart(t1, t2);
             }
         };
@@ -136,9 +134,9 @@ public final class RxJavaHooks {
             }
         };
         
-        onCompletableStart = new Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe>() {
+        onCompletableStart = new Func2<Completable, Completable.OnSubscribe, Completable.OnSubscribe>() {
             @Override
-            public Completable.CompletableOnSubscribe call(Completable t1, Completable.CompletableOnSubscribe t2) {
+            public Completable.OnSubscribe call(Completable t1, Completable.OnSubscribe t2) {
                 return RxJavaPlugins.getInstance().getCompletableExecutionHook().onSubscribeStart(t1, t2);
             }
         };
@@ -157,9 +155,9 @@ public final class RxJavaHooks {
             }
         };
         
-        onObservableLift = new Func1<Operator, Operator>() {
+        onObservableLift = new Func1<Observable.Operator, Observable.Operator>() {
             @Override
-            public Operator call(Operator t) {
+            public Observable.Operator call(Observable.Operator t) {
                 return RxJavaPlugins.getInstance().getObservableExecutionHook().onLift(t);
             }
         };
@@ -171,9 +169,9 @@ public final class RxJavaHooks {
             }
         };
         
-        onSingleLift = new Func1<Operator, Operator>() {
+        onSingleLift = new Func1<Observable.Operator, Observable.Operator>() {
             @Override
-            public Operator call(Operator t) {
+            public Observable.Operator call(Observable.Operator t) {
                 return RxJavaPlugins.getInstance().getSingleExecutionHook().onLift(t);
             }
         };
@@ -185,9 +183,9 @@ public final class RxJavaHooks {
             }
         };
         
-        onCompletableLift = new Func1<CompletableOperator, CompletableOperator>() {
+        onCompletableLift = new Func1<Completable.Operator, Completable.Operator>() {
             @Override
-            public CompletableOperator call(CompletableOperator t) {
+            public Completable.Operator call(Completable.Operator t) {
                 return RxJavaPlugins.getInstance().getCompletableExecutionHook().onLift(t);
             }
         };
@@ -197,9 +195,9 @@ public final class RxJavaHooks {
     
     @SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
     static void initCreate() {
-        onObservableCreate = new Func1<OnSubscribe, OnSubscribe>() {
+        onObservableCreate = new Func1<Observable.OnSubscribe, Observable.OnSubscribe>() {
             @Override
-            public OnSubscribe call(OnSubscribe f) {
+            public Observable.OnSubscribe call(Observable.OnSubscribe f) {
                 return RxJavaPlugins.getInstance().getObservableExecutionHook().onCreate(f);
             }
         };
@@ -211,9 +209,9 @@ public final class RxJavaHooks {
             }
         };
 
-        onCompletableCreate = new Func1<CompletableOnSubscribe, CompletableOnSubscribe>() {
+        onCompletableCreate = new Func1<Completable.OnSubscribe, Completable.OnSubscribe>() {
             @Override
-            public CompletableOnSubscribe call(CompletableOnSubscribe f) {
+            public Completable.OnSubscribe call(Completable.OnSubscribe f) {
                 return RxJavaPlugins.getInstance().getCompletableExecutionHook().onCreate(f);
             }
         };
@@ -327,7 +325,7 @@ public final class RxJavaHooks {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> Observable.OnSubscribe<T> onCreate(Observable.OnSubscribe<T> onSubscribe) {
-        Func1<OnSubscribe, OnSubscribe> f = onObservableCreate;
+        Func1<Observable.OnSubscribe, Observable.OnSubscribe> f = onObservableCreate;
         if (f != null) {
             return f.call(onSubscribe);
         }
@@ -354,8 +352,8 @@ public final class RxJavaHooks {
      * @param onSubscribe the original OnSubscribe logic
      * @return the original or replacement OnSubscribe instance
      */
-    public static Completable.CompletableOnSubscribe onCreate(Completable.CompletableOnSubscribe onSubscribe) {
-        Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> f = onCompletableCreate;
+    public static Completable.OnSubscribe onCreate(Completable.OnSubscribe onSubscribe) {
+        Func1<Completable.OnSubscribe, Completable.OnSubscribe> f = onCompletableCreate;
         if (f != null) {
             return f.call(onSubscribe);
         }
@@ -423,8 +421,8 @@ public final class RxJavaHooks {
      * @return the original or alternative action that will be subscribed to
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> OnSubscribe<T> onObservableStart(Observable<T> instance, OnSubscribe<T> onSubscribe) {
-        Func2<Observable, OnSubscribe, OnSubscribe> f = onObservableStart;
+    public static <T> Observable.OnSubscribe onObservableStart(Observable<T> instance, Observable.OnSubscribe onSubscribe) {
+        Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe> f = onObservableStart;
         if (f != null) {
             return f.call(instance, onSubscribe);
         }
@@ -465,8 +463,8 @@ public final class RxJavaHooks {
      * @return the original or alternative operator that will be subscribed to
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T, R> Operator<R, T> onObservableLift(Operator<R, T> operator) {
-        Func1<Operator, Operator> f = onObservableLift;
+    public static <T, R> Observable.Operator<R, T> onObservableLift(Observable.Operator<R, T> operator) {
+        Func1<Observable.Operator, Observable.Operator> f = onObservableLift;
         if (f != null) {
             return f.call(operator);
         }
@@ -481,7 +479,7 @@ public final class RxJavaHooks {
      * @return the original or alternative action that will be subscribed to
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Observable.OnSubscribe<T> onSingleStart(Single<T> instance, Observable.OnSubscribe<T> onSubscribe) {
+    public static <T> Observable.OnSubscribe onSingleStart(Single<T> instance, Observable.OnSubscribe onSubscribe) {
         Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> f = onSingleStart;
         if (f != null) {
             return f.call(instance, onSubscribe);
@@ -523,8 +521,8 @@ public final class RxJavaHooks {
      * @return the original or alternative operator that will be subscribed to
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T, R> Operator<R, T> onSingleLift(Operator<R, T> operator) {
-        Func1<Operator, Operator> f = onSingleLift;
+    public static <T, R> Observable.Operator<R, T> onSingleLift(Observable.Operator<R, T> operator) {
+        Func1<Observable.Operator, Observable.Operator> f = onSingleLift;
         if (f != null) {
             return f.call(operator);
         }
@@ -538,8 +536,8 @@ public final class RxJavaHooks {
      * @param onSubscribe the original OnSubscribe action
      * @return the original or alternative action that will be subscribed to
      */
-    public static <T> Completable.CompletableOnSubscribe onCompletableStart(Completable instance, Completable.CompletableOnSubscribe onSubscribe) {
-        Func2<Completable, CompletableOnSubscribe, CompletableOnSubscribe> f = onCompletableStart;
+    public static <T> Completable.OnSubscribe onCompletableStart(Completable instance, Completable.OnSubscribe onSubscribe) {
+        Func2<Completable, Completable.OnSubscribe, Completable.OnSubscribe> f = onCompletableStart;
         if (f != null) {
             return f.call(instance, onSubscribe);
         }
@@ -566,8 +564,8 @@ public final class RxJavaHooks {
      * @param operator the original operator
      * @return the original or alternative operator that will be subscribed to
      */
-    public static <T, R> Completable.CompletableOperator onCompletableLift(Completable.CompletableOperator operator) {
-        Func1<CompletableOperator, CompletableOperator> f = onCompletableLift;
+    public static <T, R> Completable.Operator onCompletableLift(Completable.Operator operator) {
+        Func1<Completable.Operator, Completable.Operator> f = onCompletableLift;
         if (f != null) {
             return f.call(operator);
         }
@@ -602,7 +600,7 @@ public final class RxJavaHooks {
      * and should return a CompletableOnSubscribe.
      */
     public static void setOnCompletableCreate(
-            Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableCreate) {
+            Func1<Completable.OnSubscribe, Completable.OnSubscribe> onCompletableCreate) {
         if (lockdown) {
             return;
         }
@@ -731,7 +729,7 @@ public final class RxJavaHooks {
      * that gets actually subscribed to.
      */
     public static void setOnCompletableStart(
-            Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> onCompletableStart) {
+            Func2<Completable, Completable.OnSubscribe, Completable.OnSubscribe> onCompletableStart) {
         if (lockdown) {
             return;
         }
@@ -916,7 +914,7 @@ public final class RxJavaHooks {
      * return an Operator instance.
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnObservableLift(Func1<Operator, Operator> onObservableLift) {
+    public static void setOnObservableLift(Func1<Observable.Operator, Observable.Operator> onObservableLift) {
         if (lockdown) {
             return;
         }
@@ -931,7 +929,7 @@ public final class RxJavaHooks {
      * @return the current hook function
      */
     @SuppressWarnings("rawtypes")
-    public static Func1<Operator, Operator> getOnObservableLift() {
+    public static Func1<Observable.Operator, Observable.Operator> getOnObservableLift() {
         return onObservableLift;
     }
 
@@ -947,7 +945,7 @@ public final class RxJavaHooks {
      * return an Operator instance.
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnSingleLift(Func1<Operator, Operator> onSingleLift) {
+    public static void setOnSingleLift(Func1<Observable.Operator, Observable.Operator> onSingleLift) {
         if (lockdown) {
             return;
         }
@@ -962,7 +960,7 @@ public final class RxJavaHooks {
      * @return the current hook function
      */
     @SuppressWarnings("rawtypes")
-    public static Func1<Operator, Operator> getOnSingleLift() {
+    public static Func1<Observable.Operator, Observable.Operator> getOnSingleLift() {
         return onSingleLift;
     }
 
@@ -977,7 +975,7 @@ public final class RxJavaHooks {
      * @param onCompletableLift the function that is called with original Operator and should
      * return an Operator instance.
      */
-    public static void setOnCompletableLift(Func1<CompletableOperator, CompletableOperator> onCompletableLift) {
+    public static void setOnCompletableLift(Func1<Completable.Operator, Completable.Operator> onCompletableLift) {
         if (lockdown) {
             return;
         }
@@ -991,7 +989,7 @@ public final class RxJavaHooks {
      * This operation is threadsafe.
      * @return the current hook function
      */
-    public static Func1<CompletableOperator, CompletableOperator> getOnCompletableLift() {
+    public static Func1<Completable.Operator, Completable.Operator> getOnCompletableLift() {
         return onCompletableLift;
     }
 
@@ -1082,7 +1080,7 @@ public final class RxJavaHooks {
      * This operation is threadsafe.
      * @return the current hook function
      */
-    public static Func1<Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> getOnCompletableCreate() {
+    public static Func1<Completable.OnSubscribe, Completable.OnSubscribe> getOnCompletableCreate() {
         return onCompletableCreate;
     }
     
@@ -1093,7 +1091,7 @@ public final class RxJavaHooks {
      * This operation is threadsafe.
      * @return the current hook function
      */
-    public static Func2<Completable, Completable.CompletableOnSubscribe, Completable.CompletableOnSubscribe> getOnCompletableStart() {
+    public static Func2<Completable, Completable.OnSubscribe, Completable.OnSubscribe> getOnCompletableStart() {
         return onCompletableStart;
     }
     
@@ -1178,9 +1176,9 @@ public final class RxJavaHooks {
             return;
         }
         
-        onObservableCreate = new Func1<OnSubscribe, OnSubscribe>() {
+        onObservableCreate = new Func1<Observable.OnSubscribe, Observable.OnSubscribe>() {
             @Override
-            public OnSubscribe call(OnSubscribe f) {
+            public Observable.OnSubscribe call(Observable.OnSubscribe f) {
                 return new OnSubscribeOnAssembly(f);
             }
         };
@@ -1192,9 +1190,9 @@ public final class RxJavaHooks {
             }
         };
 
-        onCompletableCreate = new Func1<CompletableOnSubscribe, CompletableOnSubscribe>() {
+        onCompletableCreate = new Func1<Completable.OnSubscribe, Completable.OnSubscribe>() {
             @Override
-            public CompletableOnSubscribe call(CompletableOnSubscribe f) {
+            public Completable.OnSubscribe call(Completable.OnSubscribe f) {
                 return new OnSubscribeOnAssemblyCompletable(f);
             }
         };

--- a/src/test/java/rx/observers/CompletableSubscriberTest.java
+++ b/src/test/java/rx/observers/CompletableSubscriberTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.*;
 
-import rx.Completable.CompletableSubscriber;
+import rx.CompletableSubscriber;
 import rx.exceptions.*;
 import rx.Subscription;
 import rx.subscriptions.Subscriptions;

--- a/src/test/java/rx/plugins/RxJavaHooksTest.java
+++ b/src/test/java/rx/plugins/RxJavaHooksTest.java
@@ -26,9 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import rx.*;
-import rx.Completable.*;
 import rx.Observable;
-import rx.Observable.*;
 import rx.Scheduler.Worker;
 import rx.exceptions.*;
 import rx.functions.*;
@@ -307,9 +305,9 @@ public class RxJavaHooksTest {
     @Test
     public void observableCreate() {
         try {
-            RxJavaHooks.setOnObservableCreate(new Func1<OnSubscribe, OnSubscribe>() {
+            RxJavaHooks.setOnObservableCreate(new Func1<Observable.OnSubscribe, Observable.OnSubscribe>() {
                 @Override
-                public OnSubscribe call(OnSubscribe t) {
+                public Observable.OnSubscribe call(Observable.OnSubscribe t) {
                     return new OnSubscribeRange(1, 2);
                 }
             });
@@ -338,9 +336,9 @@ public class RxJavaHooksTest {
     @Test
     public void observableStart() {
         try {
-            RxJavaHooks.setOnObservableStart(new Func2<Observable, OnSubscribe, OnSubscribe>() {
+            RxJavaHooks.setOnObservableStart(new Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe>() {
                 @Override
-                public OnSubscribe call(Observable o, OnSubscribe t) {
+                public Observable.OnSubscribe call(Observable o, Observable.OnSubscribe t) {
                     return new OnSubscribeRange(1, 2);
                 }
             });
@@ -400,7 +398,7 @@ public class RxJavaHooksTest {
                 public Single.OnSubscribe call(Single.OnSubscribe t) {
                     return new Single.OnSubscribe<Object>() {
                         @Override
-                        public void call(SingleSubscriber<Object> t) {
+                        public void call(SingleSubscriber<? super Object> t) {
                             t.onSuccess(10);
                         }
                     };
@@ -431,12 +429,12 @@ public class RxJavaHooksTest {
     @Test
     public void singleStart() {
         try {
-            RxJavaHooks.setOnSingleStart(new Func2<Single, OnSubscribe, OnSubscribe>() {
+            RxJavaHooks.setOnSingleStart(new Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe>() {
                 @Override
-                public OnSubscribe call(Single o, OnSubscribe t) {
-                    return new OnSubscribe<Object>() {
+                public Observable.OnSubscribe call(Single o, Observable.OnSubscribe t) {
+                    return new Observable.OnSubscribe<Object>() {
                         @Override
-                        public void call(Subscriber<Object> t) {
+                        public void call(Subscriber<? super Object> t) {
                             t.setProducer(new SingleProducer<Integer>(t, 10));
                         }
                     };
@@ -492,10 +490,10 @@ public class RxJavaHooksTest {
     @Test
     public void completableCreate() {
         try {
-            RxJavaHooks.setOnCompletableCreate(new Func1<CompletableOnSubscribe, CompletableOnSubscribe>() {
+            RxJavaHooks.setOnCompletableCreate(new Func1<Completable.OnSubscribe, Completable.OnSubscribe>() {
                 @Override
-                public CompletableOnSubscribe call(CompletableOnSubscribe t) {
-                    return new CompletableOnSubscribe() {
+                public Completable.OnSubscribe call(Completable.OnSubscribe t) {
+                    return new Completable.OnSubscribe() {
                         @Override
                         public void call(CompletableSubscriber t) {
                             t.onError(new TestException());
@@ -527,10 +525,10 @@ public class RxJavaHooksTest {
     @Test
     public void completableStart() {
         try {
-            RxJavaHooks.setOnCompletableStart(new Func2<Completable, CompletableOnSubscribe, CompletableOnSubscribe>() {
+            RxJavaHooks.setOnCompletableStart(new Func2<Completable, Completable.OnSubscribe, Completable.OnSubscribe>() {
                 @Override
-                public CompletableOnSubscribe call(Completable o, CompletableOnSubscribe t) {
-                    return new CompletableOnSubscribe() {
+                public Completable.OnSubscribe call(Completable o, Completable.OnSubscribe t) {
+                    return new Completable.OnSubscribe() {
                         @Override
                         public void call(CompletableSubscriber t) {
                             t.onError(new TestException());
@@ -772,7 +770,7 @@ public class RxJavaHooksTest {
             
             assertNull(RxJavaHooks.onCreate((Single.OnSubscribe)null));
 
-            Completable.CompletableOnSubscribe cos = new Completable.CompletableOnSubscribe() {
+            Completable.OnSubscribe cos = new Completable.OnSubscribe() {
                 @Override
                 public void call(CompletableSubscriber t) {
                     
@@ -839,7 +837,7 @@ public class RxJavaHooksTest {
             
             assertSame(oop, RxJavaHooks.onSingleLift(oop));
             
-            Completable.CompletableOperator cop = new Completable.CompletableOperator() {
+            Completable.Operator cop = new Completable.Operator() {
                 @Override
                 public CompletableSubscriber call(CompletableSubscriber t) {
                     return t;
@@ -958,7 +956,7 @@ public class RxJavaHooksTest {
     @Test
     public void onXLift() {
         try {
-            Completable.CompletableOperator cop = new Completable.CompletableOperator() {
+            Completable.Operator cop = new Completable.Operator() {
                 @Override
                 public CompletableSubscriber call(CompletableSubscriber t) {
                     return t;
@@ -974,25 +972,25 @@ public class RxJavaHooksTest {
 
             final int[] counter = { 0 };
 
-            RxJavaHooks.setOnObservableLift(new Func1<Operator, Operator>() {
+            RxJavaHooks.setOnObservableLift(new Func1<Observable.Operator, Observable.Operator>() {
                 @Override
-                public Operator call(Operator t) {
+                public Observable.Operator call(Observable.Operator t) {
                     counter[0]++;
                     return t;
                 }
             });
 
-            RxJavaHooks.setOnSingleLift(new Func1<Operator, Operator>() {
+            RxJavaHooks.setOnSingleLift(new Func1<Observable.Operator, Observable.Operator>() {
                 @Override
-                public Operator call(Operator t) {
+                public Observable.Operator call(Observable.Operator t) {
                     counter[0]++;
                     return t;
                 }
             });
 
-            RxJavaHooks.setOnCompletableLift(new Func1<CompletableOperator, CompletableOperator>() {
+            RxJavaHooks.setOnCompletableLift(new Func1<Completable.Operator, Completable.Operator>() {
                 @Override
-                public CompletableOperator call(CompletableOperator t) {
+                public Completable.Operator call(Completable.Operator t) {
                     counter[0]++;
                     return t;
                 }
@@ -1019,7 +1017,7 @@ public class RxJavaHooksTest {
             RxJavaPlugins.getInstance().reset();
             RxJavaHooks.reset();
 
-            Completable.CompletableOperator cop = new Completable.CompletableOperator() {
+            Completable.Operator cop = new Completable.Operator() {
                 @Override
                 public CompletableSubscriber call(CompletableSubscriber t) {
                     return t;
@@ -1035,17 +1033,17 @@ public class RxJavaHooksTest {
 
             final int[] counter = { 0 };
 
-            final Func1<Operator, Operator> onObservableLift = new Func1<Operator, Operator>() {
+            final Func1<Observable.Operator, Observable.Operator> onObservableLift = new Func1<Observable.Operator, Observable.Operator>() {
                 @Override
-                public Operator call(Operator t) {
+                public Observable.Operator call(Observable.Operator t) {
                     counter[0]++;
                     return t;
                 }
             };
 
-            final Func1<CompletableOperator, CompletableOperator> onCompletableLift = new Func1<CompletableOperator, CompletableOperator>() {
+            final Func1<Completable.Operator, Completable.Operator> onCompletableLift = new Func1<Completable.Operator, Completable.Operator>() {
                 @Override
-                public CompletableOperator call(CompletableOperator t) {
+                public Completable.Operator call(Completable.Operator t) {
                     counter[0]++;
                     return t;
                 }
@@ -1053,21 +1051,21 @@ public class RxJavaHooksTest {
             
             RxJavaPlugins.getInstance().registerObservableExecutionHook(new RxJavaObservableExecutionHook() {
                 @Override
-                public <T, R> Operator<? extends R, ? super T> onLift(Operator<? extends R, ? super T> lift) {
+                public <T, R> Observable.Operator<? extends R, ? super T> onLift(Observable.Operator<? extends R, ? super T> lift) {
                     return onObservableLift.call(lift);
                 }
             });
             
             RxJavaPlugins.getInstance().registerSingleExecutionHook(new RxJavaSingleExecutionHook() {
                 @Override
-                public <T, R> Operator<? extends R, ? super T> onLift(Operator<? extends R, ? super T> lift) {
+                public <T, R> Observable.Operator<? extends R, ? super T> onLift(Observable.Operator<? extends R, ? super T> lift) {
                     return onObservableLift.call(lift);
                 }
             });
             
             RxJavaPlugins.getInstance().registerCompletableExecutionHook(new RxJavaCompletableExecutionHook() {
                 @Override
-                public CompletableOperator onLift(CompletableOperator lift) {
+                public Completable.Operator onLift(Completable.Operator lift) {
                     return onCompletableLift.call(lift);
                 }
             });


### PR DESCRIPTION
This is only the `Completable` part of #4420. It does not make `CompletableSubscriber` an abstract class nor create `Single.Operator`.
