### PR TITLE
2.x: collect - handle post terminal events  - Observable

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/observable/Burst.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/Burst.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
+
+/**
+ * Creates {@link Observable} of a number of items followed by either an error or
+ * completion. Subscription status is not checked before emitting an event.
+ * 
+ * @param <T> the value type
+ */
+public final class Burst<T> extends Observable<T> {
+
+    private final List<T> items;
+    private final Throwable error;
+
+    private Burst(Throwable error, List<T> items) {
+        this.error = error;
+        this.items = items;
+    }
+
+    @Override
+    protected void subscribeActual(final Observer<? super T> observer) {
+        observer.onSubscribe(Disposables.empty());
+        for (T item: items) {
+            observer.onNext(item);
+        }
+        if (error != null) {
+            observer.onError(error);
+        } else {
+            observer.onComplete();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Builder<T> item(T item) {
+        return items(item);
+    }
+
+    public static <T> Builder<T> items(T... items) {
+        return new Builder<T>(Arrays.asList(items));
+    }
+
+    public static final class Builder<T> {
+
+        private final List<T> items;
+        private Throwable error = null;
+
+        private Builder(List<T> items) {
+            this.items = items;
+        }
+
+        public Observable<T> error(Throwable e) {
+            this.error = e;
+            return create();
+        }
+
+        public Observable<T> create() {
+            return new Burst<T>(error, items);
+        }
+
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -1,17 +1,4 @@
-/**
- * Copyright 2016 Netflix, Inc.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License is
- * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
- * the License for the specific language governing permissions and limitations under the License.
- */
-
-package io.reactivex.flowable;
+package io.reactivex.internal.operators.observable;
 
 import static io.reactivex.internal.util.TestingHelper.addToList;
 import static io.reactivex.internal.util.TestingHelper.biConsumerThrows;
@@ -28,15 +15,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.Observable;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableCollectTest {
+public final class ObservableCollectTest {
     
     @Test
     public void testCollectToList() {
-        Flowable<List<Integer>> o = Flowable.just(1, 2, 3)
+        Observable<List<Integer>> o = Observable.just(1, 2, 3)
         .collect(new Callable<List<Integer>>() {
             @Override
             public List<Integer> call() {
@@ -67,50 +54,25 @@ public final class FlowableCollectTest {
 
     @Test
     public void testCollectToString() {
-        String value = Flowable.just(1, 2, 3)
-            .collect(
-                new Callable<StringBuilder>() {
-                    @Override
-                    public StringBuilder call() {
-                        return new StringBuilder();
-                    }
-                }, 
-                new BiConsumer<StringBuilder, Integer>() {
-                    @Override
-                    public void accept(StringBuilder sb, Integer v) {
-                    if (sb.length() > 0) {
-                        sb.append("-");
-                    }
-                    sb.append(v);
+        String value = Observable.just(1, 2, 3).collect(new Callable<StringBuilder>() {
+            @Override
+            public StringBuilder call() {
+                return new StringBuilder();
+            }
+        }, 
+            new BiConsumer<StringBuilder, Integer>() {
+                @Override
+                public void accept(StringBuilder sb, Integer v) {
+                if (sb.length() > 0) {
+                    sb.append("-");
                 }
+                sb.append(v);
+      }
             }).blockingLast().toString();
 
         assertEquals("1-2-3", value);
     }
-
-
-    @Test
-    public void testFactoryFailureResultsInErrorEmission() {
-        final RuntimeException e = new RuntimeException();
-        Flowable.just(1).collect(new Callable<List<Integer>>() {
-
-            @Override
-            public List<Integer> call() throws Exception {
-                throw e;
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-
-            @Override
-            public void accept(List<Integer> list, Integer t) {
-                list.add(t);
-            }
-        })
-        .test()
-        .assertNoValues()
-        .assertError(e)
-        .assertNotComplete();
-    }
-
+    
     @Test
     public void testCollectorFailureDoesNotResultInTwoErrorEmissions() {
         try {

--- a/src/test/java/io/reactivex/internal/util/TestingHelper.java
+++ b/src/test/java/io/reactivex/internal/util/TestingHelper.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.reactivex.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.Consumer;
+
+public final class TestingHelper {
+    
+    private TestingHelper() {
+        // prevent instantiation
+    }
+    
+    public static <T> Consumer<T> addToList(final List<T> list) {
+        return new Consumer<T>() {
+
+            @Override
+            public void accept(T t) {
+                list.add(t);
+            }
+        };
+    }
+
+    public static <T> Callable<List<T>> callableListCreator() {
+        return new Callable<List<T>>() {
+
+            @Override
+            public List<T> call() {
+                return new ArrayList<T>();
+            }
+        };
+    }
+
+    public static BiConsumer<Object, Object> biConsumerThrows(final RuntimeException e) {
+        return new BiConsumer<Object, Object>() {
+
+            @Override
+            public void accept(Object t1, Object t2) {
+                throw e;
+            }
+        };
+    }
+}

--- a/src/test/java/io/reactivex/observable/ObservableTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableTests.java
@@ -887,58 +887,6 @@ public class ObservableTests {
     }
 
     @Test
-    public void testCollectToList() {
-        Observable<List<Integer>> o = Observable.just(1, 2, 3)
-        .collect(new Callable<List<Integer>>() {
-            @Override
-            public List<Integer> call() {
-                return new ArrayList<Integer>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> list, Integer v) {
-                list.add(v);
-            }
-        });
-        
-        List<Integer> list =  o.blockingLast();
-
-        assertEquals(3, list.size());
-        assertEquals(1, list.get(0).intValue());
-        assertEquals(2, list.get(1).intValue());
-        assertEquals(3, list.get(2).intValue());
-        
-        // test multiple subscribe
-        List<Integer> list2 =  o.blockingLast();
-
-        assertEquals(3, list2.size());
-        assertEquals(1, list2.get(0).intValue());
-        assertEquals(2, list2.get(1).intValue());
-        assertEquals(3, list2.get(2).intValue());
-    }
-
-    @Test
-    public void testCollectToString() {
-        String value = Observable.just(1, 2, 3).collect(new Callable<StringBuilder>() {
-            @Override
-            public StringBuilder call() {
-                return new StringBuilder();
-            }
-        }, 
-            new BiConsumer<StringBuilder, Integer>() {
-                @Override
-                public void accept(StringBuilder sb, Integer v) {
-                if (sb.length() > 0) {
-                    sb.append("-");
-                }
-                sb.append(v);
-      }
-            }).blockingLast().toString();
-
-        assertEquals("1-2-3", value);
-    }
-    
-    @Test
     public void testMergeWith() {
         TestObserver<Integer> ts = new TestObserver<Integer>();
         Observable.just(1).mergeWith(Observable.just(2)).subscribe(ts);


### PR DESCRIPTION
Post-terminal event handling for `Observable.collect`.

Added three unit tests that failed on original logic.
