### PR TITLE
2.x: cleanup, bugfixes, coverage 8/27-2

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -225,15 +225,7 @@ public abstract class Completable implements CompletableSource {
         if (source instanceof Completable) {
             throw new IllegalArgumentException("Use of unsafeCreate(Completable)!");
         }
-        try {
-            return RxJavaPlugins.onAssembly(new CompletableFromUnsafeSource(source));
-        } catch (NullPointerException ex) { // NOPMD
-            throw ex;
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            RxJavaPlugins.onError(ex);
-            throw toNpe(ex);
-        } 
+        return RxJavaPlugins.onAssembly(new CompletableFromUnsafeSource(source));
     }
     
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -801,7 +801,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param source the source to wrap
      * @return the Single wrapper or the source cast to Single (if possible)
      */
-    static <T> Single<T> wrap(SingleSource<T> source) {
+    public static <T> Single<T> wrap(SingleSource<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Single) {
             return RxJavaPlugins.onAssembly((Single<T>)source);
@@ -1824,7 +1824,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
-    public final Single<T> onErrorReturnValue(final T value) {
+    public final Single<T> onErrorReturnItem(final T value) {
         ObjectHelper.requireNonNull(value, "value is null");
         return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, null, value));
     }
@@ -2034,16 +2034,6 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     public final Single<T> retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
         return toFlowable().retryWhen(handler).toSingle();
-    }
-    
-    /**
-     * Subscribes the given Reactive-Streams Subscriber to this Single with a safety wrapper
-     * that handles exceptions thrown from the Subscriber's onXXX methods.
-     * @param s the Subscriber to wrap and subscribe to the current Single
-     * @since 2.0
-     */
-    public final void safeSubscribe(Subscriber<? super T> s) {
-        toFlowable().safeSubscribe(s);
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimer.java
@@ -20,6 +20,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
@@ -75,7 +76,7 @@ public final class FlowableTimer extends Flowable<Long> {
                     actual.onNext(0L);
                     actual.onComplete();
                 } else {
-                    actual.onError(new IllegalStateException("Can't deliver value due to lack of requests"));
+                    actual.onError(new MissingBackpressureException("Can't deliver value due to lack of requests"));
                 }
                 lazySet(EmptyDisposable.INSTANCE);
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqual.java
@@ -39,6 +39,7 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
     @Override
     public void subscribeActual(Observer<? super Boolean> s) {
         EqualCoordinator<T> ec = new EqualCoordinator<T>(s, bufferSize, first, second, comparer);
+        s.onSubscribe(ec);
         ec.subscribe();
     }
     

--- a/src/main/java/io/reactivex/internal/operators/single/SingleAmbArray.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleAmbArray.java
@@ -60,6 +60,7 @@ public final class SingleAmbArray<T> extends Single<T> {
                 @Override
                 public void onSuccess(T value) {
                     if (once.compareAndSet(false, true)) {
+                        set.dispose();
                         s.onSuccess(value);
                     }
                 }
@@ -67,6 +68,7 @@ public final class SingleAmbArray<T> extends Single<T> {
                 @Override
                 public void onError(Throwable e) {
                     if (once.compareAndSet(false, true)) {
+                        set.dispose();
                         s.onError(e);
                     } else {
                         RxJavaPlugins.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
@@ -73,7 +73,7 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
         
         @Override
         public void onNext(U value) {
-            get().dispose();
+            s.cancel();
             onComplete();
         }
         

--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -45,7 +45,7 @@ public final class SpscLinkedArrayQueue<T> implements SimpleQueue<T> {
     private static final Object HAS_NEXT = new Object();
 
     public SpscLinkedArrayQueue(final int bufferSize) {
-        int p2capacity = Pow2.roundToPowerOfTwo(bufferSize);
+        int p2capacity = Pow2.roundToPowerOfTwo(Math.max(8, bufferSize));
         int mask = p2capacity - 1;
         AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<Object>(p2capacity + 1);
         producerBuffer = buffer;

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -54,6 +54,7 @@ public final class TrampolineScheduler extends Scheduler {
     public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         try {
             unit.sleep(delay);
+            run.run();
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -895,15 +895,16 @@ public class TestObserver<T> implements Observer<T>, Disposable {
      * @param time the waiting time
      * @param unit the time unit of the waiting time
      * @return this
-     * @throws InterruptedException if the wait is interrupted
+     * @throws RuntimeException wrapping an InterruptedException if the wait is interrupted
      */
-    public final TestObserver<T> awaitDone(long time, TimeUnit unit) throws InterruptedException {
+    public final TestObserver<T> awaitDone(long time, TimeUnit unit) {
         try {
             if (!done.await(time, unit)) {
                 cancel();
             }
         } catch (InterruptedException ex) {
             cancel();
+            throw ExceptionHelper.wrapOrThrow(ex);
         }
         return this;
     }

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -957,15 +957,16 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * @param time the waiting time
      * @param unit the time unit of the waiting time
      * @return this
-     * @throws InterruptedException if the wait is interrupted
+     * @throws RuntimeException wrapping an InterruptedException if the wait is interrupted
      */
-    public final TestSubscriber<T> awaitDone(long time, TimeUnit unit) throws InterruptedException {
+    public final TestSubscriber<T> awaitDone(long time, TimeUnit unit) {
         try {
             if (!done.await(time, unit)) {
                 cancel();
             }
         } catch (InterruptedException ex) {
             cancel();
+            throw ExceptionHelper.wrapOrThrow(ex);
         }
         return this;
     }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAwaitTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAwaitTest.java
@@ -13,11 +13,14 @@
 
 package io.reactivex.internal.operators.completable;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.TestHelper;
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.processors.PublishProcessor;
 
 public class CompletableAwaitTest {
@@ -42,4 +45,48 @@ public class CompletableAwaitTest {
         }
         
     }
+    
+    @Test
+    public void awaitTimeoutInterrupted() {
+        
+        Thread.currentThread().interrupt();
+        
+        try {
+            PublishProcessor.create().toCompletable().blockingAwait(1, TimeUnit.SECONDS);
+            fail("Should have thrown RuntimeException");
+        } catch (RuntimeException ex) {
+            if (!(ex.getCause() instanceof InterruptedException)) {
+                fail("Wrong cause: " + ex.getCause());
+            }
+        }
+        
+    }
+    
+    @Test
+    public void awaitTimeout() {
+        assertFalse(PublishProcessor.create().toCompletable().blockingAwait(100, TimeUnit.MILLISECONDS));
+    }
+    
+    @Test
+    public void blockingGet() {
+        assertNull(Completable.complete().blockingGet());
+    }
+
+    @Test
+    public void blockingGetTimeout() {
+        assertNull(Completable.complete().blockingGet(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void blockingGetError() {
+        TestException ex = new TestException();
+        assertSame(ex, Completable.error(ex).blockingGet());
+    }
+
+    @Test
+    public void blockingGetErrorTimeout() {
+        TestException ex = new TestException();
+        assertSame(ex, Completable.error(ex).blockingGet(1, TimeUnit.SECONDS));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.completable;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -39,5 +40,15 @@ public class CompletableConcatTest {
         )
         .test()
         .assertFailure(MissingBackpressureException.class);
+    }
+    
+    @Test
+    public void invalidPrefetch() {
+        try {
+            Completable.concat(Flowable.just(Completable.complete()), -99);
+            fail("Should have thrown IllegalArgumentExceptio");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("prefetch > 0 required but it was -99", ex.getMessage());
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDelayTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.Completable;
+import io.reactivex.schedulers.Schedulers;
+
+public class CompletableDelayTest {
+
+    @Test
+    public void delayCustomScheduler() {
+        
+        Completable.complete()
+        .delay(100, TimeUnit.MILLISECONDS, Schedulers.trampoline())
+        .test()
+        .assertResult();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+
+public class CompletableMergeTest {
+    @Test
+    public void invalidPrefetch() {
+        try {
+            Completable.merge(Flowable.just(Completable.complete()), -99);
+            fail("Should have thrown IllegalArgumentExceptio");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("maxConcurrency > 0 required but it was -99", ex.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableRepeatWhenTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableRepeatWhenTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+
+public class CompletableRepeatWhenTest {
+    @Test
+    public void whenCounted() {
+        
+        final int[] counter = { 0 };
+        
+        Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter[0]++;
+            }
+        })
+        .repeatWhen(new Function<Flowable<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
+                final int[] j = { 3 };
+                return f.takeWhile(new Predicate<Object>() {
+                    @Override
+                    public boolean test(Object v) throws Exception {
+                        return j[0]-- != 0;
+                    }
+                });
+            }
+        })
+        .subscribe();
+        
+        assertEquals(4, counter[0]);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.processors.PublishProcessor;
+
+public class CompletableSubscribeTest {
+    @Test
+    public void subscribeAlreadyCancelled() {
+        
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        
+        pp.toCompletable().test(true);
+        
+        assertFalse(pp.hasSubscribers());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.Completable;
+import io.reactivex.functions.Action;
+import io.reactivex.schedulers.Schedulers;
+
+public class CompletableTimeoutTest {
+
+    @Test
+    public void timeoutException() throws Exception {
+        
+        Completable.never()
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void timeoutContinueOther() throws Exception {
+        
+        final int[] call = { 0 };
+        
+        Completable other = Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                call[0]++;
+            }
+        });
+        
+        Completable.never()
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io(), other)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+        
+        assertEquals(1, call[0]);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUnsafeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUnsafeTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
+
+public class CompletableUnsafeTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unsafeCreateRejectsCompletable() {
+        Completable.unsafeCreate(Completable.complete());
+    }
+    
+    @Test
+    public void wrapAlreadyCompletable() {
+        assertSame(Completable.complete(), Completable.wrap(Completable.complete()));
+    }
+    
+    @Test
+    public void wrapCustomCompletable() {
+        
+        Completable.wrap(new CompletableSource() {
+            @Override
+            public void subscribe(CompletableObserver s) {
+                s.onSubscribe(Disposables.empty());
+                s.onComplete();
+            }
+        })
+        .test()
+        .assertResult();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsafeCreateThrowsNPE() {
+        Completable.unsafeCreate(new CompletableSource() {
+            @Override
+            public void subscribe(CompletableObserver s) {
+                throw new NullPointerException();
+            }
+        }).test();
+    }
+    
+    @Test
+    public void unsafeCreateThrowsIAE() {
+        try {
+            Completable.unsafeCreate(new CompletableSource() {
+                @Override
+                public void subscribe(CompletableObserver s) {
+                    throw new IllegalArgumentException();
+                }
+            }).test();
+            fail("Should have thrown!");
+        } catch (NullPointerException ex) {
+            if (!(ex.getCause() instanceof IllegalArgumentException)) {
+                fail(ex.toString() + ": should have thrown NPA(IAE)");
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.schedulers.*;
 
 public class FlowableSkipLastTimedTest {
 
@@ -148,4 +148,32 @@ public class FlowableSkipLastTimedTest {
         inOrder.verify(o).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void skipLastTimedDefaultScheduler() {
+        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        .skipLast(300, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void skipLastTimedDefaultSchedulerDelayError() {
+        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        .skipLast(300, TimeUnit.MILLISECONDS, true)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void skipLastTimedCustomSchedulerDelayError() {
+        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.io(), true)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
@@ -123,4 +123,12 @@ public class FlowableTakeTimedTest {
         verify(o, never()).onNext(4);
         verify(o, never()).onError(any(TestException.class));
     }
+    
+    @Test
+    public void timedDefaultScheduler() {
+        Observable.range(1, 5).take(1, TimeUnit.MINUTES)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -220,4 +220,17 @@ public class ObservableAmbTest {
         assertFalse("Source 2 still has subscribers!", source3.hasObservers());
         
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ambArrayEmpty() {
+        assertSame(Observable.empty(), Observable.ambArray());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ambArraySingleElement() {
+        assertSame(Observable.never(), Observable.ambArray(Observable.never()));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBlockingTest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.schedulers.Schedulers;
+
+public class ObservableBlockingTest {
+
+    @Test
+    public void blockingFirst() {
+        assertEquals(1, Observable.range(1, 10)
+                .subscribeOn(Schedulers.computation()).blockingFirst().intValue());
+    }
+
+    @Test
+    public void blockingFirstDefault() {
+        assertEquals(1, Observable.<Integer>empty()
+                .subscribeOn(Schedulers.computation()).blockingFirst(1).intValue());
+    }
+
+    @Test
+    public void blockingSubscribeConsumer() {
+        final List<Integer> list = new ArrayList<Integer>();
+        
+        Observable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void blockingSubscribeConsumerConsumer() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Observable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        }, Functions.emptyConsumer());
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void blockingSubscribeConsumerConsumerError() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        TestException ex = new TestException();
+        
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+        
+        Observable.range(1, 5).concatWith(Observable.<Integer>error(ex))
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(cons, cons);
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, ex), list);
+    }
+
+    @Test
+    public void blockingSubscribeConsumerConsumerAction() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+        
+        Observable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(cons, cons, new Action() {
+            @Override
+            public void run() throws Exception {
+                list.add(100);
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void blockingSubscribeObserver() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Observable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Observer<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                
+            }
+
+            @Override
+            public void onNext(Object value) {
+                list.add(value);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                list.add(e);
+            }
+
+            @Override
+            public void onComplete() {
+                list.add(100);
+            }
+            
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void blockingSubscribeObserverError() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        final TestException ex = new TestException();
+        
+        Observable.range(1, 5).concatWith(Observable.<Integer>error(ex))
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Observer<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                
+            }
+
+            @Override
+            public void onNext(Object value) {
+                list.add(value);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                list.add(e);
+            }
+
+            @Override
+            public void onComplete() {
+                list.add(100);
+            }
+            
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, ex), list);
+    }
+
+    @Test(expected = TestException.class)
+    public void blockingForEachThrows() {
+        Observable.just(1)
+        .blockingForEach(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer e) throws Exception {
+                throw new TestException();
+            }
+        });
+    }
+    
+    @Test(expected = NoSuchElementException.class)
+    public void blockingFirstEmpty() {
+        Observable.empty().blockingFirst();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void blockingLastEmpty() {
+        Observable.empty().blockingLast();
+    }
+
+    @Test
+    public void blockingFirstNormal() {
+        assertEquals(1, Observable.just(1, 2).blockingFirst(3).intValue());
+    }
+
+    @Test
+    public void blockingLastNormal() {
+        assertEquals(2, Observable.just(1, 2).blockingLast(3).intValue());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -790,4 +790,53 @@ public class ObservableBufferTest {
         
         assertFalse(s.isDisposed());
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferTimeSkipDefault() {
+        Observable.range(1, 5).buffer(1, 1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferBoundaryHint() {
+        Observable.range(1, 5).buffer(Observable.timer(1, TimeUnit.MINUTES), 2)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    static HashSet<Integer> set(Integer... values) {
+        return new HashSet<Integer>(Arrays.asList(values));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferIntoCustomCollection() {
+        Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
+        .buffer(3, new Callable<Collection<Integer>>() {
+            @Override
+            public Collection<Integer> call() throws Exception {
+                return new HashSet<Integer>();
+            }
+        })
+        .test()
+        .assertResult(set(1, 2), set(2, 3), set(4));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferSkipIntoCustomCollection() {
+        Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
+        .buffer(3, 3, new Callable<Collection<Integer>>() {
+            @Override
+            public Collection<Integer> call() throws Exception {
+                return new HashSet<Integer>();
+            }
+        })
+        .test()
+        .assertResult(set(1, 2), set(2, 3), set(4));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -1,16 +1,10 @@
 package io.reactivex.internal.operators.observable;
 
-import static io.reactivex.internal.util.TestingHelper.addToList;
-import static io.reactivex.internal.util.TestingHelper.biConsumerThrows;
-import static io.reactivex.internal.util.TestingHelper.callableListCreator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static io.reactivex.internal.util.TestingHelper.*;
+import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
@@ -129,4 +123,18 @@ public final class ObservableCollectTest {
         assertFalse(added.get());
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void collectInto() {
+        Observable.just(1, 1, 1, 1, 2)
+        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+            @Override
+            public void accept(HashSet<Integer> s, Integer v) throws Exception {
+                s.add(v);
+            }
+        })
+        .test()
+        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+        
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -27,7 +27,9 @@ import org.mockito.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
@@ -766,5 +768,91 @@ public class ObservableCombineLatestTest {
         }
 
         assertEquals(SIZE, count.get());
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void combineLatestArrayOfSources() {
+        
+        Observable.combineLatest(new ObservableSource[] {
+                Observable.just(1), Observable.just(2)
+        }, new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) throws Exception {
+                return Arrays.toString(a);
+            }
+        })
+        .test()
+        .assertResult("[1, 2]");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void combineLatestDelayErrorArrayOfSources() {
+        
+        Observable.combineLatestDelayError(new ObservableSource[] {
+                Observable.just(1), Observable.just(2)
+        }, new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) throws Exception {
+                return Arrays.toString(a);
+            }
+        })
+        .test()
+        .assertResult("[1, 2]");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void combineLatestDelayErrorArrayOfSourcesWithError() {
+        
+        Observable.combineLatestDelayError(new ObservableSource[] {
+                Observable.just(1), Observable.just(2).concatWith(Observable.<Integer>error(new TestException()))
+        }, new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) throws Exception {
+                return Arrays.toString(a);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, "[1, 2]");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void combineLatestDelayErrorIterableOfSources() {
+        
+        Observable.combineLatestDelayError(Arrays.asList(
+                Observable.just(1), Observable.just(2)
+        ), new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) throws Exception {
+                return Arrays.toString(a);
+            }
+        })
+        .test()
+        .assertResult("[1, 2]");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void combineLatestDelayErrorIterableOfSourcesWithError() {
+        
+        Observable.combineLatestDelayError(Arrays.asList(
+                Observable.just(1), Observable.just(2).concatWith(Observable.<Integer>error(new TestException()))
+        ), new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) throws Exception {
+                return Arrays.toString(a);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, "[1, 2]");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void combineLatestDelayErrorEmpty() {
+        assertSame(Observable.empty(), Observable.combineLatestDelayError(new ObservableSource[0], Functions.<Object[]>identity(), 16));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -731,4 +731,12 @@ public class ObservableConcatMapEagerTest {
         }
         
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatEagerIterable() {
+        Observable.concatEager(Arrays.asList(Observable.just(1), Observable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -130,4 +130,45 @@ public class ObservableCreateTest {
         assertTrue(d.isDisposed());
     }
 
+    @Test
+    public void wrap() {
+        Observable.wrap(new ObservableSource<Integer>() {
+            @Override
+            public void subscribe(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onNext(3);
+                observer.onNext(4);
+                observer.onNext(5);
+                observer.onComplete();
+            }
+        })
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void unsafe() {
+        Observable.unsafeCreate(new ObservableSource<Integer>() {
+            @Override
+            public void subscribe(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onNext(3);
+                observer.onNext(4);
+                observer.onNext(5);
+                observer.onComplete();
+            }
+        })
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unsafeWithObservable() {
+        Observable.unsafeCreate(Observable.just(1));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -290,4 +290,13 @@ public class ObservableDebounceTest {
         NbpSubscriber.assertTerminated();
         NbpSubscriber.assertNoErrors();
     }
+    
+    @Test
+    public void debounceDefault() throws Exception {
+        
+        Observable.just(1).debounce(1, TimeUnit.SECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -850,4 +850,12 @@ public class ObservableDelayTest {
         ts.assertError(TestException.class);
     }
 
+    @Test
+    public void delayWithTimeDelayError() throws Exception {
+        Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
+        .delay(100, TimeUnit.MILLISECONDS, true)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class, 1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlattenIterable.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlattenIterable.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.functions.Function;
+
+public class ObservableFlattenIterable {
+
+    @Test
+    public void flatMapIterablePrefetch() {
+        
+        Observable.just(1, 2)
+        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer t) throws Exception {
+                return Arrays.asList(t * 10);
+            }
+        }, 1)
+        .test()
+        .assertResult(10, 20);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableForEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableForEachTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+
+public class ObservableForEachTest {
+
+    @Test
+    public void forEachWile() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Observable.range(1, 5)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        })
+        .forEachWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v < 3;
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3), list);
+    }
+
+    @Test
+    public void forEachWileWithError() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Observable.range(1, 5).concatWith(Observable.<Integer>error(new TestException()))
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        })
+        .forEachWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return true;
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                list.add(100);
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.schedulers.Schedulers;
+
+public class ObservableFromTest {
+
+    @Test
+    public void fromFutureTimeout() throws Exception {
+        Observable.fromFuture(Observable.never()
+        .toFuture(), 100, TimeUnit.MILLISECONDS, Schedulers.io())
+        .test()
+        .awaitDone()
+        .assertFailure(TimeoutException.class);
+    }
+    
+    @Test
+    public void fromPublisher() {
+        Observable.fromPublisher(Flowable.just(1))
+        .test()
+        .assertResult(1);
+    }
+    
+    @Test
+    public void just10() {
+        Observable.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+    
+    @Test
+    public void fromArrayEmpty() {
+        assertSame(Observable.empty(), Observable.fromArray());
+    }
+
+    @Test
+    public void fromArraySingle() {
+        assertTrue(Observable.fromArray(1) instanceof ScalarCallable);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+
+public class ObservableGenerateTest {
+
+    @Test
+    public void statefulBiconsumer() {
+        Observable.generate(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 10;
+            }
+        }, new BiConsumer<Object, Emitter<Object>>() {
+            @Override
+            public void accept(Object s, Emitter<Object> e) throws Exception {
+                e.onNext(s);
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception { 
+                
+            }
+        })
+        .take(5)
+        .test()
+        .assertResult(10, 10, 10, 10, 10);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -30,6 +30,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.observables.GroupedObservable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
@@ -1442,4 +1443,33 @@ public class ObservableGroupByTest {
         assertEquals(Arrays.asList(e), inner1.errors());
         assertEquals(Arrays.asList(e), inner2.errors());
     }
+    
+    @Test
+    public void keySelectorAndDelayError() {
+        Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
+        .groupBy(Functions.identity(), true)
+        .flatMap(new Function<GroupedObservable<Object, Integer>, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(GroupedObservable<Object, Integer> g) throws Exception {
+                return g;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void keyAndValueSelectorAndDelayError() {
+        Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
+        .groupBy(Functions.identity(), Functions.<Integer>identity(), true)
+        .flatMap(new Function<GroupedObservable<Object, Integer>, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(GroupedObservable<Object, Integer> g) throws Exception {
+                return g;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalRangeTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+
+public class ObservableIntervalRangeTest {
+
+    @Test
+    public void simple() throws Exception {
+        Observable.intervalRange(5, 5, 50, 50, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(5L, 6L, 7L, 8L, 9L);
+    }
+
+    @Test
+    public void noOverflow() {
+        Observable.intervalRange(Long.MAX_VALUE - 1, 2, 1, 1, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void longOverflow() {
+        Observable.intervalRange(Long.MAX_VALUE - 1, 3, 1, 1, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -553,4 +553,109 @@ public class ObservableMergeDelayErrorTest {
             t.start();
         }
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayError() {
+        Observable.mergeDelayError(Arrays.asList(Observable.just(1), Observable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeArrayDelayError() {
+        Observable.mergeArrayDelayError(Observable.just(1), Observable.just(2))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayErrorWithError() {
+        Observable.mergeDelayError(
+                Arrays.asList(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())), 
+                Observable.just(2)))
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayError() {
+        Observable.mergeDelayError(
+                Observable.just(Observable.just(1), 
+                Observable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorWithError() {
+        Observable.mergeDelayError(
+                Observable.just(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())), 
+                Observable.just(2)))
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorMaxConcurrency() {
+        Observable.mergeDelayError(
+                Observable.just(Observable.just(1), 
+                Observable.just(2)), 1)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorWithErrorMaxConcurrency() {
+        Observable.mergeDelayError(
+                Observable.just(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())), 
+                Observable.just(2)), 1)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayErrorMaxConcurrency() {
+        Observable.mergeDelayError(
+                Arrays.asList(Observable.just(1), 
+                Observable.just(2)), 1)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayErrorWithErrorMaxConcurrency() {
+        Observable.mergeDelayError(
+                Arrays.asList(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())), 
+                Observable.just(2)), 1)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayError3() {
+        Observable.mergeDelayError(
+                Observable.just(1), 
+                Observable.just(2),
+                Observable.just(3)
+        )
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void mergeDelayError3WithError() {
+        Observable.mergeDelayError(
+                Observable.just(1), 
+                Observable.just(2).concatWith(Observable.<Integer>error(new TestException())),
+                Observable.just(3)
+        )
+        .test()
+        .assertFailure(TestException.class, 1, 2, 3);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -1116,4 +1116,12 @@ public class ObservableMergeTest {
             runMerge(toHiddenScalar, ts);
         }
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeArray() {
+        Observable.mergeArray(Observable.just(1), Observable.just(2))
+        .test()
+        .assertResult(1, 2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -439,4 +439,21 @@ public class ObservableObserveOnTest {
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
     }
+    
+    @Test
+    public void delayError() {
+        Observable.range(1, 5).concatWith(Observable.<Integer>error(new TestException()))
+        .observeOn(Schedulers.computation(), true)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (v == 1) {
+                    Thread.sleep(100);
+                }
+            }
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
@@ -212,6 +213,12 @@ public class ObservableOnErrorReturnTest {
         }
     }
     
-    
+    @Test
+    public void returnItem() {
+        Observable.error(new TestException())
+        .onErrorReturnItem(1)
+        .test()
+        .assertResult(1);
+    }
     
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
@@ -142,4 +142,15 @@ public class ObservableRangeTest {
         ts.assertNoErrors();
         ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
     }
+    
+    @Test
+    public void negativeCount() {
+        try {
+            Observable.range(1, -1);
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("count >= 0 required but it was -1", ex.getMessage());
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
@@ -28,7 +28,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
@@ -194,4 +194,29 @@ public class ObservableRepeatTest {
         
         assertEquals(Arrays.asList(1, 2, 1, 2, 1, 2, 1, 2, 1, 2), concatBase);
     }
+    
+    @Test
+    public void repeatUntil() {
+        Observable.just(1)
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return false;
+            }
+        })
+        .take(5)
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void repeatLongPredicateInvalid() {
+        try {
+            Observable.just(1).repeat(-99);
+            fail("Should have thrown");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("times >= 0 required but it was -99", ex.getMessage());
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -31,6 +31,7 @@ import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.ObservableReplay.*;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.observers.TestObserver;
@@ -1004,4 +1005,67 @@ public class ObservableReplayTest {
         ts.assertNotComplete();
         ts.assertError(TestException.class);
     }
+    
+    @Test
+    public void replayScheduler() {
+        
+        Observable.just(1).replay(Schedulers.computation())
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+    
+    @Test
+    public void replayTime() {
+        Observable.just(1).replay(1, TimeUnit.MINUTES)
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySizeScheduler() {
+        
+        Observable.just(1).replay(1, Schedulers.computation())
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySizeAndTime() {
+        Observable.just(1).replay(1, 1, TimeUnit.MILLISECONDS)
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+    
+    @Test
+    public void replaySelectorSizeScheduler() {
+        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), 1, Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySelectorScheduler() {
+        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySelectorTime() {
+        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), 1, TimeUnit.MINUTES)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -148,4 +148,11 @@ public class ObservableSequenceEqualTest {
         inOrder.verify(NbpObserver, times(1)).onError(isA(TestException.class));
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void sequenceEqualBufferSize() {
+        Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), 2)
+        .test()
+        .assertResult(true);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTimedTest.java
@@ -156,4 +156,12 @@ public class ObservableSkipTimedTest {
         verify(o, never()).onComplete();
 
     }
+
+    @Test
+    public void skipTimedDefaultScheduler() {
+        Observable.just(1).skip(1, TimeUnit.MINUTES)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
@@ -23,7 +23,7 @@ import org.mockito.InOrder;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableTakeLastTimedTest {
@@ -199,4 +199,37 @@ public class ObservableTakeLastTimedTest {
         verify(o, never()).onNext(any());
         verify(o, never()).onError(any(Throwable.class));
     }
+    
+    @Test
+    public void takeLastTimeAndSize() {
+        Observable.just(1, 2)
+        .takeLast(1, 1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(2);
+    }
+
+    @Test
+    public void takeLastTime() {
+        Observable.just(1, 2)
+        .takeLast(1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void takeLastTimeDelayError() {
+        Observable.just(1, 2).concatWith(Observable.<Integer>error(new TestException()))
+        .takeLast(1, TimeUnit.MINUTES, true)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void takeLastTimeDelayErrorCustomScheduler() {
+        Observable.just(1, 2).concatWith(Observable.<Integer>error(new TestException()))
+        .takeLast(1, TimeUnit.MINUTES, Schedulers.io(), true)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -357,4 +357,14 @@ public class ObservableTakeTest {
         ts.assertNoErrors();
         ts.assertComplete();
     }
+    
+    @Test
+    public void takeNegative() {
+        try {
+            Observable.just(1).take(-99);
+            fail("Should have thrown");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("count >= 0 required but it was -99", ex.getMessage());
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
@@ -149,4 +149,12 @@ public class ObservableThrottleFirstTest {
         inOrder.verify(NbpObserver).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void throttleFirstDefaultScheduler() {
+        Observable.just(1).throttleFirst(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeIntervalTest.java
@@ -21,6 +21,8 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
@@ -64,4 +66,59 @@ public class ObservableTimeIntervalTest {
         inOrder.verify(NbpObserver, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void timeIntervalDefault() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Observable.range(1, 5)
+            .timeInterval()
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void timeIntervalDefaultSchedulerCustomUnit() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Observable.range(1, 5)
+            .timeInterval(TimeUnit.SECONDS)
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -356,4 +356,12 @@ public class ObservableTimeoutTests {
 
         verify(s, times(1)).dispose();
     }
+    
+    @Test
+    public void timedAndOther() {
+        Observable.never().timeout(100, TimeUnit.MILLISECONDS, Observable.just(1))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimestampTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimestampTest.java
@@ -22,6 +22,8 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
@@ -80,4 +82,59 @@ public class ObservableTimestampTest {
         verify(NbpObserver, never()).onError(any(Throwable.class));
         verify(NbpObserver, never()).onComplete();
     }
+
+    @Test
+    public void timeIntervalDefault() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Observable.range(1, 5)
+            .timestamp()
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void timeIntervalDefaultSchedulerCustomUnit() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Observable.range(1, 5)
+            .timestamp(TimeUnit.SECONDS)
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToObservableListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToObservableListTest.java
@@ -103,4 +103,13 @@ public class ObservableToObservableListTest {
             ex.printStackTrace();
         }
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void capacityHint() {
+        Observable.range(1, 10)
+        .toList(4)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToObservableSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToObservableSortedListTest.java
@@ -75,4 +75,45 @@ public class ObservableToObservableSortedListTest {
             ex.printStackTrace();
         }
     }
+    
+    @Test
+    public void sorted() {
+        Observable.just(5, 1, 2, 4, 3).sorted()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+    
+    @Test
+    public void sortedComparator() {
+        Observable.just(5, 1, 2, 4, 3).sorted(new Comparator<Integer>() {
+            @Override
+            public int compare(Integer a, Integer b) {
+                return b - a;
+            }
+        })
+        .test()
+        .assertResult(5, 4, 3, 2, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void toSortedListCapacity() {
+        Observable.just(5, 1, 2, 4, 3).toSortedList(4)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void toSortedListComparatorCapacity() {
+        Observable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {
+            @Override
+            public int compare(Integer a, Integer b) {
+                return b - a;
+            }
+        }, 4)
+        .test()
+        .assertResult(Arrays.asList(5, 4, 3, 2, 1));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToXTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ObservableToXTest {
+
+    @Test
+    public void toFlowableBuffer() {
+        Observable.range(1, 5)
+        .toFlowable(BackpressureStrategy.BUFFER)
+        .test(2L)
+        .assertValues(1, 2)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void toFlowableDrop() {
+        Observable.range(1, 5)
+        .toFlowable(BackpressureStrategy.DROP)
+        .test(1)
+        .assertResult(1);
+    }
+
+    @Test
+    public void toFlowableLatest() {
+        TestSubscriber<Integer> ts = Observable.range(1, 5)
+        .toFlowable(BackpressureStrategy.LATEST)
+        .test(0);
+        
+        ts.request(1);
+        ts
+        .assertResult(5);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -129,7 +129,14 @@ public class ObservableWindowWithSizeTest {
 
                     @Override
                     public void accept(Integer t1) {
-                        count.incrementAndGet();
+                        if (count.incrementAndGet() == 500000) {
+                            // give it a small break halfway through
+                            try {
+                                Thread.sleep(1);
+                            } catch (InterruptedException ex) {
+                                // ignored
+                            }
+                        }
                     }
 
                 })

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -28,6 +28,7 @@ import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.*;
@@ -1143,5 +1144,192 @@ public class ObservableZipTest {
             
             Assert.assertEquals(11, value);
         }
+    }
+
+    @Test
+    public void zip2() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2),
+            new BiFunction<Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b) throws Exception {
+                    return "" + a + b;
+                }
+            }
+        )
+        .test()
+        .assertResult("12");
+    }
+
+    @Test
+    public void zip3() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+            new Function3<Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c) throws Exception {
+                    return "" + a + b + c;
+                }
+            }
+        )
+        .test()
+        .assertResult("123");
+    }
+
+    @Test
+    public void zip4() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+                Observable.just(4),
+            new Function4<Integer, Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c, Integer d) throws Exception {
+                    return "" + a + b + c + d;
+                }
+            }
+        )
+        .test()
+        .assertResult("1234");
+    }
+
+    @Test
+    public void zip5() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+                Observable.just(4), Observable.just(5),
+            new Function5<Integer, Integer, Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e) throws Exception {
+                    return "" + a + b + c + d + e;
+                }
+            }
+        )
+        .test()
+        .assertResult("12345");
+    }
+
+    @Test
+    public void zip6() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+                Observable.just(4), Observable.just(5),
+                Observable.just(6),
+            new Function6<Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f) throws Exception {
+                    return "" + a + b + c + d + e + f;
+                }
+            }
+        )
+        .test()
+        .assertResult("123456");
+    }
+
+    @Test
+    public void zip7() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+                Observable.just(4), Observable.just(5),
+                Observable.just(6), Observable.just(7),
+            new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g)
+                        throws Exception {
+                    return "" + a + b + c + d + e + f + g;
+                }
+            }
+        )
+        .test()
+        .assertResult("1234567");
+    }
+
+    @Test
+    public void zip8() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+                Observable.just(4), Observable.just(5),
+                Observable.just(6), Observable.just(7),
+                Observable.just(8), 
+            new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
+                        Integer h) throws Exception {
+                    return "" + a + b + c + d + e + f + g + h;
+                }
+            }
+        )
+        .test()
+        .assertResult("12345678");
+    }
+    @Test
+    public void zip9() {
+        Observable.zip(Observable.just(1),
+                Observable.just(2), Observable.just(3),
+                Observable.just(4), Observable.just(5),
+                Observable.just(6), Observable.just(7),
+                Observable.just(8), Observable.just(9),
+            new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
+                        Integer h, Integer i) throws Exception {
+                    return "" + a + b + c + d + e + f + g + h + i;
+                }
+            }
+        )
+        .test()
+        .assertResult("123456789");
+    }
+
+    @Test
+    public void zip2DelayError() {
+        Observable.zip(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())),
+                Observable.just(2),
+            new BiFunction<Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b) throws Exception {
+                    return "" + a + b;
+                }
+            }, true
+        )
+        .test()
+        .assertFailure(TestException.class, "12");
+    }
+
+    @Test
+    public void zip2Prefetch() {
+        Observable.zip(Observable.range(1, 9),
+                Observable.range(21, 9),
+            new BiFunction<Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b) throws Exception {
+                    return "" + a + b;
+                }
+            }, false, 2
+        )
+        .takeLast(1)
+        .test()
+        .assertResult("929");
+    }
+
+    @Test
+    public void zip2DelayErrorPrefetch() {
+        Observable.zip(Observable.range(1, 9).concatWith(Observable.<Integer>error(new TestException())),
+                Observable.range(21, 9),
+            new BiFunction<Integer, Integer, Object>() {
+                @Override
+                public Object apply(Integer a, Integer b) throws Exception {
+                    return "" + a + b;
+                }
+            }, true, 2
+        )
+        .skip(8)
+        .test()
+        .assertFailure(TestException.class, "929");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void zipArrayEmpty() {
+        assertSame(Observable.empty(), Observable.zipArray(Functions.<Object[]>identity(), false, 16));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class SingleAmbTest {
+    @Test
+    public void ambWithFirstFires() {
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
+        
+        assertTrue(pp1.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+        
+        pp1.onNext(1);
+        pp1.onComplete();
+        
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+        
+        ts.assertResult(1);
+    
+    }
+
+    @Test
+    public void ambWithSecondFires() {
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        
+        TestSubscriber<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
+        
+        assertTrue(pp1.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+        
+        pp2.onNext(2);
+        pp2.onComplete();
+        
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+        
+        ts.assertResult(2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ambArrayEmpty() {
+        Single.ambArray()
+        .test()
+        .assertFailure(NoSuchElementException.class);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ambSingleSource() {
+        assertSame(Single.never(), Single.ambArray(Single.never()));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+
+public class SingleConcatTest {
+    @Test
+    public void concatWith() {
+        Single.just(1).concatWith(Single.just(2))
+        .test()
+        .assertResult(1, 2);
+    }
+    
+    @Test
+    public void concat2() {
+        Single.concat(Single.just(1), Single.just(2))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void concat3() {
+        Single.concat(Single.just(1), Single.just(2), Single.just(3))
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void concat4() {
+        Single.concat(Single.just(1), Single.just(2), Single.just(3), Single.just(4))
+        .test()
+        .assertResult(1, 2, 3, 4);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
@@ -68,4 +68,9 @@ public class SingleCreateTest {
         
         assertTrue(d.isDisposed());
     }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void unsafeCreate() {
+        Single.unsafeCreate(Single.just(1));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.BiConsumer;
+import io.reactivex.schedulers.Schedulers;
+
+public class SingleDelayTest {
+    @Test
+    public void delay() throws Exception {
+        final AtomicInteger value = new AtomicInteger();
+        
+        Single.just(1).delay(200, TimeUnit.MILLISECONDS)
+        .subscribe(new BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer v, Throwable e) throws Exception {
+                value.set(v);
+            }
+        });
+        
+        Thread.sleep(100);
+        
+        assertEquals(0, value.get());
+        
+        Thread.sleep(200);
+        
+        assertEquals(1, value.get());
+    }
+    
+    @Test
+    public void delaySubscriptionCompletable() throws Exception {
+        Single.just(1).delaySubscription(Completable.complete().delay(100, TimeUnit.MILLISECONDS))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void delaySubscriptionObservable() throws Exception {
+        Single.just(1).delaySubscription(Observable.timer(100, TimeUnit.MILLISECONDS))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void delaySubscriptionFlowable() throws Exception {
+        Single.just(1).delaySubscription(Flowable.timer(100, TimeUnit.MILLISECONDS))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void delaySubscriptionSingle() throws Exception {
+        Single.just(1).delaySubscription(Single.timer(100, TimeUnit.MILLISECONDS))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void delaySubscriptionTime() throws Exception {
+        Single.just(1).delaySubscription(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void delaySubscriptionTimeCustomScheduler() throws Exception {
+        Single.just(1).delaySubscription(100, TimeUnit.MILLISECONDS, Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+
+public class SingleDoOnTest {
+
+    @Test
+    public void doOnCancel() {
+        final int[] count = { 0 };
+        
+        Single.never().doOnCancel(new Action() {
+            @Override
+            public void run() throws Exception { 
+                count[0]++; 
+            }
+        }).test(true);
+        
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void doOnError() {
+        final Object[] event = { null };
+        
+        Single.error(new TestException()).doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                event[0] = e;
+            }
+        })
+        .test();
+        
+        assertTrue(event[0].toString(), event[0] instanceof TestException);
+    }
+
+    @Test
+    public void doOnSubscribe() {
+        final int[] count = { 0 };
+        
+        Single.never().doOnSubscribe(new Consumer<Disposable>() {
+            @Override
+            public void accept(Disposable d) throws Exception { 
+                count[0]++; 
+            }
+        }).test();
+        
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void doOnSuccess() {
+        final Object[] event = { null };
+        
+        Single.just(1).doOnSuccess(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer e) throws Exception {
+                event[0] = e;
+            }
+        })
+        .test();
+        
+        assertEquals((Integer)1, event[0]);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class SingleFromTest {
+
+    @Test
+    public void fromFuture() throws Exception {
+        Single.fromFuture(Flowable.just(1).toFuture(), Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void fromFutureTimeout() throws Exception {
+        Single.fromFuture(Flowable.never().toFuture(), 1, TimeUnit.SECONDS, Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+    
+    @Test
+    public void fromPublisher() {
+        Single.fromPublisher(Flowable.just(1))
+        .test()
+        .assertResult(1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+
+public class SingleMergeTest {
+    
+    @Test
+    public void mergeSingleSingle() {
+        
+        Single.merge(Single.just(Single.just(1)))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void merge2() {
+        Single.merge(Single.just(1), Single.just(2))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void merge3() {
+        Single.merge(Single.just(1), Single.just(2), Single.just(3))
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void merge4() {
+        Single.merge(Single.just(1), Single.just(2), Single.just(3), Single.just(4))
+        .test()
+        .assertResult(1, 2, 3, 4);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class SingleMiscTest {
+    @Test
+    public void never() {
+        Single.never()
+        .test()
+        .assertNoValues()
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+    
+    @Test
+    public void timer() throws Exception {
+        Single.timer(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(0L);
+    }
+    
+    @Test
+    public void wrap() {
+        assertSame(Single.never(), Single.wrap(Single.never()));
+        
+        Single.wrap(new SingleSource<Object>() {
+            @Override
+            public void subscribe(SingleObserver<? super Object> s) {
+                s.onSubscribe(Disposables.empty());
+                s.onSuccess(1);
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+    
+    @Test
+    public void cast() {
+        Single<Number> source = Single.just(1d)
+                .cast(Number.class);
+        source.test()
+        .assertResult((Number)1d);
+    }
+    
+    @Test
+    public void contains() {
+        Single.just(1).contains(1).test().assertResult(true);
+        
+        Single.just(2).contains(1).test().assertResult(false);
+    }
+    
+    @Test
+    public void compose() {
+        
+        Single.just(1)
+        .compose(new Function<Single<Integer>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Single<Integer> f) throws Exception {
+                return f.map(new Function<Integer, Object>() {
+                    @Override
+                    public Object apply(Integer v) throws Exception {
+                        return v + 1;
+                    }
+                });
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
+    
+    @Test
+    public void hide() {
+        assertNotSame(Single.never(), Single.never().hide());
+    }
+    
+    @Test
+    public void onErrorResumeNext() {
+        Single.<Integer>error(new TestException())
+        .onErrorResumeNext(Single.just(1))
+        .test()
+        .assertResult(1);
+    }
+    
+    @Test
+    public void onErrorReturnValue() {
+        Single.<Integer>error(new TestException())
+        .onErrorReturnItem(1)
+        .test()
+        .assertResult(1);
+    }
+    
+    @Test
+    public void repeat() {
+        Single.just(1).repeat().take(5)
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+    }
+    
+    @Test
+    public void repeatTimes() {
+        Single.just(1).repeat(5)
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+    }
+    
+    @Test
+    public void repeatUntil() {
+        final AtomicBoolean flag = new AtomicBoolean();
+        
+        Single.just(1)
+        .doOnSuccess(new Consumer<Integer>() {
+            int c;
+            @Override
+            public void accept(Integer v) throws Exception { 
+                if (++c == 5) {
+                    flag.set(true);
+                }
+                
+            }
+        })
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return flag.get();
+            }
+        })
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void retry() {
+        Single.fromCallable(new Callable<Object>() {
+            int c;
+            @Override
+            public Object call() throws Exception {
+                if (++c != 5) {
+                    throw new TestException();
+                }
+                return 1;
+            }
+        })
+        .retry()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void retryBiPredicate() {
+        Single.fromCallable(new Callable<Object>() {
+            int c;
+            @Override
+            public Object call() throws Exception {
+                if (++c != 5) {
+                    throw new TestException();
+                }
+                return 1;
+            }
+        })
+        .retry(new BiPredicate<Integer, Throwable>() {
+            @Override
+            public boolean test(Integer i, Throwable e) throws Exception {
+                return true;
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void retryTimes() {
+        Single.fromCallable(new Callable<Object>() {
+            int c;
+            @Override
+            public Object call() throws Exception {
+                if (++c != 5) {
+                    throw new TestException();
+                }
+                return 1;
+            }
+        })
+        .retry(5)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void retryPredicate() {
+        Single.fromCallable(new Callable<Object>() {
+            int c;
+            @Override
+            public Object call() throws Exception {
+                if (++c != 5) {
+                    throw new TestException();
+                }
+                return 1;
+            }
+        })
+        .retry(new Predicate<Throwable>() {
+            @Override
+            public boolean test(Throwable e) throws Exception {
+                return true;
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+    
+    @Test
+    public void timeout() throws Exception {
+        Single.never().timeout(100, TimeUnit.MILLISECONDS, Schedulers.io())
+        .test()
+        .awaitDone()
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void timeoutOther() throws Exception {
+        Single.never()
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io(), Single.just(1))
+        .test()
+        .awaitDone()
+        .assertResult(1);
+    }
+    
+    @Test
+    public void toCompletable() {
+        Single.just(1)
+        .toCompletable()
+        .test()
+        .assertResult();
+
+        Single.error(new TestException())
+        .toCompletable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void toObservable() {
+        Single.just(1)
+        .toObservable()
+        .test()
+        .assertResult(1);
+
+        Single.error(new TestException())
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void equals() {
+        Single.equals(Single.just(1), Single.just(1).hide())
+        .test()
+        .assertResult(true);
+
+        Single.equals(Single.just(1), Single.just(2))
+        .test()
+        .assertResult(false);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+import io.reactivex.functions.*;
+
+public class SingleZipTest {
+
+    @Test
+    public void zip2() {
+        Single.zip(Single.just(1), Single.just(2), new BiFunction<Integer, Integer, Object>() {
+            @Override
+            public Object apply(Integer a, Integer b) throws Exception {
+                return a + "" + b;
+            }
+        })
+        .test()
+        .assertResult("12");
+    }
+
+    @Test
+    public void zip3() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3), new Function3<Integer, Integer, Integer, Object>() {
+            @Override
+            public Object apply(Integer a, Integer b, Integer c) throws Exception {
+                return a + "" + b + c;
+            }
+        })
+        .test()
+        .assertResult("123");
+    }
+
+    @Test
+    public void zip4() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3),
+                Single.just(4),
+                new Function4<Integer, Integer, Integer, Integer, Object>() {
+                    @Override
+                    public Object apply(Integer a, Integer b, Integer c, Integer d) throws Exception {
+                        return a + "" + b + c + d;
+                    }
+                })
+        .test()
+        .assertResult("1234");
+    }
+
+    @Test
+    public void zip5() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3),
+                Single.just(4), Single.just(5),
+                new Function5<Integer, Integer, Integer, Integer, Integer, Object>() {
+                    @Override
+                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e) throws Exception {
+                        return a + "" + b + c + d + e;
+                    }
+                })
+        .test()
+        .assertResult("12345");
+    }
+
+    @Test
+    public void zip6() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3),
+                Single.just(4), Single.just(5), Single.just(6),
+                new Function6<Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                    @Override
+                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f)
+                            throws Exception {
+                        return a + "" + b + c + d + e + f;
+                    }
+                })
+        .test()
+        .assertResult("123456");
+    }
+
+    @Test
+    public void zip7() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3),
+                Single.just(4), Single.just(5), Single.just(6),
+                Single.just(7),
+                new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                    @Override
+                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g)
+                            throws Exception {
+                        return a + "" + b + c + d + e + f + g;
+                    }
+                })
+        .test()
+        .assertResult("1234567");
+    }
+
+    @Test
+    public void zip8() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3),
+                Single.just(4), Single.just(5), Single.just(6),
+                Single.just(7), Single.just(8),
+                new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                    @Override
+                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
+                            Integer h) throws Exception {
+                        return a + "" + b + c + d + e + f + g + h;
+                    }
+                })
+        .test()
+        .assertResult("12345678");
+    }
+
+    @Test
+    public void zip9() {
+        Single.zip(Single.just(1), Single.just(2), Single.just(3),
+                Single.just(4), Single.just(5), Single.just(6),
+                Single.just(7), Single.just(8), Single.just(9),
+                new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
+                    @Override
+                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
+                            Integer h, Integer i) throws Exception {
+                        return a + "" + b + c + d + e + f + g + h + i;
+                    }
+                })
+        .test()
+        .assertResult("123456789");
+    }
+
+}

--- a/src/test/java/io/reactivex/observable/ObservableDoOnTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableDoOnTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.Observable;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 
 public class ObservableDoOnTest {
@@ -71,5 +72,35 @@ public class ObservableDoOnTest {
 
         assertEquals("one", output);
         assertTrue(r.get());
+    }
+    
+    @Test
+    public void doOnTerminateComplete() {
+        final AtomicBoolean r = new AtomicBoolean();
+        String output = Observable.just("one").doOnTerminate(new Action() {
+            @Override
+            public void run() {
+                r.set(true);
+            }
+        }).blockingSingle();
+
+        assertEquals("one", output);
+        assertTrue(r.get());
+        
+    }
+
+    @Test
+    public void doOnTerminateError() {
+        final AtomicBoolean r = new AtomicBoolean();
+        Observable.<String>error(new TestException()).doOnTerminate(new Action() {
+            @Override
+            public void run() {
+                r.set(true);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+        assertTrue(r.get());
+        
     }
 }

--- a/src/test/java/io/reactivex/observable/ObservableStartWithTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableStartWithTests.java
@@ -61,4 +61,8 @@ public class ObservableStartWithTests {
         assertEquals("two", values.get(3));
     }
 
+    @Test
+    public void startWithEmpty() {
+        Observable.just(1).startWithArray().test().assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/observable/ObservableThrottleWithTimeoutTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableThrottleWithTimeoutTests.java
@@ -58,4 +58,13 @@ public class ObservableThrottleWithTimeoutTests {
         inOrder.verify(observer).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+
+    @Test
+    public void throttleFirstDefaultScheduler() {
+        Observable.just(1).throttleWithTimeout(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableZipTests.java
@@ -123,4 +123,31 @@ public class ObservableZipTests {
             System.out.println("Result: " + t1);
         }
     };
+    
+    @Test
+    public void zipWithDelayError() {
+        Observable.just(1)
+        .zipWith(Observable.just(2), new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        }, true)
+        .test()
+        .assertResult(3);
+    }
+
+    @Test
+    public void zipWithDelayErrorBufferSize() {
+        Observable.just(1)
+        .zipWith(Observable.just(2), new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        }, true, 16)
+        .test()
+        .assertResult(3);
+    }
+
 }

--- a/src/test/java/io/reactivex/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/CachedThreadSchedulerTest.java
@@ -57,12 +57,12 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     @Test
     @Ignore("Unhandled errors are no longer thrown")
     public final void testUnhandledErrorIsDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
     }
 
     @Test
     public final void testHandledErrorIsNotDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
     @Test(timeout = 60000)

--- a/src/test/java/io/reactivex/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/ComputationSchedulerTests.java
@@ -139,12 +139,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     @Test
     @Ignore("Unhandled errors are no longer thrown")
     public final void testUnhandledErrorIsDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
     }
 
     @Test
     public final void testHandledErrorIsNotDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
     @Test(timeout = 60000)

--- a/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
@@ -47,12 +47,12 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
     @Test
     @Ignore("Unhandled errors are no longer thrown")
     public final void testUnhandledErrorIsDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
     }
 
     @Test
     public final void testHandledErrorIsNotDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
     public static void testCancelledRetention(Scheduler.Worker w, boolean periodic) throws InterruptedException {
@@ -109,8 +109,18 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         int t = (int)(n * Math.log(n) / 100) + SchedulerPoolFactory.PURGE_PERIOD_SECONDS * 1000;
         while (t > 0) {
             System.out.printf("  >> Waiting for purge: %.2f s remaining%n", t / 1000d);
+
+            System.gc();
+            
             Thread.sleep(1000);
+            
             t -= 1000;
+            memHeap = memoryMXBean.getHeapMemoryUsage();
+            long finish = memHeap.getUsed();
+            System.out.printf("After: %.3f MB%n", finish / 1024.0 / 1024.0);
+            if (finish <= initial * 5) {
+                break;
+            }
         }
         
         System.out.println("Second GC");

--- a/src/test/java/io/reactivex/schedulers/NewThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/NewThreadSchedulerTest.java
@@ -27,12 +27,12 @@ public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
     @Test
     @Ignore("Unhandled errors are no longer thrown")
     public final void testUnhandledErrorIsDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testUnhandledErrorIsDeliveredToThreadHandler(getScheduler());
     }
 
     @Test
     public final void testHandledErrorIsNotDeliveredToThreadHandler() throws InterruptedException {
-        SchedulerTests.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
+        SchedulerTestHelper.testHandledErrorIsNotDeliveredToThreadHandler(getScheduler());
     }
     
     // FIXME no longer testable due to internal changes

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.disposables.SequentialDisposable;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class SchedulerTest {
+
+    @Test
+    public void defaultPeriodicTask() {
+        final int[] count = { 0 };
+        
+        TestScheduler scheduler = new TestScheduler();
+        
+        Disposable d = scheduler.schedulePeriodicallyDirect(new Runnable() {
+            @Override
+            public void run() {
+                count[0]++;
+            }
+        }, 100, 100, TimeUnit.MILLISECONDS);
+        
+        assertEquals(0, count[0]);
+        assertFalse(d.isDisposed());
+        
+        scheduler.advanceTimeBy(200, TimeUnit.MILLISECONDS);
+        
+        assertEquals(2, count[0]);
+        
+        d.dispose();
+        
+        assertTrue(d.isDisposed());
+        
+        scheduler.advanceTimeBy(200, TimeUnit.MILLISECONDS);
+        
+        assertEquals(2, count[0]);
+    }
+    
+    @Test(expected = TestException.class)
+    public void periodicDirectThrows() {
+        TestScheduler scheduler = new TestScheduler();
+        
+        scheduler.schedulePeriodicallyDirect(new Runnable() {
+            @Override
+            public void run() {
+                throw new TestException();
+            }
+        }, 100, 100, TimeUnit.MILLISECONDS);
+    
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void disposePeriodicDirect() {
+        final int[] count = { 0 };
+        
+        TestScheduler scheduler = new TestScheduler();
+        
+        Disposable d = scheduler.schedulePeriodicallyDirect(new Runnable() {
+            @Override
+            public void run() {
+                count[0]++;
+            }
+        }, 100, 100, TimeUnit.MILLISECONDS);
+
+        d.dispose();
+        
+        assertEquals(0, count[0]);
+        assertTrue(d.isDisposed());
+        
+        scheduler.advanceTimeBy(200, TimeUnit.MILLISECONDS);
+
+        assertEquals(0, count[0]);
+        assertTrue(d.isDisposed());
+    }
+    
+    @Test
+    public void scheduleDirect() {
+        final int[] count = { 0 };
+        
+        TestScheduler scheduler = new TestScheduler();
+        
+        scheduler.scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                count[0]++;
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+
+        assertEquals(0, count[0]);
+        
+        scheduler.advanceTimeBy(200, TimeUnit.MILLISECONDS);
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void disposeSelfPeriodicDirect() {
+        final int[] count = { 0 };
+        
+        TestScheduler scheduler = new TestScheduler();
+        
+        final SequentialDisposable sd = new SequentialDisposable();
+        
+        Disposable d = scheduler.schedulePeriodicallyDirect(new Runnable() {
+            @Override
+            public void run() {
+                count[0]++;
+                sd.dispose();
+            }
+        }, 100, 100, TimeUnit.MILLISECONDS);
+
+        sd.set(d);
+        
+        assertEquals(0, count[0]);
+        assertFalse(d.isDisposed());
+        
+        scheduler.advanceTimeBy(400, TimeUnit.MILLISECONDS);
+
+        assertEquals(1, count[0]);
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void disposeSelfPeriodic() {
+        final int[] count = { 0 };
+        
+        TestScheduler scheduler = new TestScheduler();
+        
+        Worker worker = scheduler.createWorker();
+        
+        try {
+            final SequentialDisposable sd = new SequentialDisposable();
+            
+            Disposable d = worker.schedulePeriodically(new Runnable() {
+                @Override
+                public void run() {
+                    count[0]++;
+                    sd.dispose();
+                }
+            }, 100, 100, TimeUnit.MILLISECONDS);
+    
+            sd.set(d);
+            
+            assertEquals(0, count[0]);
+            assertFalse(d.isDisposed());
+            
+            scheduler.advanceTimeBy(400, TimeUnit.MILLISECONDS);
+    
+            assertEquals(1, count[0]);
+            assertTrue(d.isDisposed());
+        } finally {
+            worker.dispose();
+        }
+    }
+
+    @Test
+    public void periodicDirectTaskRace() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        for (int i = 0; i < 100; i++) {
+            final Disposable d = scheduler.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 1, 1, TimeUnit.MILLISECONDS);
+            
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    d.dispose();
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.io());
+        }
+        
+    }
+
+
+    @Test
+    public void periodicDirectTaskRaceIO() throws Exception{
+        final Scheduler scheduler = Schedulers.io();
+        
+        for (int i = 0; i < 100; i++) {
+            final Disposable d = scheduler.schedulePeriodicallyDirect(
+                    Functions.EMPTY_RUNNABLE, 0, 0, TimeUnit.MILLISECONDS);
+            
+            Thread.sleep(1);
+            
+            d.dispose();
+        }
+        
+    }
+    
+    @Test
+    public void scheduleDirectThrows() throws Exception {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        try {
+            Schedulers.io().scheduleDirect(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            });
+            
+            Thread.sleep(250);
+            
+            assertEquals(1, list.size());
+            TestHelper.assertError(list, 0, TestException.class, null);
+            
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/schedulers/SchedulerTestHelper.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTestHelper.java
@@ -20,8 +20,8 @@ import java.util.concurrent.*;
 import io.reactivex.*;
 import io.reactivex.subscribers.DefaultSubscriber;
 
-final class SchedulerTests {
-    private SchedulerTests() {
+final class SchedulerTestHelper {
+    private SchedulerTestHelper() {
         // No instances.
     }
 

--- a/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.schedulers;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -83,7 +83,7 @@ public class SchedulerWorkerTest {
 
             Thread.sleep(150);
             
-            s.drift = -1000 - TimeUnit.NANOSECONDS.toMillis(Scheduler.clockDriftTolerance());
+            s.drift = -TimeUnit.SECONDS.toNanos(1) - Scheduler.clockDriftTolerance();
             
             Thread.sleep(400);
             
@@ -125,7 +125,7 @@ public class SchedulerWorkerTest {
 
             Thread.sleep(150);
             
-            s.drift = 1000 + TimeUnit.NANOSECONDS.toMillis(Scheduler.clockDriftTolerance());
+            s.drift = TimeUnit.SECONDS.toNanos(1) + Scheduler.clockDriftTolerance();
             
             Thread.sleep(400);
             

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -688,7 +688,7 @@ public class SingleNullTests {
     
     @Test(expected = NullPointerException.class)
     public void onErrorReturnValueNull() {
-        error.onErrorReturnValue(null);
+        error.onErrorReturnItem(null);
     }
     
     @Test(expected = NullPointerException.class)
@@ -754,11 +754,6 @@ public class SingleNullTests {
                 return null;
             }
         }).blockingGet();
-    }
-    
-    @Test(expected = NullPointerException.class)
-    public void safeSubscribeNull() {
-        just1.safeSubscribe(null);
     }
     
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import io.reactivex.Single;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 
@@ -69,6 +69,22 @@ public class SingleSubscribeTest {
         
         assertNull(value[0]);
         assertEquals(ex, value[1]);
+    }
+    
+    @Test
+    public void subscribeThrows() {
+        try {
+            new Single<Integer>() {
+                @Override
+                protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                    throw new IllegalArgumentException();
+                }
+            }.test();
+        } catch (NullPointerException ex) {
+            if (!(ex.getCause() instanceof IllegalArgumentException)) {
+                fail(ex.toString() + ": should have thrown NPE(IAE)");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
- Remove unused code
- Improve coverage of `Single`, `Completable` and `Observable`
- Fix minor bugs in operators
