### PR TITLE
2.x: cleanup, behavior clarifications, fixes, coverage 8/28-1

### DIFF
--- a/src/main/java/io/reactivex/disposables/RunnableDisposable.java
+++ b/src/main/java/io/reactivex/disposables/RunnableDisposable.java
@@ -27,4 +27,9 @@ final class RunnableDisposable extends ReferenceDisposable<Runnable> {
     protected void onDisposed(Runnable value) {
         value.run();
     }
+    
+    @Override
+    public String toString() {
+        return "RunnableDisposable(disposed=" + isDisposed() + ", " + get() + ")";
+    }
 }

--- a/src/main/java/io/reactivex/disposables/SerialDisposable.java
+++ b/src/main/java/io/reactivex/disposables/SerialDisposable.java
@@ -15,7 +15,7 @@ package io.reactivex.disposables;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 
 /**
  * A Disposable container that allows atomically updating/replacing the contained

--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -22,14 +22,13 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Utility methods for working with Disposables atomically.
  */
-public enum DisposableHelper {
-    ;
-    
-    /**
-     * Marker instance compared by identity for indicating a previously referenced
-     * {@link Disposable} was disposed. DO NOT USE this instance as an arbitrary, empty disposable!
+public enum DisposableHelper implements Disposable {
+    /** 
+     * The singleton instance representing a terminal, disposed state;
+     * Don't leak it!
      */
-    public static final Disposable DISPOSED = Disposed.INSTANCE;
+    DISPOSED
+    ;
     
     public static boolean isDisposed(Disposable d) {
         return d == DISPOSED;
@@ -82,9 +81,10 @@ public enum DisposableHelper {
     
     public static boolean dispose(AtomicReference<Disposable> field) {
         Disposable current = field.get();
-        if (current != DISPOSED) {
-            current = field.getAndSet(DISPOSED);
-            if (current != DISPOSED) {
+        Disposable d = DISPOSED;
+        if (current != d) {
+            current = field.getAndSet(d);
+            if (current != d) {
                 if (current != null) {
                     current.dispose();
                 }
@@ -121,18 +121,13 @@ public enum DisposableHelper {
         RxJavaPlugins.onError(new IllegalStateException("Disposable already set!"));
     }
 
-    enum Disposed implements Disposable {
-        INSTANCE;
-        
-        @Override
-        public void dispose() {
-            // deliberately no-op
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return true;
-        }
+    @Override
+    public void dispose() {
+        // deliberately no-op
     }
-
+    
+    @Override
+    public boolean isDisposed() {
+        return true;
+    }
 }

--- a/src/main/java/io/reactivex/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/ListCompositeDisposable.java
@@ -42,6 +42,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
     
     public ListCompositeDisposable(Iterable<? extends Disposable> resources) {
         ObjectHelper.requireNonNull(resources, "resources is null");
+        this.resources = new LinkedList<Disposable>();
         for (Disposable d : resources) {
             ObjectHelper.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -148,6 +148,11 @@ public enum Functions {
         public Object apply(Object v) {
             return v;
         }
+
+        @Override
+        public String toString() {
+            return "IdentityFunction";
+        }
     };
     
     /**
@@ -163,16 +168,31 @@ public enum Functions {
     public static final Runnable EMPTY_RUNNABLE = new Runnable() {
         @Override
         public void run() { }
+        
+        @Override
+        public String toString() {
+            return "EmptyRunnable";
+        }
     };
 
     public static final Action EMPTY_ACTION = new Action() {
         @Override
         public void run() { }
+
+        @Override
+        public String toString() {
+            return "EmptyAction";
+        }
     };
 
     static final Consumer<Object> EMPTY_CONSUMER = new Consumer<Object>() {
         @Override
         public void accept(Object v) { }
+
+        @Override
+        public String toString() {
+            return "EmptyConsumer";
+        }
     };
     
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
-import io.reactivex.*;
+import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -18,10 +18,10 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.*;
+import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.flowable.QueueDrainSubscriber;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -22,7 +22,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.*;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInterval.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 
 public final class ObservableInterval extends Observable<Long> {
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableIntervalRange.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 
 public final class ObservableIntervalRange extends Observable<Long> {
     final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleWithObservable.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
 
 public final class ObservableSampleWithObservable<T> extends AbstractObservableWithUpstream<T, T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTimed.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.observers.SerializedObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObserverResourceWrapper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObserverResourceWrapper.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 
 public final class ObserverResourceWrapper<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
     /** */

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/internal/subscribers/completable/CallbackCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/completable/CallbackCompletableObserver.java
@@ -19,7 +19,7 @@ import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CallbackCompletableObserver

--- a/src/main/java/io/reactivex/internal/subscribers/completable/EmptyCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/completable/EmptyCompletableObserver.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class EmptyCompletableObserver

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/ForEachWhileSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/ForEachWhileSubscriber.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -85,7 +85,7 @@ implements Subscriber<T>, Disposable {
             onError.accept(t);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            RxJavaPlugins.onError(ex);
+            RxJavaPlugins.onError(new CompositeException(t, ex));
         }
     }
     

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BlockingObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BlockingObserver.java
@@ -16,9 +16,9 @@ package io.reactivex.internal.subscribers.observable;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.*;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.util.NotificationLite;
 
 public final class BlockingObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/subscribers/observable/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/LambdaObserver.java
@@ -19,7 +19,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class LambdaObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/subscribers/single/BiConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/single/BiConsumerSingleObserver.java
@@ -17,9 +17,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.BiConsumer;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class BiConsumerSingleObserver<T>
@@ -40,7 +40,7 @@ implements SingleObserver<T>, Disposable {
             onCallback.accept(null, e);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            RxJavaPlugins.onError(ex);
+            RxJavaPlugins.onError(new CompositeException(e, ex));
         }
     }
     

--- a/src/main/java/io/reactivex/internal/subscribers/single/ConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/single/ConsumerSingleObserver.java
@@ -19,7 +19,7 @@ import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ConsumerSingleObserver<T>

--- a/src/main/java/io/reactivex/internal/subscriptions/BooleanSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/BooleanSubscription.java
@@ -41,4 +41,9 @@ public final class BooleanSubscription extends AtomicBoolean implements Subscrip
     public boolean isCancelled() {
         return get();
     }
+    
+    @Override
+    public String toString() {
+        return "BooleanSubscription(cancelled=" + get() + ")";
+    }
 }

--- a/src/main/java/io/reactivex/internal/util/BlockingHelper.java
+++ b/src/main/java/io/reactivex/internal/util/BlockingHelper.java
@@ -20,8 +20,11 @@ import io.reactivex.disposables.Disposable;
 /**
  * Utility methods for helping common blocking operations.
  */
-public enum BlockingHelper {
-    ;
+public final class BlockingHelper {
+    /** Utility class. */
+    private BlockingHelper() {
+        throw new IllegalStateException("No instances!");
+    }
     
     public static void awaitForComplete(CountDownLatch latch, Disposable subscription) {
         if (latch.getCount() == 0) {

--- a/src/main/java/io/reactivex/internal/util/NotificationLite.java
+++ b/src/main/java/io/reactivex/internal/util/NotificationLite.java
@@ -24,19 +24,8 @@ import io.reactivex.internal.functions.ObjectHelper;
  * Lightweight notification handling utility class.
  */
 public enum NotificationLite {
-    // No instances
+    COMPLETE
     ;
-    
-    /**
-     * Indicates a completion notification.
-     */
-    private enum Complete {
-        INSTANCE;
-        @Override
-        public String toString() {
-            return "NotificationLite.Complete";
-        }
-    }
     
     /**
      * Wraps a Throwable.
@@ -119,7 +108,7 @@ public enum NotificationLite {
      * @return a complete notification
      */
     public static Object complete() {
-        return Complete.INSTANCE;
+        return COMPLETE;
     }
     
     /**
@@ -155,7 +144,7 @@ public enum NotificationLite {
      * @return true if the object represents a complete notification
      */
     public static boolean isComplete(Object o) {
-        return o == Complete.INSTANCE;
+        return o == COMPLETE;
     }
     
     /**
@@ -224,7 +213,7 @@ public enum NotificationLite {
      */
     @SuppressWarnings("unchecked")
     public static <T> boolean accept(Object o, Subscriber<? super T> s) {
-        if (o == Complete.INSTANCE) {
+        if (o == COMPLETE) {
             s.onComplete();
             return true;
         } else
@@ -246,7 +235,7 @@ public enum NotificationLite {
      */
     @SuppressWarnings("unchecked")
     public static <T> boolean accept(Object o, Observer<? super T> s) {
-        if (o == Complete.INSTANCE) {
+        if (o == COMPLETE) {
             s.onComplete();
             return true;
         } else
@@ -268,7 +257,7 @@ public enum NotificationLite {
      */
     @SuppressWarnings("unchecked")
     public static <T> boolean acceptFull(Object o, Subscriber<? super T> s) {
-        if (o == Complete.INSTANCE) {
+        if (o == COMPLETE) {
             s.onComplete();
             return true;
         } else
@@ -294,7 +283,7 @@ public enum NotificationLite {
      */
     @SuppressWarnings("unchecked")
     public static <T> boolean acceptFull(Object o, Observer<? super T> s) {
-        if (o == Complete.INSTANCE) {
+        if (o == COMPLETE) {
             s.onComplete();
             return true;
         } else
@@ -308,5 +297,10 @@ public enum NotificationLite {
         }
         s.onNext((T)o);
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationLite.Complete";
     }
 }

--- a/src/main/java/io/reactivex/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableObserver.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 
 /**
  * An abstract Observer that allows asynchronous cancellation by implementing Disposable.

--- a/src/test/java/io/reactivex/disposables/DisposablesTest.java
+++ b/src/test/java/io/reactivex/disposables/DisposablesTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import io.reactivex.TestHelper;
 import io.reactivex.functions.Action;
+import io.reactivex.schedulers.Schedulers;
 
 
 public class DisposablesTest {
@@ -115,5 +116,21 @@ public class DisposablesTest {
             // expected
         }
 
+    }
+    
+    @Test
+    public void disposeRace() {
+        for (int i = 0; i < 100; i++) {
+            final Disposable d = Disposables.empty();
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    d.dispose();
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/disposables/ArrayCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/ArrayCompositeDisposableTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class ArrayCompositeDisposableTest {
+
+    @Test
+    public void normal() {
+        ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
+        
+        Disposable d1 = Disposables.empty();
+        Disposable d2 = Disposables.empty();
+        
+        assertTrue(acd.setResource(0, d1));
+        assertTrue(acd.setResource(1, d2));
+        
+        Disposable d3 = Disposables.empty();
+        Disposable d4 = Disposables.empty();
+        
+        acd.replaceResource(0, d3);
+        acd.replaceResource(1, d4);
+        
+        assertFalse(d1.isDisposed());
+        assertFalse(d2.isDisposed());
+        
+        acd.setResource(0, d1);
+        acd.setResource(1, d2);
+        
+        assertTrue(d3.isDisposed());
+        assertTrue(d4.isDisposed());
+
+        assertFalse(acd.isDisposed());
+
+        acd.dispose();
+        acd.dispose();
+        
+        assertTrue(acd.isDisposed());
+        
+        assertTrue(d1.isDisposed());
+        assertTrue(d2.isDisposed());
+        
+        Disposable d5 = Disposables.empty();
+        Disposable d6 = Disposables.empty();
+
+        assertFalse(acd.setResource(0, d5));
+        acd.replaceResource(1, d6);
+    
+        assertTrue(d5.isDisposed());
+        assertTrue(d6.isDisposed());
+    }
+    
+    @Test
+    public void disposeRace() {
+        for (int i = 0; i < 100; i++) {
+            final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    acd.dispose();
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }        
+    }
+
+    @Test
+    public void replaceRace() {
+        for (int i = 0; i < 100; i++) {
+            final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    acd.replaceResource(0, Disposables.empty());
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }        
+    }
+
+    @Test
+    public void setRace() {
+        for (int i = 0; i < 100; i++) {
+            final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    acd.setResource(0, Disposables.empty());
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }        
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/disposables/CancellableDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/CancellableDisposableTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Cancellable;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+public class CancellableDisposableTest {
+
+    @Test
+    public void normal() {
+        final AtomicInteger count = new AtomicInteger();
+        
+        Cancellable c = new Cancellable() {
+            @Override
+            public void cancel() throws Exception {
+                count.getAndIncrement();
+            }
+        };
+        
+        CancellableDisposable cd = new CancellableDisposable(c);
+        
+        assertFalse(cd.isDisposed());
+        
+        cd.dispose();
+        cd.dispose();
+        
+        assertTrue(cd.isDisposed());
+        
+        assertEquals(1, count.get());
+    }
+
+    @Test
+    public void cancelThrows() {
+        final AtomicInteger count = new AtomicInteger();
+        
+        Cancellable c = new Cancellable() {
+            @Override
+            public void cancel() throws Exception {
+                count.getAndIncrement();
+                throw new TestException();
+            }
+        };
+        
+        CancellableDisposable cd = new CancellableDisposable(c);
+        
+        assertFalse(cd.isDisposed());
+
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        try {
+            cd.dispose();
+            cd.dispose();
+            
+            TestHelper.assertError(list, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+        assertTrue(cd.isDisposed());
+        
+        assertEquals(1, count.get());
+    }
+    
+    @Test
+    public void disposeRace() {
+
+        for (int i = 0; i < 100; i++) {
+            final AtomicInteger count = new AtomicInteger();
+            
+            Cancellable c = new Cancellable() {
+                @Override
+                public void cancel() throws Exception {
+                    count.getAndIncrement();
+                }
+            };
+            
+            final CancellableDisposable cd = new CancellableDisposable(c);
+    
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    cd.dispose();
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+            
+            assertEquals(1, count.get());
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/disposables/DisposableHelperTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/DisposableHelperTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+public class DisposableHelperTest {
+    @Test
+    public void enumMethods() {
+        assertEquals(1, DisposableHelper.values().length);
+        assertNotNull(DisposableHelper.valueOf("DISPOSED"));
+    }
+    
+    @Test
+    public void innerDisposed() {
+        assertTrue(DisposableHelper.DISPOSED.isDisposed());
+        DisposableHelper.DISPOSED.dispose();
+        assertTrue(DisposableHelper.DISPOSED.isDisposed());
+    }
+    
+    @Test
+    public void validationNull() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        try {
+            assertFalse(DisposableHelper.validate(null, null));
+            
+            TestHelper.assertError(list, 0, NullPointerException.class, "next is null");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void disposeRace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    DisposableHelper.dispose(d);
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }
+    }
+
+    @Test
+    public void setReplace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    DisposableHelper.replace(d, Disposables.empty());
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }
+    }
+
+    @Test
+    public void setRace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    DisposableHelper.set(d, Disposables.empty());
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.io());
+        }
+    }
+    
+    @Test
+    public void setReplaceNull() {
+        final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+
+        DisposableHelper.dispose(d);
+        
+        assertFalse(DisposableHelper.set(d, null));
+        assertFalse(DisposableHelper.replace(d, null));
+    }
+
+    @Test
+    public void dispose() {
+        Disposable u = Disposables.empty();
+        final AtomicReference<Disposable> d = new AtomicReference<Disposable>(u);
+        
+        DisposableHelper.dispose(d);
+        
+        assertTrue(u.isDisposed());
+    }
+}

--- a/src/test/java/io/reactivex/internal/disposables/EmptyDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/EmptyDisposableTest.java
@@ -11,32 +11,30 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.completable;
+package io.reactivex.internal.disposables;
 
 import static org.junit.Assert.*;
 import org.junit.Test;
 
-import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.TestHelper;
+import io.reactivex.internal.fuseable.QueueDisposable;
 
-public class CompletableSubscribeTest {
+public class EmptyDisposableTest {
+
     @Test
-    public void subscribeAlreadyCancelled() {
-        
-        PublishProcessor<Integer> pp = PublishProcessor.create();
-        
-        pp.toCompletable().test(true);
-        
-        assertFalse(pp.hasSubscribers());
+    public void noOffer() {
+        TestHelper.assertNoOffer(EmptyDisposable.INSTANCE);
     }
-
-
+    
     @Test
-    public void methodTestNoCancel() {
-        PublishSubject<Integer> ps = PublishSubject.create();
-        
-        ps.toCompletable().test(false);
-        
-        assertTrue(ps.hasObservers());
+    public void asyncFusion() {
+        assertEquals(QueueDisposable.NONE, EmptyDisposable.INSTANCE.requestFusion(QueueDisposable.SYNC));
+        assertEquals(QueueDisposable.ASYNC, EmptyDisposable.INSTANCE.requestFusion(QueueDisposable.ASYNC));
+    }
+    
+    @Test
+    public void checkEnum() {
+        assertEquals(1, EmptyDisposable.values().length);
+        assertNotNull(EmptyDisposable.valueOf("INSTANCE"));
     }
 }

--- a/src/test/java/io/reactivex/internal/disposables/ListCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/ListCompositeDisposableTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+
+public class ListCompositeDisposableTest {
+
+    @Test
+    public void constructorAndAddVarargs() {
+        Disposable d1 = Disposables.empty();
+        Disposable d2 = Disposables.empty();
+        
+        ListCompositeDisposable lcd = new ListCompositeDisposable(d1, d2);
+        
+        lcd.clear();
+        
+        assertFalse(lcd.isDisposed());
+        
+        assertTrue(d1.isDisposed());
+        assertTrue(d2.isDisposed());
+
+        d1 = Disposables.empty();
+        d2 = Disposables.empty();
+
+        lcd.addAll(d1, d2);
+        
+        lcd.dispose();
+        
+        assertTrue(lcd.isDisposed());
+        assertTrue(d1.isDisposed());
+        assertTrue(d2.isDisposed());
+    }
+
+    @Test
+    public void constructorIterable() {
+        Disposable d1 = Disposables.empty();
+        Disposable d2 = Disposables.empty();
+        
+        ListCompositeDisposable lcd = new ListCompositeDisposable(Arrays.asList(d1, d2));
+        
+        lcd.clear();
+        
+        assertFalse(lcd.isDisposed());
+        
+        assertTrue(d1.isDisposed());
+        assertTrue(d2.isDisposed());
+
+        d1 = Disposables.empty();
+        d2 = Disposables.empty();
+
+        lcd.add(d1);
+        lcd.addAll(d2);
+        
+        lcd.dispose();
+        
+        assertTrue(lcd.isDisposed());
+        assertTrue(d1.isDisposed());
+        assertTrue(d2.isDisposed());
+    }
+
+    @Test
+    public void empty() {
+        ListCompositeDisposable lcd = new ListCompositeDisposable();
+        
+        assertFalse(lcd.isDisposed());
+        
+        lcd.clear();
+        
+        assertFalse(lcd.isDisposed());
+        
+        lcd.dispose();
+
+        lcd.dispose();
+        
+        lcd.clear();
+        
+        assertTrue(lcd.isDisposed());
+    }
+    
+    @Test
+    public void afterDispose() {
+        ListCompositeDisposable lcd = new ListCompositeDisposable();
+        lcd.dispose();
+        
+        Disposable d = Disposables.empty();
+        assertFalse(lcd.add(d));
+        assertTrue(d.isDisposed());
+        
+        d = Disposables.empty();
+        assertFalse(lcd.addAll(d));
+        assertTrue(d.isDisposed());
+    }
+    
+    @Test
+    public void disposeThrows() {
+        Disposable d = new Disposable() {
+
+            @Override
+            public void dispose() {
+                throw new TestException();
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return false;
+            }
+            
+        };
+        
+        ListCompositeDisposable lcd = new ListCompositeDisposable(d, d);
+        
+        try {
+            lcd.dispose();
+            fail("Should have thrown!");
+        } catch (CompositeException ex) {
+            List<Throwable> list = ex.getExceptions();
+            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertError(list, 1, TestException.class);
+        }
+        
+        lcd = new ListCompositeDisposable(d);
+        
+        try {
+            lcd.dispose();
+            fail("Should have thrown!");
+        } catch (TestException  ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void remove() {
+        ListCompositeDisposable lcd = new ListCompositeDisposable();
+        Disposable d = Disposables.empty();
+        
+        lcd.add(d);
+        
+        assertTrue(lcd.delete(d));
+        
+        assertFalse(d.isDisposed());
+        
+        lcd.add(d);
+        
+        assertTrue(lcd.remove(d));
+        
+        assertTrue(d.isDisposed());
+        
+        assertFalse(lcd.remove(d));
+        
+        assertFalse(lcd.delete(d));
+        
+        lcd = new ListCompositeDisposable();
+        
+        assertFalse(lcd.remove(d));
+
+        assertFalse(lcd.delete(d));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.schedulers.Schedulers;
+
+public class FlowableBlockingTest {
+
+    @Test
+    public void blockingFirst() {
+        assertEquals(1, Flowable.range(1, 10)
+                .subscribeOn(Schedulers.computation()).blockingFirst().intValue());
+    }
+
+    @Test
+    public void blockingFirstDefault() {
+        assertEquals(1, Flowable.<Integer>empty()
+                .subscribeOn(Schedulers.computation()).blockingFirst(1).intValue());
+    }
+
+    @Test
+    public void blockingSubscribeConsumer() {
+        final List<Integer> list = new ArrayList<Integer>();
+        
+        Flowable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void blockingSubscribeConsumerConsumer() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Flowable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        }, Functions.emptyConsumer());
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void blockingSubscribeConsumerConsumerError() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        TestException ex = new TestException();
+        
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+        
+        Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(cons, cons);
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, ex), list);
+    }
+
+    @Test
+    public void blockingSubscribeConsumerConsumerAction() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+        
+        Flowable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(cons, cons, new Action() {
+            @Override
+            public void run() throws Exception {
+                list.add(100);
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void blockingSubscribeObserver() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Flowable.range(1, 5)
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Subscriber<Object>() {
+
+            @Override
+            public void onSubscribe(Subscription d) {
+                d.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(Object value) {
+                list.add(value);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                list.add(e);
+            }
+
+            @Override
+            public void onComplete() {
+                list.add(100);
+            }
+            
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void blockingSubscribeObserverError() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        final TestException ex = new TestException();
+        
+        Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
+        .subscribeOn(Schedulers.computation())
+        .blockingSubscribe(new Subscriber<Object>() {
+
+            @Override
+            public void onSubscribe(Subscription d) {
+                d.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(Object value) {
+                list.add(value);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                list.add(e);
+            }
+
+            @Override
+            public void onComplete() {
+                list.add(100);
+            }
+            
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, ex), list);
+    }
+
+    @Test(expected = TestException.class)
+    public void blockingForEachThrows() {
+        Flowable.just(1)
+        .blockingForEach(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer e) throws Exception {
+                throw new TestException();
+            }
+        });
+    }
+    
+    @Test(expected = NoSuchElementException.class)
+    public void blockingFirstEmpty() {
+        Flowable.empty().blockingFirst();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void blockingLastEmpty() {
+        Flowable.empty().blockingLast();
+    }
+
+    @Test
+    public void blockingFirstNormal() {
+        assertEquals(1, Flowable.just(1, 2).blockingFirst(3).intValue());
+    }
+
+    @Test
+    public void blockingLastNormal() {
+        assertEquals(2, Flowable.just(1, 2).blockingLast(3).intValue());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/NotificationLiteTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/NotificationLiteTest.java
@@ -16,7 +16,12 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.NotificationLite;
 
 
@@ -38,6 +43,70 @@ public class NotificationLiteTest {
         assertSame(1, NotificationLite.next(1));
     }
     
+    @Test
+    public void soloEnum() {
+        TestHelper.checkEnum(NotificationLite.class);
+    }
+    
+    @Test
+    public void errorNotification() {
+        Object o = NotificationLite.error(new TestException());
+        
+        assertEquals("NotificationLite.Error[io.reactivex.exceptions.TestException]", o.toString());
+        
+        assertTrue(NotificationLite.isError(o));
+        assertFalse(NotificationLite.isComplete(o));
+        assertFalse(NotificationLite.isDisposable(o));
+        assertFalse(NotificationLite.isSubscription(o));
+        
+        assertTrue(NotificationLite.getError(o) instanceof TestException);
+    }
+    
+    @Test
+    public void completeNotification() {
+        Object o = NotificationLite.complete();
+        Object o2 = NotificationLite.complete();
+        
+        assertSame(o, o2);
+
+        assertFalse(NotificationLite.isError(o));
+        assertTrue(NotificationLite.isComplete(o));
+        assertFalse(NotificationLite.isDisposable(o));
+        assertFalse(NotificationLite.isSubscription(o));
+
+        assertEquals("NotificationLite.Complete", o.toString());
+        
+        assertTrue(NotificationLite.isComplete(o));
+    }
+
+    @Test
+    public void disposableNotification() {
+        Object o = NotificationLite.disposable(Disposables.empty());
+        
+        assertEquals("NotificationLite.Disposable[RunnableDisposable(disposed=false, EmptyRunnable)]", o.toString());
+
+        assertFalse(NotificationLite.isError(o));
+        assertFalse(NotificationLite.isComplete(o));
+        assertTrue(NotificationLite.isDisposable(o));
+        assertFalse(NotificationLite.isSubscription(o));
+
+        assertTrue(NotificationLite.getDisposable(o) instanceof Disposable);
+    }
+    
+    @Test
+    public void subscriptionNotification() {
+        Object o = NotificationLite.subscription(new BooleanSubscription());
+        
+        assertEquals("NotificationLite.Subscription[BooleanSubscription(cancelled=false)]", o.toString());
+
+        assertFalse(NotificationLite.isError(o));
+        assertFalse(NotificationLite.isComplete(o));
+        assertFalse(NotificationLite.isDisposable(o));
+        assertTrue(NotificationLite.isSubscription(o));
+
+        assertTrue(NotificationLite.getSubscription(o) instanceof Subscription);
+    }
+
     // TODO this test is no longer relevant as nulls are not allowed and value maps to itself
 //    @Test
 //    public void testValueKind() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.operators.observable;
 
 import static io.reactivex.internal.util.TestingHelper.*;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
@@ -30,7 +30,7 @@ public class ObservableFromTest {
         Observable.fromFuture(Observable.never()
         .toFuture(), 100, TimeUnit.MILLISECONDS, Schedulers.io())
         .test()
-        .awaitDone()
+        .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TimeoutException.class);
     }
     

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -296,7 +296,7 @@ public class ObservableUsingTest {
         
         o.safeSubscribe(NbpObserver);
 
-        assertEquals(Arrays.asList("disposed", "completed", "unsub"), events);
+        assertEquals(Arrays.asList("disposed", "completed" /* , "unsub" */), events);
 
     }
 
@@ -323,7 +323,7 @@ public class ObservableUsingTest {
         
         o.safeSubscribe(NbpObserver);
 
-        assertEquals(Arrays.asList("completed", "unsub", "disposed"), events);
+        assertEquals(Arrays.asList("completed", /*"unsub",*/ "disposed"), events);
 
     }
 
@@ -353,7 +353,7 @@ public class ObservableUsingTest {
         
         o.safeSubscribe(NbpObserver);
 
-        assertEquals(Arrays.asList("disposed", "error", "unsub"), events);
+        assertEquals(Arrays.asList("disposed", "error" /*, "unsub"*/), events);
 
     }
     
@@ -381,7 +381,7 @@ public class ObservableUsingTest {
         
         o.safeSubscribe(NbpObserver);
 
-        assertEquals(Arrays.asList("error", "unsub", "disposed"), events);
+        assertEquals(Arrays.asList("error", /* "unsub",*/ "disposed"), events);
     }
 
     private static Action createUnsubAction(final List<String> events) {

--- a/src/test/java/io/reactivex/internal/subscribers/observable/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/observable/DeferredScalarObserverTest.java
@@ -1,0 +1,460 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.observable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.observers.*;
+
+public class DeferredScalarObserverTest {
+
+    static final class TakeFirst extends DeferredScalarObserver<Integer, Integer> {
+        public TakeFirst(Observer<? super Integer> actual) {
+            super(actual);
+        }
+
+        /** */
+        private static final long serialVersionUID = -2793723002312330530L;
+
+        @Override
+        public void onNext(Integer value) {
+            s.dispose();
+            complete(value);
+            complete(value);
+        }
+        
+    }
+    
+    @Test
+    public void normal() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeFirst source = new TakeFirst(to);
+        
+        source.onSubscribe(Disposables.empty());
+        
+        Disposable d = Disposables.empty();
+        source.onSubscribe(d);
+        
+        assertTrue(d.isDisposed());
+        
+        source.onNext(1);
+        
+        to.assertResult(1);
+    }
+
+    @Test
+    public void error() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeFirst source = new TakeFirst(to);
+        
+        source.onSubscribe(Disposables.empty());
+        source.onError(new TestException());
+        
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void complete() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeFirst source = new TakeFirst(to);
+        
+        source.onSubscribe(Disposables.empty());
+        source.onComplete();
+        
+        to.assertResult();
+    }
+    
+    @Test
+    public void dispose() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeFirst source = new TakeFirst(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        assertFalse(d.isDisposed());
+        
+        to.cancel();
+        
+        assertTrue(d.isDisposed());
+        
+        assertTrue(source.isDisposed());
+    }
+
+    @Test
+    public void fused() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        
+        TakeFirst source = new TakeFirst(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+        
+        to.assertOf(ObserverFusion.<Integer>assertFuseable());
+        to.assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC));
+        
+        source.onNext(1);
+        source.onNext(1);
+        source.onError(new TestException());
+        source.onComplete();
+        
+        assertTrue(d.isDisposed());
+        
+        to.assertResult(1);
+    }
+
+    @Test
+    public void fusedReject() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.SYNC);
+        
+        TakeFirst source = new TakeFirst(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+        
+        to.assertOf(ObserverFusion.<Integer>assertFuseable());
+        to.assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.NONE));
+        
+        source.onNext(1);
+        source.onNext(1);
+        source.onError(new TestException());
+        source.onComplete();
+        
+        assertTrue(d.isDisposed());
+        
+        to.assertResult(1);
+    }
+
+    static final class TakeLast extends DeferredScalarObserver<Integer, Integer> {
+        public TakeLast(Observer<? super Integer> actual) {
+            super(actual);
+        }
+
+        /** */
+        private static final long serialVersionUID = -2793723002312330530L;
+
+        @Override
+        public void onNext(Integer value) {
+            hasValue = true;
+            this.value = value;
+        }
+        
+    }
+
+    @Test
+    public void nonfusedTerminateMore() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        source.onNext(1);
+        source.onComplete();
+        source.onComplete();
+        source.onError(new TestException());
+        
+        to.assertResult(1);
+    }
+
+    @Test
+    public void nonfusedError() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        source.onNext(1);
+        source.onError(new TestException());
+        source.onError(new TestException());
+        source.onComplete();
+        
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedTerminateMore() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        source.onNext(1);
+        source.onComplete();
+        source.onComplete();
+        source.onError(new TestException());
+        
+        to.assertResult(1);
+    }
+
+    @Test
+    public void fusedError() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        source.onNext(1);
+        source.onError(new TestException());
+        source.onError(new TestException());
+        source.onComplete();
+        
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void disposed() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        to.cancel();
+        
+        source.onNext(1);
+        source.onComplete();
+
+        to.assertNoValues().assertNoErrors().assertNotComplete();
+    }
+    
+    @Test
+    public void disposedAfterOnNext() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeLast source = new TakeLast(new Observer<Integer>() {
+            Disposable d;
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                this.d = d;
+                to.onSubscribe(d);
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                to.onNext(value);
+                d.dispose();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                to.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                to.onComplete();
+            }
+        });
+        
+        source.onSubscribe(Disposables.empty());
+        source.onNext(1);
+        source.onComplete();
+        
+        to.assertValue(1).assertNoErrors().assertNotComplete();
+    }
+
+    @Test
+    public void fusedEmpty() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        source.onComplete();
+        
+        to.assertResult();
+    }
+
+    @Test
+    public void nonfusedEmpty() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        
+        TakeLast source = new TakeLast(to);
+        
+        Disposable d = Disposables.empty();
+        
+        source.onSubscribe(d);
+
+        source.onComplete();
+        
+        to.assertResult();
+    }
+
+    @Test
+    public void customFusion() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeLast source = new TakeLast(new Observer<Integer>() {
+            QueueDisposable<Integer> d;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onSubscribe(Disposable d) {
+                this.d = (QueueDisposable<Integer>)d;
+                to.onSubscribe(d);
+                this.d.requestFusion(QueueDisposable.ANY);
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                if (!d.isEmpty()) {
+                    Integer v = null;
+                    try {
+                        to.onNext(d.poll());
+                    
+                        v = d.poll();
+                    } catch (Throwable ex) {
+                        to.onError(ex);
+                    }
+                        
+                    assertNull(v);
+                    assertTrue(d.isEmpty());
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                to.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                to.onComplete();
+            }
+        });
+        
+        source.onSubscribe(Disposables.empty());
+        source.onNext(1);
+        source.onComplete();
+        
+        to.assertResult(1);
+    }
+
+    @Test
+    public void customFusionClear() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeLast source = new TakeLast(new Observer<Integer>() {
+            QueueDisposable<Integer> d;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onSubscribe(Disposable d) {
+                this.d = (QueueDisposable<Integer>)d;
+                to.onSubscribe(d);
+                this.d.requestFusion(QueueDisposable.ANY);
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                d.clear();
+                assertTrue(d.isEmpty());
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                to.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                to.onComplete();
+            }
+        });
+        
+        source.onSubscribe(Disposables.empty());
+        source.onNext(1);
+        source.onComplete();
+        
+        to.assertNoValues().assertNoErrors().assertComplete();
+    }
+
+    @Test
+    public void offerThrow() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        
+        TakeLast source = new TakeLast(to);
+
+        TestHelper.assertNoOffer(source);
+    }
+
+    @Test
+    public void customFusionDontConsume() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+        
+        TakeFirst source = new TakeFirst(new Observer<Integer>() {
+            QueueDisposable<Integer> d;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onSubscribe(Disposable d) {
+                this.d = (QueueDisposable<Integer>)d;
+                to.onSubscribe(d);
+                this.d.requestFusion(QueueDisposable.ANY);
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                // not consuming
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                to.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                to.onComplete();
+            }
+        });
+        
+        source.onSubscribe(Disposables.empty());
+        source.onNext(1);
+        
+        to.assertNoValues().assertNoErrors().assertComplete();
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/util/BlockingHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/BlockingHelperTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class BlockingHelperTest {
+
+    @Test
+    public void emptyEnum() {
+        TestHelper.checkUtilityClass(BlockingHelper.class);
+    }
+    
+    @Test
+    public void interrupted() {
+        CountDownLatch cdl = new CountDownLatch(1);
+        Disposable d = Disposables.empty();
+        
+        Thread.currentThread().interrupt();
+        
+        try {
+            BlockingHelper.awaitForComplete(cdl, d);
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+        assertTrue(d.isDisposed());
+        assertTrue(Thread.interrupted());
+    }
+    
+    @Test
+    public void unblock() {
+        final CountDownLatch cdl = new CountDownLatch(1);
+        Disposable d = Disposables.empty();
+        
+        Schedulers.computation().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                cdl.countDown();
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+        
+        BlockingHelper.awaitForComplete(cdl, d);
+        
+        assertFalse(d.isDisposed());
+    }
+}

--- a/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
@@ -11,32 +11,33 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.completable;
+package io.reactivex.internal.util;
 
 import static org.junit.Assert.*;
 import org.junit.Test;
 
-import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.TestHelper;
 
-public class CompletableSubscribeTest {
+public class MiscUtilTest {
     @Test
-    public void subscribeAlreadyCancelled() {
-        
-        PublishProcessor<Integer> pp = PublishProcessor.create();
-        
-        pp.toCompletable().test(true);
-        
-        assertFalse(pp.hasSubscribers());
+    public void pow2UtilityClass() {
+        TestHelper.checkUtilityClass(Pow2.class);
     }
-
-
+    
     @Test
-    public void methodTestNoCancel() {
-        PublishSubject<Integer> ps = PublishSubject.create();
+    public void isPowerOf2() {
+        for (int i = 1; i > 0; i *= 2) {
+            assertTrue(Pow2.isPowerOfTwo(i));
+        }
         
-        ps.toCompletable().test(false);
-        
-        assertTrue(ps.hasObservers());
+        assertFalse(Pow2.isPowerOfTwo(3));
+        assertFalse(Pow2.isPowerOfTwo(5));
+        assertFalse(Pow2.isPowerOfTwo(6));
+        assertFalse(Pow2.isPowerOfTwo(7));
+    }
+    
+    @Test
+    public void hashMapSupplier() {
+        TestHelper.checkEnum(HashMapSupplier.class);
     }
 }

--- a/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
@@ -178,4 +178,15 @@ public class ObservableSubscriberTest {
         
         ts.assertResult(1);
     }
+
+
+    @Test
+    public void methodTestNoCancel() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        
+        ps.test(false);
+        
+        assertTrue(ps.hasObservers());
+    }
+
 }

--- a/src/test/java/io/reactivex/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SafeObserverTest.java
@@ -20,9 +20,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.*;
 
-import io.reactivex.Observer;
+import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class SafeObserverTest {
 
@@ -486,4 +487,433 @@ public class SafeObserverTest {
 
         assertSame(actual, s.actual);
     }
+    
+    @Test
+    public void dispose() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        Disposable d = Disposables.empty();
+        
+        so.onSubscribe(d);
+        
+        ts.dispose();
+        
+        assertTrue(d.isDisposed());
+        
+        assertTrue(so.isDisposed());
+    }
+
+    @Test
+    public void onNextAfterComplete() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        Disposable d = Disposables.empty();
+        
+        so.onSubscribe(d);
+
+        so.onComplete();
+        
+        so.onNext(1);
+        
+        so.onError(new TestException());
+        
+        so.onComplete();
+        
+        ts.assertResult();
+    }
+
+    @Test
+    public void onNextNull() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        Disposable d = Disposables.empty();
+        
+        so.onSubscribe(d);
+
+        so.onNext(null);
+        
+        ts.assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void onNextWithoutOnSubscribe() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        so.onNext(1);
+        
+        ts.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
+    }
+
+    @Test
+    public void onErrorWithoutOnSubscribe() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        so.onError(new TestException());
+        
+        ts.assertFailure(CompositeException.class);
+        
+        TestHelper.assertError(ts, 0, TestException.class);
+        TestHelper.assertError(ts, 1, NullPointerException.class, "Subscription not set!");
+    }
+
+    @Test
+    public void onCompleteWithoutOnSubscribe() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        so.onComplete();
+        
+        ts.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
+    }
+
+    @Test
+    public void onNextNormal() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        
+        Disposable d = Disposables.empty();
+        
+        so.onSubscribe(d);
+
+        so.onNext(1);
+        so.onComplete();
+        
+        ts.assertResult(1);
+    }
+    
+    static final class CrashDummy implements Observer<Object>, Disposable {
+        boolean crashOnSubscribe;
+        int crashOnNext;
+        boolean crashOnError;
+        boolean crashOnComplete;
+        
+        boolean crashDispose;
+        
+        Throwable error;
+        
+        public CrashDummy(boolean crashOnSubscribe, int crashOnNext, 
+                boolean crashOnError, boolean crashOnComplete, boolean crashDispose) {
+            this.crashOnSubscribe = crashOnSubscribe;
+            this.crashOnNext = crashOnNext;
+            this.crashOnError = crashOnError;
+            this.crashOnComplete = crashOnComplete;
+            this.crashDispose = crashDispose;
+        }
+
+        @Override
+        public void dispose() {
+            if (crashDispose) {
+                throw new TestException("dispose()");
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return false;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (crashOnSubscribe) {
+                throw new TestException("onSubscribe()");
+            }
+        }
+
+        @Override
+        public void onNext(Object value) {
+            if (--crashOnNext == 0) {
+                throw new TestException("onNext(" + value + ")");
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (crashOnError) {
+                throw new TestException("onError(" + e + ")");
+            }
+            error = e;
+        }
+
+        @Override
+        public void onComplete() {
+            if (crashOnComplete) {
+                throw new TestException("onComplete()");
+            }
+        }
+        
+        public SafeObserver<Object> toSafe() {
+            return new SafeObserver<Object>(this);
+        }
+        
+        public CrashDummy assertError(Class<? extends Throwable> clazz) {
+            if (!clazz.isInstance(error)) {
+                throw new AssertionError("Different error: " + error);
+            }
+            return this;
+        }
+        
+        public CrashDummy assertInnerError(int index, Class<? extends Throwable> clazz) {
+            List<Throwable> cel = TestHelper.compositeList(error);
+            TestHelper.assertError(cel, index, clazz);
+            return this;
+        }
+
+        public CrashDummy assertInnerError(int index, Class<? extends Throwable> clazz, String message) {
+            List<Throwable> cel = TestHelper.compositeList(error);
+            TestHelper.assertError(cel, index, clazz, message);
+            return this;
+        }
+
+    }
+
+    @Test
+    public void onNextOnErrorCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            
+            so.onNext(1);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
+            TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.exceptions.TestException: onNext(1))");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextDisposeCrash() {
+        CrashDummy cd = new CrashDummy(false, 1, false, false, true);
+        SafeObserver<Object> so = cd.toSafe();
+        so.onSubscribe(cd);
+        
+        so.onNext(1);
+
+        cd.assertError(CompositeException.class);
+        cd.assertInnerError(0, TestException.class, "onNext(1)");
+        cd.assertInnerError(1, TestException.class, "dispose()");
+    }
+
+    @Test
+    public void onSubscribeTwice() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, false, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            so.onSubscribe(cd);
+            
+            TestHelper.assertError(list, 0, IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onSubscribeCrashes() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            
+            TestHelper.assertError(list, 0, TestException.class, "onSubscribe()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onSubscribeAndDisposeCrashes() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, true);
+            SafeObserver<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
+            TestHelper.assertError(ce, 1, TestException.class, "dispose()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextOnSubscribeCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+
+            so.onNext(1);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void onNextNullDisposeCrashes() {
+        CrashDummy cd = new CrashDummy(false, 1, false, false, true);
+        SafeObserver<Object> so = cd.toSafe();
+        so.onSubscribe(cd);
+        
+        so.onNext(null);
+        
+        cd.assertInnerError(0, NullPointerException.class);
+        cd.assertInnerError(1, TestException.class, "dispose()");
+    }
+
+    @Test
+    public void noSubscribeOnErrorCrashes() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+
+            so.onNext(1);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorNull() {
+        CrashDummy cd = new CrashDummy(false, 1, false, false, false);
+        SafeObserver<Object> so = cd.toSafe();
+        so.onSubscribe(cd);
+        
+        so.onError(null);
+        
+        cd.assertError(NullPointerException.class);
+    }
+
+    @Test
+    public void onErrorNoSubscribeCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+            
+            so.onError(new TestException());
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class);
+            TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorNoSubscribeOnErrorCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, false, false);
+            SafeObserver<Object> so = cd.toSafe();
+            
+            so.onError(new TestException());
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class);
+            TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 2, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteteCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, false, true, false);
+            SafeObserver<Object> so = cd.toSafe();
+            
+            so.onSubscribe(cd);
+            
+            so.onComplete();
+            
+            TestHelper.assertError(list, 0, TestException.class, "onComplete()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteteNoSubscribeCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, true, false);
+            SafeObserver<Object> so = cd.toSafe();
+            
+            so.onComplete();
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteteNoSubscribeOnErrorCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, true, false);
+            SafeObserver<Object> so = cd.toSafe();
+            
+            so.onComplete();
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -16,7 +16,9 @@ package io.reactivex.observers;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.*;
 
 import org.junit.*;
 import org.junit.rules.ExpectedException;
@@ -24,9 +26,14 @@ import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class TestObserverTest {
@@ -231,5 +238,642 @@ public class TestObserverTest {
             return;
         }
         fail("Failed to report multiple kinds of events!");
+    }
+    
+    @Test
+    public void createDelegate() {
+        TestObserver<Integer> ts1 = TestObserver.create();
+        
+        TestObserver<Integer> ts = TestObserver.create(ts1);
+        
+        ts.assertNotSubscribed();
+
+        assertFalse(ts.hasSubscription());
+
+        ts.onSubscribe(Disposables.empty());
+        
+        try {
+            ts.assertNotSubscribed();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+
+        assertTrue(ts.hasSubscription());
+        
+        assertFalse(ts.isDisposed());
+        
+        ts.onNext(1);
+        ts.onError(new TestException());
+        ts.onComplete();
+        
+        ts1.assertValue(1).assertError(TestException.class).assertComplete();
+        
+        ts.dispose();
+        
+        assertTrue(ts.isDisposed());
+        
+        assertTrue(ts.isTerminated());
+        
+        assertSame(Thread.currentThread(), ts.lastThread());
+
+        try {
+            ts.assertNoValues();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+
+        try {
+            ts.assertValueCount(0);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+        
+        ts.assertValueSequence(Arrays.asList(1));
+        
+        try {
+            ts.assertValueSequence(Arrays.asList(2));
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+
+        ts.assertValueSet(Collections.singleton(1));
+
+        try {
+            ts.assertValueSet(Collections.singleton(2));
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+
+    }
+    
+    @Test
+    public void assertError() {
+        TestObserver<Integer> ts = TestObserver.create();
+        
+        try {
+            ts.assertError(TestException.class);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+
+        try {
+            ts.assertError(new TestException());
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+
+        try {
+            ts.assertErrorMessage("");
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            
+        }
+
+        try {
+            ts.assertSubscribed();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            
+        }
+
+        try {
+            ts.assertTerminated();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            
+        }
+
+        ts.onSubscribe(Disposables.empty());
+
+        ts.assertSubscribed();
+        
+        ts.assertNoErrors();
+
+        TestException ex = new TestException("Forced failure");
+        
+        ts.onError(ex);
+
+        ts.assertError(ex);
+        
+        ts.assertError(TestException.class);
+
+        ts.assertErrorMessage("Forced failure");
+        
+        try {
+            ts.assertErrorMessage("");
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            
+        }
+        
+        try {
+            ts.assertError(new RuntimeException());
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+
+        try {
+            ts.assertError(IOException.class);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+
+        try {
+            ts.assertNoErrors();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError exc) {
+            // expected
+        }
+        
+        ts.assertTerminated();
+        
+        ts.assertValueCount(0);
+        
+        ts.assertNoValues();
+        
+        
+    }
+    
+    @Test
+    public void emptyObserverEnum() {
+        assertEquals(1, TestObserver.EmptyObserver.values().length);
+        assertNotNull(TestObserver.EmptyObserver.valueOf("INSTANCE"));
+    }
+    
+    @Test
+    public void valueAndClass() {
+        assertEquals("null", TestObserver.valueAndClass(null));
+        assertEquals("1 (class: Integer)", TestObserver.valueAndClass(1));
+    }
+    
+    @Test
+    public void assertFailure() {
+        TestObserver<Integer> ts = TestObserver.create();
+        
+        ts.onSubscribe(Disposables.empty());
+        
+        ts.onError(new TestException("Forced failure"));
+
+        ts.assertFailure(TestException.class);
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure");
+        
+        ts.onNext(1);
+
+        ts.assertFailure(TestException.class, 1);
+        
+        ts.assertFailureAndMessage(TestException.class, "Forced failure", 1);
+    }
+    
+    @Test
+    public void assertFuseable() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+        
+        ts.assertNotFuseable();
+        
+        try {
+            ts.assertFuseable();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        ts = TestObserver.create();
+        ts.setInitialFusionMode(QueueDisposable.ANY);
+        
+        ts.onSubscribe(new ScalarDisposable<Integer>(ts, 1));
+        
+        ts.assertFuseable();
+        
+        ts.assertFusionMode(QueueDisposable.SYNC);
+        
+        try {
+            ts.assertFusionMode(QueueDisposable.NONE);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        try {
+            ts.assertNotFuseable();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+    }
+    
+    @Test
+    public void assertTerminated() {
+        TestObserver<Integer> ts = TestObserver.create();
+        
+        ts.assertNotTerminated();
+        
+        ts.onError(null);
+        
+        try {
+            ts.assertNotTerminated();
+            throw new RuntimeException("Should have thrown!");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void assertOf() {
+        TestObserver<Integer> ts = TestObserver.create();
+       
+        ts.assertOf(new Consumer<TestObserver<Integer>>() {
+            @Override
+            public void accept(TestObserver<Integer> f) throws Exception {
+                f.assertNotSubscribed();
+            }
+        });
+        
+        try {
+            ts.assertOf(new Consumer<TestObserver<Integer>>() {
+                @Override
+                public void accept(TestObserver<Integer> f) throws Exception {
+                    f.assertSubscribed();
+                }
+            });
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        try {
+            ts.assertOf(new Consumer<TestObserver<Integer>>() {
+                @Override
+                public void accept(TestObserver<Integer> f) throws Exception {
+                    throw new IllegalArgumentException();
+                }
+            });
+            throw new RuntimeException("Should have thrown");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void assertResult() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+        
+        ts.onComplete();
+        
+        ts.assertResult();
+        
+        try {
+            ts.assertResult(1);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        ts.onNext(1);
+        
+        ts.assertResult(1);
+        
+        try {
+            ts.assertResult(2);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        try {
+            ts.assertResult();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+
+    }
+    
+    @Test(timeout = 5000)
+    public void await() throws Exception {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+
+        assertFalse(ts.await(100, TimeUnit.MILLISECONDS));
+        
+        ts.awaitDone(100, TimeUnit.MILLISECONDS);
+        
+        assertTrue(ts.isDisposed());
+
+        assertFalse(ts.awaitTerminalEvent(100, TimeUnit.MILLISECONDS));
+        
+        assertEquals(0, ts.completions());
+        assertEquals(0, ts.errorCount());
+
+        ts.onComplete();
+        
+        assertTrue(ts.await(100, TimeUnit.MILLISECONDS));
+        
+        ts.await();
+        
+        ts.awaitDone(5, TimeUnit.SECONDS);
+        
+        assertEquals(1, ts.completions());
+        assertEquals(0, ts.errorCount());
+        
+        assertTrue(ts.awaitTerminalEvent());
+        
+        final TestObserver<Integer> ts1 = TestObserver.create();
+
+        ts1.onSubscribe(Disposables.empty());
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                ts1.onComplete();
+            }
+        }, 200, TimeUnit.MILLISECONDS);
+        
+        ts1.await();
+        
+        ts1.assertValueSet(Collections.<Integer>emptySet());
+    }
+    
+    @Test
+    public void errors() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+
+        assertEquals(0, ts.errors().size());
+        
+        ts.onError(new TestException());
+
+        assertEquals(1, ts.errors().size());
+        
+        TestHelper.assertError(ts.errors(), 0, TestException.class);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void onNext() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+
+        assertEquals(0, ts.valueCount());
+        
+        assertEquals(Arrays.asList(), ts.values());
+        
+        ts.onNext(1);
+        
+        assertEquals(Arrays.asList(1), ts.values());
+        
+        ts.cancel();
+        
+        assertTrue(ts.isCancelled());
+        assertTrue(ts.isDisposed());
+        
+        ts.assertValue(1);
+        
+        assertEquals(Arrays.asList(Arrays.asList(1), Collections.emptyList(), Collections.emptyList()), ts.getEvents());
+    }
+    
+    @Test
+    public void fusionModeToString() {
+        assertEquals("NONE", TestObserver.fusionModeToString(QueueDisposable.NONE));
+        assertEquals("SYNC", TestObserver.fusionModeToString(QueueDisposable.SYNC));
+        assertEquals("ASYNC", TestObserver.fusionModeToString(QueueDisposable.ASYNC));
+        assertEquals("Unknown(100)", TestObserver.fusionModeToString(100));
+    }
+    
+    @Test
+    public void multipleTerminals() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+
+        ts.assertNotComplete();
+
+        ts.onComplete();
+
+        try {
+            ts.assertNotComplete();
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+
+        ts.assertTerminated();
+        
+        ts.onComplete();
+        
+        try {
+            ts.assertComplete();
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+
+        try {
+            ts.assertTerminated();
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+
+        try {
+            ts.assertNotComplete();
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void assertValue() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+
+        try {
+            ts.assertValue(1);
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+        
+        ts.onNext(1);
+        
+        ts.assertValue(1);
+        
+        try {
+            ts.assertValue(2);
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+
+        ts.onNext(2);
+        
+        try {
+            ts.assertValue(1);
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void onNextMisbehave() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onNext(1);
+        
+        ts.assertError(IllegalStateException.class);
+        
+        ts = TestObserver.create();
+        
+        ts.onSubscribe(Disposables.empty());
+        
+        ts.onNext(null);
+        
+        ts.assertFailure(NullPointerException.class, (Integer)null);
+    }
+    
+    @Test
+    public void awaitTerminalEventInterrupt() {
+        final TestObserver<Integer> ts = TestObserver.create();
+        
+        ts.onSubscribe(Disposables.empty());
+
+        Thread.currentThread().interrupt();
+        
+        ts.awaitTerminalEvent();
+
+        assertTrue(Thread.interrupted());
+        
+        Thread.currentThread().interrupt();
+
+        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+
+        assertTrue(Thread.interrupted());
+    }
+    
+    @Test
+    public void assertTerminated2() {
+        TestObserver<Integer> ts = TestObserver.create();
+        
+        ts.onSubscribe(Disposables.empty());
+
+        assertFalse(ts.isTerminated());
+        
+        ts.onError(new TestException());
+        ts.onError(new IOException());
+        
+        assertTrue(ts.isTerminated());
+        
+        try {
+            ts.assertTerminated();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+        try {
+            ts.assertError(TestException.class);
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+        
+
+        ts = TestObserver.create();
+        
+        ts.onSubscribe(Disposables.empty());
+
+        ts.onError(new TestException());
+        ts.onComplete();
+
+        try {
+            ts.assertTerminated();
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void onSubscribe() {
+        TestObserver<Integer> ts = TestObserver.create();
+        
+        ts.onSubscribe(null);
+        
+        ts.assertFailure(NullPointerException.class);
+
+        ts = TestObserver.create();
+        
+        ts.onSubscribe(Disposables.empty());
+        
+        Disposable d1 = Disposables.empty();
+        
+        ts.onSubscribe(d1);
+        
+        assertTrue(d1.isDisposed());
+        
+        ts.assertError(IllegalStateException.class);
+
+        ts = TestObserver.create();
+        ts.dispose();
+        
+        d1 = Disposables.empty();
+        
+        ts.onSubscribe(d1);
+        
+        assertTrue(d1.isDisposed());
+        
+    }
+
+    @Test
+    public void assertValueSequence() {
+        TestObserver<Integer> ts = TestObserver.create();
+
+        ts.onSubscribe(Disposables.empty());
+        
+        ts.onNext(1);
+        ts.onNext(2);
+        
+        try {
+            ts.assertValueSequence(Arrays.<Integer>asList());
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+
+        try {
+            ts.assertValueSequence(Arrays.asList(1));
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
+
+        ts.assertValueSequence(Arrays.asList(1, 2));
+
+        try {
+            ts.assertValueSequence(Arrays.asList(1, 2, 3));
+            throw new RuntimeException("Should have thrown");
+        } catch (AssertionError ex) {
+            // expected
+        }
     }
 }

--- a/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
@@ -649,7 +649,7 @@ public class PublishSubjectTest {
 
             TestHelper.race(r1, r2, Schedulers.io());
             
-            ts.awaitDone()
+            ts.awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
         }
     }


### PR DESCRIPTION
- Add tests
- fix mistakes in `TestObserver`
- Combine `DisposableHelper` and its inner `Disposed` enum
- Compact `NotificationLite` and its inner `Complete` enum
- Fix NPE in `ListCompositeDisposable` constructor
- Fix `DeferredScalarObserver` fusion and state management
- Turned a few empty enums into classes with private constructor: coverage can't cover them 100% otherwise. These empty enums have a constructor in their bytecode which never gets called and thus there's always 10 instructions / 2 method calls missing.
- Removed `TestObserver.awaitDone()`, one should always await with timeout
