### PR TITLE
2.x: Maybe for lazy Optional

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -27,6 +27,7 @@ import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.completable.CompletableFromPublisher;
 import io.reactivex.internal.operators.flowable.*;
+import io.reactivex.internal.operators.maybe.MaybeFromPublisher;
 import io.reactivex.internal.operators.observable.ObservableFromPublisher;
 import io.reactivex.internal.operators.single.SingleFromPublisher;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
@@ -13596,6 +13597,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
         return RxJavaPlugins.onAssembly(new SingleFromPublisher<T>(this));
+    }
+
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> toMaybe() {
+        return new MaybeFromPublisher<T>(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1,0 +1,850 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.*;
+import io.reactivex.internal.operators.maybe.*;
+import io.reactivex.internal.subscribers.maybe.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Represents a deferred computation and emission of a maybe value or exception.
+ * 
+ * @param <T> the value type
+ */
+public abstract class Maybe<T> implements MaybeSource<T> {
+    static <T> Maybe<T> wrap(MaybeSource<T> source) {
+        ObjectHelper.requireNonNull(source, "source is null");
+        if (source instanceof Maybe) {
+            return (Maybe<T>)source;
+        }
+        return new MaybeFromUnsafeSource<T>(source);
+    }
+    
+    public static <T> Maybe<T> amb(final Iterable<? extends MaybeSource<? extends T>> sources) {
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        return new MaybeAmbIterable<T>(sources);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Maybe<T> amb(final MaybeSource<? extends T>... sources) {
+        if (sources.length == 0) {
+            return Maybe.complete();
+        }
+        if (sources.length == 1) {
+            return wrap((MaybeSource<T>)sources[0]);
+        }
+        return new MaybeAmbArray<T>(sources);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Maybe<T> complete() {
+        return (Maybe<T>) MaybeComplete.INSTANCE;
+    }
+
+    public static <T> Flowable<T> concat(Iterable<? extends MaybeSource<? extends T>> sources) {
+        return concat(Flowable.fromIterable(sources));
+    }
+    
+    public static <T> Flowable<T> concat(Flowable<? extends MaybeSource<? extends T>> sources) { // FIXME Publisher
+        return sources.concatMap(new Function<MaybeSource<? extends T>, Publisher<? extends T>>() {
+            @Override 
+            public Publisher<? extends T> apply(MaybeSource<? extends T> v){
+                return new MaybeToFlowable<T>(v);
+            }
+        });
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        return concat(Flowable.fromArray(s1, s2));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        return concat(Flowable.fromArray(s1, s2, s3));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        return concat(Flowable.fromArray(s1, s2, s3, s4));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        return concat(Flowable.fromArray(s1, s2, s3, s4, s5));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6,
+            MaybeSource<? extends T> s7
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6,
+            MaybeSource<? extends T> s7, MaybeSource<? extends T> s8
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> concat(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6,
+            MaybeSource<? extends T> s7, MaybeSource<? extends T> s8,
+            MaybeSource<? extends T> s9
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s9, "s9 is null");
+        return concat(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
+    }
+
+    public static <T> Maybe<T> create(MaybeSource<T> source) {
+        ObjectHelper.requireNonNull(source, "source is null");
+        // TODO plugin wrapper
+        return new MaybeFromSource<T>(source);
+    }
+
+    public static <T> Maybe<T> unsafeCreate(MaybeSource<T> source) {
+        ObjectHelper.requireNonNull(source, "source is null");
+        // TODO plugin wrapper
+        return new MaybeFromUnsafeSource<T>(source);
+    }
+    
+    public static <T> Maybe<T> defer(final Callable<? extends MaybeSource<? extends T>> maybeSupplier) {
+        ObjectHelper.requireNonNull(maybeSupplier, "maybeSupplier is null");
+        return new MaybeDefer<T>(maybeSupplier);
+    }
+    
+    public static <T> Maybe<T> error(final Callable<? extends Throwable> errorSupplier) {
+        ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
+        return new MaybeError<T>(errorSupplier);
+    }
+    
+    public static <T> Maybe<T> error(final Throwable error) {
+        ObjectHelper.requireNonNull(error, "error is null");
+        return error(new Callable<Throwable>() {
+            @Override
+            public Throwable call() {
+                return error;
+            }
+        });
+    }
+    
+    public static <T> Maybe<T> fromCallable(final Callable<? extends T> callable) {
+        ObjectHelper.requireNonNull(callable, "callable is null");
+        return new MaybeFromCallable<T>(callable);
+    }
+    
+    public static <T> Maybe<T> fromFuture(Future<? extends T> future) {
+        return Flowable.<T>fromFuture(future).toMaybe();
+    }
+
+    public static <T> Maybe<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
+        return Flowable.<T>fromFuture(future, timeout, unit).toMaybe();
+    }
+
+    public static <T> Maybe<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
+        return Flowable.<T>fromFuture(future, timeout, unit, scheduler).toMaybe();
+    }
+
+    public static <T> Maybe<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
+        return Flowable.<T>fromFuture(future, scheduler).toMaybe();
+    }
+
+    public static <T> Maybe<T> fromPublisher(final Publisher<? extends T> publisher) {
+        ObjectHelper.requireNonNull(publisher, "publisher is null");
+        return new MaybeFromPublisher<T>(publisher);
+    }
+
+    public static <T> Maybe<T> just(final T value) {
+        ObjectHelper.requireNonNull(value, "value is null");
+        return new MaybeJust<T>(value);
+    }
+
+    public static <T> Flowable<T> merge(Iterable<? extends MaybeSource<? extends T>> sources) {
+        return merge(Flowable.fromIterable(sources));
+    }
+
+    public static <T> Flowable<T> merge(Flowable<? extends MaybeSource<? extends T>> sources) { // FIXME Publisher
+        return sources.flatMap(new Function<MaybeSource<? extends T>, Publisher<? extends T>>() {
+            @Override 
+            public Publisher<? extends T> apply(MaybeSource<? extends T> v){
+                return new MaybeToFlowable<T>(v);
+            }
+        });
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T> Maybe<T> merge(MaybeSource<? extends MaybeSource<? extends T>> source) {
+        ObjectHelper.requireNonNull(source, "source is null");
+        return new MaybeFlatMap<MaybeSource<? extends T>, T>(source, (Function)Functions.identity());
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        return merge(Flowable.fromArray(s1, s2));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        return merge(Flowable.fromArray(s1, s2, s3));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        return merge(Flowable.fromArray(s1, s2, s3, s4));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        return merge(Flowable.fromArray(s1, s2, s3, s4, s5));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6,
+            MaybeSource<? extends T> s7
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6,
+            MaybeSource<? extends T> s7, MaybeSource<? extends T> s8
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Flowable<T> merge(
+            MaybeSource<? extends T> s1, MaybeSource<? extends T> s2,
+            MaybeSource<? extends T> s3, MaybeSource<? extends T> s4,
+            MaybeSource<? extends T> s5, MaybeSource<? extends T> s6,
+            MaybeSource<? extends T> s7, MaybeSource<? extends T> s8,
+            MaybeSource<? extends T> s9
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s9, "s9 is null");
+        return merge(Flowable.fromArray(s1, s2, s3, s4, s5, s6, s7, s8, s9));
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> Maybe<T> never() {
+        return (Maybe<T>) MaybeNever.INSTANCE;
+    }
+    
+    public static Maybe<Long> timer(long delay, TimeUnit unit) {
+        return timer(delay, unit, Schedulers.computation());
+    }
+    
+    public static Maybe<Long> timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return new MaybeTimer(delay, unit, scheduler);
+    }
+    
+    public static <T> Maybe<Boolean> equals(final MaybeSource<? extends T> first, final MaybeSource<? extends T> second) { // NOPMD
+        ObjectHelper.requireNonNull(first, "first is null");
+        ObjectHelper.requireNonNull(second, "second is null");
+        return new MaybeEquals<T>(first, second);
+    }
+
+    public static <T, U> Maybe<T> using(Callable<U> resourceSupplier,
+                                         Function<? super U, ? extends MaybeSource<? extends T>> maybeFunction, Consumer<? super U> disposer) {
+        return using(resourceSupplier, maybeFunction, disposer, true);
+    }
+        
+    public static <T, U> Maybe<T> using(
+            final Callable<U> resourceSupplier, 
+            final Function<? super U, ? extends MaybeSource<? extends T>> maybeFunction,
+            final Consumer<? super U> disposer, 
+            final boolean eager) {
+        ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
+        ObjectHelper.requireNonNull(maybeFunction, "maybeFunction is null");
+        ObjectHelper.requireNonNull(disposer, "disposer is null");
+        
+        return new MaybeUsing<T, U>(resourceSupplier, maybeFunction, disposer, eager);
+    }
+
+    public static <T, R> Maybe<R> zip(final Iterable<? extends MaybeSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        return Flowable.zipIterable(MaybeInternalHelper.iterableToFlowable(sources), zipper, false, 1).toMaybe();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            BiFunction<? super T1, ? super T2, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3,
+            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, T4, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3, MaybeSource<? extends T4> s4,
+            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, T4, T5, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3, MaybeSource<? extends T4> s4,
+            MaybeSource<? extends T5> s5,
+            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, T4, T5, T6, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3, MaybeSource<? extends T4> s4,
+            MaybeSource<? extends T5> s5, MaybeSource<? extends T6> s6,
+            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, T4, T5, T6, T7, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3, MaybeSource<? extends T4> s4,
+            MaybeSource<? extends T5> s5, MaybeSource<? extends T6> s6,
+            MaybeSource<? extends T7> s7,
+            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3, MaybeSource<? extends T4> s4,
+            MaybeSource<? extends T5> s5, MaybeSource<? extends T6> s6,
+            MaybeSource<? extends T7> s7, MaybeSource<? extends T8> s8,
+            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7, s8);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Maybe<R> zip(
+            MaybeSource<? extends T1> s1, MaybeSource<? extends T2> s2,
+            MaybeSource<? extends T3> s3, MaybeSource<? extends T4> s4,
+            MaybeSource<? extends T5> s5, MaybeSource<? extends T6> s6,
+            MaybeSource<? extends T7> s7, MaybeSource<? extends T8> s8,
+            MaybeSource<? extends T9> s9,
+            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper
+     ) {
+        ObjectHelper.requireNonNull(s1, "s1 is null");
+        ObjectHelper.requireNonNull(s2, "s2 is null");
+        ObjectHelper.requireNonNull(s3, "s3 is null");
+        ObjectHelper.requireNonNull(s4, "s4 is null");
+        ObjectHelper.requireNonNull(s5, "s5 is null");
+        ObjectHelper.requireNonNull(s6, "s6 is null");
+        ObjectHelper.requireNonNull(s7, "s7 is null");
+        ObjectHelper.requireNonNull(s8, "s8 is null");
+        ObjectHelper.requireNonNull(s9, "s9 is null");
+        return zipArray(Functions.toFunction(zipper), s1, s2, s3, s4, s5, s6, s7, s8, s9);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static <T, R> Maybe<R> zipArray(Function<? super Object[], ? extends R> zipper, MaybeSource<? extends T>... sources) {
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        Publisher[] sourcePublishers = new Publisher[sources.length];
+        int i = 0;
+        for (MaybeSource<? extends T> s : sources) {
+            ObjectHelper.requireNonNull(s, "The " + i + "th source is null");
+            sourcePublishers[i] = new MaybeToFlowable<T>(s);
+            i++;
+        }
+        return Flowable.zipArray(zipper, false, 1, sourcePublishers).toMaybe();
+    }
+
+    @SuppressWarnings("unchecked")
+    public final Maybe<T> ambWith(MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return amb(this, other);
+    }
+    
+    public final Maybe<T> asMaybe() {
+        return new MaybeHide<T>(this);
+    }
+    
+    public final <R> Maybe<R> compose(Function<? super Maybe<T>, ? extends MaybeSource<R>> convert) {
+        return wrap(to(convert));
+    }
+
+    public final Maybe<T> cache() {
+        return new MaybeCache<T>(this);
+    }
+    
+    public final <U> Maybe<U> cast(final Class<? extends U> clazz) {
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
+        return map(new Function<T, U>() {
+            @Override
+            public U apply(T v) {
+                return clazz.cast(v);
+            }
+        });
+    }
+    
+    public final Flowable<T> concatWith(MaybeSource<? extends T> other) {
+        return concat(this, other);
+    }
+    
+    public final Maybe<T> delay(long time, TimeUnit unit) {
+        return delay(time, unit, Schedulers.computation());
+    }
+    
+    public final Maybe<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler) {
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return new MaybeDelay<T>(this, time, unit, scheduler);
+    }
+
+    public final Maybe<T> delaySubscription(CompletableSource other) {
+        return new MaybeDelayWithCompletable<T>(this, other);
+    }
+
+    public final <U> Maybe<T> delaySubscription(MaybeSource<U> other) {
+        return new MaybeDelayWithMaybe<T, U>(this, other);
+    }
+
+    public final <U> Maybe<T> delaySubscription(ObservableSource<U> other) {
+        return new MaybeDelayWithObservable<T, U>(this, other);
+    }
+
+    public final <U> Maybe<T> delaySubscription(Publisher<U> other) {
+        return new MaybeDelayWithPublisher<T, U>(this, other);
+    }
+    
+    public final <U> Maybe<T> delaySubscription(long time, TimeUnit unit) {
+        return delaySubscription(time, unit, Schedulers.computation());
+    }
+
+    public final <U> Maybe<T> delaySubscription(long time, TimeUnit unit, Scheduler scheduler) {
+        return delaySubscription(Observable.timer(time, unit, scheduler));
+    }
+
+    public final Maybe<T> doOnSubscribe(final Consumer<? super Disposable> onSubscribe) {
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
+        return new MaybeDoOnSubscribe<T>(this, onSubscribe);
+    }
+    
+    public final Maybe<T> doOnSuccess(final Consumer<? super T> onSuccess) {
+        ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
+        return new MaybeDoOnSuccess<T>(this, onSuccess);
+    }
+    
+    public final Maybe<T> doOnComplete(final Action onComplete) {
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        return new MaybeDoOnComplete<T>(this, onComplete);
+    }
+
+    public final Maybe<T> doOnError(final Consumer<? super Throwable> onError) {
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        return new MaybeDoOnError<T>(this, onError);
+    }
+    
+    public final Maybe<T> doOnCancel(final Action onCancel) {
+        ObjectHelper.requireNonNull(onCancel, "onCancel is null");
+        return new MaybeDoOnCancel<T>(this, onCancel);
+    }
+
+    public final <R> Maybe<R> flatMap(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        return new MaybeFlatMap<T, R>(this, mapper);
+    }
+
+    public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        return toFlowable().flatMap(mapper);
+    }
+    
+    public final T get(T valueIfComplete) {
+        return MaybeAwait.get(this, valueIfComplete);
+    }
+    
+    public final <R> Maybe<R> lift(final MaybeOperator<? extends R, ? super T> onLift) {
+        ObjectHelper.requireNonNull(onLift, "onLift is null");
+        return new MaybeLift<T, R>(this, onLift);
+    }
+    
+    public final <R> Maybe<R> map(Function<? super T, ? extends R> mapper) {
+        return new MaybeMap<T, R>(this, mapper);
+    }
+
+    public final Maybe<Boolean> contains(Object value) {
+        return contains(value, ObjectHelper.equalsPredicate());
+    }
+
+    public final Maybe<Boolean> contains(final Object value, final BiPredicate<Object, Object> comparer) {
+        ObjectHelper.requireNonNull(value, "value is null");
+        ObjectHelper.requireNonNull(comparer, "comparer is null");
+        return new MaybeContains<T>(this, value, comparer);
+    }
+    
+    public final Flowable<T> mergeWith(MaybeSource<? extends T> other) {
+        return merge(this, other);
+    }
+    
+    public final Maybe<Maybe<T>> nest() {
+        return just(this);
+    }
+    
+    public final Maybe<T> observeOn(final Scheduler scheduler) {
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return new MaybeObserveOn<T>(this, scheduler);
+    }
+
+    public final Maybe<T> onErrorReturn(final Function<? super Throwable, ? extends T> valueFunction) {
+        ObjectHelper.requireNonNull(valueFunction, "valueFunction is null");
+        return new MaybeOnErrorReturn<T>(this, valueFunction, null);
+    }
+    
+    public final Maybe<T> onErrorReturn(final T value) {
+        ObjectHelper.requireNonNull(value, "value is null");
+        return new MaybeOnErrorReturn<T>(this, null, value);
+    }
+
+    public final Maybe<T> onErrorResumeNext(
+            final Function<? super Throwable, ? extends MaybeSource<? extends T>> nextFunction) {
+        ObjectHelper.requireNonNull(nextFunction, "nextFunction is null");
+        return new MaybeOnErrorResumeNext<T>(this, nextFunction);
+    }
+    
+    public final Flowable<T> repeat() {
+        return toFlowable().repeat();
+    }
+    
+    public final Flowable<T> repeat(long times) {
+        return toFlowable().repeat(times);
+    }
+    
+    public final Flowable<T> repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
+        return toFlowable().repeatWhen(handler);
+    }
+    
+    public final Flowable<T> repeatUntil(BooleanSupplier stop) {
+        return toFlowable().repeatUntil(stop);
+    }
+    
+    public final Maybe<T> retry() {
+        return toFlowable().retry().toMaybe();
+    }
+    
+    public final Maybe<T> retry(long times) {
+        return toFlowable().retry(times).toMaybe();
+    }
+    
+    public final Maybe<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+        return toFlowable().retry(predicate).toMaybe();
+    }
+    
+    public final Maybe<T> retry(Predicate<? super Throwable> predicate) {
+        return toFlowable().retry(predicate).toMaybe();
+    }
+    
+    public final Maybe<T> retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
+        return toFlowable().retryWhen(handler).toMaybe();
+    }
+    
+    public final void safeSubscribe(Subscriber<? super T> s) {
+        toFlowable().safeSubscribe(s);
+    }
+    
+    public final Disposable subscribe() {
+        return subscribe(Functions.emptyConsumer(), Functions.EMPTY_ACTION, RxJavaPlugins.getErrorHandler());
+    }
+    
+    public final Disposable subscribe(Consumer<? super T> onSuccess) {
+        return subscribe(onSuccess, Functions.EMPTY_ACTION, RxJavaPlugins.getErrorHandler());
+    }
+    
+    public final Disposable subscribe(Consumer<? super T> onSuccess, final Action onComplete) {
+        return subscribe(onSuccess, onComplete, RxJavaPlugins.getErrorHandler());
+    }
+    
+    public final Disposable subscribe(final Consumer<? super T> onSuccess, final Action onComplete, final Consumer<? super Throwable> onError) {
+        ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        
+        ConsumerMaybeObserver<T> s = new ConsumerMaybeObserver<T>(onSuccess, onComplete, onError);
+        subscribe(s);
+        return s;
+    }
+    
+    @Override
+    public final void subscribe(MaybeObserver<? super T> subscriber) {
+        ObjectHelper.requireNonNull(subscriber, "subscriber is null");
+        // TODO plugin wrapper
+        subscribeActual(subscriber);
+    }
+    
+    protected abstract void subscribeActual(MaybeObserver<? super T> subscriber);
+    
+    public final void subscribe(Subscriber<? super T> s) {
+        toFlowable().subscribe(s);
+    }
+    
+    public final void subscribe(Observer<? super T> s) {
+        toObservable().subscribe(s);
+    }
+    
+    public final Maybe<T> subscribeOn(final Scheduler scheduler) {
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return new MaybeSubscribeOn<T>(this, scheduler);
+    }
+    
+    public final Maybe<T> timeout(long timeout, TimeUnit unit) {
+        return timeout0(timeout, unit, Schedulers.computation(), null);
+    }
+    
+    public final Maybe<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler) {
+        return timeout0(timeout, unit, scheduler, null);
+    }
+
+    public final Maybe<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler, MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return timeout0(timeout, unit, scheduler, other);
+    }
+
+    public final Maybe<T> timeout(long timeout, TimeUnit unit, MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return timeout0(timeout, unit, Schedulers.computation(), other);
+    }
+
+    private Maybe<T> timeout0(final long timeout, final TimeUnit unit, final Scheduler scheduler, final MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return new MaybeTimeout<T>(this, timeout, unit, scheduler, other);
+    }
+
+    public final <R> R to(Function<? super Maybe<T>, R> convert) {
+        try {
+            return convert.apply(this);
+        } catch (Throwable ex) {
+            throw Exceptions.propagate(ex);
+        }
+    }
+    
+    public final Flowable<T> toFlowable() {
+        return new MaybeToFlowable<T>(this);
+    }
+    
+    public final Observable<T> toObservable() {
+        return new MaybeToObservable<T>(this);
+    }
+    
+    public final <U, R> Maybe<R> zipWith(MaybeSource<U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+        return zip(this, other, zipper);
+    }
+}

--- a/src/main/java/io/reactivex/MaybeObserver.java
+++ b/src/main/java/io/reactivex/MaybeObserver.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.disposables.Disposable;
+
+public interface MaybeObserver<T> {
+    void onSubscribe(Disposable d);
+
+    void onSuccess(T value);
+
+    void onComplete();
+
+    void onError(Throwable e);
+}

--- a/src/main/java/io/reactivex/MaybeOperator.java
+++ b/src/main/java/io/reactivex/MaybeOperator.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.functions.Function;
+
+public interface MaybeOperator<Downstream, Upstream> extends Function<MaybeObserver<? super Downstream>, MaybeObserver<? super Upstream>> {
+
+}

--- a/src/main/java/io/reactivex/MaybeSource.java
+++ b/src/main/java/io/reactivex/MaybeSource.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex;
+
+/**
+ * Represents a basic {@link Single} source base interface,
+ * consumable via an {@link SingleObserver}.
+ * <p>
+ * This class also serves the base type for custom operators wrapped into
+ * Single via {@link Single#create(MaybeSource)}.
+ * 
+ * @param <T> the element type
+ * @since 2.0
+ */
+public interface MaybeSource<T> {
+
+    void subscribe(MaybeObserver<? super T> s);
+}

--- a/src/main/java/io/reactivex/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/MaybeTransformer.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.functions.Function;
+
+public interface MaybeTransformer<Upstream, Downstream> extends Function<Maybe<Upstream>, MaybeSource<Downstream>> {
+
+}

--- a/src/main/java/io/reactivex/functions/Supplier.java
+++ b/src/main/java/io/reactivex/functions/Supplier.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.functions;
+
+/**
+ * A functional interface (callback) that returns an Object value.
+ */
+public interface Supplier<R> {
+    /**
+     * Returns an Object value.
+     * @return an Object value
+     * @throws Exception on error
+     */
+    R get() throws Exception; // NOPMD
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeAmbArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeAmbArray.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeAmbArray<T> extends Maybe<T> {
+
+    final MaybeSource<? extends T>[] sources;
+    
+    public MaybeAmbArray(MaybeSource<? extends T>[] sources) {
+        this.sources = sources;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final AtomicBoolean once = new AtomicBoolean();
+        final CompositeDisposable set = new CompositeDisposable();
+        s.onSubscribe(set);
+        
+        for (MaybeSource<? extends T> s1 : sources) {
+            if (once.get()) {
+                return;
+            }
+            
+            if (s1 == null) {
+                set.dispose();
+                Throwable e = new NullPointerException("One of the sources is null");
+                if (once.compareAndSet(false, true)) {
+                    s.onError(e);
+                } else {
+                    RxJavaPlugins.onError(e);
+                }
+                return;
+            }
+            
+            s1.subscribe(new MaybeObserver<T>() {
+
+                @Override
+                public void onSubscribe(Disposable d) {
+                    set.add(d);
+                }
+
+                @Override
+                public void onSuccess(T value) {
+                    if (once.compareAndSet(false, true)) {
+                        s.onSuccess(value);
+                    }
+                }
+
+                @Override
+                public void onComplete() {
+                    if (once.compareAndSet(false, true)) {
+                        s.onComplete();
+                    }
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    if (once.compareAndSet(false, true)) {
+                        s.onError(e);
+                    } else {
+                        RxJavaPlugins.onError(e);
+                    }
+                }
+                
+            });
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeAmbIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeAmbIterable.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeAmbIterable<T> extends Maybe<T> {
+
+    final Iterable<? extends MaybeSource<? extends T>> sources;
+    
+    public MaybeAmbIterable(Iterable<? extends MaybeSource<? extends T>> sources) {
+        this.sources = sources;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+        final CompositeDisposable set = new CompositeDisposable();
+        s.onSubscribe(set);
+        
+        Iterator<? extends MaybeSource<? extends T>> iterator;
+        
+        try {
+            iterator = sources.iterator();
+        } catch (Throwable e) {
+            s.onError(e);
+            return;
+        }
+        
+        if (iterator == null) {
+            s.onError(new NullPointerException("The iterator returned is null"));
+            return;
+        }
+
+        final AtomicBoolean once = new AtomicBoolean();
+        int c = 0;
+        
+        for (;;) {
+            if (once.get()) {
+                return;
+            }
+            
+            boolean b;
+            
+            try {
+                b = iterator.hasNext();
+            } catch (Throwable e) {
+                s.onError(e);
+                return;
+            }
+            
+            if (once.get()) {
+                return;
+            }
+
+            if (!b) {
+                break;
+            }
+            
+            if (once.get()) {
+                return;
+            }
+
+            MaybeSource<? extends T> s1;
+
+            try {
+                s1 = iterator.next();
+            } catch (Throwable e) {
+                set.dispose();
+                s.onError(e);
+                return;
+            }
+            
+            if (s1 == null) {
+                set.dispose();
+                s.onError(new NullPointerException("The single source returned by the iterator is null"));
+                return;
+            }
+            
+            s1.subscribe(new MaybeObserver<T>() {
+
+                @Override
+                public void onSubscribe(Disposable d) {
+                    set.add(d);
+                }
+
+                @Override
+                public void onSuccess(T value) {
+                    if (once.compareAndSet(false, true)) {
+                        s.onSuccess(value);
+                    }
+                }
+
+                @Override
+                public void onComplete() {
+                    if (once.compareAndSet(false, true)) {
+                        s.onComplete();
+                    }
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    if (once.compareAndSet(false, true)) {
+                        s.onError(e);
+                    } else {
+                        RxJavaPlugins.onError(e);
+                    }
+                }
+                
+            });
+            c++;
+        }
+        
+        if (c == 0 && !set.isDisposed()) {
+            s.onError(new NoSuchElementException());
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeAwait.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeAwait.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.util.NotificationLite;
+
+public enum MaybeAwait {
+    ;
+    
+    public static <T> T get(MaybeSource<T> source, T defaultIfComplete) {
+        final AtomicReference<Object> valueRef = new AtomicReference<Object>();
+        final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
+        final CountDownLatch cdl = new CountDownLatch(1);
+        
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onError(Throwable e) {
+                errorRef.lazySet(e);
+                cdl.countDown();
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                valueRef.lazySet(NotificationLite.next(value));
+                cdl.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                valueRef.lazySet(NotificationLite.complete());
+            }
+        });
+        
+        if (cdl.getCount() != 0L) {
+            try {
+                cdl.await();
+            } catch (InterruptedException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+        Throwable e = errorRef.get();
+        if (e != null) {
+            throw Exceptions.propagate(e);
+        }
+
+        Object value = valueRef.get();
+        if (NotificationLite.isComplete(value))
+            return defaultIfComplete;
+        else
+            return NotificationLite.getValue(value);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCache.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCache.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.util.NotificationLite;
+
+public final class MaybeCache<T> extends Maybe<T> {
+
+    final MaybeSource<? extends T> source;
+    
+    final AtomicInteger wip;
+    final AtomicReference<Object> notification;
+    final List<MaybeObserver<? super T>> subscribers;
+
+    public MaybeCache(MaybeSource<? extends T> source) {
+        this.source = source;
+        this.wip = new AtomicInteger();
+        this.notification = new AtomicReference<Object>();
+        this.subscribers = new ArrayList<MaybeObserver<? super T>>();
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+
+        Object o = notification.get();
+        if (o != null) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            if (NotificationLite.isError(o)) {
+                s.onError(NotificationLite.getError(o));
+            } else {
+                s.onSuccess(NotificationLite.<T>getValue(o));
+            }
+            return;
+        }
+        
+        synchronized (subscribers) {
+            o = notification.get();
+            if (o == null) {
+                subscribers.add(s);
+            }
+        }
+        if (o != null) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            if (NotificationLite.isError(o)) {
+                s.onError(NotificationLite.getError(o));
+            } else {
+                s.onSuccess(NotificationLite.<T>getValue(o));
+            }
+            return;
+        }
+        
+        if (wip.getAndIncrement() != 0) {
+            return;
+        }
+        
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                notification.set(NotificationLite.next(value));
+                List<MaybeObserver<? super T>> list;
+                synchronized (subscribers) {
+                    list = new ArrayList<MaybeObserver<? super T>>(subscribers);
+                    subscribers.clear();
+                }
+                for (MaybeObserver<? super T> s1 : list) {
+                    s1.onSuccess(value);
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                notification.set(NotificationLite.complete());
+                List<MaybeObserver<? super T>> list;
+                synchronized (subscribers) {
+                    list = new ArrayList<MaybeObserver<? super T>>(subscribers);
+                    subscribers.clear();
+                }
+                for (MaybeObserver<? super T> s1 : list) {
+                    s1.onComplete();
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                notification.set(NotificationLite.error(e));
+                List<MaybeObserver<? super T>> list;
+                synchronized (subscribers) {
+                    list = new ArrayList<MaybeObserver<? super T>>(subscribers);
+                    subscribers.clear();
+                }
+                for (MaybeObserver<? super T> s1 : list) {
+                    s1.onError(e);
+                }
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeComplete.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+public final class MaybeComplete extends Maybe<Object> {
+    public static final Maybe<Object> INSTANCE = new MaybeComplete();
+
+    private MaybeComplete() {
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super Object> s) {
+        s.onSubscribe(EmptyDisposable.INSTANCE);
+        s.onComplete();
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeContains.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeContains.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiPredicate;
+
+public final class MaybeContains<T> extends Maybe<Boolean> {
+
+    final MaybeSource<T> source;
+    
+    final Object value;
+    
+    final BiPredicate<Object, Object> comparer;
+    
+    public MaybeContains(MaybeSource<T> source, Object value, BiPredicate<Object, Object> comparer) {
+        this.source = source;
+        this.value = value;
+        this.comparer = comparer;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super Boolean> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onSuccess(T v) {
+                boolean b;
+                
+                try {
+                    b = comparer.test(v, value);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    s.onError(ex);
+                    return;
+                }
+                s.onSuccess(b);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onSuccess(false);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDefer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+public final class MaybeDefer<T> extends Maybe<T> {
+
+    final Callable<? extends MaybeSource<? extends T>> maybeSupplier;
+    
+    public MaybeDefer(Callable<? extends MaybeSource<? extends T>> maybeSupplier) {
+        this.maybeSupplier = maybeSupplier;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+        MaybeSource<? extends T> next;
+        
+        try {
+            next = maybeSupplier.call();
+        } catch (Throwable e) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            s.onError(e);
+            return;
+        }
+        
+        if (next == null) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            s.onError(new NullPointerException("The Maybe supplied was null"));
+            return;
+        }
+        
+        next.subscribe(s);
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelay.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+
+public final class MaybeDelay<T> extends Maybe<T> {
+
+    
+    final MaybeSource<? extends T> source;
+    final long time;
+    final TimeUnit unit;
+    final Scheduler scheduler;
+    
+    public MaybeDelay(MaybeSource<? extends T> source, long time, TimeUnit unit, Scheduler scheduler) {
+        this.source = source;
+        this.time = time;
+        this.unit = unit;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final SerialDisposable sd = new SerialDisposable();
+        s.onSubscribe(sd);
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                sd.replace(d);
+            }
+
+            @Override
+            public void onSuccess(final T value) {
+                sd.replace(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onSuccess(value);
+                    }
+                }, time, unit));
+            }
+
+            @Override
+            public void onComplete() {
+                sd.replace(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onComplete();
+                    }
+                }, time, unit));
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithCompletable.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+public final class MaybeDelayWithCompletable<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final CompletableSource other;
+    
+    public MaybeDelayWithCompletable(MaybeSource<T> source, CompletableSource other) {
+        this.source = source;
+        this.other = other;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
+        other.subscribe(new OtherObserver<T>(subscriber, source));
+    }
+    
+    static final class OtherObserver<T>
+    extends AtomicReference<Disposable>
+    implements CompletableObserver, Disposable {
+        
+        /** */
+        private static final long serialVersionUID = -8565274649390031272L;
+
+        final MaybeObserver<? super T> actual;
+        
+        final MaybeSource<T> source;
+
+        public OtherObserver(MaybeObserver<? super T> actual, MaybeSource<T> source) {
+            this.actual = actual;
+            this.source = source;
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.set(this, d)) {
+                
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onComplete() {
+            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+    
+    static final class DelayWithMainObserver<T> implements MaybeObserver<T> {
+        
+        final AtomicReference<Disposable> parent;
+        
+        final MaybeObserver<? super T> actual;
+
+        public DelayWithMainObserver(AtomicReference<Disposable> parent, MaybeObserver<? super T> actual) {
+            this.parent = parent;
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.replace(parent, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithMaybe.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.operators.maybe.MaybeDelayWithCompletable.DelayWithMainObserver;
+
+public final class MaybeDelayWithMaybe<T, U> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final MaybeSource<U> other;
+    
+    public MaybeDelayWithMaybe(MaybeSource<T> source, MaybeSource<U> other) {
+        this.source = source;
+        this.other = other;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
+        other.subscribe(new OtherObserver<T, U>(subscriber, source));
+    }
+    
+    static final class OtherObserver<T, U>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<U>, Disposable {
+        
+        /** */
+        private static final long serialVersionUID = -8565274649390031272L;
+
+        final MaybeObserver<? super T> actual;
+
+        final MaybeSource<T> source;
+
+        boolean done;
+
+        public OtherObserver(MaybeObserver<? super T> actual, MaybeSource<T> source) {
+            this.actual = actual;
+            this.source = source;
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.set(this, d)) {
+                
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onSuccess(U value) {
+            if (done) {
+                return;
+            }
+            done = true;
+            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithObservable.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.operators.maybe.MaybeDelayWithCompletable.DelayWithMainObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeDelayWithObservable<T, U> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final ObservableSource<U> other;
+    
+    public MaybeDelayWithObservable(MaybeSource<T> source, ObservableSource<U> other) {
+        this.source = source;
+        this.other = other;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
+        other.subscribe(new OtherSubscriber<T, U>(subscriber, source));
+    }
+    
+    static final class OtherSubscriber<T, U> 
+    extends AtomicReference<Disposable>
+    implements Observer<U>, Disposable {
+        
+        /** */
+        private static final long serialVersionUID = -8565274649390031272L;
+
+        final MaybeObserver<? super T> actual;
+        
+        final MaybeSource<T> source;
+
+        boolean done;
+        
+        public OtherSubscriber(MaybeObserver<? super T> actual, MaybeSource<T> source) {
+            this.actual = actual;
+            this.source = source;
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.set(this, d)) {
+                
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onNext(U value) {
+            get().dispose();
+            onComplete();
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            done = true;
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithPublisher.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.operators.maybe.MaybeDelayWithCompletable.DelayWithMainObserver;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeDelayWithPublisher<T, U> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final Publisher<U> other;
+    
+    public MaybeDelayWithPublisher(MaybeSource<T> source, Publisher<U> other) {
+        this.source = source;
+        this.other = other;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
+        other.subscribe(new OtherSubscriber<T, U>(subscriber, source));
+    }
+    
+    static final class OtherSubscriber<T, U> 
+    extends AtomicReference<Disposable>
+    implements Subscriber<U>, Disposable {
+        
+        /** */
+        private static final long serialVersionUID = -8565274649390031272L;
+
+        final MaybeObserver<? super T> actual;
+        
+        final MaybeSource<T> source;
+
+        boolean done;
+        
+        Subscription s;
+        
+        public OtherSubscriber(MaybeObserver<? super T> actual, MaybeSource<T> source) {
+            this.actual = actual;
+            this.source = source;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+                
+                s.request(Long.MAX_VALUE);
+            }
+        }
+        
+        @Override
+        public void onNext(U value) {
+            get().dispose();
+            onComplete();
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            done = true;
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+        }
+        
+        @Override
+        public void dispose() {
+            s.cancel();
+            DisposableHelper.dispose(this);
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithSingle.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.operators.maybe.MaybeDelayWithCompletable.DelayWithMainObserver;
+
+public final class MaybeDelayWithSingle<T, U> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final SingleSource<U> other;
+    
+    public MaybeDelayWithSingle(MaybeSource<T> source, SingleSource<U> other) {
+        this.source = source;
+        this.other = other;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
+        other.subscribe(new OtherObserver<T, U>(subscriber, source));
+    }
+    
+    static final class OtherObserver<T, U>
+    extends AtomicReference<Disposable>
+    implements SingleObserver<U>, Disposable {
+        
+        /** */
+        private static final long serialVersionUID = -8565274649390031272L;
+
+        final MaybeObserver<? super T> actual;
+        
+        final MaybeSource<T> source;
+
+        public OtherObserver(MaybeObserver<? super T> actual, MaybeSource<T> source) {
+            this.actual = actual;
+            this.source = source;
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.set(this, d)) {
+                
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onSuccess(U value) {
+            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+        
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnCancel.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnCancel.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.functions.Action;
+
+public final class MaybeDoOnCancel<T> extends Maybe<T> {
+    final MaybeSource<T> source;
+
+    final Action onCancel;
+
+    public MaybeDoOnCancel(MaybeSource<T> source, Action onCancel) {
+        this.source = source;
+        this.onCancel = onCancel;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                CompositeDisposable set = new CompositeDisposable();
+                set.add(Disposables.from(onCancel));
+                set.add(d);
+                s.onSubscribe(set);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnComplete.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Action;
+
+public class MaybeDoOnComplete<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+
+    final Action onComplete;
+
+    public MaybeDoOnComplete(MaybeSource<T> source, Action onComplete) {
+        this.source = source;
+        this.onComplete = onComplete;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                try {
+                    onComplete.run();
+                } catch (Throwable ex) {
+                    s.onError(ex);
+                    return;
+                }
+                s.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnError.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnError.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.functions.Consumer;
+
+public final class MaybeDoOnError<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final Consumer<? super Throwable> onError;
+    
+    public MaybeDoOnError(MaybeSource<T> source, Consumer<? super Throwable> onError) {
+        this.source = source;
+        this.onError = onError;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                try {
+                    onError.accept(e);
+                } catch (Throwable ex) {
+                    e = new CompositeException(ex, e);
+                }
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnSubscribe.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeDoOnSubscribe<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final Consumer<? super Disposable> onSubscribe;
+    
+    public MaybeDoOnSubscribe(MaybeSource<T> source, Consumer<? super Disposable> onSubscribe) {
+        this.source = source;
+        this.onSubscribe = onSubscribe;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+            boolean done;
+            @Override
+            public void onSubscribe(Disposable d) {
+                try {
+                    onSubscribe.accept(d);
+                } catch (Throwable ex) {
+                    done = true;
+                    d.dispose();
+                    s.onSubscribe(EmptyDisposable.INSTANCE);
+                    s.onError(ex);
+                    return;
+                }
+                
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                if (done) {
+                    return;
+                }
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                if (done) {
+                    return;
+                }
+                s.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                if (done) {
+                    RxJavaPlugins.onError(e);
+                    return;
+                }
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoOnSuccess.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
+
+public class MaybeDoOnSuccess<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final Consumer<? super T> onSuccess;
+    
+    public MaybeDoOnSuccess(MaybeSource<T> source, Consumer<? super T> onSuccess) {
+        this.source = source;
+        this.onSuccess = onSuccess;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                try {
+                    onSuccess.accept(value);
+                } catch (Throwable ex) {
+                    s.onError(ex);
+                    return;
+                }
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeEquals.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeEquals.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeEquals<T> extends Maybe<Boolean> {
+
+    final MaybeSource<? extends T> first;
+    final MaybeSource<? extends T> second;
+    
+    public MaybeEquals(MaybeSource<? extends T> first, MaybeSource<? extends T> second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super Boolean> s) {
+
+        final AtomicInteger count = new AtomicInteger();
+        final Object[] values = { null, null };
+        
+        final CompositeDisposable set = new CompositeDisposable();
+        s.onSubscribe(set);
+        
+        class InnerObserver implements MaybeObserver<T> {
+            final int index;
+            public InnerObserver(int index) {
+                this.index = index;
+            }
+            @Override
+            public void onSubscribe(Disposable d) {
+                set.add(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                values[index] = value;
+                
+                if (count.incrementAndGet() == 2) {
+                    s.onSuccess(ObjectHelper.equals(values[0], values[1]));
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                values[index] = Notification.createOnComplete();
+
+                if (count.incrementAndGet() == 2) {
+                    s.onSuccess(ObjectHelper.equals(values[0], values[1]));
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                for (;;) {
+                    int state = count.get();
+                    if (state >= 2) {
+                        RxJavaPlugins.onError(e);
+                        return;
+                    }
+                    if (count.compareAndSet(state, 2)) {
+                        s.onError(e);
+                        return;
+                    }
+                }
+            }
+            
+        }
+        
+        first.subscribe(new InnerObserver(0));
+        second.subscribe(new InnerObserver(1));
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeError.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeError.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+public final class MaybeError<T> extends Maybe<T> {
+
+    final Callable<? extends Throwable> errorSupplier;
+    
+    public MaybeError(Callable<? extends Throwable> errorSupplier) {
+        this.errorSupplier = errorSupplier;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+        Throwable error;
+        
+        try {
+            error = errorSupplier.call();
+        } catch (Throwable e) {
+            error = e;
+        }
+        
+        if (error == null) {
+            error = new NullPointerException();
+        }
+        
+        s.onSubscribe(EmptyDisposable.INSTANCE);
+        s.onError(error);
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMap.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.functions.Function;
+
+public final class MaybeFlatMap<T, R> extends Maybe<R> {
+    final MaybeSource<? extends T> source;
+    
+    final Function<? super T, ? extends MaybeSource<? extends R>> mapper;
+
+    public MaybeFlatMap(MaybeSource<? extends T> source, Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+        this.mapper = mapper;
+        this.source = source;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super R> subscriber) {
+        MaybeFlatMapCallback<T, R> parent = new MaybeFlatMapCallback<T, R>(subscriber, mapper);
+        subscriber.onSubscribe(parent.sd);
+        source.subscribe(parent);
+    }
+    
+    static final class MaybeFlatMapCallback<T, R> implements MaybeObserver<T> {
+        final MaybeObserver<? super R> actual;
+        final Function<? super T, ? extends MaybeSource<? extends R>> mapper;
+        
+        final SerialDisposable sd;
+
+        public MaybeFlatMapCallback(MaybeObserver<? super R> actual,
+                Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.sd = new SerialDisposable();
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            sd.replace(d);
+        }
+        
+        @Override
+        public void onSuccess(T value) {
+            MaybeSource<? extends R> o;
+            
+            try {
+                o = mapper.apply(value);
+            } catch (Throwable e) {
+                actual.onError(e);
+                return;
+            }
+            
+            if (o == null) {
+                actual.onError(new NullPointerException("The single returned by the mapper is null"));
+                return;
+            }
+            
+            if (sd.isDisposed()) {
+                return;
+            }
+            
+            o.subscribe(new MaybeObserver<R>() {
+                @Override
+                public void onSubscribe(Disposable d) {
+                    sd.replace(d);
+                }
+                
+                @Override
+                public void onSuccess(R value) {
+                    actual.onSuccess(value);
+                }
+
+                @Override
+                public void onComplete() {
+                    actual.onComplete();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    actual.onError(e);
+                }
+            });
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromCallable.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+public final class MaybeFromCallable<T> extends Maybe<T> {
+
+    final Callable<? extends T> callable;
+    
+    public MaybeFromCallable(Callable<? extends T> callable) {
+        this.callable = callable;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+
+        s.onSubscribe(EmptyDisposable.INSTANCE);
+        try {
+            T v = callable.call();
+            if (v != null) {
+                s.onSuccess(v);
+            } else {
+                s.onComplete();
+            }
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            s.onError(e);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromObservable.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.disposables.Disposable;
+
+public final class MaybeFromObservable<T> extends Maybe<T> {
+    private final Observable<T> upstream;
+
+    public MaybeFromObservable(Observable<T> upstream) {
+        this.upstream = upstream;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+        upstream.subscribe(new Observer<T>() {
+            T last;
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+            @Override
+            public void onNext(T value) {
+                last = value;
+            }
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            @Override
+            public void onComplete() {
+                T v = last;
+                last = null;
+                if (v != null) {
+                    s.onSuccess(v);
+                } else {
+                    s.onComplete();
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromPublisher.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeFromPublisher<T> extends Maybe<T> {
+
+    final Publisher<? extends T> publisher;
+    
+    public MaybeFromPublisher(Publisher<? extends T> publisher) {
+        this.publisher = publisher;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+        publisher.subscribe(new ToMaybeSubscriber<T>(s));
+    }
+    
+    static final class ToMaybeSubscriber<T> implements Subscriber<T>, Disposable {
+        final MaybeObserver<? super T> actual;
+        
+        Subscription s;
+        
+        T value;
+        
+        boolean done;
+        
+        volatile boolean disposed;
+
+        public ToMaybeSubscriber(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+        
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+                
+                s.request(Long.MAX_VALUE);
+            }
+        }
+        
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            if (value != null) {
+                s.cancel();
+                done = true;
+                this.value = null;
+                actual.onError(new IndexOutOfBoundsException("Too many elements in the Publisher"));
+            } else {
+                value = t;
+            }
+        }
+        
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            this.value = null;
+            actual.onError(t);
+        }
+        
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            T v = this.value;
+            this.value = null;
+            if (v == null) {
+                actual.onComplete();
+            } else {
+                actual.onSuccess(v);
+            }
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+        
+        @Override
+        public void dispose() {
+            disposed = true;
+            s.cancel();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromSource.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromSource.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.disposables.Disposable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class MaybeFromSource<T> extends Maybe<T> {
+    private final MaybeSource<T> source;
+
+    public MaybeFromSource(MaybeSource<T> source) {
+        this.source = source;
+    }
+
+    @Override protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new DisposeAwareMaybeObserver<T>(observer));
+    }
+
+    /**
+     * An observer which does not send downstream notifications once disposed. Used to guard against
+     * naive implementations of {@link MaybeSource} which do not check for this.
+     */
+    static final class DisposeAwareMaybeObserver<T>
+    extends AtomicBoolean
+    implements MaybeObserver<T>, Disposable {
+        private final MaybeObserver<? super T> o;
+        private Disposable d;
+
+        DisposeAwareMaybeObserver(MaybeObserver<? super T> o) {
+            this.o = o;
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            if (!get()) {
+                o.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!get()) {
+                o.onComplete();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (!get()) {
+                o.onError(e);
+            }
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            this.d = d;
+            o.onSubscribe(this);
+        }
+
+        @Override
+        public void dispose() {
+            if (compareAndSet(false, true)) {
+                d.dispose();
+                d = null;
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromUnsafeSource.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromUnsafeSource.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+
+public final class MaybeFromUnsafeSource<T> extends Maybe<T> {
+    final MaybeSource<T> source;
+
+    public MaybeFromUnsafeSource(MaybeSource<T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(observer);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeHide.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeHide.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+public final class MaybeHide<T> extends Maybe<T> {
+
+    final MaybeSource<? extends T> source;
+    
+    public MaybeHide(MaybeSource<? extends T> source) {
+        this.source = source;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
+        source.subscribe(new HideMaybeObserver<T>(subscriber));
+    }
+    
+    static final class HideMaybeObserver<T> implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super T> actual;
+        
+        Disposable d;
+        
+        public HideMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeInternalHelper.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+/**
+ * Helper utility class to support Maybe with inner classes.
+ */
+public enum MaybeInternalHelper {
+    ;
+
+    enum NoSuchElementCallable implements Callable<NoSuchElementException> {
+        INSTANCE;
+        
+        @Override
+        public NoSuchElementException call() throws Exception {
+            return new NoSuchElementException();
+        }
+    }
+    
+    public static <T> Callable<NoSuchElementException> emptyThrower() {
+        return NoSuchElementCallable.INSTANCE;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    enum ToFlowable implements Function<MaybeSource, Publisher> {
+        INSTANCE;
+        @SuppressWarnings("unchecked")
+        @Override 
+        public Publisher apply(MaybeSource v){
+            return new MaybeToFlowable(v);
+        }
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Function<MaybeSource<? extends T>, Publisher<? extends T>> toFlowable() {
+        return (Function)ToFlowable.INSTANCE;
+    }
+
+    static final class ToFlowableIterator<T> implements Iterator<Flowable<T>> {
+        private final Iterator<? extends MaybeSource<? extends T>> sit;
+
+        ToFlowableIterator(Iterator<? extends MaybeSource<? extends T>> sit) {
+            this.sit = sit;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return sit.hasNext();
+        }
+
+        @Override
+        public Flowable<T> next() {
+            return new MaybeToFlowable<T>(sit.next());
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static final class ToFlowableIterable<T> implements Iterable<Flowable<T>> {
+
+        private final Iterable<? extends MaybeSource<? extends T>> sources;
+
+        ToFlowableIterable(Iterable<? extends MaybeSource<? extends T>> sources) {
+            this.sources = sources;
+        }
+
+        @Override
+        public Iterator<Flowable<T>> iterator() {
+            return new ToFlowableIterator<T>(sources.iterator());
+        }
+    }
+
+    public static <T> Iterable<? extends Flowable<T>> iterableToFlowable(final Iterable<? extends MaybeSource<? extends T>> sources) {
+        return new ToFlowableIterable<T>(sources);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeJust.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeJust.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+public final class MaybeJust<T> extends Maybe<T> {
+
+    final T value;
+    
+    public MaybeJust(T value) {
+        this.value = value;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+        s.onSubscribe(EmptyDisposable.INSTANCE);
+        s.onSuccess(value);
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeLift.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeLift.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeLift<T, R> extends Maybe<R> {
+
+    final MaybeSource<T> source;
+    
+    final MaybeOperator<? extends R, ? super T> onLift;
+    
+    public MaybeLift(MaybeSource<T> source, MaybeOperator<? extends R, ? super T> onLift) {
+        this.source = source;
+        this.onLift = onLift;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super R> s) {
+        try {
+            MaybeObserver<? super T> sr = onLift.apply(s);
+            
+            if (sr == null) {
+                throw new NullPointerException("The onLift returned a null subscriber");
+            }
+            // TODO plugin wrapper
+            source.subscribe(sr);
+        } catch (NullPointerException ex) { // NOPMD
+            throw ex;
+        } catch (Throwable ex) {
+            RxJavaPlugins.onError(ex);
+            NullPointerException npe = new NullPointerException("Not really but can't throw other than NPE");
+            npe.initCause(ex);
+            throw npe;
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeMap.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeMap.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Function;
+
+public final class MaybeMap<T, R> extends Maybe<R> {
+    final MaybeSource<? extends T> source;
+    
+    final Function<? super T, ? extends R> mapper;
+
+    public MaybeMap(MaybeSource<? extends T> source, Function<? super T, ? extends R> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super R> t) {
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                t.onSubscribe(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                R v;
+                try {
+                    v = mapper.apply(value);
+                } catch (Throwable e) {
+                    onError(e);
+                    return;
+                }
+                
+                t.onSuccess(v);
+            }
+
+            @Override
+            public void onComplete() {
+                t.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                t.onError(e);
+            }
+        });
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeNever.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeNever.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+public final class MaybeNever extends Maybe<Object> {
+    public static final Maybe<Object> INSTANCE = new MaybeNever();
+
+    private MaybeNever() {
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super Object> s) {
+        s.onSubscribe(EmptyDisposable.INSTANCE);
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeObserveOn.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+
+public final class MaybeObserveOn<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+
+    final Scheduler scheduler;
+    
+    public MaybeObserveOn(MaybeSource<T> source, Scheduler scheduler) {
+        this.source = source;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final CompositeDisposable mad = new CompositeDisposable();
+        s.onSubscribe(mad);
+        
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onError(final Throwable e) {
+                mad.add(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onError(e);
+                    }
+                }));
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                mad.add(d);
+            }
+
+            @Override
+            public void onSuccess(final T value) {
+                mad.add(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onSuccess(value);
+                    }
+                }));
+            }
+
+            @Override
+            public void onComplete() {
+                mad.add(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onComplete();
+                    }
+                }));
+            }
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnCompleteResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnCompleteResumeNext.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.functions.Supplier;
+
+public final class MaybeOnCompleteResumeNext<T> extends Maybe<T> {
+    final MaybeSource<? extends T> source;
+    
+    final Supplier<? extends MaybeSource<? extends T>> nextSupplier;
+    
+    public MaybeOnCompleteResumeNext(MaybeSource<? extends T> source,
+            Supplier<? extends MaybeSource<? extends T>> nextSupplier) {
+        this.source = source;
+        this.nextSupplier = nextSupplier;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final SerialDisposable sd = new SerialDisposable();
+        s.onSubscribe(sd);
+        
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                sd.replace(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                MaybeSource<? extends T> next;
+                
+                try {
+                    next = nextSupplier.get();
+                } catch (Throwable ex) {
+                    s.onError(ex);
+                    return;
+                }
+                
+                if (next == null) {
+                    NullPointerException npe = new NullPointerException("The next Maybe supplied was null");
+                    s.onError(npe);
+                    return;
+                }
+                
+                next.subscribe(new MaybeObserver<T>() {
+
+                    @Override
+                    public void onSubscribe(Disposable d) {
+                        sd.replace(d);
+                    }
+
+                    @Override
+                    public void onSuccess(T value) {
+                        s.onSuccess(value);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        s.onComplete();
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        s.onError(e);
+                    }
+                    
+                });
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                s.onError(e);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorComplete.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+
+public final class MaybeOnErrorComplete<T> extends Maybe<T> {
+    final MaybeSource<? extends T> source;
+
+    final Callable<? extends T> valueSupplier;
+    
+    final T value;
+    
+    public MaybeOnErrorComplete(MaybeSource<? extends T> source, Callable<? extends T> valueSupplier, T value) {
+        this.source = source;
+        this.valueSupplier = valueSupplier;
+        this.value = value;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onError(Throwable e) {
+                T v;
+
+                if (valueSupplier != null) {
+                    try {
+                        v = valueSupplier.call();
+                    } catch (Throwable ex) {
+                        s.onError(new CompositeException(ex, e));
+                        return;
+                    }
+                } else {
+                    v = value;
+                }
+                
+                if (v == null) {
+                    NullPointerException npe = new NullPointerException("Value supplied was null");
+                    npe.initCause(e);
+                    s.onError(npe);
+                    return;
+                }
+                
+                s.onSuccess(v);
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onComplete();
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorResumeNext.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.functions.Function;
+
+public final class MaybeOnErrorResumeNext<T> extends Maybe<T> {
+    final MaybeSource<? extends T> source;
+    
+    final Function<? super Throwable, ? extends MaybeSource<? extends T>> nextFunction;
+    
+    public MaybeOnErrorResumeNext(MaybeSource<? extends T> source,
+            Function<? super Throwable, ? extends MaybeSource<? extends T>> nextFunction) {
+        this.source = source;
+        this.nextFunction = nextFunction;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final SerialDisposable sd = new SerialDisposable();
+        s.onSubscribe(sd);
+        
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                sd.replace(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                MaybeSource<? extends T> next;
+                
+                try {
+                    next = nextFunction.apply(e);
+                } catch (Throwable ex) {
+                    s.onError(new CompositeException(ex, e));
+                    return;
+                }
+                
+                if (next == null) {
+                    NullPointerException npe = new NullPointerException("The next Maybe supplied was null");
+                    npe.initCause(e);
+                    s.onError(npe);
+                    return;
+                }
+                
+                next.subscribe(new MaybeObserver<T>() {
+
+                    @Override
+                    public void onSubscribe(Disposable d) {
+                        sd.replace(d);
+                    }
+
+                    @Override
+                    public void onSuccess(T value) {
+                        s.onSuccess(value);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        s.onComplete();
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        s.onError(e);
+                    }
+                    
+                });
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorReturn.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.functions.Function;
+
+public final class MaybeOnErrorReturn<T> extends Maybe<T> {
+    final MaybeSource<? extends T> source;
+
+    final Function<? super Throwable, ? extends T> valueFunction;
+    
+    final T value;
+    
+    public MaybeOnErrorReturn(MaybeSource<? extends T> source, Function<? super Throwable, ? extends T> valueFunction, T value) {
+        this.source = source;
+        this.valueFunction = valueFunction;
+        this.value = value;
+    }
+
+
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onError(Throwable e) {
+                T v;
+
+                if (valueFunction != null) {
+                    try {
+                        v = valueFunction.apply(e);
+                    } catch (Throwable ex) {
+                        s.onError(new CompositeException(ex, e));
+                        return;
+                    }
+                } else {
+                    v = value;
+                }
+                
+                if (v == null) {
+                    NullPointerException npe = new NullPointerException("Value supplied was null");
+                    npe.initCause(e);
+                    s.onError(npe);
+                    return;
+                }
+                
+                s.onSuccess(v);
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                s.onSubscribe(d);
+            }
+
+            @Override
+            public void onComplete() {
+                s.onComplete();
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                s.onSuccess(value);
+            }
+            
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeSubscribeOn.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+
+public final class MaybeSubscribeOn<T> extends Maybe<T> {
+    final MaybeSource<? extends T> source;
+
+    final Scheduler scheduler;
+    
+    public MaybeSubscribeOn(MaybeSource<? extends T> source, Scheduler scheduler) {
+        this.source = source;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        // FIXME cancel schedule
+        scheduler.scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                source.subscribe(s);
+            }
+        });
+    
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeout.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+
+public final class MaybeTimeout<T> extends Maybe<T> {
+
+    final MaybeSource<T> source;
+    
+    final long timeout;
+    
+    final TimeUnit unit;
+    
+    final Scheduler scheduler;
+    
+    final MaybeSource<? extends T> other;
+    
+    public MaybeTimeout(MaybeSource<T> source, long timeout, TimeUnit unit, Scheduler scheduler,
+                         MaybeSource<? extends T> other) {
+        this.source = source;
+        this.timeout = timeout;
+        this.unit = unit;
+        this.scheduler = scheduler;
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final CompositeDisposable set = new CompositeDisposable();
+        s.onSubscribe(set);
+        
+        final AtomicBoolean once = new AtomicBoolean();
+        
+        Disposable timer = scheduler.scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                if (once.compareAndSet(false, true)) {
+                    if (other != null) {
+                        set.clear();
+                        other.subscribe(new MaybeObserver<T>() {
+
+                            @Override
+                            public void onError(Throwable e) {
+                                set.dispose();
+                                s.onError(e);
+                            }
+
+                            @Override
+                            public void onSubscribe(Disposable d) {
+                                set.add(d);
+                            }
+
+                            @Override
+                            public void onSuccess(T value) {
+                                set.dispose();
+                                s.onSuccess(value);
+                            }
+
+                            @Override
+                            public void onComplete() {
+                                set.dispose();
+                                s.onComplete();
+                            }
+                        });
+                    } else {
+                        set.dispose();
+                        s.onError(new TimeoutException());
+                    }
+                }
+            }
+        }, timeout, unit);
+        
+        set.add(timer);
+        
+        source.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onError(Throwable e) {
+                if (once.compareAndSet(false, true)) {
+                    set.dispose();
+                    s.onError(e);
+                }
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                set.add(d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                if (once.compareAndSet(false, true)) {
+                    set.dispose();
+                    s.onSuccess(value);
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                if (once.compareAndSet(false, true)) {
+                    set.dispose();
+                    s.onComplete();
+                }
+            }
+        });
+    
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimer.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.*;
+import io.reactivex.disposables.SerialDisposable;
+
+public final class MaybeTimer extends Maybe<Long> {
+
+    final long delay;
+    final TimeUnit unit;
+    final Scheduler scheduler;
+    
+    public MaybeTimer(long delay, TimeUnit unit, Scheduler scheduler) {
+        this.delay = delay;
+        this.unit = unit;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super Long> s) {
+        SerialDisposable sd = new SerialDisposable();
+        
+        s.onSubscribe(sd);
+        
+        sd.replace(scheduler.scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                s.onSuccess(0L);
+            }
+        }, delay, unit));
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeToFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeToFlowable.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.maybe;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.DeferredScalarSubscription;
+
+/**
+ * Wraps a Maybe and exposes it as a Flowable.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeToFlowable<T> extends Flowable<T> {
+    
+    final MaybeSource<? extends T> source;
+    
+    public MaybeToFlowable(MaybeSource<? extends T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    public void subscribeActual(final Subscriber<? super T> s) {
+        source.subscribe(new MaybeToFlowableObserver<T>(s));
+    }
+    
+    static final class MaybeToFlowableObserver<T> extends DeferredScalarSubscription<T>
+    implements MaybeObserver<T> {
+
+        /** */
+        private static final long serialVersionUID = 187782011903685568L;
+        
+        Disposable d;
+        
+        public MaybeToFlowableObserver(Subscriber<? super T> actual) {
+            super(actual);
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            complete(value);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            d.dispose();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Wraps a Maybe and exposes it as a Flowable.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeToObservable<T> extends Observable<T> {
+    
+    final MaybeSource<? extends T> source;
+    
+    public MaybeToObservable(MaybeSource<? extends T> source) {
+        this.source = source;
+    }
+    
+    @Override
+    public void subscribeActual(final Observer<? super T> s) {
+        source.subscribe(new MaybeToObservableObserver<T>(s));
+    }
+    
+    static final class MaybeToObservableObserver<T> 
+    implements MaybeObserver<T>, Disposable {
+
+        final Observer<? super T> actual;
+        
+        Disposable d;
+        
+        public MaybeToObservableObserver(Observer<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onNext(value);
+            actual.onComplete();
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeUsing.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class MaybeUsing<T, U> extends Maybe<T> {
+
+    final Callable<U> resourceSupplier;
+    final Function<? super U, ? extends MaybeSource<? extends T>> maybeFunction;
+    final Consumer<? super U> disposer;
+    final boolean eager;
+
+    public MaybeUsing(Callable<U> resourceSupplier, Function<? super U, ? extends MaybeSource<? extends T>> maybeFunction, Consumer<? super U> disposer, boolean eager) {
+        this.resourceSupplier = resourceSupplier;
+        this.maybeFunction = maybeFunction;
+        this.disposer = disposer;
+        this.eager = eager;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> s) {
+
+        final U resource; // NOPMD
+
+        try {
+            resource = resourceSupplier.call();
+        } catch (Throwable ex) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            s.onError(ex);
+            return;
+        }
+
+        MaybeSource<? extends T> s1;
+
+        try {
+            s1 = maybeFunction.apply(resource);
+        } catch (Throwable ex) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            s.onError(ex);
+            return;
+        }
+
+        if (s1 == null) {
+            s.onSubscribe(EmptyDisposable.INSTANCE);
+            s.onError(new NullPointerException("The Maybe supplied by the function was null"));
+            return;
+        }
+
+        s1.subscribe(new MaybeObserver<T>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                if (eager) {
+                    CompositeDisposable set = new CompositeDisposable();
+                    set.add(d);
+                    set.add(Disposables.from(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                disposer.accept(resource);
+                            } catch (Throwable e) {
+                                RxJavaPlugins.onError(e);
+                            }
+                        }
+                    }));
+                } else {
+                    s.onSubscribe(d);
+                }
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                if (eager) {
+                    try {
+                        disposer.accept(resource);
+                    } catch (Throwable e) {
+                        s.onError(e);
+                        return;
+                    }
+                }
+                s.onSuccess(value);
+                if (!eager) {
+                    try {
+                        disposer.accept(resource);
+                    } catch (Throwable e) {
+                        RxJavaPlugins.onError(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                if (eager) {
+                    try {
+                        disposer.accept(resource);
+                    } catch (Throwable e) {
+                        s.onError(e);
+                        return;
+                    }
+                }
+                s.onComplete();
+                if (!eager) {
+                    try {
+                        disposer.accept(resource);
+                    } catch (Throwable e) {
+                        RxJavaPlugins.onError(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                if (eager) {
+                    try {
+                        disposer.accept(resource);
+                    } catch (Throwable ex) {
+                        e = new CompositeException(ex, e);
+                    }
+                }
+                s.onError(e);
+                if (!eager) {
+                    try {
+                        disposer.accept(resource);
+                    } catch (Throwable ex) {
+                        RxJavaPlugins.onError(ex);
+                    }
+                }
+            }
+
+        });
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/subscribers/maybe/ConsumerMaybeObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/maybe/ConsumerMaybeObserver.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.MaybeObserver;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ConsumerMaybeObserver<T>
+extends AtomicReference<Disposable>
+implements MaybeObserver<T>, Disposable {
+
+    /** */
+    private static final long serialVersionUID = -7012088219455310787L;
+
+    final Consumer<? super T> onSuccess;
+
+    final Action onComplete;
+
+    final Consumer<? super Throwable> onError;
+
+    public ConsumerMaybeObserver(Consumer<? super T> onSuccess, Action onComplete, Consumer<? super Throwable> onError) {
+        this.onSuccess = onSuccess;
+        this.onComplete = onComplete;
+        this.onError = onError;
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        try {
+            onError.accept(e);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(new CompositeException(e, ex));
+        }
+    }
+    
+    @Override
+    public void onSubscribe(Disposable d) {
+        DisposableHelper.setOnce(this, d);
+    }
+    
+    @Override
+    public void onSuccess(T value) {
+        try {
+            onSuccess.accept(value);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        try {
+            onComplete.run();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        DisposableHelper.dispose(this);
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return get() == DisposableHelper.DISPOSED;
+    }
+}


### PR DESCRIPTION
In #4321 I hit on the problem of needing a lazy object that could either be zero or one value. In that issue the idea of switching the return value of `reduce(R, Func2<R,T,R>)` from `Observable<R>` to `Single<R>` because that operator can only ever produce an Observable that emits exactly one value. The problem was that `reduce(Func2<T,T,T>)` could not be changed to `Single<T>` because the source Observable could be empty and therefore not produce one and only one value.

To solve this problem I mentioned we could create a lazy type that represents either 1 or no value could fill the gap between `Completable` and `Single<T>`.

This PR is for the introduction of the `Maybe<T>` type.
