### PR TITLE
2.x: Subject/Processor improvements & small cleanup

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -3757,12 +3757,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      * the parameter name.
      * @param value the value to validate
      * @param paramName the parameter name of the value
+     * @return the value
      * @throws IllegalArgumentException if bufferSize &lt;= 0
      */
-    private static void verifyPositive(int value, String paramName) {
+    protected static int verifyPositive(int value, String paramName) {
         if (value <= 0) {
             throw new IllegalArgumentException(paramName + " > 0 required but it was " + value);
         }
+        return value;
     }
 
     /**
@@ -3770,12 +3772,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      * the parameter name.
      * @param value the value to validate
      * @param paramName the parameter name of the value
+     * @return the value
      * @throws IllegalArgumentException if bufferSize &lt;= 0
      */
-    private static void verifyPositive(long value, String paramName) {
+    protected static long verifyPositive(long value, String paramName) {
         if (value <= 0L) {
             throw new IllegalArgumentException(paramName + " > 0 required but it was " + value);
         }
+        return value;
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -3307,12 +3307,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the parameter name.
      * @param value the value to validate
      * @param paramName the parameter name of the value
+     * @return value
      * @throws IllegalArgumentException if bufferSize &lt;= 0
      */
-    private static void verifyPositive(int value, String paramName) {
+    protected static int verifyPositive(int value, String paramName) {
         if (value <= 0) {
             throw new IllegalArgumentException(paramName + " > 0 required but it was " + value);
         }
+        return value;
     }
     
     /**
@@ -3320,12 +3322,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the parameter name.
      * @param value the value to validate
      * @param paramName the parameter name of the value
+     * @return value
      * @throws IllegalArgumentException if bufferSize &lt;= 0
      */
-    private static void verifyPositive(long value, String paramName) {
+    protected static long verifyPositive(long value, String paramName) {
         if (value <= 0L) {
             throw new IllegalArgumentException(paramName + " > 0 required but it was " + value);
         }
+        return value;
     }
     
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -241,7 +241,7 @@ public class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends Ab
                         @SuppressWarnings("unchecked")
                         TLeft left = (TLeft)val;
                         
-                        UnicastProcessor<TRight> up = new UnicastProcessor<TRight>();
+                        UnicastProcessor<TRight> up = UnicastProcessor.<TRight>create();
                         int idx = leftIndex++;
                         lefts.put(idx, up);
                         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
@@ -39,7 +39,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         
         SerializedSubscriber<T> z = new SerializedSubscriber<T>(s);
         
-        FlowableProcessor<Object> processor = new UnicastProcessor<Object>(8).toSerialized();
+        FlowableProcessor<Object> processor = UnicastProcessor.<Object>create(8).toSerialized();
         
         Publisher<?> when;
         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
@@ -37,7 +37,7 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
     public void subscribeActual(Subscriber<? super T> s) {
         SerializedSubscriber<T> z = new SerializedSubscriber<T>(s);
         
-        FlowableProcessor<Throwable> processor = new UnicastProcessor<Throwable>(8).toSerialized();
+        FlowableProcessor<Throwable> processor = UnicastProcessor.<Throwable>create(8).toSerialized();
         
         Publisher<?> when;
         

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
@@ -102,7 +102,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
             if (i == 0) {
                 getAndIncrement();
                 
-                w = new UnicastProcessor<T>(bufferSize, this);
+                w = UnicastProcessor.<T>create(bufferSize, this);
                 window = w;
                 
                 actual.onNext(w);
@@ -232,7 +232,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
                 getAndIncrement();
                 
                 
-                w = new UnicastProcessor<T>(bufferSize, this);
+                w = UnicastProcessor.<T>create(bufferSize, this);
                 window = w;
                 
                 actual.onNext(w);
@@ -388,7 +388,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
                 if (!cancelled) {
                     getAndIncrement();
                     
-                    UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize, this);
+                    UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize, this);
                     
                     windows.offer(w);
                     

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -86,7 +86,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                 return;
             }
             
-            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
+            UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
             
             long r = requested();
             if (r != 0L) {
@@ -226,7 +226,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                             continue;
                         }
                         
-                        w = new UnicastProcessor<T>(bufferSize);
+                        w = UnicastProcessor.<T>create(bufferSize);
                         
                         long r = requested();
                         if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -263,7 +263,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                         }
                         
 
-                        w = new UnicastProcessor<T>(bufferSize);
+                        w = UnicastProcessor.<T>create(bufferSize);
                         
                         long r = requested();
                         if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -104,7 +104,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                 return;
             }
             
-            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
+            UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
             
             long r = requested();
             if (r != 0L) {
@@ -262,7 +262,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                             return;
                         }
                         
-                        w = new UnicastProcessor<T>(bufferSize);
+                        w = UnicastProcessor.<T>create(bufferSize);
                         
                         long r = requested();
                         if (r != 0L) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -112,7 +112,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
             this.s = s;
             
-            window = new UnicastProcessor<T>(bufferSize);
+            window = UnicastProcessor.<T>create(bufferSize);
             
             Subscriber<? super Flowable<T>> a = actual;
             a.onSubscribe(this);
@@ -267,7 +267,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     if (o == NEXT) {
                         w.onComplete();
                         if (!term) {
-                            w = new UnicastProcessor<T>(bufferSize);
+                            w = UnicastProcessor.<T>create(bufferSize);
                             window = w;
                             
                             long r = requested();
@@ -362,7 +362,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 return;
             }
             
-            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
+            UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
             window = w;
             
             long r = requested();
@@ -416,7 +416,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     long r = requested();
                     
                     if (r != 0L) {
-                        w = new UnicastProcessor<T>(bufferSize);
+                        w = UnicastProcessor.<T>create(bufferSize);
                         window = w;
                         actual.onNext(w);
                         if (r != Long.MAX_VALUE) {
@@ -558,7 +558,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     if (isHolder) {
                         ConsumerIndexHolder consumerIndexHolder = (ConsumerIndexHolder) o;
                         if (producerIndex == consumerIndexHolder.index) {
-                            w = new UnicastProcessor<T>(bufferSize);
+                            w = UnicastProcessor.<T>create(bufferSize);
                             window = w;
                             
                             long r = requested();
@@ -591,7 +591,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         long r = requested();
                         
                         if (r != 0L) {
-                            w = new UnicastProcessor<T>(bufferSize);
+                            w = UnicastProcessor.<T>create(bufferSize);
                             window = w;
                             actual.onNext(w);
                             if (r != Long.MAX_VALUE) {
@@ -699,7 +699,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             
             long r = requested();
             if (r != 0L) {
-                final UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
+                final UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
                 windows.add(w);
                 
                 actual.onNext(w);
@@ -864,7 +864,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                             
                             long r = requested();
                             if (r != 0L) {
-                                final UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
+                                final UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
                                 ws.add(w);
                                 a.onNext(w);
                                 if (r != Long.MAX_VALUE) {
@@ -906,7 +906,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         @Override
         public void run() {
 
-            UnicastProcessor<T> w = new UnicastProcessor<T>(bufferSize);
+            UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
             
             SubjectWork<T> sw = new SubjectWork<T>(w, true);
             if (!cancelled) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.subscribers.observable.BaseQueueDisposable;
+import io.reactivex.internal.subscribers.observable.BasicQueueDisposable;
 
 public final class ObservableFromArray<T> extends Observable<T> {
     final T[] array;
@@ -38,7 +38,7 @@ public final class ObservableFromArray<T> extends Observable<T> {
         d.run();
     }
     
-    static final class FromArrayDisposable<T> extends BaseQueueDisposable<T> {
+    static final class FromArrayDisposable<T> extends BasicQueueDisposable<T> {
 
         final Observer<? super T> actual;
         

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.subscribers.observable.BaseQueueDisposable;
+import io.reactivex.internal.subscribers.observable.BasicQueueDisposable;
 
 public final class ObservableFromIterable<T> extends Observable<T> {
     final Iterable<? extends T> source;
@@ -58,7 +58,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
         }
     }
     
-    static final class FromIterableDisposable<T> extends BaseQueueDisposable<T> {
+    static final class FromIterableDisposable<T> extends BasicQueueDisposable<T> {
         
         final Observer<? super T> actual;
         

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BasicIntQueueDisposable.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BasicIntQueueDisposable.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.fuseable.QueueDisposable;
  * that defaults all unnecessary Queue methods to throw UnsupportedOperationException.
  * @param <T> the output value type
  */
-public abstract class BaseIntQueueDisposable<T> 
+public abstract class BasicIntQueueDisposable<T> 
 extends AtomicInteger
 implements QueueDisposable<T> {
 

--- a/src/main/java/io/reactivex/internal/subscribers/observable/BasicQueueDisposable.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/BasicQueueDisposable.java
@@ -20,7 +20,7 @@ import io.reactivex.internal.fuseable.QueueDisposable;
  * unnecessary Queue methods to throw UnsupportedOperationException.
  * @param <T> the output value type
  */
-public abstract class BaseQueueDisposable<T> implements QueueDisposable<T> {
+public abstract class BasicQueueDisposable<T> implements QueueDisposable<T> {
 
     @Override
     public final boolean offer(T e) {

--- a/src/main/java/io/reactivex/internal/subscribers/observable/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/DeferredScalarDisposable.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.observable;
+
+import io.reactivex.Observer;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Represents a fuseable container for a single value.
+ *
+ * @param <T> the value type received and emitted
+ */
+public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
+    /** */
+    private static final long serialVersionUID = -5502432239815349361L;
+
+    /** The target of the events. */
+    protected final Observer<? super T> actual;
+    
+    /** The value stored temporarily when in fusion mode. */
+    protected T value;
+    
+    /** Indicates there was a call to complete(T). */
+    static final int TERMINATED = 2;
+    
+    /** Indicates the Disposable has been disposed. */
+    static final int DISPOSED = 4;
+    
+    /** Indicates this Disposable is in fusion mode and is currently empty. */
+    static final int FUSED_EMPTY = 8;
+    /** Indicates this Disposable is in fusion mode and has a value. */
+    static final int FUSED_READY = 16;
+    /** Indicates this Disposable is in fusion mode and its value has been consumed. */
+    static final int FUSED_CONSUMED = 32;
+    
+    /**
+     * Constructs a DeferredScalarDisposable by wrapping the Observer.
+     * @param actual the Observer to wrap, not null (not verified)
+     */
+    public DeferredScalarDisposable(Observer<? super T> actual) {
+        this.actual = actual;
+    }
+    
+    @Override
+    public final int requestFusion(int mode) {
+        if ((mode & ASYNC) != 0) {
+            lazySet(FUSED_EMPTY);
+            return ASYNC;
+        }
+        return NONE;
+    }
+
+    /**
+     * Complete the target with a single value or indicate there is a value available in
+     * fusion mode.
+     * @param value the value to signal, not null (not verified)
+     */
+    public final void complete(T value) {
+        int state = get();
+        if ((state & (FUSED_READY | FUSED_CONSUMED | TERMINATED | DISPOSED)) != 0) {
+            return;
+        }
+        if (state == FUSED_EMPTY) {
+            this.value = value;
+            lazySet(FUSED_READY);
+        } else {
+            lazySet(TERMINATED);
+        }
+        Observer<? super T> a = actual;
+        a.onNext(value);
+        if (get() != DISPOSED) {
+            a.onComplete();
+        }
+    }
+
+    /**
+     * Complete the target with an error signal
+     * @param t the Throwable to signal, not null (not verified)
+     */
+     public final void error(Throwable t) {
+        int state = get();
+        if ((state & (FUSED_READY | FUSED_CONSUMED | TERMINATED | DISPOSED)) != 0) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        lazySet(TERMINATED);
+        actual.onError(t);
+    }
+
+     /**
+      * Complete the target without any value.
+      */
+    public final void complete() {
+        int state = get();
+        if ((state & (FUSED_READY | FUSED_CONSUMED | TERMINATED | DISPOSED)) != 0) {
+            return;
+        }
+        lazySet(TERMINATED);
+        actual.onComplete();
+    }
+    
+    @Override
+    public final T poll() throws Exception {
+        if (get() == FUSED_READY) {
+            T v = value;
+            value = null;
+            lazySet(FUSED_CONSUMED);
+            return v;
+        }
+        return null;
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return get() != FUSED_READY;
+    }
+
+    @Override
+    public final void clear() {
+        lazySet(FUSED_CONSUMED);
+        value = null;
+    }
+
+    @Override
+    public void dispose() {
+        set(DISPOSED);
+        value = null;
+    }
+    
+    /**
+     * Try disposing this Disposable and return true if the current thread succeeded.
+     * @return true if the current thread succeeded
+     */
+    public final boolean tryDispose() {
+        return getAndSet(DISPOSED) != DISPOSED;
+    }
+
+    @Override
+    public final boolean isDisposed() {
+        return get() == DISPOSED;
+    }
+
+}

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -13,13 +13,11 @@
 package io.reactivex.processors;
 
 import java.util.Arrays;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
-import io.reactivex.functions.IntFunction;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.internal.subscriptions.DeferredScalarSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -28,117 +26,225 @@ import io.reactivex.plugins.RxJavaPlugins;
  * <p>The implementation of onXXX methods are technically thread-safe but non-serialized calls
  * to them may lead to undefined state in the currently subscribed Subscribers.
  * 
- * <p>Due to the nature Observables are constructed, the AsyncSubject can't be instantiated through
- * {@code new} but must be created via the {@link #create()} method.
- *
  * @param <T> the value type
  */
 public final class AsyncProcessor<T> extends FlowableProcessor<T> {
-    /** The state holding onto the latest value or error and the array of subscribers. */
-    final State<T> state;
-    /** 
-     * Indicates the subject has been terminated. It is checked in the onXXX methods in
-     * a relaxed matter: concurrent calls may not properly see it (which shouldn't happen if
-     * the reactive-streams contract is held).
-     */
-    boolean done;
+
+    @SuppressWarnings("rawtypes")
+    static final AsyncSubscription[] EMPTY = new AsyncSubscription[0];
+
+    @SuppressWarnings("rawtypes")
+    static final AsyncSubscription[] TERMINATED = new AsyncSubscription[0];
+
+    final AtomicReference<AsyncSubscription<T>[]> subscribers;
+    
+    /** Write before updating subscribers, read after reading subscribers as TERMINATED. */
+    Throwable error;
+    
+    /** Write before updating subscribers, read after reading subscribers as TERMINATED. */
+    T value;
     
     /**
-     * Constructs an empty AsyncSubject.
-     * @param <T> the observed and observable value type
-     * @return the new AsyncSubject instance.
+     * Creates a new AsyncProcessor.
+     * @param <T> the value type to be received and emitted
+     * @return the new AsyncProcessor instance
      */
     public static <T> AsyncProcessor<T> create() {
         return new AsyncProcessor<T>();
     }
     
-    protected AsyncProcessor() {
-        this.state = new State<T>();
+    /**
+     * Constructs an AsyncProcessor.
+     * @since 2.0
+     */
+    @SuppressWarnings("unchecked")
+    AsyncProcessor() {
+        this.subscribers = new AtomicReference<AsyncSubscription<T>[]>(EMPTY);
     }
-    
+
     @Override
     public void onSubscribe(Subscription s) {
-        if (done) {
+        if (subscribers.get() == TERMINATED) {
             s.cancel();
             return;
         }
+        // PublishSubject doesn't bother with request coordination.
         s.request(Long.MAX_VALUE);
     }
-    
+
     @Override
     public void onNext(T t) {
-        if (done) {
+        if (subscribers.get() == TERMINATED) {
             return;
         }
         if (t == null) {
-            onError(new NullPointerException());
+            nullOnNext();
             return;
         }
-        state.lazySet(t);
+        value = t;
     }
     
+    @SuppressWarnings("unchecked")
+    void nullOnNext() {
+        value = null;
+        Throwable ex = new NullPointerException();
+        error = ex;
+        for (AsyncSubscription<T> as : subscribers.getAndSet(TERMINATED)) {
+            as.onError(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable t) {
-        if (done) {
-            RxJavaPlugins.onError(t);
-            return;
-        }
         if (t == null) {
             t = new NullPointerException();
         }
-        done = true;
-        state.lazySet(NotificationLite.error(t));
-        for (AsyncSubscription<T> as : state.terminate()) {
-            as.setError(t);
-        }
-    }
-    
-    @Override
-    public void onComplete() {
-        if (done) {
+        if (subscribers.get() == TERMINATED) {
+            RxJavaPlugins.onError(t);
             return;
         }
-        done = true;
-        @SuppressWarnings("unchecked")
-        T value = (T)state.get();
-        for (AsyncSubscription<T> as : state.terminate()) {
-            as.setValue(value);
+        value = null;
+        error = t;
+        for (AsyncSubscription<T> as : subscribers.getAndSet(TERMINATED)) {
+            as.onError(t);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onComplete() {
+        if (subscribers.get() == TERMINATED) {
+            return;
+        }
+        T v = value;
+        AsyncSubscription<T>[] array = subscribers.getAndSet(TERMINATED);
+        if (v == null) {
+            for (AsyncSubscription<T> as : array) {
+                as.onComplete();
+            }
+        } else {
+            for (AsyncSubscription<T> as : array) {
+                as.complete(v);
+            }
+        }
+    }
+
+    @Override
+    public boolean hasSubscribers() {
+        return subscribers.get().length != 0;
+    }
+
+    @Override
+    public boolean hasThrowable() {
+        return subscribers.get() == TERMINATED && error != null;
+    }
+
+    @Override
+    public boolean hasComplete() {
+        return subscribers.get() == TERMINATED && error == null;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return subscribers.get() == TERMINATED ? error : null;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        AsyncSubscription<T> as = new AsyncSubscription<T>(s, this);
+        s.onSubscribe(as);
+        if (add(as)) {
+            if (as.isCancelled()) {
+                remove(as);
+            }
+        } else {
+            Throwable ex = error;
+            if (ex != null) {
+                s.onError(ex);
+            } else {
+                T v = value;
+                if (v != null) {
+                    as.complete(v);
+                } else {
+                    as.onComplete();
+                }
+            }
+        }
+    }
+
+    /**
+     * Tries to add the given subscriber to the subscribers array atomically
+     * or returns false if the subject has terminated.
+     * @param ps the subscriber to add
+     * @return true if successful, false if the subject has terminated
+     */
+    boolean add(AsyncSubscription<T> ps) {
+        for (;;) {
+            AsyncSubscription<T>[] a = subscribers.get();
+            if (a == TERMINATED) {
+                return false;
+            }
+            
+            int n = a.length;
+            @SuppressWarnings("unchecked")
+            AsyncSubscription<T>[] b = new AsyncSubscription[n + 1];
+            System.arraycopy(a, 0, b, 0, n);
+            b[n] = ps;
+            
+            if (subscribers.compareAndSet(a, b)) {
+                return true;
+            }
         }
     }
     
-    @Override
-    public boolean hasSubscribers() {
-        return state.subscribers().length != 0;
+    /**
+     * Atomically removes the given subscriber if it is subscribed to the subject.
+     * @param ps the subject to remove
+     */
+    @SuppressWarnings("unchecked")
+    void remove(AsyncSubscription<T> ps) {
+        for (;;) {
+            AsyncSubscription<T>[] a = subscribers.get();
+            int n = a.length;
+            if (n == 0) {
+                return;
+            }
+            
+            int j = -1;
+            for (int i = 0; i < n; i++) {
+                if (a[i] == ps) {
+                    j = i;
+                    break;
+                }
+            }
+            
+            if (j < 0) {
+                return;
+            }
+            
+            AsyncSubscription<T>[] b;
+            
+            if (n == 1) {
+                b = EMPTY;
+            } else {
+                b = new AsyncSubscription[n - 1];
+                System.arraycopy(a, 0, b, 0, j);
+                System.arraycopy(a, j + 1, b, j, n - j - 1);
+            }
+            if (subscribers.compareAndSet(a, b)) {
+                return;
+            }
+        }
     }
-    
+
     /**
      * Returns true if the subject has any value.
      * <p>The method is thread-safe.
      * @return true if the subject has any value
      */
     public boolean hasValue() {
-        Object o = state.get();
-        return o != null && !NotificationLite.isError(o);
-    }
-    
-    @Override
-    public boolean hasComplete() {
-        Object o = state.get();
-        return state.subscribers() == State.TERMINATED && !NotificationLite.isError(o);
-    }
-    
-    @Override
-    public boolean hasThrowable() {
-        return NotificationLite.isError(state.get());
-    }
-    
-    @Override
-    public Throwable getThrowable() {
-        Object o = state.get();
-        if (NotificationLite.isError(o)) {
-            return NotificationLite.getError(o);
-        }
-        return null;
+        return subscribers.get() == TERMINATED && value != null;
     }
     
     /**
@@ -146,32 +252,18 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @return a single value the Subject currently has or null if no such value exists
      */
-    @SuppressWarnings("unchecked")
     public T getValue() {
-        Object o = state.get();
-        if (o != null && !NotificationLite.isError(o)) {
-            return (T)o;
-        }
-        return null;
+        return subscribers.get() == TERMINATED ? value : null;
     }
     
-    /** An empty array to avoid allocation in getValues(). */
-    private static final Object[] EMPTY = new Object[0];
-
     /**
      * Returns an Object array containing snapshot all values of the Subject.
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the Subject
      */
     public Object[] getValues() {
-        @SuppressWarnings("unchecked")
-        T[] a = (T[])EMPTY;
-        T[] b = getValues(a);
-        if (b == EMPTY) {
-            return new Object[0];
-        }
-        return b;
-            
+        T v = getValue();
+        return v != null ? new Object[] { v } : new Object[0];
     }
     
     /**
@@ -182,276 +274,54 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
      */
-    @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
-        Object o = state.get();
-        if (o != null && !NotificationLite.isError(o) && !NotificationLite.isComplete(o)) {
-            int n = array.length;
-            if (n == 0) {
-                array = Arrays.copyOf(array, 1);
-            }
-            array[0] = (T)o;
-            if (array.length > 1) {
-                array[1] = null;
-            }
-        } else {
+        T v = getValue();
+        if (v == null) {
             if (array.length != 0) {
                 array[0] = null;
             }
+            return array;
+        }
+        if (array.length == 0) {
+            array = Arrays.copyOf(array, 1);
+        }
+        array[0] = v;
+        if (array.length != 1) {
+            array[1] = null;
         }
         return array;
     }
     
-    @Override
-    protected void subscribeActual(Subscriber<? super T> s) {
-        state.subscribe(s);
-    }
-    /**
-     * The state of the AsyncSubject.
-     *
-     * @param <T> the value type
-     */
-    @SuppressWarnings("rawtypes")
-    static final class State<T> extends AtomicReference<Object> 
-    implements Publisher<T>, IntFunction<AsyncSubscription<T>[]> {
-        
+    static final class AsyncSubscription<T> extends DeferredScalarSubscription<T> {
         /** */
-        private static final long serialVersionUID = 2983503212425065796L;
-
-        /** An empty AsyncSubscription array to avoid allocating it in remove. */
-        static final AsyncSubscription[] EMPTY = new AsyncSubscription[0];
-        /** An empty array indicating a terminal state .*/
-        static final AsyncSubscription[] TERMINATED = new AsyncSubscription[0];
+        private static final long serialVersionUID = 5629876084736248016L;
         
-        /** The array of current subscribers. */
-        @SuppressWarnings("unchecked")
-        final AtomicReference<AsyncSubscription<T>[]> subscribers = new AtomicReference<AsyncSubscription<T>[]>(EMPTY);
+        final AsyncProcessor<T> parent;
         
-        /**
-         * Returns the array of current subscribers.
-         * @return the array of current subscribers
-         */
-        public AsyncSubscription<T>[] subscribers() {
-            return subscribers.get();
-        }
-
-        /**
-         * Terminates the state and returns the last array of subscribers.
-         * @return the last array of subscribers
-         */
-        @SuppressWarnings("unchecked")
-        public AsyncSubscription<T>[] terminate() {
-            AsyncSubscription<T>[] a = subscribers.get();
-            if (a != TERMINATED) {
-                a = subscribers.getAndSet(TERMINATED);
-            }
-            return a;
-        }
-        
-        /**
-         * Atomically tries to add the AsyncSubscription to the subscribers array
-         * or returns false if the state has been terminated.
-         * @param as the AsyncSubscription to add
-         * @return true if successful, false if the state has been terminated
-         */
-        boolean add(AsyncSubscription<T> as) {
-            for (;;) {
-                AsyncSubscription<T>[] a = subscribers.get();
-                if (a == TERMINATED) {
-                    return false;
-                }
-                
-                int n = a.length;
-                AsyncSubscription<T>[] b = apply(n + 1);
-                System.arraycopy(a, 0, b, 0, n);
-                b[n] = as;
-                
-                if (subscribers.compareAndSet(a, b)) {
-                    return true;
-                }
-            }
-        }
-        
-        /**
-         * Atomically removes the given AsyncSubscription.
-         * @param as the AsyncSubscription to remove
-         */
-        @SuppressWarnings("unchecked")
-        void remove(AsyncSubscription<T> as) {
-            for (;;) {
-                AsyncSubscription<T>[] a = subscribers.get();
-                if (a == TERMINATED || a == EMPTY) {
-                    return;
-                }
-                
-                int n = a.length;
-                int j = -1;
-                for (int i = 0; i < n; i++) {
-                    if (a[i] == as) {
-                        j = i;
-                        break;
-                    }
-                }
-                
-                if (j < 0) {
-                    return;
-                }
-                
-                AsyncSubscription<T>[] b;
-                
-                if (n == 1) {
-                    b = EMPTY;
-                } else {
-                    b = apply(n - 1);
-                    System.arraycopy(a, 0, b, 0, j);
-                    System.arraycopy(a, j + 1, b, j, n - j - 1);
-                }
-                if (subscribers.compareAndSet(a, b)) {
-                    return;
-                }
-            }
-        }
-        
-        @SuppressWarnings("unchecked")
-        @Override
-        public AsyncSubscription<T>[] apply(int value) {
-            return new AsyncSubscription[value];
-        }
-        
-        @Override
-        @SuppressWarnings("unchecked")
-        public void subscribe(Subscriber<? super T> t) {
-            AsyncSubscription<T> as = new AsyncSubscription<T>(t, this);
-            t.onSubscribe(as);
-            
-            if (add(as)) {
-                if (as.isDone()) {
-                    remove(as);
-                }
-            } else {
-                Object o = get();
-                if (NotificationLite.isError(o)) {
-                    as.setError(NotificationLite.getError(o));
-                } else {
-                    as.setValue((T)o);
-                }
-            }
-        }
-    }
-    
-    /**
-     * A subscription implementation that wraps the actual Subscriber and manages the request and cancel calls.
-     *
-     * @param <T> the value type
-     */
-    static final class AsyncSubscription<T> extends AtomicInteger implements Subscription {
-        /** */
-        private static final long serialVersionUID = 2900823026377918858L;
-        /** The actual subscriber. */
-        final Subscriber<? super T> actual;
-        /** The AsyncSubject state containing the value. */
-        final State<T> state;
-        
-        /** State management: no request and no value has been set. */
-        static final int NO_REQUEST_NO_VALUE = 0;
-        /** State management: no request but value is available. */
-        static final int NO_REQUEST_HAS_VALUE = 1;
-        /** State management: a positive request has been made but no value is available. */
-        static final int HAS_REQUEST_NO_VALUE = 2;
-        /** State management: both positive request and value is available, terminal state. */
-        static final int HAS_REQUEST_HAS_VALUE = 3;
-        
-        public AsyncSubscription(Subscriber<? super T> actual, State<T> state) {
-            this.actual = actual;
-            this.state = state;
-        }
-        
-        /**
-         * Indicates the given value is available and emits it to the actual Subscriber if
-         * it has requested.
-         * @param value the value to emit
-         */
-        public void setValue(T value) {
-            for (;;) {
-                int s = get();
-                if (s == NO_REQUEST_HAS_VALUE || s == HAS_REQUEST_HAS_VALUE) {
-                    return;
-                } else
-                if (s == NO_REQUEST_NO_VALUE) {
-                    if (compareAndSet(NO_REQUEST_NO_VALUE, NO_REQUEST_HAS_VALUE)) {
-                        return;
-                    }
-                } else
-                if (s == HAS_REQUEST_NO_VALUE) {
-                    lazySet(HAS_REQUEST_HAS_VALUE); // setValue is called once, no need for CAS
-                    if (value != null) {
-                        actual.onNext(value);
-                    }
-                    actual.onComplete();
-                }
-            }
-        }
-        
-        /**
-         * Terminates the AsyncSubscription and emits the given error
-         * if not already terminated.
-         * @param e the Throwable to emit to the Subscriber
-         */
-        public void setError(Throwable e) {
-            int s = get();
-            if (s != HAS_REQUEST_HAS_VALUE) {
-                s = getAndSet(HAS_REQUEST_HAS_VALUE);
-                if (s != HAS_REQUEST_HAS_VALUE) {
-                    actual.onError(e);
-                }
-            }
-        }
-        
-        @Override
-        public void request(long n) {
-            if (!SubscriptionHelper.validate(n)) {
-                return;
-            }
-            for (;;) {
-                int s = get();
-                if (s == HAS_REQUEST_NO_VALUE || s == HAS_REQUEST_HAS_VALUE) {
-                    return;
-                } else
-                if (s == NO_REQUEST_NO_VALUE) {
-                    if (compareAndSet(NO_REQUEST_NO_VALUE, HAS_REQUEST_NO_VALUE)) {
-                        return;
-                    }
-                } else {
-                    if (compareAndSet(NO_REQUEST_HAS_VALUE, HAS_REQUEST_HAS_VALUE)) {
-                        @SuppressWarnings("unchecked")
-                        T v = (T)state.get();
-                        if (v != null) {
-                            actual.onNext(v);
-                        }
-                        actual.onComplete();
-                        return;
-                    }
-                }
-            }
+        public AsyncSubscription(Subscriber<? super T> actual, AsyncProcessor<T> parent) {
+            super(actual);
+            this.parent = parent;
         }
         
         @Override
         public void cancel() {
-            int s = get();
-            if (s != HAS_REQUEST_HAS_VALUE) {
-                s = getAndSet(HAS_REQUEST_HAS_VALUE);
-                if (s != HAS_REQUEST_HAS_VALUE) {
-                    state.remove(this);
-                }
+            if (super.tryCancel()) {
+                parent.remove(this);
+            }
+        }
+
+        void onComplete() {
+            if (!isCancelled()) {
+                actual.onComplete();
             }
         }
         
-        /**
-         * Returns true if the AsyncSubscription has reached its terminal state.
-         * @return  true if the AsyncSubscription has reached its terminal state
-         */
-        boolean isDone() {
-            return get() == HAS_REQUEST_HAS_VALUE;
+        void onError(Throwable t) {
+            if (isCancelled()) {
+                RxJavaPlugins.onError(t);
+            } else {
+                actual.onError(t);
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -13,12 +13,12 @@
 
 package io.reactivex.subjects;
 
-import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.*;
-import io.reactivex.disposables.*;
-import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscribers.observable.DeferredScalarDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -27,62 +27,223 @@ import io.reactivex.plugins.RxJavaPlugins;
  * <p>The implementation of onXXX methods are technically thread-safe but non-serialized calls
  * to them may lead to undefined state in the currently subscribed NbpSubscribers.
  * 
- * <p>Due to the nature Observables are constructed, the NbpAsyncSubject can't be instantiated through
- * {@code new} but must be created via the {@link #create()} method.
- *
  * @param <T> the value type
  */
 
 public final class AsyncSubject<T> extends Subject<T> {
-    final State<T> state;
+
+    @SuppressWarnings("rawtypes")
+    static final AsyncDisposable[] EMPTY = new AsyncDisposable[0];
+
+    @SuppressWarnings("rawtypes")
+    static final AsyncDisposable[] TERMINATED = new AsyncDisposable[0];
+
+    final AtomicReference<AsyncDisposable<T>[]> subscribers;
     
+    /** Write before updating subscribers, read after reading subscribers as TERMINATED. */
+    Throwable error;
+    
+    /** Write before updating subscribers, read after reading subscribers as TERMINATED. */
+    T value;
+    
+    /**
+     * Creates a new AsyncProcessor.
+     * @param <T> the value type to be received and emitted
+     * @return the new AsyncProcessor instance
+     */
     public static <T> AsyncSubject<T> create() {
         return new AsyncSubject<T>();
     }
     
-    protected AsyncSubject() {
-        this.state = new State<T>();
+    /**
+     * Constructs an AsyncSubject.
+     * @since 2.0
+     */
+    @SuppressWarnings("unchecked")
+    AsyncSubject() {
+        this.subscribers = new AtomicReference<AsyncDisposable<T>[]>(EMPTY);
     }
-    
+
     @Override
-    protected void subscribeActual(Observer<? super T> observer) {
-        state.subscribe(observer);
-    }
-    
-    @Override
-    public void onSubscribe(Disposable d) {
-        if (state.subscribers.get() == State.TERMINATED) {
-            d.dispose();
+    public void onSubscribe(Disposable s) {
+        if (subscribers.get() == TERMINATED) {
+            s.dispose();
         }
     }
-    
+
     @Override
-    public void onNext(T value) {
-        state.onNext(value);
+    public void onNext(T t) {
+        if (subscribers.get() == TERMINATED) {
+            return;
+        }
+        if (t == null) {
+            nullOnNext();
+            return;
+        }
+        value = t;
     }
     
-    @Override
-    public void onError(Throwable e) {
-        state.onError(e);
+    @SuppressWarnings("unchecked")
+    void nullOnNext() {
+        value = null;
+        Throwable ex = new NullPointerException();
+        error = ex;
+        for (AsyncDisposable<T> as : subscribers.getAndSet(TERMINATED)) {
+            as.onError(ex);
+        }
     }
-    
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onError(Throwable t) {
+        if (t == null) {
+            t = new NullPointerException();
+        }
+        if (subscribers.get() == TERMINATED) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        value = null;
+        error = t;
+        for (AsyncDisposable<T> as : subscribers.getAndSet(TERMINATED)) {
+            as.onError(t);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
     public void onComplete() {
-        state.onComplete();
+        if (subscribers.get() == TERMINATED) {
+            return;
+        }
+        T v = value;
+        AsyncDisposable<T>[] array = subscribers.getAndSet(TERMINATED);
+        if (v == null) {
+            for (AsyncDisposable<T> as : array) {
+                as.onComplete();
+            }
+        } else {
+            for (AsyncDisposable<T> as : array) {
+                as.complete(v);
+            }
+        }
     }
-    
+
     @Override
     public boolean hasObservers() {
-        return state.subscribers.get().length != 0;
+        return subscribers.get().length != 0;
     }
-    
+
+    @Override
+    public boolean hasThrowable() {
+        return subscribers.get() == TERMINATED && error != null;
+    }
+
+    @Override
+    public boolean hasComplete() {
+        return subscribers.get() == TERMINATED && error == null;
+    }
+
     @Override
     public Throwable getThrowable() {
-        Object o = state.get();
-        if (NotificationLite.isError(o)) {
-            return NotificationLite.getError(o);
+        return subscribers.get() == TERMINATED ? error : null;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        AsyncDisposable<T> as = new AsyncDisposable<T>(s, this);
+        s.onSubscribe(as);
+        if (add(as)) {
+            if (as.isDisposed()) {
+                remove(as);
+            }
+        } else {
+            Throwable ex = error;
+            if (ex != null) {
+                s.onError(ex);
+            } else {
+                T v = value;
+                if (v != null) {
+                    as.complete(v);
+                } else {
+                    as.onComplete();
+                }
+            }
         }
-        return null;
+    }
+
+    /**
+     * Tries to add the given subscriber to the subscribers array atomically
+     * or returns false if the subject has terminated.
+     * @param ps the subscriber to add
+     * @return true if successful, false if the subject has terminated
+     */
+    boolean add(AsyncDisposable<T> ps) {
+        for (;;) {
+            AsyncDisposable<T>[] a = subscribers.get();
+            if (a == TERMINATED) {
+                return false;
+            }
+            
+            int n = a.length;
+            @SuppressWarnings("unchecked")
+            AsyncDisposable<T>[] b = new AsyncDisposable[n + 1];
+            System.arraycopy(a, 0, b, 0, n);
+            b[n] = ps;
+            
+            if (subscribers.compareAndSet(a, b)) {
+                return true;
+            }
+        }
+    }
+    
+    /**
+     * Atomically removes the given subscriber if it is subscribed to the subject.
+     * @param ps the subject to remove
+     */
+    @SuppressWarnings("unchecked")
+    void remove(AsyncDisposable<T> ps) {
+        for (;;) {
+            AsyncDisposable<T>[] a = subscribers.get();
+            int n = a.length;
+            if (n == 0) {
+                return;
+            }
+            
+            int j = -1;
+            for (int i = 0; i < n; i++) {
+                if (a[i] == ps) {
+                    j = i;
+                    break;
+                }
+            }
+            
+            if (j < 0) {
+                return;
+            }
+            
+            AsyncDisposable<T>[] b;
+            
+            if (n == 1) {
+                b = EMPTY;
+            } else {
+                b = new AsyncDisposable[n - 1];
+                System.arraycopy(a, 0, b, 0, j);
+                System.arraycopy(a, j + 1, b, j, n - j - 1);
+            }
+            if (subscribers.compareAndSet(a, b)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Returns true if the subject has any value.
+     * <p>The method is thread-safe.
+     * @return true if the subject has any value
+     */
+    public boolean hasValue() {
+        return subscribers.get() == TERMINATED && value != null;
     }
     
     /**
@@ -91,33 +252,17 @@ public final class AsyncSubject<T> extends Subject<T> {
      * @return a single value the Subject currently has or null if no such value exists
      */
     public T getValue() {
-        Object o = state.get();
-        if (o != null) {
-            if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
-                return null;
-            }
-            return NotificationLite.getValue(o);
-        }
-        return null;
+        return subscribers.get() == TERMINATED ? value : null;
     }
     
-    /** An empty array to avoid allocation in getValues(). */
-    private static final Object[] EMPTY = new Object[0];
-
     /**
      * Returns an Object array containing snapshot all values of the Subject.
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the Subject
      */
     public Object[] getValues() {
-        @SuppressWarnings("unchecked")
-        T[] a = (T[])EMPTY;
-        T[] b = getValues(a);
-        if (b == EMPTY) {
-            return new Object[0];
-        }
-        return b;
-            
+        T v = getValue();
+        return v != null ? new Object[] { v } : new Object[0];
     }
     
     /**
@@ -128,216 +273,53 @@ public final class AsyncSubject<T> extends Subject<T> {
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
      */
-    @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
-        Object o = state.get();
-        if (o != null) {
-            if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
-                if (array.length != 0) {
-                    array[0] = null;
-                }
-            } else {
-                T v = NotificationLite.getValue(o);
-                if (array.length != 0) {
-                    array[0] = v;
-                    if (array.length != 1) {
-                        array[1] = null;
-                    }
-                } else {
-                    array = (T[])Array.newInstance(array.getClass().getComponentType(), 1);
-                    array[0] = v;
-                }
-            }
-        } else {
+        T v = getValue();
+        if (v == null) {
             if (array.length != 0) {
                 array[0] = null;
             }
+            return array;
+        }
+        if (array.length == 0) {
+            array = Arrays.copyOf(array, 1);
+        }
+        array[0] = v;
+        if (array.length != 1) {
+            array[1] = null;
         }
         return array;
     }
     
-    @Override
-    public boolean hasComplete() {
-        return state.subscribers.get() == State.TERMINATED && !NotificationLite.isError(state.get());
-    }
-    
-    @Override
-    public boolean hasThrowable() {
-        return NotificationLite.isError(state.get());
-    }
-    
-    /**
-     * Returns true if the subject has any value.
-     * <p>The method is thread-safe.
-     * @return true if the subject has any value
-     */
-    public boolean hasValue() {
-        Object o = state.get();
-        return o != null && !NotificationLite.isComplete(o) && !NotificationLite.isError(o);
-    }
-    
-    static final class State<T> extends AtomicReference<Object> implements ObservableSource<T>, Observer<T> {
+    static final class AsyncDisposable<T> extends DeferredScalarDisposable<T> {
         /** */
-        private static final long serialVersionUID = 4876574210612691772L;
+        private static final long serialVersionUID = 5629876084736248016L;
+        
+        final AsyncSubject<T> parent;
+        
+        public AsyncDisposable(Observer<? super T> actual, AsyncSubject<T> parent) {
+            super(actual);
+            this.parent = parent;
+        }
+        
+        @Override
+        public void dispose() {
+            if (super.tryDispose()) {
+                parent.remove(this);
+            }
+        }
 
-        final AtomicReference<Observer<? super T>[]> subscribers;
-        
-        @SuppressWarnings("rawtypes")
-        static final Observer[] EMPTY = new Observer[0];
-        @SuppressWarnings("rawtypes")
-        static final Observer[] TERMINATED = new Observer[0];
-
-        boolean done;
-        
-        @SuppressWarnings("unchecked")
-        public State() {
-            subscribers = new AtomicReference<Observer<? super T>[]>(EMPTY);
-        }
-        
-        boolean add(Observer<? super T> s) {
-            for (;;) {
-                Observer<? super T>[] a = subscribers.get();
-                if (a == TERMINATED) {
-                    return false;
-                }
-                int n = a.length;
-                
-                @SuppressWarnings("unchecked")
-                Observer<? super T>[] b = new Observer[n + 1];
-                System.arraycopy(a, 0, b, 0, n);
-                b[n] = s;
-                
-                if (subscribers.compareAndSet(a, b)) {
-                    return true;
-                }
+        void onComplete() {
+            if (!isDisposed()) {
+                actual.onComplete();
             }
         }
         
-        @SuppressWarnings("unchecked")
-        void remove(Observer<? super T> s) {
-            for (;;) {
-                Observer<? super T>[] a = subscribers.get();
-                if (a == TERMINATED || a == EMPTY) {
-                    return;
-                }
-                int n = a.length;
-                int j = -1;
-                for (int i = 0; i < n; i++) {
-                    Observer<? super T> e = a[i];
-                    if (e.equals(s)) {
-                        j = i;
-                        break;
-                    }
-                }
-                if (j < 0) {
-                    return;
-                }
-                Observer<? super T>[] b;
-                if (n == 1) {
-                    b = EMPTY;
-                } else {
-                    b = new Observer[n - 1];
-                    System.arraycopy(a, 0, b, 0, j);
-                    System.arraycopy(a, j + 1, b, j, n - j - 1);
-                }
-                if (subscribers.compareAndSet(a, b)) {
-                    return;
-                }
-            }
-        }
-        
-        @SuppressWarnings("unchecked")
-        Observer<? super T>[] terminate(Object notification) {
-            if (compareAndSet(get(), notification)) {
-                Observer<? super T>[] a = subscribers.get();
-                if (a != TERMINATED) {
-                    return subscribers.getAndSet(TERMINATED);
-                }
-            }
-            return TERMINATED;
-        }
-        
-        void emit(Observer<? super T> t, Object v) {
-            if (NotificationLite.isComplete(v)) {
-                t.onComplete();
-            } else
-            if (NotificationLite.isError(v)) {
-                t.onError(NotificationLite.getError(v));
+        void onError(Throwable t) {
+            if (isDisposed()) {
+                RxJavaPlugins.onError(t);
             } else {
-                t.onNext(NotificationLite.<T>getValue(v));
-                t.onComplete();
-            }
-        }
-        
-        @Override
-        public void subscribe(final Observer<? super T> t) {
-            Disposable d = Disposables.from(new Runnable() {
-                @Override
-                public void run() {
-                    remove(t);
-                }
-            });
-            t.onSubscribe(d);
-            if (add(t)) {
-                if (d.isDisposed()) {
-                    remove(t);
-                }
-                return;
-            }
-            Object v = get();
-            emit(t, v);
-        }
-        
-        @Override
-        public void onSubscribe(Disposable d) {
-            if (done) {
-                d.dispose();
-            }
-        }
-        
-        @Override
-        public void onNext(T value) {
-            if (done) {
-                return;
-            }
-            if (value == null) {
-                onError(new NullPointerException());
-                return;
-            }
-            lazySet(value);
-        }
-        
-        @Override
-        public void onError(Throwable e) {
-            if (done) {
-                RxJavaPlugins.onError(e);
-                return;
-            }
-            done = true;
-            if (e == null) {
-                e = new NullPointerException();
-            }
-            for (Observer<? super T> v : terminate(NotificationLite.error(e))) {
-                v.onError(e);
-            }
-        }
-        
-        @Override
-        public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-            T value = NotificationLite.getValue(get());
-            if (value == null) {
-                for (Observer<? super T> v : terminate(NotificationLite.complete())) {
-                    v.onComplete();
-                }
-            } else {
-                for (Observer<? super T> v : terminate(NotificationLite.next(value))) {
-                    v.onNext(value);
-                    v.onComplete();
-                }
+                actual.onError(t);
             }
         }
     }

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -15,11 +15,13 @@ package io.reactivex.subjects;
 
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.*;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.subscribers.observable.BasicIntQueueDisposable;
 
 /**
  * Subject that allows only a single Subscriber to subscribe to it during its lifetime.
@@ -34,18 +36,51 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
  * Subject has terminated.
  * 
  * @param <T> the value type received and emitted by this Subject subclass
+ * @since 2.0
  */
 public final class UnicastSubject<T> extends Subject<T> {
-    /** The subject state. */
-    final State<T> state;
+    /** The queue that buffers the source events. */
+    final SpscLinkedArrayQueue<T> queue;
     
+    /** The single Observer. */
+    final AtomicReference<Observer<? super T>> actual;
+    
+    /** The optional callback when the Subject gets cancelled or terminates. */
+    final AtomicReference<Runnable> onTerminate;
+
+    /** Indicates the single observer has cancelled. */
+    volatile boolean disposed;
+    
+    /** Indicates the source has terminated. */
+    volatile boolean done;
+    /** 
+     * The terminal error if not null. 
+     * Must be set before writing to done and read after done == true.
+     */
+    Throwable error;
+
+    /** Set to 1 atomically for the first and only Subscriber. */
+    final AtomicBoolean once;
+    
+    /** 
+     * Called when the Subscriber has called cancel.
+     * This allows early termination for those who emit into this
+     * subject so that they can stop immediately 
+     */
+    Runnable onCancelled;
+
+    /** The wip counter and QueueDisposable surface. */
+    final BasicIntQueueDisposable<T> wip;
+    
+    boolean enableOperatorFusion;
+
     /**
      * Creates an UnicastSubject with an internal buffer capacity hint 16.
      * @param <T> the value type
      * @return an UnicastSubject instance
      */
     public static <T> UnicastSubject<T> create() {
-        return create(16);
+        return new UnicastSubject<T>(bufferSize());
     }
     
     /**
@@ -55,7 +90,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @return an UnicastSubject instance
      */
     public static <T> UnicastSubject<T> create(int capacityHint) {
-        return create(capacityHint, null);
+        return new UnicastSubject<T>(capacityHint);
     }
 
     /**
@@ -71,281 +106,285 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @return an UnicastSubject instance
      */
     public static <T> UnicastSubject<T> create(int capacityHint, Runnable onCancelled) {
-        State<T> state = new State<T>(capacityHint, onCancelled);
-        return new UnicastSubject<T>(state);
+        return new UnicastSubject<T>(capacityHint, onCancelled);
     }
 
     /**
-     * Constructs the Observable base class.
-     * @param state the subject state
+     * Creates an UnicastSubject with the given capacity hint.
+     * @param capacityHint the capacity hint for the internal, unbounded queue
+     * @since 2.0
      */
-    protected UnicastSubject(State<T> state) {
-        this.state = state;
+    UnicastSubject(int capacityHint) {
+        this.queue = new SpscLinkedArrayQueue<T>(verifyPositive(capacityHint, "capacityHint"));
+        this.onTerminate = new AtomicReference<Runnable>();
+        this.actual = new AtomicReference<Observer<? super T>>();
+        this.once = new AtomicBoolean();
+        this.wip = new UnicastQueueDisposable();
     }
 
+    /**
+     * Creates an UnicastProcessor with the given capacity hint and callback
+     * for when the Processor is terminated normally or its single Subscriber cancels.
+     * @param capacityHint the capacity hint for the internal, unbounded queue
+     * @param onTerminate the callback to run when the Processor is terminated or cancelled, null allowed
+     * @since 2.0
+     */
+    UnicastSubject(int capacityHint, Runnable onTerminate) {
+        this.queue = new SpscLinkedArrayQueue<T>(verifyPositive(capacityHint, "capacityHint"));
+        this.onTerminate = new AtomicReference<Runnable>(ObjectHelper.requireNonNull(onTerminate, "onTerminate"));
+        this.actual = new AtomicReference<Observer<? super T>>();
+        this.once = new AtomicBoolean();
+        this.wip = new UnicastQueueDisposable();
+    }
+    
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        state.subscribe(observer);
-    }
-    
-    // TODO may need to have a direct WIP field to avoid clashing on the object header
-    /** Pads the WIP counter. */
-    static abstract class StatePad0 extends AtomicInteger {
-        /** */
-        private static final long serialVersionUID = 7779228232971173701L;
-        /** Cache line padding 1. */
-        volatile long p1a, p2a, p3a, p4a, p5a, p6a, p7a;
-        /** Cache line padding 2. */
-        volatile long p8a, p9a, p10a, p11a, p12a, p13a, p14a, p15a;
-    }
-    
-    /** The state of the UnicastSubject. */
-    static final class State<T> extends StatePad0 implements ObservableSource<T>, Disposable, Observer<T> {
-        /** */
-        private static final long serialVersionUID = 5058617037583835632L;
-
-        /** The queue that buffers the source events. */
-        final SpscLinkedArrayQueue<T> queue;
-        
-        /** The single subscriber. */
-        final AtomicReference<Observer<? super T>> subscriber = new AtomicReference<Observer<? super T>>();
-        
-        /** Indicates the single subscriber has cancelled. */
-        volatile boolean cancelled;
-        
-        /** Indicates the source has terminated. */
-        volatile boolean done;
-        /** 
-         * The terminal error if not null. 
-         * Must be set before writing to done and read after done == true.
-         */
-        Throwable error;
-
-        /** Set to 1 atomically for the first and only Subscriber. */
-        final AtomicBoolean once = new AtomicBoolean();
-        
-        /** 
-         * Called when the Subscriber has called cancel.
-         * This allows early termination for those who emit into this
-         * subject so that they can stop immediately 
-         */
-        Runnable onCancelled;
-        
-        /**
-         * Constructs the state with the given capacity and optional cancellation callback.
-         * @param capacityHint the capacity hint for the internal buffer
-         * @param onCancelled the optional cancellation callback
-         */
-        public State(int capacityHint, Runnable onCancelled) {
-            this.onCancelled = onCancelled;
-            queue = new SpscLinkedArrayQueue<T>(capacityHint);
-        }
-        
-        @Override
-        public void subscribe(Observer<? super T> s) {
-            if (!once.get() && once.compareAndSet(false, true)) {
-                s.onSubscribe(this);
-                subscriber.lazySet(s); // full barrier in drain
-                drain();
-            } else {
-                EmptyDisposable.error(new IllegalStateException("Only a single subscriber allowed."), s);
-            }
-        }
-        
-        @Override
-        public void dispose() {
-            if (!cancelled) {
-                cancelled = true;
-                
-                if (getAndIncrement() == 0) {
-                    clear(queue);
-                }
-            }
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return cancelled;
-        }
-
-        void notifyOnCancelled() {
-            Runnable r = onCancelled;
-            onCancelled = null;
-            if (r != null) {
-                r.run();
-            }
-        }
-        
-        /**
-         * Clears the subscriber and the queue.
-         * @param q the queue reference (avoid re-reading instance field).
-         */
-        void clear(SimpleQueue<?> q) {
-            subscriber.lazySet(null);
-            q.clear();
-            notifyOnCancelled();
-        }
-        
-        @Override
-        public void onSubscribe(Disposable s) {
-            if (done || cancelled) {
-                s.dispose();
-            }
-        }
-        
-        @Override
-        public void onNext(T t) {
-            if (done || cancelled) {
+        if (!once.get() && once.compareAndSet(false, true)) {
+            observer.onSubscribe(wip);
+            actual.lazySet(observer); // full barrier in drain
+            if (disposed) {
+                actual.lazySet(null);
                 return;
             }
-            if (t == null) {
-                onError(new NullPointerException());
-                return;
-            }
-            queue.offer(t);
             drain();
-        }
-        
-        @Override
-        public void onError(Throwable t) {
-            if (done || cancelled) {
-                return;
-            }
-            if (t == null) {
-                t = new NullPointerException();
-            }
-            error = t;
-            done = true;
-            drain();
-        }
-        
-        @Override
-        public void onComplete() {
-            if (done || cancelled) {
-                return;
-            }
-            done = true;
-            drain();
-        }
-        
-        void drain() {
-            if (getAndIncrement() != 0) {
-                return;
-            }
-            
-            final SimpleQueue<T> q = queue;
-            Observer<? super T> a = subscriber.get();
-            int missed = 1;
-            
-            for (;;) {
-                
-                if (cancelled) {
-                    clear(q);
-                    notifyOnCancelled();
-                    return;
-                }
-                
-                if (a != null) {
-                    
-                    boolean d = done;
-                    boolean empty = q.isEmpty();
-                    if (d && empty) {
-                        subscriber.lazySet(null);
-                        Throwable ex = error;
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
-                        return;
-                    }
-                    
-                    for (;;) {
-                        
-                        if (cancelled) {
-                            clear(q);
-                            notifyOnCancelled();
-                            return;
-                        }
-
-                        d = done;
-                        T v = queue.poll();
-                        empty = v == null;
-                        
-                        if (d && empty) {
-                            subscriber.lazySet(null);
-                            Throwable ex = error;
-                            if (ex != null) {
-                                a.onError(ex);
-                            } else {
-                                a.onComplete();
-                            }
-                            return;
-                        }
-                        
-                        if (empty) {
-                            break;
-                        }
-                        
-                        a.onNext(v);
-                    }
-                }
-                
-                missed = addAndGet(-missed);
-                if (missed == 0) {
-                    break;
-                }
-                
-                if (a == null) {
-                    a = subscriber.get();
-                }
-            }
+        } else {
+            EmptyDisposable.error(new IllegalStateException("Only a single observer allowed."), observer);
         }
     }
     
+    void notifyOnCancelled() {
+        Runnable r = onCancelled;
+        onCancelled = null;
+        if (r != null) {
+            r.run();
+        }
+    }
+
+    /**
+     * Clears the observer and the queue.
+     * @param q the queue reference (avoid re-reading instance field).
+     */
+    void clearAndNotify(SimpleQueue<?> q) {
+        actual.lazySet(null);
+        q.clear();
+        notifyOnCancelled();
+    }
+
     @Override
     public void onSubscribe(Disposable s) {
-        state.onSubscribe(s);
+        if (done || disposed) {
+            s.dispose();
+        }
     }
-    
+
     @Override
     public void onNext(T t) {
-        state.onNext(t);
+        if (done || disposed) {
+            return;
+        }
+        if (t == null) {
+            onError(new NullPointerException());
+            return;
+        }
+        queue.offer(t);
+        drain();
     }
     
     @Override
     public void onError(Throwable t) {
-        state.onError(t);
+        if (done || disposed) {
+            return;
+        }
+        if (t == null) {
+            t = new NullPointerException();
+        }
+        error = t;
+        done = true;
+        drain();
     }
     
     @Override
     public void onComplete() {
-        state.onComplete();
+        if (done || disposed) {
+            return;
+        }
+        done = true;
+        drain();
+    }
+
+    void drainNormal(Observer<? super T> a) {
+        int missed = 1;
+        SimpleQueue<T> q = queue;
+        for (;;) {
+            for (;;) {
+                
+                if (disposed) {
+                    clearAndNotify(q);
+                    return;
+                }
+    
+                boolean d = done;
+                T v = queue.poll();
+                boolean empty = v == null;
+                
+                if (d && empty) {
+                    actual.lazySet(null);
+                    notifyOnCancelled();
+                    Throwable ex = error;
+                    if (ex != null) {
+                        a.onError(ex);
+                    } else {
+                        a.onComplete();
+                    }
+                    return;
+                }
+                
+                if (empty) {
+                    break;
+                }
+                
+                a.onNext(v);
+            }
+            
+            missed = wip.addAndGet(-missed);
+            if (missed == 0) {
+                break;
+            }
+        }
+    }
+    
+    void drainFused(Observer<? super T> a) {
+        int missed = 1;
+        
+        final SpscLinkedArrayQueue<T> q = queue;
+        
+        for (;;) {
+            
+            if (disposed) {
+                clearAndNotify(q);
+                return;
+            }
+            
+            boolean d = done;
+            
+            a.onNext(null);
+            
+            if (d) {
+                actual.lazySet(null);
+                
+                Throwable ex = error;
+                if (ex != null) {
+                    a.onError(ex);
+                } else {
+                    a.onComplete();
+                }
+                return;
+            }
+            
+            missed = wip.addAndGet(-missed);
+            if (missed == 0) {
+                break;
+            }
+        }
+    }
+    
+    void drain() {
+        if (wip.getAndIncrement() != 0) {
+            return;
+        }
+        
+        Observer<? super T> a = actual.get();
+        int missed = 1;
+        
+        for (;;) {
+            
+            if (a != null) {
+                if (enableOperatorFusion) {
+                    drainFused(a);
+                } else {
+                    drainNormal(a);
+                }
+                return;
+            }
+            
+            missed = wip.addAndGet(-missed);
+            if (missed == 0) {
+                break;
+            }
+            
+            if (a == null) {
+                a = actual.get();
+            }
+        }
     }
     
     @Override
     public boolean hasObservers() {
-        return state.subscriber.get() != null;
+        return actual.get() != null;
     }
     
     @Override
     public Throwable getThrowable() {
-        State<T> s = state;
-        if (s.done) {
-            return s.error;
+        if (done) {
+            return error;
         }
         return null;
     }
     
     @Override
     public boolean hasThrowable() {
-        State<T> s = state;
-        return s.done && s.error != null;
+        return done && error != null;
     }
     
     @Override
     public boolean hasComplete() {
-        State<T> s = state;
-        return s.done && s.error == null;
+        return done && error == null;
+    }
+    
+    final class UnicastQueueDisposable extends BasicIntQueueDisposable<T> {
+
+        /** */
+        private static final long serialVersionUID = 7926949470189395511L;
+
+        @Override
+        public int requestFusion(int mode) {
+            if ((mode & ASYNC) != 0) {
+                enableOperatorFusion = true;
+                return ASYNC;
+            }
+            return NONE;
+        }
+
+        @Override
+        public T poll() throws Exception {
+            return queue.poll();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return queue.isEmpty();
+        }
+
+        @Override
+        public void clear() {
+            queue.clear();
+        }
+
+        @Override
+        public void dispose() {
+            if (!disposed) {
+                disposed = true;
+                actual.lazySet(null);
+                if (wip.getAndIncrement() == 0) {
+                    clearAndNotify(queue);
+                }
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+        
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -733,7 +733,7 @@ public class FlowableConcatTest {
                 Flowable<Integer> observable = Flowable.just(t)
                         .subscribeOn(sch)
                 ;
-                FlowableProcessor<Integer> subject = new UnicastProcessor<Integer>();
+                FlowableProcessor<Integer> subject = UnicastProcessor.create();
                 observable.subscribe(subject);
                 return subject;
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/NotificationLiteTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/NotificationLiteTest.java
@@ -16,10 +16,9 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import org.reactivestreams.Subscription;
 
 import io.reactivex.TestHelper;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.NotificationLite;
@@ -90,7 +89,7 @@ public class NotificationLiteTest {
         assertTrue(NotificationLite.isDisposable(o));
         assertFalse(NotificationLite.isSubscription(o));
 
-        assertTrue(NotificationLite.getDisposable(o) instanceof Disposable);
+        assertNotNull(NotificationLite.getDisposable(o));
     }
     
     @Test
@@ -104,7 +103,7 @@ public class NotificationLiteTest {
         assertFalse(NotificationLite.isDisposable(o));
         assertTrue(NotificationLite.isSubscription(o));
 
-        assertTrue(NotificationLite.getSubscription(o) instanceof Subscription);
+        assertNotNull(NotificationLite.getSubscription(o));
     }
 
     // TODO this test is no longer relevant as nulls are not allowed and value maps to itself

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
@@ -79,7 +79,7 @@ public class SingleDoOnTest {
         })
         .test();
         
-        assertEquals((Integer)1, event[0]);
+        assertEquals(1, event[0]);
     }
 
 }

--- a/src/test/java/io/reactivex/internal/subscribers/observable/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/observable/DeferredScalarObserverTest.java
@@ -159,7 +159,6 @@ public class DeferredScalarObserverTest {
 
         @Override
         public void onNext(Integer value) {
-            hasValue = true;
             this.value = value;
         }
         

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -924,7 +924,7 @@ public class ReplayProcessorTest {
             ReplayProcessor.createWithSize(-99);
             fail("Didn't throw IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
-            assertEquals("size > 0 required but it was -99", ex.getMessage());
+            assertEquals("maxSize > 0 required but it was -99", ex.getMessage());
         }
     }
 
@@ -934,7 +934,7 @@ public class ReplayProcessorTest {
             ReplayProcessor.createWithTimeAndSize(1, TimeUnit.DAYS, Schedulers.computation(), -99);
             fail("Didn't throw IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
-            assertEquals("size > 0 required but it was -99", ex.getMessage());
+            assertEquals("maxSize > 0 required but it was -99", ex.getMessage());
         }
     }
 

--- a/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.processors;
+
+import org.junit.Test;
+
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.subscribers.*;
+
+public class UnicastProcessorTest {
+
+    @Test
+    public void fusionLive() {
+        UnicastProcessor<Integer> ap = UnicastProcessor.create();
+        
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        
+        ap.subscribe(ts);
+        
+        ts
+        .assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC));
+        
+        ts.assertNoValues().assertNoErrors().assertNotComplete();
+        
+        ap.onNext(1);
+
+        ts.assertValue(1).assertNoErrors().assertNotComplete();
+        
+        ap.onComplete();
+        
+        ts.assertResult(1);
+    }
+    
+    @Test
+    public void fusionOfflie() {
+        UnicastProcessor<Integer> ap = UnicastProcessor.create();
+        ap.onNext(1);
+        ap.onComplete();
+        
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        
+        ap.subscribe(ts);
+        
+        ts
+        .assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertResult(1);
+    }}

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -55,7 +55,7 @@ public class SingleSubscribeTest {
             }
         });
         
-        assertEquals((Integer)1, value[0]);
+        assertEquals(1, value[0]);
         assertNull(value[1]);
     }
 

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -348,11 +348,11 @@ public class ReplaySubjectTest {
         
         Disposable s = subject.subscribe();
 
-        assertEquals(1, subject.subscriberCount());
+        assertEquals(1, subject.observerCount());
 
         s.dispose();
         
-        assertEquals(0, subject.subscriberCount());
+        assertEquals(0, subject.observerCount());
     }
     @Test(timeout = 1000)
     public void testUnsubscriptionCase() {
@@ -835,7 +835,7 @@ public class ReplaySubjectTest {
             ReplaySubject.createWithSize(-99);
             fail("Didn't throw IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
-            assertEquals("size > 0 required but it was -99", ex.getMessage());
+            assertEquals("maxSize > 0 required but it was -99", ex.getMessage());
         }
     }
 
@@ -845,7 +845,7 @@ public class ReplaySubjectTest {
             ReplaySubject.createWithTimeAndSize(1, TimeUnit.DAYS, Schedulers.computation(), -99);
             fail("Didn't throw IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
-            assertEquals("size > 0 required but it was -99", ex.getMessage());
+            assertEquals("maxSize > 0 required but it was -99", ex.getMessage());
         }
     }
 

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.subjects;
+
+import org.junit.Test;
+
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.observers.*;
+
+public class UnicastSubjectTest {
+
+    @Test
+    public void fusionLive() {
+        UnicastSubject<Integer> ap = UnicastSubject.create();
+        
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
+        
+        ap.subscribe(ts);
+        
+        ts
+        .assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC));
+        
+        ts.assertNoValues().assertNoErrors().assertNotComplete();
+        
+        ap.onNext(1);
+
+        ts.assertValue(1).assertNoErrors().assertNotComplete();
+        
+        ap.onComplete();
+        
+        ts.assertResult(1);
+    }
+    
+    @Test
+    public void fusionOfflie() {
+        UnicastSubject<Integer> ap = UnicastSubject.create();
+        ap.onNext(1);
+        ap.onComplete();
+        
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
+        
+        ap.subscribe(ts);
+        
+        ts
+        .assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertResult(1);
+    }}


### PR DESCRIPTION
- open up `verifyPositive` as protected for validation convenience in subclasses
- improve size and state handling of `DeferredScalarSubscription`
- enable async-fusion on `AsyncSubject` and `AsyncProcessor`, compact the classes
- **behavior change** `AsyncX.hasValue()` returns false until the terminal state has been reached
- compact the classes `PublishSubject`, `PublishProcessor`, `BehaviorSubject`, `BehaviorProcessor`, `ReplaySubject` and `ReplayProcessor`
- enable async-fusion on `UnicastSubject`, compact the class
- rename `BaseXQueueDisposable` to `BasicXQueueDisposable` to match `BasicXQueueSubscription`
- introduce `DeferredScalarDisposable`, refactor `DeferredScalarObserver`
- adjust tests that asserted on the former parameter names
- subjects and processors can now be created with newing up their constructor: `new PublishSubject<>()`; there is no mandatory shared state between the `Observer` part and the `Observable` part because both are now stateless on their own.
