### PR TITLE
1.x: cleanup, javadoc, Completable.fromEmitter

### DIFF
--- a/src/main/java/rx/AsyncEmitter.java
+++ b/src/main/java/rx/AsyncEmitter.java
@@ -28,6 +28,7 @@ import rx.annotations.Experimental;
  * other methods are threadsafe.
  *
  * @param <T> the value type to emit
+ * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
  */
 @Experimental
 public interface AsyncEmitter<T> extends Observer<T> {
@@ -69,14 +70,28 @@ public interface AsyncEmitter<T> extends Observer<T> {
      * Options to handle backpressure in the emitter.
      */
     enum BackpressureMode {
+        /**
+         * No backpressure is applied an the onNext calls pass through the AsyncEmitter;
+         * note that this may cause {@link rx.exceptions.MissingBackpressureException} or {@link IllegalStateException}
+         * somewhere downstream.
+         */
         NONE,
-        
+        /**
+         * Signals a {@link rx.exceptions.MissingBackpressureException} if the downstream can't keep up.
+         */
         ERROR,
-        
+        /**
+         * Buffers (unbounded) all onNext calls until the dowsntream can consume them.
+         */
         BUFFER,
-        
+        /**
+         * Drops the incoming onNext value if the downstream can't keep up.
+         */
         DROP,
-        
+        /**
+         * Keeps the latest onNext value and overwrites it with newer ones until the downstream
+         * can consume it.
+         */
         LATEST
     }
 }

--- a/src/main/java/rx/CompletableEmitter.java
+++ b/src/main/java/rx/CompletableEmitter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx;
+
+import rx.AsyncEmitter.Cancellable;
+import rx.annotations.Experimental;
+
+/**
+ * Abstraction over a {@link CompletableSubscriber} that gets either an onCompleted or onError
+ * signal and allows registering an cancellation/unsubscription callback.
+ * <p>
+ * All methods are thread-safe; calling onCompleted or onError twice or one after the other has
+ * no effect.
+ * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ */
+@Experimental
+public interface CompletableEmitter {
+
+    /**
+     * Notifies the CompletableSubscriber that the {@link Completable} has finished 
+     * sending push-based notifications.
+     * <p>
+     * The {@link Observable} will not call this method if it calls {@link #onError}.
+     */
+    void onCompleted();
+    
+    /**
+     * Notifies the CompletableSubscriber that the {@link Completable} has experienced an error condition.
+     * <p>
+     * If the {@link Completable} calls this method, it will not thereafter call
+     * {@link #onCompleted}.
+     * 
+     * @param t
+     *          the exception encountered by the Observable
+     */
+    void onError(Throwable t);
+
+    /**
+     * Sets a Subscription on this emitter; any previous Subscription
+     * or Cancellation will be unsubscribed/cancelled.
+     * @param s the subscription, null is allowed
+     */
+    void setSubscription(Subscription s);
+    
+    /**
+     * Sets a Cancellable on this emitter; any previous Subscription
+     * or Cancellation will be unsubscribed/cancelled.
+     * @param c the cancellable resource, null is allowed
+     */
+    void setCancellation(Cancellable c);
+}

--- a/src/main/java/rx/internal/operators/CompletableFromEmitter.java
+++ b/src/main/java/rx/internal/operators/CompletableFromEmitter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.*;
+import rx.AsyncEmitter.Cancellable;
+import rx.exceptions.Exceptions;
+import rx.functions.Action1;
+import rx.internal.operators.OnSubscribeFromEmitter.CancellableSubscription;
+import rx.internal.subscriptions.SequentialSubscription;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Allows push-based emission of terminal events to a CompletableSubscriber.
+ */
+public final class CompletableFromEmitter implements Completable.OnSubscribe {
+
+    final Action1<CompletableEmitter> producer;
+
+    public CompletableFromEmitter(Action1<CompletableEmitter> producer) {
+        this.producer = producer;
+    }
+    
+    @Override
+    public void call(CompletableSubscriber t) {
+        FromEmitter emitter = new FromEmitter(t);
+        t.onSubscribe(emitter);
+        
+        try {
+            producer.call(emitter);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            emitter.onError(ex);
+        }
+        
+    }
+    
+    static final class FromEmitter 
+    extends AtomicBoolean
+    implements CompletableEmitter, Subscription {
+
+        /** */
+        private static final long serialVersionUID = 5539301318568668881L;
+
+        final CompletableSubscriber actual;
+        
+        final SequentialSubscription resource;
+        
+        public FromEmitter(CompletableSubscriber actual) {
+            this.actual = actual;
+            resource = new SequentialSubscription();
+        }
+        
+        @Override
+        public void onCompleted() {
+            if (compareAndSet(false, true)) {
+                try {
+                    actual.onCompleted();
+                } finally {
+                    resource.unsubscribe();
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (compareAndSet(false, true)) {
+                try {
+                    actual.onError(t);
+                } finally {
+                    resource.unsubscribe();
+                }
+            } else {
+                RxJavaHooks.onError(t);
+            }
+        }
+
+        @Override
+        public void setSubscription(Subscription s) {
+            resource.update(s);
+        }
+
+        @Override
+        public void setCancellation(Cancellable c) {
+            setSubscription(new CancellableSubscription(c));
+        }
+
+        @Override
+        public void unsubscribe() {
+            if (compareAndSet(false, true)) {
+                resource.unsubscribe();
+            }
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return get();
+        }
+        
+    }
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeFromEmitter.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromEmitter.java
@@ -28,13 +28,13 @@ import rx.internal.util.unsafe.*;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
-public final class OnSubscribeFromAsync<T> implements OnSubscribe<T> {
+public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
 
     final Action1<AsyncEmitter<T>> asyncEmitter;
     
     final AsyncEmitter.BackpressureMode backpressure;
     
-    public OnSubscribeFromAsync(Action1<AsyncEmitter<T>> asyncEmitter, AsyncEmitter.BackpressureMode backpressure) {
+    public OnSubscribeFromEmitter(Action1<AsyncEmitter<T>> asyncEmitter, AsyncEmitter.BackpressureMode backpressure) {
         this.asyncEmitter = asyncEmitter;
         this.backpressure = backpressure;
     }
@@ -72,6 +72,9 @@ public final class OnSubscribeFromAsync<T> implements OnSubscribe<T> {
         
     }
     
+    /**
+     * A Subscription that wraps an AsyncEmitter.Cancellable instance.
+     */
     static final class CancellableSubscription 
     extends AtomicReference<AsyncEmitter.Cancellable>
     implements Subscription {
@@ -299,7 +302,7 @@ public final class OnSubscribeFromAsync<T> implements OnSubscribe<T> {
 
         @Override
         void onOverflow() {
-            onError(new MissingBackpressureException("fromAsync: could not emit value due to lack of requests"));
+            onError(new MissingBackpressureException("fromEmitter: could not emit value due to lack of requests"));
         }
         
     }

--- a/src/main/java/rx/internal/operators/OnSubscribeToMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeToMap.java
@@ -47,6 +47,7 @@ public final class OnSubscribeToMap<T, K, V> implements OnSubscribe<Map<K, V>>, 
 
     /**
      * ToMap with key selector, value selector and default HashMap factory.
+     * @param source the source Observable instance
      * @param keySelector the function extracting the map-key from the main value
      * @param valueSelector the function extracting the map-value from the main value
      */
@@ -59,6 +60,7 @@ public final class OnSubscribeToMap<T, K, V> implements OnSubscribe<Map<K, V>>, 
 
     /**
      * ToMap with key selector, value selector and custom Map factory.
+     * @param source the source Observable instance
      * @param keySelector the function extracting the map-key from the main value
      * @param valueSelector the function extracting the map-value from the main value
      * @param mapFactory function that returns a Map instance to store keys and values into

--- a/src/main/java/rx/internal/operators/OnSubscribeToMultimap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeToMultimap.java
@@ -49,6 +49,7 @@ public final class OnSubscribeToMultimap<T, K, V> implements OnSubscribe<Map<K, 
     /**
      * ToMultimap with key selector, custom value selector,
      * default HashMap factory and default ArrayList collection factory.
+     * @param source the source Observable instance
      * @param keySelector the function extracting the map-key from the main value
      * @param valueSelector the function extracting the map-value from the main value
      */
@@ -64,7 +65,7 @@ public final class OnSubscribeToMultimap<T, K, V> implements OnSubscribe<Map<K, 
     /**
      * ToMultimap with key selector, custom value selector,
      * custom Map factory and default ArrayList collection factory.
-     * @param the observable source
+     * @param source the source Observable instance
      * @param keySelector the function extracting the map-key from the main value
      * @param valueSelector the function extracting the map-value from the main value
      * @param mapFactory function that returns a Map instance to store keys and values into

--- a/src/main/java/rx/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/rx/internal/schedulers/SchedulerWhen.java
@@ -53,7 +53,7 @@ import rx.subscriptions.Subscriptions;
  * Finally the actions scheduled on the parent {@link Scheduler} when the inner
  * most {@link Completable}s are subscribed to.
  * <p>
- * When the {@link Worker} is unsubscribed the {@link Completable} emits an
+ * When the {@link rx.Scheduler.Worker} is unsubscribed the {@link Completable} emits an
  * onComplete and triggers any behavior in the flattening operator. The
  * {@link Observable} and all {@link Completable}s give to the flattening
  * function never onError.
@@ -71,8 +71,8 @@ import rx.subscriptions.Subscriptions;
  * <p>
  * This is a slightly different way to limit the concurrency but it has some
  * interesting benefits and drawbacks to the method above. It works by limited
- * the number of concurrent {@link Worker}s rather than individual actions.
- * Generally each {@link Observable} uses its own {@link Worker}. This means
+ * the number of concurrent {@link rx.Scheduler.Worker}s rather than individual actions.
+ * Generally each {@link Observable} uses its own {@link rx.Scheduler.Worker}. This means
  * that this will essentially limit the number of concurrent subscribes. The
  * danger comes from using operators like
  * {@link Observable#zip(Observable, Observable, rx.functions.Func2)} where
@@ -101,9 +101,6 @@ import rx.subscriptions.Subscriptions;
  * 	}));
  * });
  * </pre>
- * 
- * @param combine
- * @return
  */
 @Experimental
 public class SchedulerWhen extends Scheduler implements Subscription {

--- a/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
@@ -46,8 +46,8 @@ public abstract class RxJavaCompletableExecutionHook { // NOPMD
      * logging, metrics and other such things and pass through the function.
      *
      * @param f
-     *            original {@link Completable.OnSubscribe}<{@code T}> to be executed
-     * @return {@link Completable.OnSubscribe} function that can be modified, decorated, replaced or just
+     *            original {@link rx.Completable.OnSubscribe}<{@code T}> to be executed
+     * @return {@link rx.Completable.OnSubscribe} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     @Deprecated
@@ -63,8 +63,8 @@ public abstract class RxJavaCompletableExecutionHook { // NOPMD
      *
      * @param completableInstance the target completable instance
      * @param onSubscribe
-     *            original {@link Completable.OnSubscribe}<{@code T}> to be executed
-     * @return {@link Completable.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
+     *            original {@link rx.Completable.OnSubscribe}<{@code T}> to be executed
+     * @return {@link rx.Completable.OnSubscribe}<{@code T}> function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     @Deprecated
@@ -93,12 +93,12 @@ public abstract class RxJavaCompletableExecutionHook { // NOPMD
      * Invoked just as the operator functions is called to bind two operations together into a new
      * {@link Completable} and the return value is used as the lifted function
      * <p>
-     * This can be used to decorate or replace the {@link Completable.Operator} instance or just perform extra
+     * This can be used to decorate or replace the {@link rx.Completable.Operator} instance or just perform extra
      * logging, metrics and other such things and pass through the onSubscribe.
      *
      * @param lift
-     *            original {@link Completable.Operator}{@code <R, T>}
-     * @return {@link Completable.Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
+     *            original {@link rx.Completable.Operator}{@code <R, T>}
+     * @return {@link rx.Completable.Operator}{@code <R, T>} function that can be modified, decorated, replaced or just
      *         returned as a pass through
      */
     @Deprecated

--- a/src/main/java/rx/plugins/RxJavaHooks.java
+++ b/src/main/java/rx/plugins/RxJavaHooks.java
@@ -421,7 +421,7 @@ public final class RxJavaHooks {
      * @return the original or alternative action that will be subscribed to
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Observable.OnSubscribe onObservableStart(Observable<T> instance, Observable.OnSubscribe onSubscribe) {
+    public static <T> Observable.OnSubscribe<T> onObservableStart(Observable<T> instance, Observable.OnSubscribe<T> onSubscribe) {
         Func2<Observable, Observable.OnSubscribe, Observable.OnSubscribe> f = onObservableStart;
         if (f != null) {
             return f.call(instance, onSubscribe);
@@ -479,7 +479,7 @@ public final class RxJavaHooks {
      * @return the original or alternative action that will be subscribed to
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Observable.OnSubscribe onSingleStart(Single<T> instance, Observable.OnSubscribe onSubscribe) {
+    public static <T> Observable.OnSubscribe<T> onSingleStart(Single<T> instance, Observable.OnSubscribe<T> onSubscribe) {
         Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> f = onSingleStart;
         if (f != null) {
             return f.call(instance, onSubscribe);

--- a/src/test/java/rx/ObservableConversionTest.java
+++ b/src/test/java/rx/ObservableConversionTest.java
@@ -36,6 +36,7 @@ import rx.internal.operators.OnSubscribeMap;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
+@SuppressWarnings("deprecation")
 public class ObservableConversionTest {
     
     public static class Cylon {}

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -1107,6 +1107,7 @@ public class ObservableTests {
         .forEach(null);
     }
     
+    @SuppressWarnings("deprecation")
     @Test
     public void testExtend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();

--- a/src/test/java/rx/internal/operators/CompletableFromEmitterTest.java
+++ b/src/test/java/rx/internal/operators/CompletableFromEmitterTest.java
@@ -1,0 +1,330 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import rx.*;
+import rx.exceptions.TestException;
+import rx.functions.*;
+import rx.observers.TestSubscriber;
+import rx.subscriptions.BooleanSubscription;
+
+public class CompletableFromEmitterTest {
+
+    @Test
+    public void normal() {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.onCompleted();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void error() {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.onError(new TestException());
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+    
+    @Test
+    public void ensureProtocol1() { 
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.onError(new TestException());
+                e.onCompleted();
+                e.onError(new IOException());
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void ensureProtocol2() { 
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.onCompleted();
+                e.onError(new TestException());
+                e.onCompleted();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void resourceCleanupNormal() {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+
+        final BooleanSubscription bs = new BooleanSubscription();
+
+        assertFalse(bs.isUnsubscribed());
+
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.setSubscription(bs);
+                e.onCompleted();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+        
+        assertTrue(bs.isUnsubscribed());
+    }
+    
+    @Test
+    public void resourceCleanupError() {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+
+        final BooleanSubscription bs = new BooleanSubscription();
+
+        assertFalse(bs.isUnsubscribed());
+
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.setSubscription(bs);
+                e.onError(new TestException());
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+        
+        assertTrue(bs.isUnsubscribed());
+    }
+    
+    @Test
+    public void resourceCleanupCancellable() throws Exception {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+
+        final AsyncEmitter.Cancellable c = Mockito.mock(AsyncEmitter.Cancellable.class);
+
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.setCancellation(c);
+                e.onCompleted();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+
+        Mockito.verify(c).cancel();
+    }
+    
+    @Test
+    public void resourceCleanupUnsubscirbe() throws Exception {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        ts.unsubscribe();
+
+        final AsyncEmitter.Cancellable c = Mockito.mock(AsyncEmitter.Cancellable.class);
+
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.setCancellation(c);
+                e.onCompleted();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotCompleted();
+
+        Mockito.verify(c).cancel();
+    }
+    
+    @Test
+    public void resourceCleanupOnCompleteCrashes() throws Exception {
+        final AsyncEmitter.Cancellable c = Mockito.mock(AsyncEmitter.Cancellable.class);
+
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.setCancellation(c);
+                e.onCompleted();
+            }
+        }).unsafeSubscribe(new CompletableSubscriber() {
+
+            @Override
+            public void onCompleted() {
+                throw new TestException();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onSubscribe(Subscription d) {
+                
+            }
+            
+        });
+        
+
+        Mockito.verify(c).cancel();
+    }
+    
+    @Test
+    public void resourceCleanupOnErrorCrashes() throws Exception {
+        final AsyncEmitter.Cancellable c = Mockito.mock(AsyncEmitter.Cancellable.class);
+
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.setCancellation(c);
+                e.onError(new IOException());
+            }
+        }).unsafeSubscribe(new CompletableSubscriber() {
+
+            @Override
+            public void onCompleted() {
+                throw new TestException();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onSubscribe(Subscription d) {
+                
+            }
+            
+        });
+        
+
+        Mockito.verify(c).cancel();
+    }
+    @Test
+    public void producerCrashes() {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                throw new TestException();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotCompleted();
+    }
+
+    @Test
+    public void producerCrashesAfterSignal() {
+        TestSubscriber<Void> ts = TestSubscriber.create();
+        
+        Completable.fromEmitter(new Action1<CompletableEmitter>() {
+            @Override
+            public void call(CompletableEmitter e) {
+                e.onCompleted();
+                throw new TestException();
+            }
+        }).subscribe(ts);
+        
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+    
+    @Test
+    public void concurrentUse() {
+        for (int i = 0; i < 500; i++) {
+            TestSubscriber<Void> ts = TestSubscriber.create();
+            
+            final CompletableEmitter[] emitter = { null };
+            
+            Completable.fromEmitter(new Action1<CompletableEmitter>() {
+                @Override
+                public void call(CompletableEmitter e) {
+                    emitter[0] = e;
+                }
+            }).subscribe(ts);
+            
+            final TestException ex = new TestException();
+            final CompletableEmitter e = emitter[0];
+            
+            TestUtil.race(new Action0() {
+                @Override
+                public void call() { 
+                    e.onCompleted();
+                }
+            }, new Action0() {
+                @Override
+                public void call() { 
+                    e.onError(ex);
+                }
+            });
+            
+            if (ts.getCompletions() != 0) {
+                ts.assertNoValues();
+                ts.assertNoErrors();
+                ts.assertCompleted();
+            }
+            if (!ts.getOnErrorEvents().isEmpty()) {
+                ts.assertNoValues();
+                ts.assertError(ex);
+                ts.assertNotCompleted();
+            }
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/OnSubscribeConcatDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeConcatDelayErrorTest.java
@@ -277,7 +277,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(2, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError2() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -292,7 +291,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError2Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -309,7 +307,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(2, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError3() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -325,7 +322,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError3Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -343,7 +339,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(3, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError4() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -360,7 +355,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError4Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -379,7 +373,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(4, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError5() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -397,7 +390,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError5Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -417,7 +409,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(5, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError6() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -436,7 +427,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError6Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -457,7 +447,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(6, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError7() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -477,7 +466,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError7Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -499,7 +487,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(7, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError8() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -521,7 +508,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError8Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -544,7 +530,6 @@ public class OnSubscribeConcatDelayErrorTest {
         assertEquals(8, ((CompositeException)ts.getOnErrorEvents().get(0)).getExceptions().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError9() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -567,7 +552,6 @@ public class OnSubscribeConcatDelayErrorTest {
         ts.assertCompleted();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayError9Error() {
         TestSubscriber<Integer> ts = TestSubscriber.create();

--- a/src/test/java/rx/internal/operators/OnSubscribeFromEmitterTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromEmitterTest.java
@@ -31,7 +31,7 @@ import rx.observers.TestSubscriber;
 import rx.plugins.RxJavaHooks;
 import rx.subjects.PublishSubject;
 
-public class OnSubscribeFromAsyncTest {
+public class OnSubscribeFromEmitterTest {
 
     PublishAsyncEmitter source;
 
@@ -48,7 +48,7 @@ public class OnSubscribeFromAsyncTest {
     
     @Test
     public void normalBuffered() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -69,7 +69,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void normalDrop() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
         
         source.onNext(1);
 
@@ -85,7 +85,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void normalLatest() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         source.onNext(1);
 
@@ -101,7 +101,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void normalNone() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -114,7 +114,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void normalNoneRequested() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
         ts.requestMore(2);
         
         source.onNext(1);
@@ -129,7 +129,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void normalError() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -139,7 +139,7 @@ public class OnSubscribeFromAsyncTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotCompleted();
         
-        Assert.assertEquals("fromAsync: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+        Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
     }
     
     @Test
@@ -152,13 +152,13 @@ public class OnSubscribeFromAsyncTest {
                 //don't check for unsubscription
                 emitter.onNext(2);
             }};
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
         
         ts.assertNoValues();
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotCompleted();
         
-        Assert.assertEquals("fromAsync: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+        Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
     }
     
     @Test
@@ -171,13 +171,13 @@ public class OnSubscribeFromAsyncTest {
                 //don't check for unsubscription
                 emitter.onCompleted();
             }};
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
         
         ts.assertNoValues();
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotCompleted();
         
-        Assert.assertEquals("fromAsync: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+        Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
     }
     
     @Test
@@ -198,13 +198,13 @@ public class OnSubscribeFromAsyncTest {
                     //don't check for unsubscription
                     emitter.onError(e);
                 }};
-            Observable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
+            Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
             
             ts.assertNoValues();
             ts.assertError(MissingBackpressureException.class);
             ts.assertNotCompleted();
             
-            Assert.assertEquals("fromAsync: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+            Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
             assertEquals(Arrays.asList(e), list);
         } finally {
             RxJavaHooks.reset();
@@ -213,7 +213,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void errorBuffered() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -232,7 +232,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void errorLatest() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -247,7 +247,7 @@ public class OnSubscribeFromAsyncTest {
     
     @Test
     public void errorNone() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -262,7 +262,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedBuffer() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.unsubscribe();
         
         source.onNext(1);
@@ -278,7 +278,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedLatest() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         ts.unsubscribe();
         
         source.onNext(1);
@@ -294,7 +294,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedError() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
         ts.unsubscribe();
         
         source.onNext(1);
@@ -310,7 +310,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedDrop() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
         ts.unsubscribe();
         
         source.onNext(1);
@@ -326,7 +326,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedNone() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
         ts.unsubscribe();
         
         source.onNext(1);
@@ -342,7 +342,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelBuffer() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.unsubscribe();
         
         sourceNoCancel.onNext(1);
@@ -358,7 +358,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelLatest() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         ts.unsubscribe();
         
         sourceNoCancel.onNext(1);
@@ -374,7 +374,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelError() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.ERROR).subscribe(ts);
         ts.unsubscribe();
         
         sourceNoCancel.onNext(1);
@@ -390,7 +390,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelDrop() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.DROP).subscribe(ts);
         ts.unsubscribe();
         
         sourceNoCancel.onNext(1);
@@ -406,7 +406,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribedNoCancelNone() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.NONE).subscribe(ts);
         ts.unsubscribe();
         
         sourceNoCancel.onNext(1);
@@ -422,7 +422,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void deferredRequest() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -437,7 +437,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void take() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
         
         source.onNext(1);
         source.onNext(2);
@@ -452,7 +452,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void takeOne() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
         ts.requestMore(2);
         
         source.onNext(1);
@@ -466,7 +466,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void requestExact() {
-        Observable.fromAsync(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(source, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.requestMore(2);
         
         source.onNext(1);
@@ -480,7 +480,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void takeNoCancel() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -495,7 +495,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void takeOneNoCancel() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
         ts.requestMore(2);
         
         sourceNoCancel.onNext(1);
@@ -509,7 +509,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void unsubscribeNoCancel() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.requestMore(2);
         
         sourceNoCancel.onNext(1);
@@ -534,7 +534,7 @@ public class OnSubscribeFromAsyncTest {
             }
         };
         
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         
@@ -545,7 +545,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void completeInline() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onCompleted();
@@ -559,7 +559,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void errorInline() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onError(new TestException());
@@ -581,7 +581,7 @@ public class OnSubscribeFromAsyncTest {
             }
         };
         
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.BUFFER).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -601,7 +601,7 @@ public class OnSubscribeFromAsyncTest {
             }
         };
         
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         
@@ -620,7 +620,7 @@ public class OnSubscribeFromAsyncTest {
             }
         };
         
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         
@@ -631,7 +631,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void completeInlineLatest() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onCompleted();
@@ -645,7 +645,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void completeInlineExactLatest() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onCompleted();
@@ -659,7 +659,7 @@ public class OnSubscribeFromAsyncTest {
 
     @Test
     public void errorInlineLatest() {
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onError(new TestException());
@@ -681,7 +681,7 @@ public class OnSubscribeFromAsyncTest {
             }
         };
         
-        Observable.fromAsync(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
+        Observable.fromEmitter(sourceNoCancel, AsyncEmitter.BackpressureMode.LATEST).subscribe(ts1);
         
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);

--- a/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
+++ b/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
@@ -259,7 +259,7 @@ public class OperatorToObservableSortedListTest {
         testSubscriber.assertNotCompleted();
     }
 
-    private final static class NonComparable{
+    final static class NonComparable{
         public int i;
         public String s;
 

--- a/src/test/java/rx/schedulers/SchedulerWhenTest.java
+++ b/src/test/java/rx/schedulers/SchedulerWhenTest.java
@@ -195,7 +195,8 @@ public class SchedulerWhenTest {
 					}
 				});
 				return Completable.concat(workers.map(new Func1<Completable, Completable>() {
-					public Completable call(Completable worker) {
+					@Override
+				    public Completable call(Completable worker) {
 						return worker.delay(1, SECONDS, tSched);
 					}
 				}));

--- a/src/test/java/rx/subjects/ReplaySubjectTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectTest.java
@@ -1140,5 +1140,39 @@ public class ReplaySubjectTest {
         backpressureOffline(ReplaySubject.<Integer>createWithTimeAndSize(1, TimeUnit.DAYS, 10, Schedulers.immediate()));
         backpressureOffline(ReplaySubject.<Integer>createWithTimeAndSize(1, TimeUnit.DAYS, 100, Schedulers.immediate()));
     }
+    
+    @Test
+    public void filtered() {
+        ReplaySubject<Integer> subject = ReplaySubject.create();
+        
+        TestSubscriber<Integer> ts1 = TestSubscriber.create();
+        TestSubscriber<Integer> ts2 = TestSubscriber.create();
+        
+        Observable<Integer> o = subject.filter(new Func1<Integer, Boolean>() {
+            @Override
+            public Boolean call(Integer v) {
+                return v > 0;
+            }
+        });
+        
+        o.subscribe(ts1);
+        o.subscribe(ts2);
+        
+        subject.onNext(1);
+        subject.onNext(2);
+        subject.onNext(0);
+        subject.onNext(3);
+        subject.onNext(0);
+        subject.onNext(6);
+        
+        ts1.assertValues(1, 2, 3, 6);
+        ts2.assertValues(1, 2, 3, 6);
+        
+        subject.onNext(0);
+        subject.onNext(7);
+        
+        ts1.assertValues(1, 2, 3, 6, 7);
+        ts2.assertValues(1, 2, 3, 6, 7);
+    }
 
 }


### PR DESCRIPTION
- Add javadoc to `AsyncEmitter.BackpressureMode` (#4199)
- Deprecate `Observable.fromAsync`, add `Observable.fromEmitter` instead (#4255)
- Add `Completable.fromEmitter()` (#4356)
- Add missing placeholder `@since` tags
- Fix some generics error `RxJavaHooks`
- Add race helper to `TestUtil`
- Fix javadoc warnings
