### PR TITLE
Wrap InterruptedException with an unchecked exception in TestSubscriber#awaitValueCount().

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -355,13 +355,17 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * @param timeout the time to wait for the events
      * @param unit the time unit of waiting
      * @return true if the expected number of onNext events happened
-     * @throws InterruptedException if the sleep is interrupted
+     * @throws RuntimeException if the sleep is interrupted
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
     @Experimental
-    public final boolean awaitValueCount(int expected, long timeout, TimeUnit unit) throws InterruptedException {
+    public final boolean awaitValueCount(int expected, long timeout, TimeUnit unit) {
         while (timeout != 0 && valueCount < expected) {
-            unit.sleep(1);
+            try {
+                unit.sleep(1);
+            } catch (InterruptedException e) {
+                throw new IllegalStateException("Interrupted", e);
+            }
             timeout--;
         }
         return valueCount >= expected;

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -750,7 +750,7 @@ public class TestSubscriberTest {
     }
     
     @Test
-    public void awaitValueCount() throws Exception {
+    public void awaitValueCount() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Observable.range(1, 5).delay(100, TimeUnit.MILLISECONDS)
@@ -763,7 +763,7 @@ public class TestSubscriberTest {
     }
     
     @Test
-    public void awaitValueCountFails() throws Exception {
+    public void awaitValueCountFails() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
         
         Observable.range(1, 2).delay(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
In its current form, `awaitValueCount()` is the only `TestSubscriber#await*`method that throws a checked exception (that is, `InterruptedException`), whereas the others wrap it with a `IllegalStateException`. This spreads a try-catch disease throughout the entire code base where `awaitValueCount()` is used. One can argue that why not just declaring the exception in the caller method footprint: Because you might be implementing an interface (e.g. `Runnable`) which does not allow any exceptions in its footprint. This patch wraps the `InterruptedException` with an unchecked exception in `TestSubscriber#awaitValueCount()`.
