### PR TITLE
2.x: rename Observable and Single #doOnCancel to #doOnDispose

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -956,7 +956,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onDispose the callback to call when the child subscriber cancels the subscription
+     * @param onDispose the callback to call when the child subscriber disposes the subscription
      * @return the new Completable instance
      * @throws NullPointerException if onDispose is null
      */
@@ -995,7 +995,7 @@ public abstract class Completable implements CompletableSource {
      * @param onError the consumer called when this emits an onError event
      * @param onComplete the runnable called just before when this Completable completes normally
      * @param onAfterTerminate the runnable called after this Completable completes normally
-     * @param onDisposed the runnable called when the child cancels the subscription
+     * @param onDispose the runnable called when the child disposes the subscription
      * @return the new Completable instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1005,14 +1005,14 @@ public abstract class Completable implements CompletableSource {
             final Action onComplete, 
             final Action onTerminate,
             final Action onAfterTerminate,
-            final Action onDisposed) {
+            final Action onDispose) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         ObjectHelper.requireNonNull(onError, "onError is null");
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         ObjectHelper.requireNonNull(onTerminate, "onTerminate is null");
         ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        ObjectHelper.requireNonNull(onDisposed, "onDisposed is null");
-        return RxJavaPlugins.onAssembly(new CompletablePeek(this, onSubscribe, onError, onComplete, onTerminate, onAfterTerminate, onDisposed));
+        ObjectHelper.requireNonNull(onDispose, "onDispose is null");
+        return RxJavaPlugins.onAssembly(new CompletablePeek(this, onSubscribe, onError, onComplete, onTerminate, onAfterTerminate, onDispose));
     }
     
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6297,14 +6297,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code doOnUnsubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param onCancel
+     * @param onDispose
      *            the action that gets called when the source {@code ObservableSource}'s Subscription is cancelled
      * @return the source {@code ObservableSource} modified so as to call this Action when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnCancel(Action onCancel) {
-        return doOnLifecycle(Functions.emptyConsumer(), onCancel);
+    public final Observable<T> doOnDispose(Action onDispose) {
+        return doOnLifecycle(Functions.emptyConsumer(), onDispose);
     }
 
     /**
@@ -6437,16 +6437,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * 
      * @param onSubscribe
      *              a Consumer called with the Subscription sent via Subscriber.onSubscribe()
-     * @param onCancel
-     *              called when the downstream cancels the Subscription via cancel()
+     * @param onDispose
+     *              called when the downstream disposes the Subscription via dispose()
      * @return the source ObservableSource with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnLifecycle(final Consumer<? super Disposable> onSubscribe, final Action onCancel) {
+    public final Observable<T> doOnLifecycle(final Consumer<? super Disposable> onSubscribe, final Action onDispose) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
-        ObjectHelper.requireNonNull(onCancel, "onCancel is null");
-        return RxJavaPlugins.onAssembly(new ObservableDoOnLifecycle<T>(this, onSubscribe, onCancel));
+        ObjectHelper.requireNonNull(onDispose, "onDispose is null");
+        return RxJavaPlugins.onAssembly(new ObservableDoOnLifecycle<T>(this, onSubscribe, onDispose));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6294,11 +6294,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnUnsubscribe.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doOnUnsubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onDispose
-     *            the action that gets called when the source {@code ObservableSource}'s Subscription is cancelled
+     *            the action that gets called when the source {@code ObservableSource}'s Subscription is disposed
      * @return the source {@code ObservableSource} modified so as to call this Action when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1579,13 +1579,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onCancel the runnable called when the subscription is cancelled (disposed)
+     * @param onDispose the runnable called when the subscription is disposed
      * @return the new Single instance
      * @since 2.0
      */
-    public final Single<T> doOnCancel(final Action onCancel) {
-        ObjectHelper.requireNonNull(onCancel, "onCancel is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnCancel<T>(this, onCancel));
+    public final Single<T> doOnDispose(final Action onDispose) {
+        ObjectHelper.requireNonNull(onDispose, "onDispose is null");
+        return RxJavaPlugins.onAssembly(new SingleDoOnDispose<T>(this, onDispose));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -28,21 +28,21 @@ public final class CompletablePeek extends Completable {
     final Action onComplete;
     final Action onTerminate;
     final Action onAfterTerminate;
-    final Action onDisposed;
+    final Action onDispose;
     
     public CompletablePeek(CompletableSource source, Consumer<? super Disposable> onSubscribe,
                            Consumer<? super Throwable> onError,
                            Action onComplete,
                            Action onTerminate,
                            Action onAfterTerminate,
-                           Action onDisposed) {
+                           Action onDispose) {
         this.source = source;
         this.onSubscribe = onSubscribe;
         this.onError = onError;
         this.onComplete = onComplete;
         this.onTerminate = onTerminate;
         this.onAfterTerminate = onAfterTerminate;
-        this.onDisposed = onDisposed;
+        this.onDispose = onDispose;
     }
 
     @Override
@@ -107,7 +107,7 @@ public final class CompletablePeek extends Completable {
                     @Override
                     public void run() {
                         try {
-                            onDisposed.run();
+                            onDispose.run();
                         } catch (Throwable e) {
                             Exceptions.throwIfFatal(e);
                             RxJavaPlugins.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnLifecycle.java
@@ -19,17 +19,17 @@ import io.reactivex.internal.subscribers.observable.SubscriptionLambdaObserver;
 
 public final class ObservableDoOnLifecycle<T> extends AbstractObservableWithUpstream<T, T> {
     private final Consumer<? super Disposable> onSubscribe;
-    private final Action onCancel;
+    private final Action onDispose;
 
     public ObservableDoOnLifecycle(Observable<T> upstream, Consumer<? super Disposable> onSubscribe,
-            Action onCancel) {
+            Action onDispose) {
         super(upstream);
         this.onSubscribe = onSubscribe;
-        this.onCancel = onCancel;
+        this.onDispose = onDispose;
     }
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new SubscriptionLambdaObserver<T>(observer, onSubscribe, onCancel));
+        source.subscribe(new SubscriptionLambdaObserver<T>(observer, onSubscribe, onDispose));
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnDispose.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnDispose.java
@@ -20,38 +20,38 @@ import io.reactivex.functions.Action;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class SingleDoOnCancel<T> extends Single<T> {
+public final class SingleDoOnDispose<T> extends Single<T> {
     final SingleSource<T> source;
 
-    final Action onCancel;
+    final Action onDispose;
 
-    public SingleDoOnCancel(SingleSource<T> source, Action onCancel) {
+    public SingleDoOnDispose(SingleSource<T> source, Action onDispose) {
         this.source = source;
-        this.onCancel = onCancel;
+        this.onDispose = onDispose;
     }
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
 
-        source.subscribe(new DoOnCancelObserver<T>(s, onCancel));
+        source.subscribe(new DoOnDisposeObserver<T>(s, onDispose));
     }
     
-    static final class DoOnCancelObserver<T> implements SingleObserver<T>, Disposable {
+    static final class DoOnDisposeObserver<T> implements SingleObserver<T>, Disposable {
         final SingleObserver<? super T> actual;
         
-        final Action onCancel;
+        final Action onDispose;
 
         Disposable d;
         
-        public DoOnCancelObserver(SingleObserver<? super T> actual, Action onCancel) {
+        public DoOnDisposeObserver(SingleObserver<? super T> actual, Action onDispose) {
             this.actual = actual;
-            this.onCancel = onCancel;
+            this.onDispose = onDispose;
         }
 
         @Override
         public void dispose() {
             try {
-                onCancel.run();
+                onDispose.run();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/internal/subscribers/observable/SubscriptionLambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/SubscriptionLambdaObserver.java
@@ -23,16 +23,16 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class SubscriptionLambdaObserver<T> implements Observer<T>, Disposable {
     final Observer<? super T> actual;
     final Consumer<? super Disposable> onSubscribe;
-    final Action onCancel;
+    final Action onDispose;
     
     Disposable s;
     
     public SubscriptionLambdaObserver(Observer<? super T> actual, 
             Consumer<? super Disposable> onSubscribe,
-            Action onCancel) {
+            Action onDispose) {
         this.actual = actual;
         this.onSubscribe = onSubscribe;
-        this.onCancel = onCancel;
+        this.onDispose = onDispose;
     }
 
     @Override
@@ -73,7 +73,7 @@ public final class SubscriptionLambdaObserver<T> implements Observer<T>, Disposa
     @Override
     public void dispose() {
         try {
-            onCancel.run();
+            onDispose.run();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             RxJavaPlugins.onError(e);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -108,7 +108,7 @@ public class ObservableCacheTest {
     @Test
     public void testUnsubscribeSource() throws Exception {
         Action unsubscribe = mock(Action.class);
-        Observable<Integer> o = Observable.just(1).doOnCancel(unsubscribe).cache();
+        Observable<Integer> o = Observable.just(1).doOnDispose(unsubscribe).cache();
         o.subscribe();
         o.subscribe();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -212,7 +212,7 @@ public class ObservableDelayTest {
     }
 
     @Test
-    public void testDelaySubscriptionCancelBeforeTime() {
+    public void testDelaySubscriptionDisposeBeforeTime() {
         Observable<Integer> result = Observable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         Observer<Object> o = TestHelper.mockObserver();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
@@ -41,7 +41,7 @@ public class ObservableDoOnUnsubscribeTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
@@ -57,7 +57,7 @@ public class ObservableDoOnUnsubscribeTest {
                             onNextLatch.countDown();
                     }
                 })
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                         // Test that lower stream will be notified for a direct un-subscription
@@ -103,7 +103,7 @@ public class ObservableDoOnUnsubscribeTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
@@ -118,7 +118,7 @@ public class ObservableDoOnUnsubscribeTest {
                             onNextLatch.countDown();
                     }
                 })
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                         // Test that lower stream will be notified for un-subscription

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -80,7 +80,7 @@ public class ObservableIgnoreElementsTest {
     @Test
     public void testUnsubscribesFromUpstream() {
         final AtomicBoolean unsub = new AtomicBoolean();
-        Observable.range(1, 10).doOnCancel(new Action() {
+        Observable.range(1, 10).doOnDispose(new Action() {
             @Override
             public void run() {
                 unsub.set(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -192,7 +192,7 @@ public class ObservablePublishTest {
                         sourceEmission.incrementAndGet();
                     }
                 })
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                         sourceUnsubscribed.set(true);
@@ -209,7 +209,7 @@ public class ObservablePublishTest {
             @Override
             public void onNext(Integer t) {
                 if (valueCount() == 2) {
-                    source.doOnCancel(new Action() {
+                    source.doOnDispose(new Action() {
                         @Override
                         public void run() {
                             child2Unsubscribed.set(true);
@@ -220,7 +220,7 @@ public class ObservablePublishTest {
             }
         };
         
-        source.doOnCancel(new Action() {
+        source.doOnDispose(new Action() {
             @Override
             public void run() {
                 child1Unsubscribed.set(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -170,7 +170,7 @@ public class ObservableRefCountTest {
                             subscribeCount.incrementAndGet();
                     }
                 })
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");
@@ -215,7 +215,7 @@ public class ObservableRefCountTest {
                             subscribeLatch.countDown();
                     }
                 })
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");
@@ -253,7 +253,7 @@ public class ObservableRefCountTest {
     public void testConnectUnsubscribeRaceCondition() throws InterruptedException {
         final AtomicInteger subUnsubCount = new AtomicInteger();
         Observable<Long> o = synchronousInterval()
-                .doOnCancel(new Action() {
+                .doOnDispose(new Action() {
                     @Override
                     public void run() {
                             System.out.println("******************************* Unsubscribe received");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -522,7 +522,7 @@ public class ObservableReplayTest {
 
         ConnectableObservable<Integer> replay = source
                 .doOnNext(sourceNext)
-                .doOnCancel(sourceUnsubscribed)
+                .doOnDispose(sourceUnsubscribed)
                 .doOnComplete(sourceCompleted)
                 .replay();
 
@@ -572,7 +572,7 @@ public class ObservableReplayTest {
         // NbpObservable under test
         ConnectableObservable<Integer> replay = Observable.just(1, 2, 3)
                 .doOnNext(sourceNext)
-                .doOnCancel(sourceUnsubscribed)
+                .doOnDispose(sourceUnsubscribed)
                 .doOnComplete(sourceCompleted)
                 .subscribeOn(mockScheduler).replay();
 
@@ -629,7 +629,7 @@ public class ObservableReplayTest {
         when(mockFunc.apply(2)).thenThrow(illegalArgumentException);
         ConnectableObservable<Integer> replay = Observable.just(1, 2, 3).map(mockFunc)
                 .doOnNext(sourceNext)
-                .doOnCancel(sourceUnsubscribed)
+                .doOnDispose(sourceUnsubscribed)
                 .doOnComplete(sourceCompleted)
                 .doOnError(sourceError)
                 .subscribeOn(mockScheduler).replay();
@@ -850,7 +850,7 @@ public class ObservableReplayTest {
     @Test
     public void testUnsubscribeSource() throws Exception {
         Action unsubscribe = mock(Action.class);
-        Observable<Integer> o = Observable.just(1).doOnCancel(unsubscribe).cache();
+        Observable<Integer> o = Observable.just(1).doOnDispose(unsubscribe).cache();
         o.subscribe();
         o.subscribe();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -67,7 +67,7 @@ public class ObservableTakeLastOneTest {
                 unsubscribed.set(true);
             }
         };
-        Observable.just(1).doOnCancel(unsubscribeAction)
+        Observable.just(1).doOnDispose(unsubscribeAction)
                 .takeLast(1).subscribe();
         assertTrue(unsubscribed.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -291,7 +291,7 @@ public class ObservableUsingTest {
         
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
-        .doOnCancel(unsub)
+        .doOnDispose(unsub)
         .doOnComplete(completion);
         
         o.safeSubscribe(NbpObserver);
@@ -318,7 +318,7 @@ public class ObservableUsingTest {
         
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
-        .doOnCancel(unsub)
+        .doOnDispose(unsub)
         .doOnComplete(completion);
         
         o.safeSubscribe(NbpObserver);
@@ -348,7 +348,7 @@ public class ObservableUsingTest {
         
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
-        .doOnCancel(unsub)
+        .doOnDispose(unsub)
         .doOnError(onError);
         
         o.safeSubscribe(NbpObserver);
@@ -376,7 +376,7 @@ public class ObservableUsingTest {
         
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
-        .doOnCancel(unsub)
+        .doOnDispose(unsub)
         .doOnError(onError);
         
         o.safeSubscribe(NbpObserver);

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
@@ -25,10 +25,10 @@ import io.reactivex.functions.*;
 public class SingleDoOnTest {
 
     @Test
-    public void doOnCancel() {
+    public void doOnDispose() {
         final int[] count = { 0 };
         
-        Single.never().doOnCancel(new Action() {
+        Single.never().doOnDispose(new Action() {
             @Override
             public void run() throws Exception { 
                 count[0]++; 

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1267,8 +1267,8 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void doOnCancelNull() {
-        just1.doOnCancel(null);
+    public void doOnDisposeNull() {
+        just1.doOnDispose(null);
     }
     
     @Test(expected = NullPointerException.class)
@@ -1297,7 +1297,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void doOnLifecycleOnCancelNull() {
+    public void doOnLifecycleOnDisposeNull() {
         just1.doOnLifecycle(new Consumer<Disposable>() {
             @Override
             public void accept(Disposable s) { }

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -602,8 +602,8 @@ public class SingleNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void doOnCancelNull() {
-        just1.doOnCancel(null);
+    public void doOnDisposeNull() {
+        just1.doOnDispose(null);
     }
     
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
#4456

Completable already used .doOnDispose() however I renamed the arguments to match Observable and Single
