### PR TITLE
2.x: coverage, bugfixes, 9/03-1

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1331,15 +1331,15 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns an NbpObservable which first delivers the events
-     * of the other NbpObservable then runs this CompletableConsumable.
+     * Returns an Observable which first delivers the events
+     * of the other Observable then runs this CompletableConsumable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param other the other NbpObservable to run first
-     * @return the new NbpObservable instance
+     * @param other the other Observable to run first
+     * @return the new Observable instance
      * @throws NullPointerException if other is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1641,14 +1641,14 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns an NbpObservable which when subscribed to subscribes to this Completable and
+     * Returns an Observable which when subscribed to subscribes to this Completable and
      * relays the terminal events to the subscriber.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @return the new NbpObservable created
+     * @return the new Observable created
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> toObservable() {

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -31,15 +31,15 @@ public final class Functions {
     }
     
     @SuppressWarnings("unchecked")
-    public static <T1, T2, R> Function<Object[], R> toFunction(final BiFunction<? super T1, ? super T2, ? extends R> biFunction) {
-        ObjectHelper.requireNonNull(biFunction, "biFunction is null");
+    public static <T1, T2, R> Function<Object[], R> toFunction(final BiFunction<? super T1, ? super T2, ? extends R> f) {
+        ObjectHelper.requireNonNull(f, "f is null");
         return new Function<Object[], R>() {
             @Override
             public R apply(Object[] a) throws Exception {
                 if (a.length != 2) {
                     throw new IllegalArgumentException("Array of size 2 expected but got " + a.length);
                 }
-                return ((BiFunction<Object, Object, R>)biFunction).apply(a[0], a[1]);
+                return ((BiFunction<Object, Object, R>)f).apply(a[0], a[1]);
             }
         };
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -77,6 +77,8 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
         Subscription s;
 
         boolean done;
+        
+        int index;
 
         public PublisherBufferExactSubscriber(Subscriber<? super C> actual, int size, Callable<C> bufferSupplier) {
             this.actual = actual;
@@ -133,10 +135,14 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
             }
 
             b.add(t);
-
-            if (b.size() == size) {
+            
+            int i = index + 1;
+            if (i == size) {
+                index = 0;
                 buffer = null;
                 actual.onNext(b);
+            } else {
+                index = i;
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -40,14 +40,14 @@ extends Flowable<R> {
 
     final Iterable<? extends Publisher<? extends T>> iterable;
 
-    final Function<Object[], ? extends R> combiner;
+    final Function<? super T[], ? extends R> combiner;
     
     final int bufferSize;
     
     final boolean delayErrors;
 
     public FlowableCombineLatest(Publisher<? extends T>[] array,
-            Function<Object[], ? extends R> combiner,
+            Function<? super T[], ? extends R> combiner,
                     int bufferSize, boolean delayErrors) {
         if (bufferSize <= 0) {
             throw new IllegalArgumentException("BUFFER_SIZE > 0 required but it was " + bufferSize);
@@ -61,7 +61,7 @@ extends Flowable<R> {
     }
     
     public FlowableCombineLatest(Iterable<? extends Publisher<? extends T>> iterable,
-            Function<Object[], ? extends R> combiner,
+            Function<? super T[], ? extends R> combiner,
                     int bufferSize, boolean delayErrors) {
         if (bufferSize <= 0) {
             throw new IllegalArgumentException("BUFFER_SIZE > 0 required but it was " + bufferSize);
@@ -150,7 +150,7 @@ extends Flowable<R> {
             new FlowableMap<T, R>((Publisher<T>)a[0], new Function<T, R>() {
                 @Override
                 public R apply(T t) throws Exception {
-                    return combiner.apply(new Object[] { t });
+                    return combiner.apply((T[])new Object[] { t });
                 }
             }).subscribe(s);
             return;
@@ -173,7 +173,7 @@ extends Flowable<R> {
 
         final Subscriber<? super R> actual;
         
-        final Function<Object[], ? extends R> combiner;
+        final Function<? super T[], ? extends R> combiner;
         
         final CombineLatestInnerSubscriber<T>[] subscribers;
         
@@ -198,7 +198,7 @@ extends Flowable<R> {
         final AtomicReference<Throwable> error;
         
         public CombineLatestCoordinator(Subscriber<? super R> actual, 
-                Function<Object[], ? extends R> combiner, int n,
+                Function<? super T[], ? extends R> combiner, int n,
                 int bufferSize, boolean delayErrors) {
             this.actual = actual;
             this.combiner = combiner;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -179,6 +179,15 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
                         e++;
                     }
                     
+                    if (e == r) {
+                        boolean d = done;
+                        boolean empty = q.isEmpty();
+                        
+                        if (checkTerminated(d, empty, a)) {
+                            return;
+                        }
+                    }
+                    
                     if (e != 0L) {
                         if (r != Long.MAX_VALUE) {
                             requested.addAndGet(-e);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -180,7 +180,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @param unit the unit of measure of the age amount
      * @param scheduler the target scheduler providing the current time
      * @param bufferSize the maximum number of elements to hold
-     * @return the new NbpConnectableObservable instance
+     * @return the new ConnectableFlowable instance
      */
     public static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final long maxAge, final TimeUnit unit, final Scheduler scheduler, final int bufferSize) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -55,7 +55,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @param <R> the result value type
      * @param connectableFactory the factory that returns a ConnectableObservable for each individual subscriber
      * @param selector the function that receives a Observable and should return another Observable that will be subscribed to
-     * @return the new NbpObservable instance
+     * @return the new Observable instance
      */
     public static <U, R> Observable<R> multicastSelector(
             final Callable<? extends ConnectableObservable<U>> connectableFactory,
@@ -94,7 +94,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @param <T> the value type
      * @param co the connectable observable instance
      * @param scheduler the target scheduler
-     * @return the new NbpConnectableObservable instance
+     * @return the new ConnectableObservable instance
      */
     public static <T> ConnectableObservable<T> observeOn(final ConnectableObservable<T> co, final Scheduler scheduler) {
         final Observable<T> observable = co.observeOn(scheduler);
@@ -115,7 +115,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * Creates a replaying ConnectableObservable with an unbounded buffer.
      * @param <T> the value type
      * @param source the source observable
-     * @return the new NbpConnectableObservable instance
+     * @return the new ConnectableObservable instance
      */
     @SuppressWarnings("unchecked")
     public static <T> ConnectableObservable<T> createFrom(Observable<? extends T> source) {
@@ -127,7 +127,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @param <T> the value type
      * @param source the source Flowable to use
      * @param bufferSize the maximum number of elements to hold
-     * @return the new NbpConnectableObservable instance
+     * @return the new ConnectableObservable instance
      */
     public static <T> ConnectableObservable<T> create(Observable<T> source,
             final int bufferSize) {
@@ -149,7 +149,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @param maxAge the maximum age of entries
      * @param unit the unit of measure of the age amount
      * @param scheduler the target scheduler providing the current time
-     * @return the new NbpConnectableObservable instance
+     * @return the new ConnectableObservable instance
      */
     public static <T> ConnectableObservable<T> create(Observable<T> source,
             long maxAge, TimeUnit unit, Scheduler scheduler) {
@@ -164,7 +164,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @param unit the unit of measure of the age amount
      * @param scheduler the target scheduler providing the current time
      * @param bufferSize the maximum number of elements to hold
-     * @return the new NbpConnectableObservable instance
+     * @return the new ConnectableObservable instance
      */
     public static <T> ConnectableObservable<T> create(Observable<T> source,
             final long maxAge, final TimeUnit unit, final Scheduler scheduler, final int bufferSize) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
@@ -95,7 +95,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
                     
                     if (p == null) {
                         dispose();
-                        EmptyDisposable.error(new NullPointerException("The first timeout NbpObservable is null"), a);
+                        EmptyDisposable.error(new NullPointerException("The first timeout Observable is null"), a);
                         return;
                     }
                     
@@ -136,7 +136,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             
             if (p == null) {
                 dispose();
-                actual.onError(new NullPointerException("The NbpObservable returned is null"));
+                actual.onError(new NullPointerException("The ObservableSource returned is null"));
                 return;
             }
             
@@ -273,7 +273,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
                     
                     if (p == null) {
                         dispose();
-                        EmptyDisposable.error(new NullPointerException("The first timeout NbpObservable is null"), a);
+                        EmptyDisposable.error(new NullPointerException("The first timeout Observable is null"), a);
                         return;
                     }
                     
@@ -317,7 +317,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             }
             
             if (p == null) {
-                actual.onError(new NullPointerException("The NbpObservable returned is null"));
+                actual.onError(new NullPointerException("The ObservableSource returned is null"));
                 return;
             }
             

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -276,7 +276,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                         
                         if (p == null) {
                             cancelled = true;
-                            a.onError(new NullPointerException("The NbpObservable supplied is null"));
+                            a.onError(new NullPointerException("The ObservableSource supplied is null"));
                             continue;
                         }
                         

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
@@ -95,7 +95,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                 
                 if (p == null) {
                     s.dispose();
-                    a.onError(new NullPointerException("The first window NbpObservable supplied is null"));
+                    a.onError(new NullPointerException("The first window ObservableSource supplied is null"));
                     return;
                 }
                 
@@ -242,7 +242,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                         
                         if (p == null) {
                             DisposableHelper.dispose(boundary);
-                            a.onError(new NullPointerException("The NbpObservable supplied is null"));
+                            a.onError(new NullPointerException("The ObservableSource supplied is null"));
                             return;
                         }
                         

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/InnerQueuedSubscriber.java
@@ -40,7 +40,7 @@ implements Subscriber<T>, Subscription {
     
     final int limit;
 
-    SimpleQueue<T> queue;
+    volatile SimpleQueue<T> queue;
     
     volatile boolean done;
     

--- a/src/main/java/io/reactivex/internal/subscribers/observable/QueueDrainObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/observable/QueueDrainObserver.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.util.*;
  * @param <U> the value type in the queue
  * @param <V> the value type the child subscriber accepts
  */
-public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPad2 implements Observer<T>, NbpQueueDrain<U, V> {
+public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPad2 implements Observer<T>, ObservableQueueDrain<U, V> {
     protected final Observer<? super V> actual;
     protected final SimpleQueue<U> queue;
     

--- a/src/main/java/io/reactivex/internal/util/NotificationLite.java
+++ b/src/main/java/io/reactivex/internal/util/NotificationLite.java
@@ -226,11 +226,11 @@ public enum NotificationLite {
     }
 
     /**
-     * Calls the appropriate NbpSubscriber method based on the type of the notification.
+     * Calls the appropriate Observer method based on the type of the notification.
      * <p>Does not check for a subscription notification.
      * @param <T> the expected value type when unwrapped
      * @param o the notification object
-     * @param s the NbpSubscriber to call methods on
+     * @param s the Observer to call methods on
      * @return true if the notification was a terminal event (i.e., complete or error)
      */
     @SuppressWarnings("unchecked")
@@ -274,7 +274,7 @@ public enum NotificationLite {
     }
     
     /**
-     * Calls the appropriate NbpSubscriber method based on the type of the notification.
+     * Calls the appropriate Observer method based on the type of the notification.
      * @param <T> the expected value type when unwrapped
      * @param o the notification object
      * @param s the subscriber to call methods on

--- a/src/main/java/io/reactivex/internal/util/ObservableQueueDrain.java
+++ b/src/main/java/io/reactivex/internal/util/ObservableQueueDrain.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.util;
 
 import io.reactivex.Observer;
 
-public interface NbpQueueDrain<T, U> {
+public interface ObservableQueueDrain<T, U> {
     
     boolean cancelled();
     

--- a/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
@@ -183,7 +183,7 @@ public final class QueueDrainHelper {
         return false;
     }
     
-    public static <T, U> void drainLoop(SimpleQueue<T> q, Observer<? super U> a, boolean delayError, Disposable dispose, NbpQueueDrain<T, U> qd) {
+    public static <T, U> void drainLoop(SimpleQueue<T> q, Observer<? super U> a, boolean delayError, Disposable dispose, ObservableQueueDrain<T, U> qd) {
         
         int missed = 1;
         
@@ -225,7 +225,7 @@ public final class QueueDrainHelper {
     }
 
     public static <T, U> boolean checkTerminated(boolean d, boolean empty, 
-            Observer<?> s, boolean delayError, SimpleQueue<?> q, Disposable disposable, NbpQueueDrain<T, U> qd) {
+            Observer<?> s, boolean delayError, SimpleQueue<?> q, Disposable disposable, ObservableQueueDrain<T, U> qd) {
         if (qd.cancelled()) {
             q.clear();
             disposable.dispose();

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -22,10 +22,10 @@ import io.reactivex.internal.subscribers.observable.DeferredScalarDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * An NbpSubject that emits the very last value followed by a completion event or the received error to NbpSubscribers.
+ * An Subject that emits the very last value followed by a completion event or the received error to Observers.
  *
  * <p>The implementation of onXXX methods are technically thread-safe but non-serialized calls
- * to them may lead to undefined state in the currently subscribed NbpSubscribers.
+ * to them may lead to undefined state in the currently subscribed Observers.
  * 
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -16,7 +16,7 @@ package io.reactivex.subjects;
 import io.reactivex.*;
 
 /**
- * Represents a NbpSubscriber and a NbpObservable at the same time, allowing
+ * Represents an Observer and a Observable at the same time, allowing
  * multicasting events from a single source to multiple child Subscribers.
  * <p>All methods except the onSubscribe, onNext, onError and onComplete are thread-safe.
  * Use {@link #toSerialized()} to make these methods thread-safe as well.

--- a/src/perf/java/io/reactivex/RxVsStreamPerf.java
+++ b/src/perf/java/io/reactivex/RxVsStreamPerf.java
@@ -34,15 +34,15 @@ public class RxVsStreamPerf {
     
     Flowable<Integer> range;
     
-    Observable<Integer> rangeNbp;
+    Observable<Integer> rangeObservable;
 
     Flowable<Integer> rangeFlatMap;
 
-    Observable<Integer> rangeNbpFlatMap;
+    Observable<Integer> rangeObservableFlatMap;
 
     Flowable<Integer> rangeFlatMapJust;
 
-    Observable<Integer> rangeNbpFlatMapJust;
+    Observable<Integer> rangeObservableFlatMapJust;
 
     List<Integer> values;
 
@@ -64,16 +64,16 @@ public class RxVsStreamPerf {
             }
         });
         
-        rangeNbp = Observable.range(1, times);
+        rangeObservable = Observable.range(1, times);
 
-        rangeNbpFlatMapJust = rangeNbp.flatMap(new Function<Integer, Observable<Integer>>() {
+        rangeObservableFlatMapJust = rangeObservable.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
         
-        rangeNbpFlatMap = rangeNbp.flatMap(new Function<Integer, Observable<Integer>>() {
+        rangeObservableFlatMap = rangeObservable.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer v) {
                 return Observable.range(v, 2);
@@ -89,8 +89,8 @@ public class RxVsStreamPerf {
     }
 
     @Benchmark
-    public void rangeNbp(Blackhole bh) {
-        rangeNbp.subscribe(new PerfObserver(bh));
+    public void rangeObservable(Blackhole bh) {
+        rangeObservable.subscribe(new PerfObserver(bh));
     }
 
     @Benchmark
@@ -99,8 +99,8 @@ public class RxVsStreamPerf {
     }
 
     @Benchmark
-    public void rangeNbpFlatMap(Blackhole bh) {
-        rangeNbpFlatMap.subscribe(new PerfObserver(bh));
+    public void rangeObservableFlatMap(Blackhole bh) {
+        rangeObservableFlatMap.subscribe(new PerfObserver(bh));
     }
     
     @Benchmark
@@ -109,8 +109,8 @@ public class RxVsStreamPerf {
     }
 
     @Benchmark
-    public void rangeNbpFlatMapJust(Blackhole bh) {
-        rangeNbpFlatMapJust.subscribe(new PerfObserver(bh));
+    public void rangeObservableFlatMapJust(Blackhole bh) {
+        rangeObservableFlatMapJust.subscribe(new PerfObserver(bh));
     }
 
 }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -578,19 +578,19 @@ public class CompletableTest {
     }
     
     @Test(expected = NullPointerException.class)
-    public void fromNbpObservableNull() {
+    public void fromObservableNull() {
         Completable.fromObservable(null);
     }
     
     @Test(timeout = 1000)
-    public void fromNbpObservableEmpty() {
+    public void fromObservableEmpty() {
         Completable c = Completable.fromObservable(Observable.empty());
         
         c.blockingAwait();
     }
 
     @Test(timeout = 5000)
-    public void fromNbpObservableSome() {
+    public void fromObservableSome() {
         for (int n = 1; n < 10000; n *= 10) {
             Completable c = Completable.fromObservable(Observable.range(1, n));
             
@@ -599,7 +599,7 @@ public class CompletableTest {
     }
     
     @Test(timeout = 1000, expected = TestException.class)
-    public void fromNbpObservableError() {
+    public void fromObservableError() {
         Completable c = Completable.fromObservable(Observable.error(new Callable<Throwable>() {
             @Override
             public Throwable call() {
@@ -2585,7 +2585,7 @@ public class CompletableTest {
     }
     
     @Test(timeout = 1000)
-    public void subscribeNbpSubscriberNormal() {
+    public void subscribeObserverNormal() {
         TestObserver<Object> ts = new TestObserver<Object>();
         
         normal.completable.toObservable().subscribe(ts);
@@ -2596,7 +2596,7 @@ public class CompletableTest {
     }
 
     @Test(timeout = 1000)
-    public void subscribeNbpSubscriberError() {
+    public void subscribeObserverError() {
         TestObserver<Object> ts = new TestObserver<Object>();
         
         error.completable.toObservable().subscribe(ts);
@@ -2645,7 +2645,7 @@ public class CompletableTest {
     }
     
     @Test(expected = NullPointerException.class)
-    public void subscribeNbpSubscriberNull() {
+    public void subscribeObserverNull() {
         normal.completable.toObservable().subscribe((Observer<Object>)null);
     }
     
@@ -2799,12 +2799,12 @@ public class CompletableTest {
     }
 
     @Test(timeout = 1000)
-    public void toNbpObservableNormal() {
+    public void toObservableNormal() {
         normal.completable.toObservable().blockingForEach(Functions.emptyConsumer());
     }
     
     @Test(timeout = 1000, expected = TestException.class)
-    public void toNbpObservableError() {
+    public void toObservableError() {
         error.completable.toObservable().blockingForEach(Functions.emptyConsumer());
     }
     
@@ -3354,7 +3354,7 @@ public class CompletableTest {
     }
     
     @Test(timeout = 1000)
-    public void startWithNbpObservableNormal() {
+    public void startWithObservableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         Observable<Object> c = normal.completable
                 .startWith(Observable.fromCallable(new Callable<Object>() {
@@ -3378,7 +3378,7 @@ public class CompletableTest {
     }
     
     @Test(timeout = 1000)
-    public void startWithNbpObservableError() {
+    public void startWithObservableError() {
         Observable<Object> c = normal.completable
                 .startWith(Observable.error(new TestException()));
         
@@ -3404,7 +3404,7 @@ public class CompletableTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void startWithNbpObservableNull() {
+    public void startWithObservableNull() {
         normal.completable.startWith((Observable<Object>)null);
     }
 
@@ -3703,34 +3703,6 @@ public class CompletableTest {
         ts.assertNoErrors();
     }
     
-    @Test(expected = NullPointerException.class)
-    public void fromObservableNull() {
-        Completable.fromObservable(null);
-    }
-    
-    @Test(timeout = 5000)
-    public void fromObservableEmpty() {
-        Completable c = Completable.fromObservable(Observable.empty());
-        
-        c.blockingAwait();
-    }
-    
-    @Test(timeout = 5000)
-    public void fromObservableSome() {
-        for (int n = 1; n < 10000; n *= 10) {
-            Completable c = Completable.fromObservable(Observable.range(1, n));
-            
-            c.blockingAwait();
-        }
-    }
-    
-    @Test(timeout = 5000, expected = TestException.class)
-    public void fromObservableError() {
-        Completable c = Completable.fromObservable(Observable.error(new TestException()));
-        
-        c.blockingAwait();
-    }
-
     private Function<Completable, Completable> onCreate;
     
     private BiFunction<Completable, CompletableObserver, CompletableObserver> onStart;
@@ -3912,22 +3884,6 @@ public class CompletableTest {
             public void run() {
                 error.completable.toSingleDefault(0).subscribe();
             }
-        });
-    }
-    
-    @Test(timeout = 5000)
-    public void toObservableNormal() {
-        normal.completable.toObservable().blockingForEach(new Consumer<Object>() {
-            @Override
-            public void accept(Object e) { }
-        });
-    }
-    
-    @Test(timeout = 5000, expected = TestException.class)
-    public void toObservableError() {
-        error.completable.toObservable().blockingForEach(new Consumer<Object>() {
-            @Override
-            public void accept(Object e) { }
         });
     }
     

--- a/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableBackpressureTests.java
@@ -260,9 +260,9 @@ public class FlowableBackpressureTests {
         ts.assertNoErrors();
         System.out.println("testFlatMapAsync => Received: " + ts.valueCount() + "  Emitted: " + c.get() + " Size: " + Flowable.bufferSize());
         assertEquals(NUM, ts.valueCount());
-        // even though we only need 10, it will request at least Observable.bufferSize(), and then as it drains keep requesting more
+        // even though we only need 10, it will request at least Flowable.bufferSize(), and then as it drains keep requesting more
         // and then it will be non-deterministic when the take() causes the unsubscribe as it is scheduled on 10 different schedulers (threads)
-        // normally this number is ~250 but can get up to ~1200 when Observable.bufferSize() == 1024
+        // normally this number is ~250 but can get up to ~1200 when Flowable.bufferSize() == 1024
         assertTrue(c.get() <= Flowable.bufferSize() * 2);
     }
 

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -13,17 +13,11 @@
 
 package io.reactivex.flowable;
 
-import static io.reactivex.internal.util.TestingHelper.addToList;
-import static io.reactivex.internal.util.TestingHelper.biConsumerThrows;
-import static io.reactivex.internal.util.TestingHelper.callableListCreator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static io.reactivex.internal.util.TestingHelper.*;
+import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
@@ -165,6 +159,21 @@ public final class FlowableCollectTest {
                 .assertNoValues() //
                 .assertNotComplete();
         assertFalse(added.get());
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void collectInto() {
+        Flowable.just(1, 1, 1, 1, 2)
+        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+            @Override
+            public void accept(HashSet<Integer> s, Integer v) throws Exception {
+                s.add(v);
+            }
+        })
+        .test()
+        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
     }
 
 }

--- a/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
@@ -38,7 +38,7 @@ public class FlowableConcatTests {
     }
 
     @Test
-    public void testConcatWithObservableOfObservable() {
+    public void testConcatWithFlowableOfFlowable() {
         Flowable<String> o1 = Flowable.just("one", "two");
         Flowable<String> o2 = Flowable.just("three", "four");
         Flowable<String> o3 = Flowable.just("five", "six");
@@ -56,7 +56,7 @@ public class FlowableConcatTests {
     }
 
     @Test
-    public void testConcatWithIterableOfObservable() {
+    public void testConcatWithIterableOfFlowable() {
         Flowable<String> o1 = Flowable.just("one", "two");
         Flowable<String> o2 = Flowable.just("three", "four");
         Flowable<String> o3 = Flowable.just("five", "six");

--- a/src/test/java/io/reactivex/flowable/FlowableDoOnTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableDoOnTest.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 
 public class FlowableDoOnTest {
@@ -71,5 +72,34 @@ public class FlowableDoOnTest {
 
         assertEquals("one", output);
         assertTrue(r.get());
+    }
+    
+    @Test
+    public void doOnTerminateError() {
+        final AtomicBoolean r = new AtomicBoolean();
+        Flowable.<String>error(new TestException()).doOnTerminate(new Action() {
+            @Override
+            public void run() {
+                r.set(true);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+        assertTrue(r.get());
+    }
+    
+    @Test
+    public void doOnTerminateComplete() {
+        final AtomicBoolean r = new AtomicBoolean();
+        String output = Flowable.just("one").doOnTerminate(new Action() {
+            @Override
+            public void run() {
+                r.set(true);
+            }
+        }).blockingSingle();
+
+        assertEquals("one", output);
+        assertTrue(r.get());
+        
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -603,7 +603,7 @@ public class FlowableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void usingObservableSupplierNull() {
+    public void usingFlowableSupplierNull() {
         Flowable.using(new Callable<Object>() {
             @Override
             public Object call() {
@@ -613,7 +613,7 @@ public class FlowableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void usingObservableSupplierReturnsNull() {
+    public void usingFlowableSupplierReturnsNull() {
         Flowable.using(new Callable<Object>() {
             @Override
             public Object call() {
@@ -2803,5 +2803,183 @@ public class FlowableNullTests {
         subject.onError(null);
         subject.blockingSubscribe();
     }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnLifecycleOnDisposeNull() {
+        just1.doOnLifecycle(new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) { }
+        },
+        new LongConsumer() {
+            @Override
+            public void accept(long v) throws Exception { }
+        },
+        null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipWithFlowableNull() {
+        just1.zipWith((Flowable<Integer>)null, new BiFunction<Integer, Integer, Object>() {
+            @Override
+            public Object apply(Integer a, Integer b) {
+                return 1;
+            }
+        });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void unsafeSubscribeNull() {
+        just1.subscribe((Subscriber<Object>)null);
+    }
 
+    @SuppressWarnings("unchecked")
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorIterableFunctionReturnsNull() {
+        Flowable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return null;
+            }
+        }, 128).blockingLast();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorIterableFunctionNull() {
+        Flowable.combineLatestDelayError(Arrays.asList(just1), null, 128);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorVarargsFunctionNull() {
+        Flowable.combineLatestDelayError(null, 128, Flowable.never());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipFlowableNull() {
+        Flowable.zip((Flowable<Flowable<Object>>)null, new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) {
+                return 1;
+            }
+        });
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void zipFlowableFunctionNull() {
+        Flowable.zip((Flowable.just(just1)), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void zipFlowableFunctionReturnsNull() {
+        Flowable.zip((Flowable.just(just1)), new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) {
+                return null;
+            }
+        }).blockingLast();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void concatFlowableNull() {
+        Flowable.concat((Flowable<Flowable<Object>>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorVarargsNull() {
+        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return 1;
+            }
+        }, 128, (Flowable<Object>[])null);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorVarargsOneIsNull() {
+        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return 1;
+            }
+        }, 128, Flowable.never(), null).blockingLast();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorIterableNull() {
+        Flowable.combineLatestDelayError((Iterable<Flowable<Object>>)null, new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return 1;
+            }
+        }, 128);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorIterableIteratorNull() {
+        Flowable.combineLatestDelayError(new Iterable<Flowable<Object>>() {
+            @Override
+            public Iterator<Flowable<Object>> iterator() {
+                return null;
+            }
+        }, new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return 1;
+            }
+        }, 128).blockingLast();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void doOnDisposeNull() {
+        just1.doOnCancel(null);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorIterableOneIsNull() {
+        Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return 1;
+            }
+        }, 128).blockingLast();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void takeUntilFlowableNull() {
+        just1.takeUntil((Flowable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void startWithFlowableNull() {
+        just1.startWith((Flowable<Integer>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void delaySubscriptionOtherNull() {
+        just1.delaySubscription((Flowable<Object>)null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void sampleFlowableNull() {
+        just1.sample(null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void onErrorResumeNextFlowableNull() {
+        just1.onErrorResumeNext((Flowable<Integer>)null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = NullPointerException.class)
+    public void combineLatestDelayErrorVarargsFunctionReturnsNull() {
+        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] v) {
+                return null;
+            }
+        }, 128, just1).blockingLast();
+    }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableStartWithTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableStartWithTests.java
@@ -61,4 +61,9 @@ public class FlowableStartWithTests {
         assertEquals("two", values.get(3));
     }
 
+    @Test
+    public void startWithEmpty() {
+        Flowable.just(1).startWithArray().test().assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -26,8 +26,8 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.FlowableTransformer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -1037,5 +1037,25 @@ public class FlowableTests {
                     return subscriber.values().get(0);
                 }
         });
+    }
+    
+    @Test
+    public void toObservableEmpty() {
+        Flowable.empty().toObservable().test().assertResult();
+    }
+
+    @Test
+    public void toObservableJust() {
+        Flowable.just(1).toObservable().test().assertResult(1);
+    }
+    
+    @Test
+    public void toObservableRange() {
+        Flowable.range(1, 5).toObservable().test().assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void toObservableError() {
+        Flowable.error(new TestException()).toObservable().test().assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableThrottleWithTimeoutTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableThrottleWithTimeoutTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
-import io.reactivex.TestHelper;
+import io.reactivex.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 
@@ -58,5 +58,13 @@ public class FlowableThrottleWithTimeoutTests {
         inOrder.verify(observer).onNext(7);
         inOrder.verify(observer).onComplete();
         inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void throttleFirstDefaultScheduler() {
+        Flowable.just(1).throttleWithTimeout(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableZipTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableZipTests.java
@@ -124,4 +124,31 @@ public class FlowableZipTests {
             System.out.println("Result: " + t1);
         }
     };
+
+    
+    @Test
+    public void zipWithDelayError() {
+        Flowable.just(1)
+        .zipWith(Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        }, true)
+        .test()
+        .assertResult(3);
+    }
+    
+    @Test
+    public void zipWithDelayErrorBufferSize() {
+        Flowable.just(1)
+        .zipWith(Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        }, true, 16)
+        .test()
+        .assertResult(3);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -519,4 +519,17 @@ public class FlowableAmbTest {
             }
         }
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ambArrayEmpty() {
+        assertSame(Flowable.empty(), Flowable.ambArray());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void ambArraySingleElement() {
+        assertSame(Flowable.never(), Flowable.ambArray(Flowable.never()));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -157,7 +157,7 @@ public class FlowableBufferTest {
                 push(observer, "two", 98);
                 /**
                  * Changed from 100. Because scheduling the cut to 100ms happens before this
-                 * Observable even runs due how lift works, pushing at 100ms would execute after the
+                 * Flowable even runs due how lift works, pushing at 100ms would execute after the
                  * buffer cut.
                  */
                 push(observer, "three", 99);
@@ -1268,4 +1268,53 @@ public class FlowableBufferTest {
             RxJavaPlugins.reset();
         }
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferBoundaryHint() {
+        Flowable.range(1, 5).buffer(Flowable.timer(1, TimeUnit.MINUTES), 2)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    static HashSet<Integer> set(Integer... values) {
+        return new HashSet<Integer>(Arrays.asList(values));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferIntoCustomCollection() {
+        Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
+        .buffer(3, new Callable<Collection<Integer>>() {
+            @Override
+            public Collection<Integer> call() throws Exception {
+                return new HashSet<Integer>();
+            }
+        })
+        .test()
+        .assertResult(set(1, 2), set(2, 3), set(4));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferSkipIntoCustomCollection() {
+        Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
+        .buffer(3, 3, new Callable<Collection<Integer>>() {
+            @Override
+            public Collection<Integer> call() throws Exception {
+                return new HashSet<Integer>();
+            }
+        })
+        .test()
+        .assertResult(set(1, 2), set(2, 3), set(4));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void bufferTimeSkipDefault() {
+        Flowable.range(1, 5).buffer(1, 1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -761,4 +761,60 @@ public class FlowableConcatMapEagerTest {
         }
         
     }
+    
+    @Test
+    public void concatEagerZero() {
+        Flowable.concatEager(Collections.<Flowable<Integer>>emptyList())
+        .test()
+        .assertResult();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatEagerOne() {
+        Flowable.concatEager(Arrays.asList(Flowable.just(1)))
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatEagerTwo() {
+        Flowable.concatEager(Arrays.asList(Flowable.just(1), Flowable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void Flowable() {
+        Flowable<Integer> source = Flowable.just(1);
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.concatEager(Flowable.just(source, source, source)).subscribe(ts);
+        
+        ts.assertValues(1, 1, 1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+    
+    @Test
+    public void ObservableCapacityHint() {
+        Flowable<Integer> source = Flowable.just(1);
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.concatEager(Flowable.just(source, source, source), 1, 1).subscribe(ts);
+        
+        ts.assertValues(1, 1, 1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatEagerIterable() {
+        Flowable.concatEager(Arrays.asList(Flowable.just(1), Flowable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+
+public class FlowableCreateTest {
+
+    @Test(expected = NullPointerException.class)
+    public void sourceNull() {
+        Flowable.create(null, FlowableEmitter.BackpressureMode.BUFFER);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void modeNull() {
+        Flowable.create(new FlowableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(FlowableEmitter<Object> s) throws Exception { }
+        }, null);
+    }
+
+    @Test
+    public void basic() {
+        final Disposable d = Disposables.empty();
+        
+        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e.setDisposable(d);
+                
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onComplete();
+                e.onError(new TestException());
+                e.onNext(4);
+                e.onError(new TestException());
+                e.onComplete();
+            }
+        }, FlowableEmitter.BackpressureMode.BUFFER)
+        .test()
+        .assertResult(1, 2, 3);
+        
+        assertTrue(d.isDisposed());
+    }
+    
+    @Test
+    public void basicWithError() {
+        final Disposable d = Disposables.empty();
+        
+        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e.setDisposable(d);
+                
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onError(new TestException());
+                e.onComplete();
+                e.onNext(4);
+                e.onError(new TestException());
+            }
+        }, FlowableEmitter.BackpressureMode.BUFFER)
+        .test()
+        .assertFailure(TestException.class, 1, 2, 3);
+        
+        assertTrue(d.isDisposed());
+    }
+    
+    @Test
+    public void basicSerialized() {
+        final Disposable d = Disposables.empty();
+        
+        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                
+                e.setDisposable(d);
+                
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onComplete();
+                e.onError(new TestException());
+                e.onNext(4);
+                e.onError(new TestException());
+                e.onComplete();
+            }
+        }, FlowableEmitter.BackpressureMode.BUFFER)
+        .test()
+        .assertResult(1, 2, 3);
+        
+        assertTrue(d.isDisposed());
+    }
+    
+    @Test
+    public void basicWithErrorSerialized() {
+        final Disposable d = Disposables.empty();
+        
+        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+
+                e.setDisposable(d);
+                
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onError(new TestException());
+                e.onComplete();
+                e.onNext(4);
+                e.onError(new TestException());
+            }
+        }, FlowableEmitter.BackpressureMode.BUFFER)
+        .test()
+        .assertFailure(TestException.class, 1, 2, 3);
+        
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void wrap() {
+        Flowable.fromPublisher(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> observer) {
+                observer.onSubscribe(new BooleanSubscription());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onNext(3);
+                observer.onNext(4);
+                observer.onNext(5);
+                observer.onComplete();
+            }
+        })
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void unsafe() {
+        Flowable.unsafeCreate(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> observer) {
+                observer.onSubscribe(new BooleanSubscription());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onNext(3);
+                observer.onNext(4);
+                observer.onNext(5);
+                observer.onComplete();
+            }
+        })
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unsafeWithFlowable() {
+        Flowable.unsafeCreate(Flowable.just(1));
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -304,4 +304,13 @@ public class FlowableDebounceTest {
         ts.assertNoErrors();
         ts.assertComplete();
     }
+    
+    @Test
+    public void debounceDefault() throws Exception {
+        
+        Flowable.just(1).debounce(1, TimeUnit.SECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableForEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableForEachTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+
+public class FlowableForEachTest {
+
+    @Test
+    public void forEachWile() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Flowable.range(1, 5)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        })
+        .forEachWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v < 3;
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3), list);
+    }
+
+    @Test
+    public void forEachWileWithError() {
+        final List<Object> list = new ArrayList<Object>();
+        
+        Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                list.add(v);
+            }
+        })
+        .forEachWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return true;
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                list.add(100);
+            }
+        });
+        
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -76,4 +76,10 @@ public class FlowableFromArrayTest {
         Assert.assertTrue(source.getClass().toString(), source instanceof ScalarCallable);
     }
 
+    @Test
+    public void just10Arguments() {
+        Flowable.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -27,6 +27,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
@@ -542,5 +543,22 @@ public class FlowableFromIterableTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
         
+    }
+
+    @Test
+    public void fusionWithConcatMap() {
+        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+        
+        Flowable.fromIterable(Arrays.asList(1, 2, 3, 4)).concatMap(
+        new Function<Integer, Flowable  <Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.range(v, 2);
+            }
+        }).subscribe(to);
+        
+        to.assertValues(1, 2, 2, 3, 3, 4, 4, 5);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+
+public class FlowableGenerateTest {
+
+    @Test
+    public void statefulBiconsumer() {
+        Flowable.generate(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 10;
+            }
+        }, new BiConsumer<Object, Emitter<Object>>() {
+            @Override
+            public void accept(Object s, Emitter<Object> e) throws Exception {
+                e.onNext(s);
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception { 
+                
+            }
+        })
+        .take(5)
+        .test()
+        .assertResult(10, 10, 10, 10, 10);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -29,6 +29,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
@@ -1631,4 +1632,34 @@ public class FlowableGroupByTest {
         .assertNoErrors()
         .assertComplete();
     }
+    
+    
+    @Test
+    public void keySelectorAndDelayError() {
+        Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .groupBy(Functions.identity(), true)
+        .flatMap(new Function<GroupedFlowable<Object, Integer>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(GroupedFlowable<Object, Integer> g) throws Exception {
+                return g;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void keyAndValueSelectorAndDelayError() {
+        Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .groupBy(Functions.identity(), Functions.<Integer>identity(), true)
+        .flatMap(new Function<GroupedFlowable<Object, Integer>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(GroupedFlowable<Object, Integer> g) throws Exception {
+                return g;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
@@ -1,17 +1,20 @@
 /**
  * Copyright 2016 Netflix, Inc.
  * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
  * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License is
- * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
- * the License for the specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-package io.reactivex.internal.operators.observable;
+package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
 
@@ -22,11 +25,10 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.schedulers.Schedulers;
 
-public class ObservableIntervalRangeTest {
-
+public class FlowableIntervalRangeTest {
     @Test
     public void simple() throws Exception {
-        Observable.intervalRange(5, 5, 50, 50, TimeUnit.MILLISECONDS)
+        Flowable.intervalRange(5, 5, 50, 50, TimeUnit.MILLISECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(5L, 6L, 7L, 8L, 9L);
@@ -34,15 +36,15 @@ public class ObservableIntervalRangeTest {
 
     @Test
     public void customScheduler() {
-        Observable.intervalRange(1, 5, 1, 1, TimeUnit.MILLISECONDS, Schedulers.single())
+        Flowable.intervalRange(1, 5, 1, 1, TimeUnit.MILLISECONDS, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1L, 2L, 3L, 4L, 5L);
     }
-
+    
     @Test
     public void countZero() {
-        Observable.intervalRange(1, 0, 1, 1, TimeUnit.MILLISECONDS)
+        Flowable.intervalRange(1, 0, 1, 1, TimeUnit.MILLISECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -51,21 +53,21 @@ public class ObservableIntervalRangeTest {
     @Test
     public void countNegative() {
         try {
-            Observable.intervalRange(1, -1, 1, 1, TimeUnit.MILLISECONDS);
+            Flowable.intervalRange(1, -1, 1, 1, TimeUnit.MILLISECONDS);
             fail("Should have thrown!");
         } catch (IllegalArgumentException ex) {
             assertEquals("count >= 0 required but it was -1", ex.getMessage());
         }
     }
-
+    
     @Test
     public void longOverflow() {
-        Observable.intervalRange(Long.MAX_VALUE - 1, 2, 1, 1, TimeUnit.MILLISECONDS);
+        Flowable.intervalRange(Long.MAX_VALUE - 1, 2, 1, 1, TimeUnit.MILLISECONDS);
 
-        Observable.intervalRange(Long.MIN_VALUE, Long.MAX_VALUE, 1, 1, TimeUnit.MILLISECONDS);
+        Flowable.intervalRange(Long.MIN_VALUE, Long.MAX_VALUE, 1, 1, TimeUnit.MILLISECONDS);
 
         try {
-            Observable.intervalRange(Long.MAX_VALUE - 1, 3, 1, 1, TimeUnit.MILLISECONDS);
+            Flowable.intervalRange(Long.MAX_VALUE - 1, 3, 1, 1, TimeUnit.MILLISECONDS);
             fail("Should have thrown!");
         } catch (IllegalArgumentException ex) {
             assertEquals("Overflow! start + count is bigger than Long.MAX_VALUE", ex.getMessage());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -26,6 +26,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.LongConsumer;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -719,4 +720,126 @@ public class FlowableMergeDelayErrorTest {
         }
     }
 
+    @Test
+    public void array() {
+        for (int i = 1; i < 100; i++) {
+            
+            @SuppressWarnings("unchecked")
+            Flowable<Integer>[] sources = new Flowable[i];
+            Arrays.fill(sources, Flowable.just(1));
+            Integer[] expected = new Integer[i];
+            for (int j = 0; j < i; j++) {
+                expected[j] = 1;
+            }
+
+            Flowable.mergeArrayDelayError(sources)
+            .test()
+            .assertResult(expected);
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeArrayDelayError() {
+        Flowable.mergeArrayDelayError(Flowable.just(1), Flowable.just(2))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayErrorWithError() {
+        Flowable.mergeDelayError(
+                Arrays.asList(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())), 
+                Flowable.just(2)))
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayError() {
+        Flowable.mergeDelayError(
+                Flowable.just(Flowable.just(1), 
+                Flowable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorWithError() {
+        Flowable.mergeDelayError(
+                Flowable.just(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())), 
+                Flowable.just(2)))
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorMaxConcurrency() {
+        Flowable.mergeDelayError(
+                Flowable.just(Flowable.just(1), 
+                Flowable.just(2)), 1)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorWithErrorMaxConcurrency() {
+        Flowable.mergeDelayError(
+                Flowable.just(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())), 
+                Flowable.just(2)), 1)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayErrorMaxConcurrency() {
+        Flowable.mergeDelayError(
+                Arrays.asList(Flowable.just(1), 
+                Flowable.just(2)), 1)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayErrorWithErrorMaxConcurrency() {
+        Flowable.mergeDelayError(
+                Arrays.asList(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())), 
+                Flowable.just(2)), 1)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayError3() {
+        Flowable.mergeDelayError(
+                Flowable.just(1), 
+                Flowable.just(2),
+                Flowable.just(3)
+        )
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void mergeDelayError3WithError() {
+        Flowable.mergeDelayError(
+                Flowable.just(1), 
+                Flowable.just(2).concatWith(Flowable.<Integer>error(new TestException())),
+                Flowable.just(3)
+        )
+        .test()
+        .assertFailure(TestException.class, 1, 2, 3);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeIterableDelayError() {
+        Flowable.mergeDelayError(Arrays.asList(Flowable.just(1), Flowable.just(2)))
+        .test()
+        .assertResult(1, 2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -27,6 +27,7 @@ import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
@@ -1593,5 +1594,32 @@ public class FlowableMergeTest {
         ms.drain();
         
         ts.assertValues(1, 2);
+    }
+    
+    @Test
+    public void array() {
+        for (int i = 1; i < 100; i++) {
+            
+            @SuppressWarnings("unchecked")
+            Flowable<Integer>[] sources = new Flowable[i];
+            Arrays.fill(sources, Flowable.just(1));
+            Integer[] expected = new Integer[i];
+            for (int j = 0; j < i; j++) {
+                expected[j] = 1;
+            }
+
+            Flowable.mergeArray(sources)
+            .test()
+            .assertResult(expected);
+        }
+    }
+    
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeArray() {
+        Flowable.mergeArray(Flowable.just(1), Flowable.just(2))
+        .test()
+        .assertResult(1, 2);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -26,6 +26,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
@@ -946,4 +947,22 @@ public class FlowableObserveOnTest {
             assertEquals("bufferSize > 0 required but it was -99", ex.getMessage());
         }
     }
+    
+    @Test
+    public void delayError() {
+        Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
+        .observeOn(Schedulers.computation(), true)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (v == 1) {
+                    Thread.sleep(100);
+                }
+            }
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
-import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
@@ -216,4 +216,35 @@ public class FlowableOnBackpressureBufferTest {
         }, null);
     }
 
+    @Test
+    public void noDelayError() {
+        
+        Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .onBackpressureBuffer(false)
+        .test(0L)
+        .assertFailure(TestException.class);
+    }
+    
+    @Test
+    public void delayError() {
+        TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .onBackpressureBuffer(true)
+        .test(0L)
+        .assertEmpty();
+        
+        ts.request(1);
+        ts.assertFailure(TestException.class, 1);
+        
+    }
+    
+    @Test
+    public void delayErrorBuffer() {
+        TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .onBackpressureBuffer(16, true)
+        .test(0L)
+        .assertEmpty();
+
+        ts.request(1);
+        ts.assertFailure(TestException.class, 1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -246,4 +246,12 @@ public class FlowableOnErrorReturnTest {
     }
     
     
+    @Test
+    public void returnItem() {
+        Flowable.error(new TestException())
+        .onErrorReturnItem(1)
+        .test()
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -25,8 +25,9 @@ import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -241,6 +242,30 @@ public class FlowableRepeatTest {
         ts.assertValues(1, 1);
         ts.assertNoErrors();
         ts.assertComplete();
+    }
+    
+    @Test
+    public void repeatUntil() {
+        Flowable.just(1)
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return false;
+            }
+        })
+        .take(5)
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void repeatLongPredicateInvalid() {
+        try {
+            Flowable.just(1).repeat(-99);
+            fail("Should have thrown");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("times >= 0 required but it was -99", ex.getMessage());
+        }
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -26,11 +26,13 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.FlowableReplay.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
@@ -516,7 +518,7 @@ public class FlowableReplayTest {
         Subscriber<Integer> spiedSubscriberBeforeConnect = TestHelper.mockSubscriber();
         Subscriber<Integer> spiedSubscriberAfterConnect = TestHelper.mockSubscriber();
 
-        // Observable under test
+        // Flowable under test
         Flowable<Integer> source = Flowable.just(1,2);
 
         ConnectableFlowable<Integer> replay = source
@@ -571,7 +573,7 @@ public class FlowableReplayTest {
 
         when(mockScheduler.createWorker()).thenReturn(spiedWorker);
 
-        // Observable under test
+        // Flowable under test
         ConnectableFlowable<Integer> replay = Flowable.just(1, 2, 3)
                 .doOnNext(sourceNext)
                 .doOnCancel(sourceUnsubscribed)
@@ -634,7 +636,7 @@ public class FlowableReplayTest {
 
         when(mockScheduler.createWorker()).thenReturn(spiedWorker);
 
-        // Observable under test
+        // Flowable under test
         Function<Integer, Integer> mockFunc = mock(Function.class);
         IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
         when(mockFunc.apply(1)).thenReturn(1);
@@ -1232,6 +1234,68 @@ public class FlowableReplayTest {
         System.out.println(ts3.values());
         ts3.assertValues(2, 3, 4, 5, 6, 7, 8, 9, 10);
         ts3.assertComplete();
+    }
+
+    @Test
+    public void replayScheduler() {
+        
+        Flowable.just(1).replay(Schedulers.computation())
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+    
+    @Test
+    public void replayTime() {
+        Flowable.just(1).replay(1, TimeUnit.MINUTES)
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySizeScheduler() {
+        
+        Flowable.just(1).replay(1, Schedulers.computation())
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySizeAndTime() {
+        Flowable.just(1).replay(1, 1, TimeUnit.MILLISECONDS)
+        .autoConnect()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+    
+    @Test
+    public void replaySelectorSizeScheduler() {
+        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), 1, Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySelectorScheduler() {
+        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void replaySelectorTime() {
+        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), 1, TimeUnit.MINUTES)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -149,4 +149,12 @@ public class FlowableSequenceEqualTest {
         inOrder.verify(observer, times(1)).onError(isA(TestException.class));
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void prefetch() {
+        
+        Flowable.sequenceEqual(Flowable.range(1, 20), Flowable.range(1, 20), 2)
+        .test()
+        .assertResult(true);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -151,7 +151,7 @@ public class FlowableSkipLastTimedTest {
     
     @Test
     public void skipLastTimedDefaultScheduler() {
-        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        Flowable.just(1).concatWith(Flowable.just(2).delay(500, TimeUnit.MILLISECONDS))
         .skipLast(300, TimeUnit.MILLISECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -160,7 +160,7 @@ public class FlowableSkipLastTimedTest {
 
     @Test
     public void skipLastTimedDefaultSchedulerDelayError() {
-        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        Flowable.just(1).concatWith(Flowable.just(2).delay(500, TimeUnit.MILLISECONDS))
         .skipLast(300, TimeUnit.MILLISECONDS, true)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -169,7 +169,7 @@ public class FlowableSkipLastTimedTest {
 
     @Test
     public void skipLastTimedCustomSchedulerDelayError() {
-        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        Flowable.just(1).concatWith(Flowable.just(2).delay(500, TimeUnit.MILLISECONDS))
         .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.io(), true)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTimedTest.java
@@ -157,4 +157,12 @@ public class FlowableSkipTimedTest {
         verify(o, never()).onComplete();
 
     }
+
+    @Test
+    public void skipTimedDefaultScheduler() {
+        Flowable.just(1).skip(1, TimeUnit.MINUTES)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -237,4 +237,37 @@ public class FlowableTakeLastTimedTest {
         ts.assertNoErrors();
         
     }
+    
+    @Test
+    public void takeLastTimeAndSize() {
+        Flowable.just(1, 2)
+        .takeLast(1, 1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(2);
+    }
+
+    @Test
+    public void takeLastTime() {
+        Flowable.just(1, 2)
+        .takeLast(1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void takeLastTimeDelayError() {
+        Flowable.just(1, 2).concatWith(Flowable.<Integer>error(new TestException()))
+        .takeLast(1, TimeUnit.MINUTES, true)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void takeLastTimeDelayErrorCustomScheduler() {
+        Flowable.just(1, 2).concatWith(Flowable.<Integer>error(new TestException()))
+        .takeLast(1, TimeUnit.MINUTES, Schedulers.io(), true)
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -437,4 +437,16 @@ public class FlowableTakeTest {
         ts.assertNoErrors();
         ts.assertComplete();
     }
+
+    
+    @Test
+    public void takeNegative() {
+        try {
+            Flowable.just(1).take(-99);
+            fail("Should have thrown");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("count >= 0 required but it was -99", ex.getMessage());
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
@@ -126,7 +126,7 @@ public class FlowableTakeTimedTest {
     
     @Test
     public void timedDefaultScheduler() {
-        Observable.range(1, 5).take(1, TimeUnit.MINUTES)
+        Flowable.range(1, 5).take(1, TimeUnit.MINUTES)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -150,4 +150,14 @@ public class FlowableThrottleFirstTest {
         inOrder.verify(observer).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+    
+    
+    @Test
+    public void throttleFirstDefaultScheduler() {
+        Flowable.just(1).throttleFirst(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -22,6 +22,8 @@ import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 
@@ -65,4 +67,59 @@ public class FlowableTimeIntervalTest {
         inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+    
+    @Test
+    public void timeIntervalDefault() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Flowable.range(1, 5)
+            .timeInterval()
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void timeIntervalDefaultSchedulerCustomUnit() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Flowable.range(1, 5)
+            .timeInterval(TimeUnit.SECONDS)
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -357,4 +357,14 @@ public class FlowableTimeoutTests {
 
         verify(s, times(1)).cancel();
     }
+
+    
+    @Test
+    public void timedAndOther() {
+        Flowable.never().timeout(100, TimeUnit.MILLISECONDS, Flowable.just(1))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimestampTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimestampTest.java
@@ -23,6 +23,8 @@ import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 
@@ -81,4 +83,59 @@ public class FlowableTimestampTest {
         verify(observer, never()).onError(any(Throwable.class));
         verify(observer, never()).onComplete();
     }
+
+    @Test
+    public void timeIntervalDefault() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Flowable.range(1, 5)
+            .timestamp()
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void timeIntervalDefaultSchedulerCustomUnit() {
+        final TestScheduler scheduler = new TestScheduler();
+        
+        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
+            @Override
+            public Scheduler apply(Scheduler v) throws Exception {
+                return scheduler;
+            }
+        });
+        
+        try {
+            Flowable.range(1, 5)
+            .timestamp(TimeUnit.SECONDS)
+            .map(new Function<Timed<Integer>, Long>() {
+                @Override
+                public Long apply(Timed<Integer> v) throws Exception {
+                    return v.time();
+                }
+            })
+            .test()
+            .assertResult(0L, 0L, 0L, 0L, 0L);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToFutureTest.java
@@ -26,7 +26,7 @@ import io.reactivex.*;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableToObservableFutureTest {
+public class FlowableToFutureTest {
 
     @Test
     public void testSuccess() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -28,7 +28,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableToObservableListTest {
+public class FlowableToListTest {
 
     @Test
     public void testList() {
@@ -161,5 +161,14 @@ public class FlowableToObservableListTest {
         } catch (BrokenBarrierException ex) {
             ex.printStackTrace();
         }
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void capacityHint() {
+        Flowable.range(1, 10)
+        .toList(4)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -25,11 +25,12 @@ import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableToObservableSortedListTest {
+public class FlowableToSortedListTest {
 
     @Test
     public void testSortedList() {
@@ -132,5 +133,45 @@ public class FlowableToObservableSortedListTest {
         } catch (BrokenBarrierException ex) {
             ex.printStackTrace();
         }
+    }
+    
+    @Test
+    public void sorted() {
+        Flowable.just(5, 1, 2, 4, 3).sorted()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+    
+    @Test
+    public void sortedComparator() {
+        Flowable.just(5, 1, 2, 4, 3).sorted(new Comparator<Integer>() {
+            @Override
+            public int compare(Integer a, Integer b) {
+                return b - a;
+            }
+        })
+        .test()
+        .assertResult(5, 4, 3, 2, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void toSortedListCapacity() {
+        Flowable.just(5, 1, 2, 4, 3).toSortedList(4)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void toSortedListComparatorCapacity() {
+        Flowable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {
+            @Override
+            public int compare(Integer a, Integer b) {
+                return b - a;
+            }
+        }, 4)
+        .test()
+        .assertResult(Arrays.asList(5, 4, 3, 2, 1));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -148,6 +148,5 @@ public final class ObservableCollectTest {
         })
         .test()
         .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
-        
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -852,6 +852,12 @@ public class ObservableCombineLatestTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void combineLatestEmpty() {
+        assertSame(Observable.empty(), Observable.combineLatest(new ObservableSource[0], Functions.<Object[]>identity(), 16));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void combineLatestDelayErrorEmpty() {
         assertSame(Observable.empty(), Observable.combineLatestDelayError(new ObservableSource[0], Functions.<Object[]>identity(), 16));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
@@ -227,7 +227,7 @@ public class ObservableFromIterableTest {
         });
         assertFalse(called.get());
     }
- 
+
     @Test
     public void fusionWithConcatMap() {
         TestObserver<Integer> to = new TestObserver<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -150,7 +150,7 @@ public class ObservableSequenceEqualTest {
     }
     
     @Test
-    public void sequenceEqualBufferSize() {
+    public void prefetch() {
         Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), 2)
         .test()
         .assertResult(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimedTest.java
@@ -23,7 +23,7 @@ import org.mockito.InOrder;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableSkipLastTimedTest {
@@ -147,4 +147,32 @@ public class ObservableSkipLastTimedTest {
         inOrder.verify(o).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+
+    @Test
+    public void skipLastTimedDefaultScheduler() {
+        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        .skipLast(300, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void skipLastTimedDefaultSchedulerDelayError() {
+        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        .skipLast(300, TimeUnit.MILLISECONDS, true)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void skipLastTimedCustomSchedulerDelayError() {
+        Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
+        .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.io(), true)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTimedTest.java
@@ -122,4 +122,12 @@ public class ObservableTakeTimedTest {
         verify(o, never()).onNext(4);
         verify(o, never()).onError(any(TestException.class));
     }
+    
+    @Test
+    public void timedDefaultScheduler() {
+        Observable.range(1, 5).take(1, TimeUnit.MINUTES)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -26,7 +26,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.TestHelper;
 
-public class ObservableToObservableListTest {
+public class ObservableToListTest {
 
     @Test
     public void testList() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
@@ -27,7 +27,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.TestHelper;
 
-public class ObservableToObservableSortedListTest {
+public class ObservableToSortedListTest {
 
     @Test
     public void testSortedList() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.operators.single;
 
+import java.util.Arrays;
+
 import org.junit.Test;
 
 import io.reactivex.Single;
@@ -44,5 +46,22 @@ public class SingleConcatTest {
         Single.concat(Single.just(1), Single.just(2), Single.just(3), Single.just(4))
         .test()
         .assertResult(1, 2, 3, 4);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatArray() {
+        for (int i = 1; i < 100; i++) {
+            Single<Integer>[] array = new Single[i];
+            
+            Arrays.fill(array, Single.just(1));
+            
+            Single.concatArray(array)
+            .test()
+            .assertSubscribed()
+            .assertValueCount(i)
+            .assertNoErrors()
+            .assertComplete();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/util/ObservableToFlowabeTestSync.java
+++ b/src/test/java/io/reactivex/internal/util/ObservableToFlowabeTestSync.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+/**
+ * Utility class that lists tests related to Observable that is not present in Flowable tests.
+ */
+public class ObservableToFlowabeTestSync {
+// Uses Java 8 and is generally not relevant
+//    static void list(String basepath, String basepackage) throws Exception {
+//        File[] observables = new File(basepath + "observable/").listFiles();
+//
+//        int count = 0;
+//        
+//        for (File f : observables) {
+//            if (!f.getName().endsWith(".java")) {
+//                continue;
+//            }
+//            Class<?> clazz = Class.forName(basepackage + "observable." + f.getName().replace(".java", ""));
+//
+//            String cn = f.getName().replace(".java", "").replace("Observable", "Flowable");
+//            
+//            File f2 = new File(basepath + "/flowable/" + cn + ".java");
+//            
+//            if (!f2.exists()) {
+//                continue;
+//            }
+//            
+//            Class<?> clazz2 = Class.forName(basepackage + "flowable." + cn);
+//            
+//            Set<String> methods2 = new HashSet<String>();
+//            
+//            for (Method m : clazz2.getMethods()) {
+//                methods2.add(m.getName());
+//            }
+//            
+//            for (Method m : clazz.getMethods()) {
+//                if (!methods2.contains(m.getName()) && !methods2.contains(m.getName().replace("Observable", "Flowable"))) {
+//                    count++;
+//                    System.out.println();
+//                    System.out.print("java.lang.RuntimeException: missing > ");
+//                    System.out.println(m.getName());
+//                    System.out.print(" at ");
+//                    System.out.print(clazz.getName());
+//                    System.out.print(" (");
+//                    System.out.print(clazz.getSimpleName());
+//                    System.out.print(".java:");
+//                    
+//                    List<String> lines = Files.readAllLines(f.toPath());
+//                    
+//                    int j = 1;
+//                    for (int i = 1; i <= lines.size(); i++) {
+//                        if (lines.get(i - 1).contains("public void " + m.getName() + "(")) {
+//                            j = i;
+//                        }
+//                    }
+//                    System.out.print(j);
+//                    System.out.println(")");
+//                    
+//                    System.out.print(" at ");
+//                    System.out.print(clazz2.getName());
+//                    System.out.print(" (");
+//                    System.out.print(clazz2.getSimpleName());
+//                    
+//                    lines = Files.readAllLines(f2.toPath());
+//                    
+//                    System.out.print(".java:");
+//                    System.out.print(lines.size() - 1);
+//                    System.out.println(")");
+//                }
+//            }
+//        }
+//
+//        System.out.println();
+//        System.out.println(count);
+//    }
+//    
+//    public static void main(String[] args) throws Exception {
+////        list("src/test/java/io/reactivex/internal/operators/", "io.reactivex.internal.operators.");
+//        list("src/test/java/io/reactivex/", "io.reactivex.");
+//    }
+}

--- a/src/test/java/io/reactivex/observable/ObservableConcatTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableConcatTests.java
@@ -39,7 +39,7 @@ public class ObservableConcatTests {
     }
 
     @Test
-    public void testConcatWithNbpObservableOfNbpObservable() {
+    public void testConcatWithObservableOfObservable() {
         Observable<String> o1 = Observable.just("one", "two");
         Observable<String> o2 = Observable.just("three", "four");
         Observable<String> o3 = Observable.just("five", "six");
@@ -57,7 +57,7 @@ public class ObservableConcatTests {
     }
 
     @Test
-    public void testConcatWithIterableOfNbpObservable() {
+    public void testConcatWithIterableOfObservable() {
         Observable<String> o1 = Observable.just("one", "two");
         Observable<String> o2 = Observable.just("three", "four");
         Observable<String> o3 = Observable.just("five", "six");

--- a/src/test/java/io/reactivex/observable/ObservableDoOnTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableDoOnTest.java
@@ -101,6 +101,5 @@ public class ObservableDoOnTest {
         .test()
         .assertFailure(TestException.class);
         assertTrue(r.get());
-        
     }
 }

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -276,9 +276,8 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void concatNbpObservableNull() {
+    public void concatObservableNull() {
         Observable.concat((Observable<Observable<Object>>)null);
-
     }
 
     @Test(expected = NullPointerException.class)
@@ -688,7 +687,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void usingNbpObservableSupplierNull() {
+    public void usingObservableSupplierNull() {
         Observable.using(new Callable<Object>() {
             @Override
             public Object call() {
@@ -701,7 +700,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void usingNbpObservableSupplierReturnsNull() {
+    public void usingObservableSupplierReturnsNull() {
         Observable.using(new Callable<Object>() {
             @Override
             public Object call() {
@@ -776,7 +775,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void zipNbpObservableNull() {
+    public void zipObservableNull() {
         Observable.zip((Observable<Observable<Object>>)null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
@@ -786,12 +785,12 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void zipNbpObservableFunctionNull() {
+    public void zipObservableFunctionNull() {
         Observable.zip((Observable.just(just1)), null);
     }
 
     @Test(expected = NullPointerException.class)
-    public void zipNbpObservableFunctionReturnsNull() {
+    public void zipObservableFunctionReturnsNull() {
         Observable.zip((Observable.just(just1)), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
@@ -1712,7 +1711,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextNbpObservableNull() {
+    public void onErrorResumeNextObservableNull() {
         just1.onErrorResumeNext((Observable<Integer>)null);
     }
     
@@ -2007,7 +2006,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void sampleNbpObservableNull() {
+    public void sampleObservableNull() {
         just1.sample(null);
     }
     
@@ -2162,7 +2161,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void startWithNbpObservableNull() {
+    public void startWithObservableNull() {
         just1.startWith((Observable<Integer>)null);
     }
     
@@ -2282,7 +2281,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void takeUntilNbpObservableNull() {
+    public void takeUntilObservableNull() {
         just1.takeUntil((Observable<Integer>)null);
     }
     
@@ -2782,7 +2781,7 @@ public class ObservableNullTests {
     }
     
     @Test(expected = NullPointerException.class)
-    public void zipWithNbpObservableNull() {
+    public void zipWithObservableNull() {
         just1.zipWith((Observable<Integer>)null, new BiFunction<Integer, Integer, Object>() {
             @Override
             public Object apply(Integer a, Integer b) {

--- a/src/test/java/io/reactivex/observable/ObservableReduceTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableReduceTests.java
@@ -83,13 +83,13 @@ public class ObservableReduceTests {
     public void reduceCovariance() {
         // must type it to <Movie>
         Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
-        libraryFunctionActingOnMovieNbpObservables(horrorMovies);
+        libraryFunctionActingOnMovieObservables(horrorMovies);
     }
 
     /*
      * This accepts <Movie> instead of <? super Movie> since `reduce` can't handle covariants
      */
-    public void libraryFunctionActingOnMovieNbpObservables(Observable<Movie> obs) {
+    public void libraryFunctionActingOnMovieObservables(Observable<Movie> obs) {
 
         obs.reduce(new BiFunction<Movie, Movie, Movie>() {
             @Override

--- a/src/test/java/io/reactivex/observable/ObservableTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableTests.java
@@ -214,10 +214,10 @@ public class ObservableTests {
     }
 
     /**
-     * A reduce should fail with an NoSuchElementException if done on an empty NbpObservable.
+     * A reduce should fail with an NoSuchElementException if done on an empty Observable.
      */
     @Test(expected = NoSuchElementException.class)
-    public void testReduceWithEmptyNbpObservable() {
+    public void testReduceWithEmptyObservable() {
         Observable<Integer> o = Observable.range(1, 0);
         o.reduce(new BiFunction<Integer, Integer, Integer>() {
             @Override
@@ -236,12 +236,12 @@ public class ObservableTests {
     }
 
     /**
-     * A reduce on an empty NbpObservable and a seed should just pass the seed through.
+     * A reduce on an empty Observable and a seed should just pass the seed through.
      * 
      * This is confirmed at https://github.com/ReactiveX/RxJava/issues/423#issuecomment-27642456
      */
     @Test
-    public void testReduceWithEmptyNbpObservableAndSeed() {
+    public void testReduceWithEmptyObservableAndSeed() {
         Observable<Integer> o = Observable.range(1, 0);
         int value = o.reduce(1, new BiFunction<Integer, Integer, Integer>() {
             @Override
@@ -309,7 +309,7 @@ public class ObservableTests {
      * @throws InterruptedException if the test is interrupted
      */
     @Test
-    public void testCustomNbpObservableWithErrorInObserverAsynchronous() throws InterruptedException {
+    public void testCustomObservableWithErrorInObserverAsynchronous() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
@@ -358,7 +358,7 @@ public class ObservableTests {
      * Result: Passes
      */
     @Test
-    public void testCustomNbpObservableWithErrorInObserverSynchronous() {
+    public void testCustomObservableWithErrorInObserverSynchronous() {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         
@@ -395,13 +395,13 @@ public class ObservableTests {
     }
 
     /**
-     * The error from the user provided NbpObservable is handled by the subscribe try/catch because this is synchronous
+     * The error from the user provided Observable is handled by the subscribe try/catch because this is synchronous
      * 
      * 
      * Result: Passes
      */
     @Test
-    public void testCustomNbpObservableWithErrorInNbpObservableSynchronous() {
+    public void testCustomObservableWithErrorInObservableSynchronous() {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         // FIXME custom built???
@@ -626,7 +626,7 @@ public class ObservableTests {
      * Rx Design Guidelines 5.2
      * 
      * "when calling the Subscribe method that only has an onNext argument, the OnError behavior will be
-     * to rethrow the exception on the thread that the message comes out from the NbpObservable.
+     * to rethrow the exception on the thread that the message comes out from the Observable.
      * The OnCompleted behavior in this case is to do nothing."
      */
     @Test
@@ -647,7 +647,7 @@ public class ObservableTests {
      * Rx Design Guidelines 5.2
      * 
      * "when calling the Subscribe method that only has an onNext argument, the OnError behavior will be
-     * to rethrow the exception on the thread that the message comes out from the NbpObservable.
+     * to rethrow the exception on the thread that the message comes out from the Observable.
      * The OnCompleted behavior in this case is to do nothing."
      * 
      * @throws InterruptedException
@@ -801,7 +801,7 @@ public class ObservableTests {
     }
 
     @Test
-    public void testContainsWithEmptyNbpObservable() {
+    public void testContainsWithEmptyObservable() {
         Observable<Boolean> o = Observable.<String> empty().contains("a");
 
         Observer<Object> observer = TestHelper.mockObserver();
@@ -909,10 +909,10 @@ public class ObservableTests {
 // FIXME Subscribers can't throw
 //    @Test(expected = OnErrorNotImplementedException.class)
 //    public void testSubscribeWithoutOnError() {
-//        NbpObservable<String> o = NbpObservable.just("a", "b").flatMap(new Func1<String, NbpObservable<String>>() {
+//        Observable<String> o = Observable.just("a", "b").flatMap(new Func1<String, Observable<String>>() {
 //            @Override
-//            public NbpObservable<String> call(String s) {
-//                return NbpObservable.error(new Exception("test"));
+//            public Observable<String> call(String s) {
+//                return Observable.error(new Exception("test"));
 //            }
 //        });
 //        o.subscribe();
@@ -997,7 +997,7 @@ public class ObservableTests {
 //    @Test // cf. https://github.com/ReactiveX/RxJava/issues/2599
 //    public void testSubscribingSubscriberAsObserverMaintainsSubscriptionChain() {
 //        NbpTestSubscriber<Object> subscriber = new NbpTestSubscriber<T>();
-//        Subscription subscription = NbpObservable.just("event").subscribe((Observer<Object>) subscriber);
+//        Subscription subscription = Observable.just("event").subscribe((Observer<Object>) subscriber);
 //        subscription.unsubscribe();
 //
 //        subscriber.assertUnsubscribed();
@@ -1006,7 +1006,7 @@ public class ObservableTests {
 // FIXME subscribers can't throw
 //    @Test(expected=OnErrorNotImplementedException.class)
 //    public void testForEachWithError() {
-//        NbpObservable.error(new Exception("boo"))
+//        Observable.error(new Exception("boo"))
 //        //
 //        .forEach(new Action1<Object>() {
 //            @Override

--- a/src/test/java/io/reactivex/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableZipTests.java
@@ -28,7 +28,7 @@ import io.reactivex.observables.GroupedObservable;
 public class ObservableZipTests {
 
     @Test
-    public void testZipNbpObservableOfNbpObservables() {
+    public void testZipObservableOfObservables() {
         ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
                 .groupBy(new Function<Event, String>() {
                     @Override
@@ -79,19 +79,19 @@ public class ObservableZipTests {
     }
 
     /**
-     * Occasionally zip may be invoked with 0 NbpObservables. Test that we don't block indefinitely instead
+     * Occasionally zip may be invoked with 0 observables. Test that we don't block indefinitely instead
      * of immediately invoking zip with 0 argument.
      * 
      * We now expect an NoSuchElementException since last() requires at least one value and nothing will be emitted.
      */
     @Test(expected = NoSuchElementException.class)
-    public void nonBlockingNbpObservable() {
+    public void nonBlockingObservable() {
 
         final Object invoked = new Object();
 
-        Collection<Observable<Object>> NbpObservables = Collections.emptyList();
+        Collection<Observable<Object>> observables = Collections.emptyList();
 
-        Observable<Object> result = Observable.zip(NbpObservables, new Function<Object[], Object>() {
+        Observable<Object> result = Observable.zip(observables, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] args) {
                 System.out.println("received: " + args);


### PR DESCRIPTION
- Fixed bugs in `Flowable.sequenceEqual`, `Flowable.zip` when errors are delayed, `Flowable.onBackpressureBuffer` when errors are delayed
- Fixed mentions of `NbpX` in some places
- Synchronized unit tests between `Observable` and `Flowable`
