### PR TITLE
2.x: coverage and fixes 9/03-2

### DIFF
--- a/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
+++ b/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
@@ -124,10 +124,12 @@ public final class ObserverFullArbiter<T> extends FullArbiterPad1 implements Dis
                 } else
                 if (NotificationLite.isDisposable(v)) {
                     Disposable next = NotificationLite.getDisposable(v);
-                    if (s != null) {
-                        s.dispose();
+                    s.dispose();
+                    if (!cancelled) {
+                        s = next;
+                    } else {
+                        next.dispose();
                     }
-                    s = next;
                 } else 
                 if (NotificationLite.isError(v)) {
                     q.clear();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
@@ -45,6 +45,8 @@ public final class ObservableRange extends Observable<Integer> {
         
         long index;
         
+        boolean fused;
+        
         public RangeDisposable(Observer<? super Integer> actual, long start, long end) {
             this.actual = actual;
             this.index = start;
@@ -52,6 +54,9 @@ public final class ObservableRange extends Observable<Integer> {
         }
         
         void run() {
+            if (fused) {
+                return;
+            }
             Observer<? super Integer> actual = this.actual;
             long e = end;
             for (long i = index; i != e && get() == 0; i++) {
@@ -107,7 +112,11 @@ public final class ObservableRange extends Observable<Integer> {
 
         @Override
         public int requestFusion(int mode) {
-            return mode & SYNC;
+            if ((mode & SYNC) != 0) {
+                fused = true;
+                return SYNC;
+            }
+            return NONE;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/BlockingSubscriber.java
@@ -35,14 +35,9 @@ public final class BlockingSubscriber<T> extends AtomicReference<Subscription> i
     
     @Override
     public void onSubscribe(Subscription s) {
-        if (!compareAndSet(null, s)) {
-            s.cancel();
-            if (get() != SubscriptionHelper.CANCELLED) {
-                onError(new IllegalStateException("Subscription already set"));
-            }
-            return;
+        if (SubscriptionHelper.setOnce(this, s)) {
+            queue.offer(NotificationLite.subscription(this));
         }
-        queue.offer(NotificationLite.subscription(this));
     }
     
     @Override

--- a/src/main/java/io/reactivex/internal/subscribers/flowable/FutureSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/flowable/FutureSubscriber.java
@@ -123,22 +123,17 @@ implements Subscriber<T>, Future<T>, Subscription {
 
     @Override
     public void onError(Throwable t) {
-        if (error == null) {
-            error = t;
-
-            for (;;) {
-                Subscription a = s.get();
-                if (a == this || a == SubscriptionHelper.CANCELLED) {
-                    RxJavaPlugins.onError(t);
-                    return;
-                }
-                if (s.compareAndSet(a, this)) {
-                    countDown();
-                    return;
-                }
+        for (;;) {
+            Subscription a = s.get();
+            if (a == this || a == SubscriptionHelper.CANCELLED) {
+                RxJavaPlugins.onError(t);
+                return;
             }
-        } else {
-            RxJavaPlugins.onError(t);
+            error = t;
+            if (s.compareAndSet(a, this)) {
+                countDown();
+                return;
+            }
         }
     }
 

--- a/src/main/java/io/reactivex/internal/subscriptions/ArrayCompositeSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/ArrayCompositeSubscription.java
@@ -44,7 +44,9 @@ public final class ArrayCompositeSubscription extends AtomicReferenceArray<Subsc
         for (;;) {
             Subscription o = get(index);
             if (o == SubscriptionHelper.CANCELLED) {
-                resource.cancel();
+                if (resource != null) {
+                    resource.cancel();
+                }
                 return false;
             }
             if (compareAndSet(index, o, resource)) {
@@ -66,7 +68,9 @@ public final class ArrayCompositeSubscription extends AtomicReferenceArray<Subsc
         for (;;) {
             Subscription o = get(index);
             if (o == SubscriptionHelper.CANCELLED) {
-                resource.cancel();
+                if (resource != null) {
+                    resource.cancel();
+                }
                 return null;
             }
             if (compareAndSet(index, o, resource)) {

--- a/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
@@ -82,11 +82,13 @@ public class DeferredScalarSubscription<T> extends BasicIntQueueSubscription<T> 
                 if (state == NO_REQUEST_HAS_VALUE) {
                     if (compareAndSet(NO_REQUEST_HAS_VALUE, HAS_REQUEST_HAS_VALUE)) {
                         T v = value;
-                        value = null;
-                        Subscriber<? super T> a = actual;
-                        a.onNext(v);
-                        if (get() != CANCELLED) {
-                            a.onComplete();
+                        if (v != null) {
+                            value = null;
+                            Subscriber<? super T> a = actual;
+                            a.onNext(v);
+                            if (get() != CANCELLED) {
+                                a.onComplete();
+                            }
                         }
                     }
                     return;

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
@@ -66,15 +66,6 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
     }
     
     /**
-     * When setting a new subscription via set(), should
-     * the previous subscription be cancelled?
-     * @return true if cancellation is needed
-     */
-    protected boolean shouldCancelCurrent() {
-        return true;
-    }
-    
-    /**
      * Atomically sets a new subscription.
      * @param s the subscription to set, not null (verified)
      */
@@ -89,7 +80,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
         if (get() == 0 && compareAndSet(0, 1)) {
             Subscription a = actual;
             
-            if (a != null && shouldCancelCurrent()) {
+            if (a != null) {
                 a.cancel();
             }
             
@@ -109,7 +100,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
         }
 
         Subscription a = missedSubscription.getAndSet(s);
-        if (a != null && shouldCancelCurrent()) {
+        if (a != null) {
             a.cancel();
         }
         drain();
@@ -150,38 +141,6 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
         }
     }
 
-    public final void producedOne() {
-        if (unbounded) {
-            return;
-        }
-        if (get() == 0 && compareAndSet(0, 1)) {
-            long r = requested;
-
-            if (r != Long.MAX_VALUE) {
-                r--;
-                if (r < 0L) {
-                    SubscriptionHelper.reportMoreProduced(r);
-                    r = 0;
-                }
-                requested = r;
-            } else {
-                unbounded = true;
-            }
-
-            if (decrementAndGet() == 0) {
-                return;
-            }
-
-            drainLoop();
-
-            return;
-        }
-
-        BackpressureHelper.add(missedProduced, 1L);
-
-        drain();
-    }
-
     public final void produced(long n) {
         if (unbounded) {
             return;
@@ -196,8 +155,6 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
                     u = 0;
                 }
                 requested = u;
-            } else {
-                unbounded = true;
             }
 
             if (decrementAndGet() == 0) {
@@ -283,7 +240,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
                 }
 
                 if (ms != null) {
-                    if (a != null && shouldCancelCurrent()) {
+                    if (a != null) {
                         a.cancel();
                     }
                     actual = ms;

--- a/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
@@ -98,7 +98,7 @@ public class AppendOnlyLinkedArrayList<T> {
     public <S> void forEachWhile(S state, BiPredicate<? super S, ? super T> consumer) throws Exception {
         Object[] a = head;
         final int c = capacity;
-        while (a != null) {
+        for (;;) {
             for (int i = 0; i < c; i++) {
                 Object o = a[i];
                 if (o == null) {

--- a/src/main/java/io/reactivex/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/observers/SafeObserver.java
@@ -55,6 +55,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
                 } catch (Throwable e1) {
                     Exceptions.throwIfFatal(e1);
                     RxJavaPlugins.onError(new CompositeException(e, e1));
+                    return;
                 }
                 RxJavaPlugins.onError(e);
             }
@@ -111,6 +112,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
     }
     
     void onNextNoSubscription() {
+        done = true;
         
         Throwable ex = new NullPointerException("Subscription not set!");
         
@@ -181,12 +183,13 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         if (done) {
             return;
         }
+
+        done = true;
+
         if (s == null) {
             onCompleteNoSubscription();
             return;
         }
-
-        done = true;
 
         try {
             actual.onComplete();

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -700,9 +700,6 @@ public class TestObserver<T> implements Observer<T>, Disposable {
         } else
         if (s == 1) {
             Throwable e = errors.get(0);
-            if (e == null) {
-                throw fail("Error is null");
-            }
             String errorMessage = e.getMessage();
             if (!ObjectHelper.equals(message, errorMessage)) {
                 throw fail("Error message differs; Expected: " + message + ", Actual: " + errorMessage);
@@ -763,7 +760,7 @@ public class TestObserver<T> implements Observer<T>, Disposable {
                 throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
                 + ", actual: " + fusionModeToString(m));
             } else {
-                throw new AssertionError("Upstream is not fuseable");
+                throw fail("Upstream is not fuseable");
             }
         }
         return this;

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -665,10 +665,10 @@ public final class RxJavaPlugins {
     
     /**
      * Sets the specific hook function.
-     * @param onFlowableSubscribe the hook function to set, null allowed
+     * @param onMaybeSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnMaybeSubscribe(BiFunction<Maybe, MaybeObserver, MaybeObserver> onFlowableSubscribe) {
+    public static void setOnMaybeSubscribe(BiFunction<Maybe, MaybeObserver, MaybeObserver> onMaybeSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -45,8 +45,9 @@ public final class Schedulers {
         NEW_THREAD = RxJavaPlugins.initNewThreadScheduler(NewThreadScheduler.instance());
     }
     
+    /** Utility class. */
     private Schedulers() {
-        throw new IllegalStateException("No instances");
+        throw new IllegalStateException("No instances!");
     }
     
     /**

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -27,9 +27,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.reactivestreams.*;
 
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -405,4 +407,135 @@ public enum TestHelper {
             }
         };
     }
+    
+    /**
+     * Calls onSubscribe twice and checks if it doesn't affect the first Subscription while
+     * reporting it to plugin error handler.
+     * @param subscriber the target
+     */
+    public static void doubleOnSubscribe(Subscriber<?> subscriber) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            BooleanSubscription s1 = new BooleanSubscription();
+            
+            subscriber.onSubscribe(s1);
+            
+            BooleanSubscription s2 = new BooleanSubscription();
+            
+            subscriber.onSubscribe(s2);
+            
+            assertFalse(s1.isCancelled());
+            
+            assertTrue(s2.isCancelled());
+            
+            assertError(errors, 0, IllegalStateException.class, "Subscription already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
+     * reporting it to plugin error handler.
+     * @param subscriber the target
+     */
+    public static void doubleOnSubscribe(Observer<?> subscriber) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            Disposable d1 = Disposables.empty();
+            
+            subscriber.onSubscribe(d1);
+            
+            Disposable d2 = Disposables.empty();
+            
+            subscriber.onSubscribe(d2);
+            
+            assertFalse(d1.isDisposed());
+            
+            assertTrue(d2.isDisposed());
+            
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
+     * reporting it to plugin error handler.
+     * @param subscriber the target
+     */
+    public static void doubleOnSubscribe(SingleObserver<?> subscriber) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            Disposable d1 = Disposables.empty();
+            
+            subscriber.onSubscribe(d1);
+            
+            Disposable d2 = Disposables.empty();
+            
+            subscriber.onSubscribe(d2);
+            
+            assertFalse(d1.isDisposed());
+            
+            assertTrue(d2.isDisposed());
+            
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
+     * reporting it to plugin error handler.
+     * @param subscriber the target
+     */
+    public static void doubleOnSubscribe(CompletableObserver subscriber) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            Disposable d1 = Disposables.empty();
+            
+            subscriber.onSubscribe(d1);
+            
+            Disposable d2 = Disposables.empty();
+            
+            subscriber.onSubscribe(d2);
+            
+            assertFalse(d1.isDisposed());
+            
+            assertTrue(d2.isDisposed());
+            
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
+     * reporting it to plugin error handler.
+     * @param subscriber the target
+     */
+    public static void doubleOnSubscribe(MaybeObserver<?> subscriber) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            Disposable d1 = Disposables.empty();
+            
+            subscriber.onSubscribe(d1);
+            
+            Disposable d2 = Disposables.empty();
+            
+            subscriber.onSubscribe(d2);
+            
+            assertFalse(d1.isDisposed());
+            
+            assertTrue(d2.isDisposed());
+            
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
 }

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -84,7 +84,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestFromChainedOperator() throws Exception {
-        TestSubscriber<String> s = new TestSubscriber<String>();
+        TestSubscriber<String> s = new TestSubscriber<String>(10L);
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
@@ -113,7 +113,6 @@ public class FlowableSubscriberTest {
                 };
             }
         };
-        s.request(10);
         Subscriber<? super String> ns = o.apply(s);
 
         final AtomicLong r = new AtomicLong();
@@ -190,7 +189,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestFromDecoupledOperatorThatRequestsN() throws Exception {
-        TestSubscriber<String> s = new TestSubscriber<String>();
+        TestSubscriber<String> s = new TestSubscriber<String>(10L);
         final AtomicLong innerR = new AtomicLong();
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
@@ -238,7 +237,6 @@ public class FlowableSubscriberTest {
                 return as;
             }
         };
-        s.request(10);
         Subscriber<? super String> ns = o.apply(s);
 
         final AtomicLong r = new AtomicLong();
@@ -263,8 +261,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void testRequestToFlowable() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ts.request(3);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3L);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/internal/disposables/ObserverFullArbiterTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/ObserverFullArbiterTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.disposables.ObserverFullArbiter;
+import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ObserverFullArbiterTest {
+
+    @Test
+    public void setSubscriptionAfterCancel() {
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(new TestObserver<Integer>(), null, 128);
+                
+        fa.dispose();
+        
+        Disposable bs = Disposables.empty();
+        
+        assertFalse(fa.setSubscription(bs));
+        
+        assertFalse(fa.setSubscription(null));
+    }
+    
+    @Test
+    public void cancelAfterPoll() {
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(new TestObserver<Integer>(), null, 128);
+
+        Disposable bs = Disposables.empty();
+        
+        fa.queue.offer(fa.s, NotificationLite.disposable(bs));
+
+        assertFalse(fa.isDisposed());
+
+        fa.dispose();
+        
+        assertTrue(fa.isDisposed());
+        
+        fa.drain();
+        
+        assertTrue(bs.isDisposed());
+    }
+    
+    @Test
+    public void errorAfterCancel() {
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(new TestObserver<Integer>(), null, 128);
+
+        Disposable bs = Disposables.empty();
+
+        fa.dispose();
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            fa.onError(new TestException(), bs);
+            
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void cancelAfterError() {
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(new TestObserver<Integer>(), null, 128);
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            fa.queue.offer(fa.s, NotificationLite.error(new TestException()));
+            
+            fa.dispose();
+            
+            fa.drain();
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void offerDifferentSubscription() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(ts, null, 128);
+
+        Disposable bs = Disposables.empty();
+        
+        fa.queue.offer(bs, NotificationLite.next(1));
+        
+        fa.drain();
+        
+        ts.assertNoValues();
+    }
+    
+    @Test
+    public void dontEnterDrain() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(ts, null, 128);
+
+        fa.queue.offer(fa.s, NotificationLite.next(1));
+        
+        fa.wip.getAndIncrement();
+        
+        fa.drain();
+        
+        ts.assertNoValues();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -297,7 +297,7 @@ public class FlowableUsingTest {
         
         observable.safeSubscribe(observer);
 
-        assertEquals(Arrays.asList("disposed", "completed", "unsub"), events);
+        assertEquals(Arrays.asList("disposed", "completed"), events);
 
     }
 
@@ -324,7 +324,7 @@ public class FlowableUsingTest {
         
         observable.safeSubscribe(observer);
 
-        assertEquals(Arrays.asList("completed", "unsub", "disposed"), events);
+        assertEquals(Arrays.asList("completed", "disposed"), events);
 
     }
 
@@ -354,7 +354,7 @@ public class FlowableUsingTest {
         
         observable.safeSubscribe(observer);
 
-        assertEquals(Arrays.asList("disposed", "error", "unsub"), events);
+        assertEquals(Arrays.asList("disposed", "error"), events);
 
     }
     
@@ -382,7 +382,7 @@ public class FlowableUsingTest {
         
         observable.safeSubscribe(observer);
 
-        assertEquals(Arrays.asList("error", "unsub", "disposed"), events);
+        assertEquals(Arrays.asList("error", "disposed"), events);
     }
 
     private static Action createUnsubAction(final List<String> events) {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -235,7 +235,7 @@ public class SingleMiscTest {
     public void timeout() throws Exception {
         Single.never().timeout(100, TimeUnit.MILLISECONDS, Schedulers.io())
         .test()
-        .awaitDone()
+        .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TimeoutException.class);
     }
 
@@ -244,7 +244,7 @@ public class SingleMiscTest {
         Single.never()
         .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io(), Single.just(1))
         .test()
-        .awaitDone()
+        .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
     }
     

--- a/src/test/java/io/reactivex/internal/subscribers/flowable/BlockingSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/flowable/BlockingSubscriberTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.TestHelper;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+
+public class BlockingSubscriberTest {
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.doubleOnSubscribe(new BlockingSubscriber<Integer>(new ArrayDeque<Object>()));
+    }
+    
+    @Test
+    public void cancel() {
+        BlockingSubscriber<Integer> bq = new BlockingSubscriber<Integer>(new ArrayDeque<Object>());
+
+        assertFalse(bq.isCancelled());
+        
+        bq.cancel();
+        
+        assertTrue(bq.isCancelled());
+        
+        bq.cancel();
+        
+        assertTrue(bq.isCancelled());
+    }
+    
+    @Test
+    public void blockingFirstDoubleOnSubscribe() {
+        TestHelper.doubleOnSubscribe(new BlockingFirstSubscriber<Integer>());
+    }
+
+    @Test(timeout = 5000)
+    public void blockingFirstTimeout() {
+        BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        
+        Thread.currentThread().interrupt();
+        
+        try {
+            bf.blockingGet();
+            fail("Should have thrown!");
+        } catch (RuntimeException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof InterruptedException);
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void blockingFirstTimeout2() {
+        BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        
+        bf.onSubscribe(new BooleanSubscription());
+        
+        Thread.currentThread().interrupt();
+        
+        try {
+            bf.blockingGet();
+            fail("Should have thrown!");
+        } catch (RuntimeException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof InterruptedException);
+        }
+    }
+
+    @Test
+    public void cancelOnRequest() {
+        
+        final BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        
+        final AtomicBoolean b = new AtomicBoolean();
+        
+        Subscription s = new Subscription() {
+            @Override
+            public void request(long n) {
+                bf.cancelled = true;
+            }
+            @Override
+            public void cancel() {
+                b.set(true);
+            }
+        };
+        
+        bf.onSubscribe(s);
+        
+        assertTrue(b.get());
+    }
+    
+    @Test
+    public void cancelUpfront() {
+        
+        final BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        
+        final AtomicBoolean b = new AtomicBoolean();
+
+        bf.cancelled = true;
+
+        Subscription s = new Subscription() {
+            @Override
+            public void request(long n) {
+                b.set(true);
+            }
+            @Override
+            public void cancel() {
+            }
+        };
+        
+        bf.onSubscribe(s);
+        
+        assertFalse(b.get());
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/flowable/EmptyComponentTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/flowable/EmptyComponentTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscribers.flowable.EmptyComponent;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class EmptyComponentTest {
+
+    @Test
+    public void normal() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        
+        try {
+            TestHelper.checkEnum(EmptyComponent.class);
+            
+            EmptyComponent c = EmptyComponent.INSTANCE;
+            
+            assertTrue(c.isDisposed());
+            
+            c.request(10);
+            
+            c.request(-10);
+            
+            Disposable d = Disposables.empty();
+            
+            c.onSubscribe(d);
+            
+            assertTrue(d.isDisposed());
+            
+            BooleanSubscription s = new BooleanSubscription();
+            
+            c.onSubscribe(s);
+            
+            assertTrue(s.isCancelled());
+            
+            c.onNext(null);
+            
+            c.onNext(1);
+            
+            c.onComplete();
+            
+            c.onError(new TestException());
+            
+            c.cancel();
+            
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/flowable/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/flowable/FutureSubscriberTest.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.flowable;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.*;
+
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+public class FutureSubscriberTest {
+
+    FutureSubscriber<Integer> fs;
+    
+    @Before
+    public void before() {
+        fs = new FutureSubscriber<Integer>();
+    }
+    
+    @Test
+    public void cancel() throws Exception {
+        assertFalse(fs.isDone());
+        
+        assertFalse(fs.isCancelled());
+        
+        fs.cancel();
+
+        fs.cancel();
+
+        fs.request(10);
+        
+        fs.request(-99);
+        
+        fs.cancel(false);
+        
+        assertTrue(fs.isDone());
+        
+        assertTrue(fs.isCancelled());
+        
+        try {
+            fs.get();
+            fail("Should have thrown");
+        } catch (CancellationException ex) {
+            // expected
+        }
+        
+        try {
+            fs.get(1, TimeUnit.MILLISECONDS);
+            fail("Should have thrown");
+        } catch (CancellationException ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void onError() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        
+        try {
+            fs.onError(new TestException("One"));
+            
+            fs.onError(new TestException("Two"));
+            
+            try {
+                fs.get(5, TimeUnit.MILLISECONDS);
+            } catch (ExecutionException ex) {
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
+                assertEquals("One", ex.getCause().getMessage());
+            }
+            
+            TestHelper.assertError(errors, 0, TestException.class, "Two");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void onNext() throws Exception {
+        fs.onNext(1);
+        fs.onComplete();
+        
+        assertEquals(1, fs.get(5, TimeUnit.MILLISECONDS).intValue());
+    }
+    
+    @Test
+    public void onSubscribe() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        
+        try {
+            
+            BooleanSubscription s = new BooleanSubscription();
+            
+            fs.onSubscribe(s);
+
+            BooleanSubscription s2 = new BooleanSubscription();
+            
+            fs.onSubscribe(s2);
+            
+            assertFalse(s.isCancelled());
+            assertTrue(s2.isCancelled());
+            
+            TestHelper.assertError(errors, 0, IllegalStateException.class, "Subscription already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void cancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    fs.cancel(false);
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.single());
+        }
+    }
+    
+    @Test
+    public void await() throws Exception {
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                fs.onNext(1);
+                fs.onComplete();
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+        
+        assertEquals(1, fs.get(5, TimeUnit.SECONDS).intValue());
+    }
+    
+    @Test
+    public void onErrorCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
+            
+            final TestException ex = new TestException();
+            
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    fs.cancel(false);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    fs.onError(ex);
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+    
+    @Test
+    public void onCompleteCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
+            
+            if (i % 3 == 0) {
+                fs.onSubscribe(new BooleanSubscription());
+            }
+
+            if (i % 2 == 0) {
+                fs.onNext(1);
+            }
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    fs.cancel(false);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    fs.onComplete();
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+    
+    @Test
+    public void onErrorOnComplete() throws Exception {
+        fs.onError(new TestException("One"));
+        fs.onComplete();
+        
+        try {
+            fs.get(5, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof TestException);
+            assertEquals("One", ex.getCause().getMessage());
+        }
+    }
+    
+    @Test
+    public void onCompleteOnError() throws Exception {
+        fs.onComplete();
+        fs.onError(new TestException("One"));
+        
+        try {
+            assertNull(fs.get(5, TimeUnit.MILLISECONDS));
+        } catch (ExecutionException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof NoSuchElementException);
+        }
+    }
+    
+    @Test
+    public void cancelOnError() throws Exception {
+        fs.cancel(true);
+        fs.onError(new TestException("One"));
+        
+        try {
+            fs.get(5, TimeUnit.MILLISECONDS);
+            fail("Should have thrown");
+        } catch (CancellationException ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void cancelOnComplete() throws Exception {
+        fs.cancel(true);
+        fs.onComplete();
+        
+        try {
+            fs.get(5, TimeUnit.MILLISECONDS);
+            fail("Should have thrown");
+        } catch (CancellationException ex) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void onNextThenOnCompleteTwice() throws Exception {
+        fs.onNext(1);
+        fs.onComplete();
+        fs.onComplete();
+
+        assertEquals(1, fs.get(5, TimeUnit.MILLISECONDS).intValue());
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/ArrayCompositeSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/ArrayCompositeSubscriptionTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.schedulers.Schedulers;
+
+public class ArrayCompositeSubscriptionTest {
+
+    @Test
+    public void set() {
+        ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1);
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        
+        ac.setResource(0, bs1);
+        
+        assertFalse(bs1.isCancelled());
+        
+        BooleanSubscription bs2 = new BooleanSubscription();
+        
+        ac.setResource(0, bs2);
+        
+        assertTrue(bs1.isCancelled());
+        
+        assertFalse(bs2.isCancelled());
+
+        assertFalse(ac.isDisposed());
+
+        ac.dispose();
+        
+        assertTrue(bs2.isCancelled());
+        
+        assertTrue(ac.isDisposed());
+        
+        BooleanSubscription bs3 = new BooleanSubscription();
+
+        assertFalse(ac.setResource(0, bs3));
+        
+        assertTrue(bs3.isCancelled());
+        
+        assertFalse(ac.setResource(0, null));
+    }
+
+    @Test
+    public void replace() {
+        ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1);
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        
+        ac.replaceResource(0, bs1);
+        
+        assertFalse(bs1.isCancelled());
+        
+        BooleanSubscription bs2 = new BooleanSubscription();
+        
+        ac.replaceResource(0, bs2);
+        
+        assertFalse(bs1.isCancelled());
+        
+        assertFalse(bs2.isCancelled());
+
+        assertFalse(ac.isDisposed());
+
+        ac.dispose();
+        
+        assertTrue(bs2.isCancelled());
+        
+        assertTrue(ac.isDisposed());
+        
+        BooleanSubscription bs3 = new BooleanSubscription();
+
+        ac.replaceResource(0, bs3);
+        
+        assertTrue(bs3.isCancelled());
+        
+        ac.replaceResource(0, null);
+    }
+    
+    @Test
+    public void disposeRace() {
+        for (int i = 0; i < 500; i++) {
+            final ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1000);
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    ac.dispose();
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void setReplaceRace() {
+        for (int i = 0; i < 500; i++) {
+            final ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1);
+            
+            final BooleanSubscription s1 = new BooleanSubscription();
+            final BooleanSubscription s2 = new BooleanSubscription();
+            
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ac.setResource(0, s1);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ac.replaceResource(0, s2);
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/AsyncSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/AsyncSubscriptionTest.java
@@ -29,7 +29,7 @@ public class AsyncSubscriptionTest {
         
         Subscription s = mock(Subscription.class);
         
-        assertTrue(as.setSubscription(s));
+        as.setSubscription(s);
         
         as.request(1);
         
@@ -47,7 +47,7 @@ public class AsyncSubscriptionTest {
         
         as.request(1);
 
-        assertTrue(as.setSubscription(s));
+        as.setSubscription(s);
         
         as.cancel();
         
@@ -64,7 +64,7 @@ public class AsyncSubscriptionTest {
         as.request(1);
         as.cancel();
 
-        assertFalse(as.setSubscription(s));
+        as.setSubscription(s);
         
         verify(s, never()).request(1);
         verify(s).cancel();
@@ -76,11 +76,11 @@ public class AsyncSubscriptionTest {
         
         Subscription s = mock(Subscription.class);
         
-        assertTrue(as.setSubscription(s));
+        as.setSubscription(s);
 
         Subscription s1 = mock(Subscription.class);
 
-        assertTrue(as.setSubscription(s1));
+        as.setSubscription(s1);
         
         assertSame(as.actual.get(), s);
         
@@ -151,7 +151,7 @@ public class AsyncSubscriptionTest {
 
         Disposable r2 = mock(Disposable.class);
         
-        assertTrue(as.replaceResource(r2));
+        as.replaceResource(r2);
 
         as.cancel();
         
@@ -167,7 +167,7 @@ public class AsyncSubscriptionTest {
         
         Disposable r = mock(Disposable.class);
         
-        assertFalse(as.setResource(r));
+        as.setResource(r);
 
         verify(r).dispose();
     }
@@ -179,7 +179,7 @@ public class AsyncSubscriptionTest {
 
         Disposable r = mock(Disposable.class);
         
-        assertFalse(as.replaceResource(r));
+        as.replaceResource(r);
         
         verify(r).dispose();
     }
@@ -190,7 +190,7 @@ public class AsyncSubscriptionTest {
         AsyncSubscription as = new AsyncSubscription(r);
         Subscription s = mock(Subscription.class);
         
-        assertTrue(as.setSubscription(s));
+        as.setSubscription(s);
         
         as.cancel();
         as.cancel();
@@ -199,5 +199,16 @@ public class AsyncSubscriptionTest {
         verify(s, never()).request(anyLong());
         verify(s).cancel();
         verify(r).dispose();
+    }
+    
+    @Test
+    public void disposed() {
+        AsyncSubscription as = new AsyncSubscription();
+        
+        assertFalse(as.isDisposed());
+        
+        as.dispose();
+        
+        assertTrue(as.isDisposed());
     }
 }

--- a/src/test/java/io/reactivex/internal/subscriptions/DeferredScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/DeferredScalarSubscriptionTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class DeferredScalarSubscriptionTest {
+
+    @Test
+    public void queueSubscriptionSyncRejected() {
+        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+        
+        assertEquals(QueueSubscription.NONE, ds.requestFusion(QueueSubscription.SYNC));
+    }
+
+    @Test
+    public void clear() {
+        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+        
+        ds.value = 1;
+        
+        ds.clear();
+        
+        assertEquals(DeferredScalarSubscription.FUSED_CONSUMED, ds.get());
+        assertNull(ds.value);
+    }
+
+    @Test
+    public void cancel() {
+        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+        
+        assertTrue(ds.tryCancel());
+
+        assertFalse(ds.tryCancel());
+    }
+    
+    @Test
+    public void completeCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ds.complete(1);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ds.cancel();
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+    
+    @Test
+    public void requestClearRace() {
+        for (int i = 0; i < 5000; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            
+            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(ts);
+            ts.onSubscribe(ds);
+            ds.complete(1);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ds.request(1);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ds.value = null;
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+            
+            if (ts.valueCount() >= 1) {
+                ts.assertValue(1);
+            }
+        }
+    }
+    
+    @Test
+    public void requestCancelRace() {
+        for (int i = 0; i < 5000; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            
+            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(ts);
+            ts.onSubscribe(ds);
+            ds.complete(1);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ds.request(1);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ds.cancel();
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+            
+            if (ts.valueCount() >= 1) {
+                ts.assertValue(1);
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/FullArbiterTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/FullArbiterTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FullArbiterTest {
+
+    @Test
+    public void initialRequested() {
+        FullArbiter.INITIAL.request(-99);
+    }
+
+    @Test
+    public void initialCancel() {
+        FullArbiter.INITIAL.cancel();
+    }
+    
+    @Test
+    public void invalidDeferredRequest() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new FullArbiter<Integer>(new TestSubscriber<Integer>(), null, 128).request(-99);
+            
+            TestHelper.assertError(errors, 0, IllegalArgumentException.class, "n > 0 required but it was -99");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void setSubscriptionAfterCancel() {
+        FullArbiter<Integer> fa = new FullArbiter<Integer>(new TestSubscriber<Integer>(), null, 128);
+                
+        fa.cancel();
+        
+        BooleanSubscription bs = new BooleanSubscription();
+        
+        assertFalse(fa.setSubscription(bs));
+        
+        assertFalse(fa.setSubscription(null));
+    }
+    
+    @Test
+    public void cancelAfterPoll() {
+        FullArbiter<Integer> fa = new FullArbiter<Integer>(new TestSubscriber<Integer>(), null, 128);
+
+        BooleanSubscription bs = new BooleanSubscription();
+        
+        fa.queue.offer(fa.s, NotificationLite.subscription(bs));
+        
+        fa.cancel();
+        
+        fa.drain();
+        
+        assertTrue(bs.isCancelled());
+    }
+    
+    @Test
+    public void errorAfterCancel() {
+        FullArbiter<Integer> fa = new FullArbiter<Integer>(new TestSubscriber<Integer>(), null, 128);
+
+        BooleanSubscription bs = new BooleanSubscription();
+
+        fa.cancel();
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            fa.onError(new TestException(), bs);
+            
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void cancelAfterError() {
+        FullArbiter<Integer> fa = new FullArbiter<Integer>(new TestSubscriber<Integer>(), null, 128);
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            fa.queue.offer(fa.s, NotificationLite.error(new TestException()));
+            
+            fa.cancel();
+            
+            fa.drain();
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void offerDifferentSubscription() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        FullArbiter<Integer> fa = new FullArbiter<Integer>(ts, null, 128);
+
+        BooleanSubscription bs = new BooleanSubscription();
+        
+        fa.queue.offer(bs, NotificationLite.next(1));
+        
+        fa.drain();
+        
+        ts.assertNoValues();
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/QueueSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/QueueSubscriptionTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import io.reactivex.TestHelper;
+
+public class QueueSubscriptionTest {
+    static final class EmptyQS extends BasicQueueSubscription<Integer> {
+
+        /**
+         * 
+         */
+        private static final long serialVersionUID = -5312809687598840520L;
+
+        @Override
+        public int requestFusion(int mode) {
+            return 0;
+        }
+
+        @Override
+        public Integer poll() throws Exception {
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public void clear() {
+            
+        }
+
+        @Override
+        public void request(long n) {
+            
+        }
+
+        @Override
+        public void cancel() {
+            
+        }
+        
+    }
+
+    static final class EmptyIntQS extends BasicIntQueueSubscription<Integer> {
+
+        /**
+         * 
+         */
+        private static final long serialVersionUID = -1374033403007296252L;
+
+        @Override
+        public int requestFusion(int mode) {
+            return 0;
+        }
+
+        @Override
+        public Integer poll() throws Exception {
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public void clear() {
+            
+        }
+
+        @Override
+        public void request(long n) {
+            
+        }
+
+        @Override
+        public void cancel() {
+            
+        }
+        
+    }
+
+    @Test
+    public void noOfferBasic() {
+        TestHelper.assertNoOffer(new EmptyQS());
+    }
+    
+    @Test
+    public void noOfferBasicInt() {
+        TestHelper.assertNoOffer(new EmptyIntQS());
+    }
+    
+    @Test
+    public void empty() {
+        TestHelper.checkEnum(EmptySubscription.class);
+        
+        assertEquals("EmptySubscription", EmptySubscription.INSTANCE.toString());
+        
+        TestHelper.assertNoOffer(EmptySubscription.INSTANCE);
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/ScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/ScalarSubscriptionTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ScalarSubscriptionTest {
+
+    @Test
+    public void badRequest() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        
+        ScalarSubscription<Integer> sc = new ScalarSubscription<Integer>(ts, 1);
+        
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            sc.request(-99);
+            
+            TestHelper.assertError(errors, 0, IllegalArgumentException.class, "n > 0 required but it was -99");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void noOffer() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        
+        ScalarSubscription<Integer> sc = new ScalarSubscription<Integer>(ts, 1);
+        
+        TestHelper.assertNoOffer(sc);
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/SubscriptionArbiterTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/SubscriptionArbiterTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class SubscriptionArbiterTest {
+
+    @Test
+    public void setSubscriptionMissed() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        sa.getAndIncrement();
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        
+        sa.setSubscription(bs1);
+        
+        BooleanSubscription bs2 = new BooleanSubscription();
+        
+        sa.setSubscription(bs2);
+        
+        assertTrue(bs1.isCancelled());
+        
+        assertFalse(bs2.isCancelled());
+    }
+    
+    @Test
+    public void invalidDeferredRequest() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            sa.request(-99);
+            
+            TestHelper.assertError(errors, 0, IllegalArgumentException.class, "n > 0 required but it was -99");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void unbounded() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        sa.request(Long.MAX_VALUE);
+        
+        assertEquals(Long.MAX_VALUE, sa.requested);
+        
+        assertTrue(sa.isUnbounded());
+        
+        sa.unbounded = false;
+        
+        sa.request(Long.MAX_VALUE);
+        
+        assertEquals(Long.MAX_VALUE, sa.requested);
+        
+        sa.produced(1);
+        
+        assertEquals(Long.MAX_VALUE, sa.requested);
+        
+        sa.unbounded = false;
+
+        sa.produced(Long.MAX_VALUE);
+        
+        assertEquals(Long.MAX_VALUE, sa.requested);
+    }
+    
+    @Test
+    public void cancelled() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        sa.cancelled = true;
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        
+        sa.missedSubscription.set(bs1);
+        
+        sa.getAndIncrement();
+        
+        sa.drainLoop();
+        
+        assertTrue(bs1.isCancelled());
+    }
+    
+    @Test
+    public void drainUnbounded() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        sa.getAndIncrement();
+
+        sa.requested = Long.MAX_VALUE;
+        
+        sa.drainLoop();
+    }
+
+    @Test
+    public void drainMissedRequested() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        sa.getAndIncrement();
+
+        sa.requested = 0;
+        
+        sa.missedRequested.set(1);
+        
+        sa.drainLoop();
+        
+        assertEquals(1, sa.requested);
+    }
+
+    @Test
+    public void drainMissedRequestedProduced() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        sa.getAndIncrement();
+
+        sa.requested = 0;
+        
+        sa.missedRequested.set(Long.MAX_VALUE);
+        
+        sa.missedProduced.set(1);
+        
+        sa.drainLoop();
+        
+        assertEquals(Long.MAX_VALUE, sa.requested);
+    }
+
+    @Test
+    public void drainMissedRequestedMoreProduced() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            SubscriptionArbiter sa = new SubscriptionArbiter();
+            
+            sa.getAndIncrement();
+    
+            sa.requested = 0;
+            
+            sa.missedRequested.set(1);
+            
+            sa.missedProduced.set(2);
+            
+            sa.drainLoop();
+            
+            assertEquals(0, sa.requested);
+            
+            TestHelper.assertError(errors, 0, IllegalStateException.class, "More produced than requested: -1");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void missedSubscriptionNoPrior() {
+        SubscriptionArbiter sa = new SubscriptionArbiter();
+        
+        sa.getAndIncrement();
+
+        BooleanSubscription bs1 = new BooleanSubscription();
+
+        sa.missedSubscription.set(bs1);
+        
+        sa.drainLoop();
+        
+        assertSame(bs1, sa.actual);
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscriptions/SubscriptionHelperTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/SubscriptionHelperTest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscriptions;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.TestHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+public class SubscriptionHelperTest {
+
+    @Test
+    public void checkEnum() {
+        TestHelper.checkEnum(SubscriptionHelper.class);
+    }
+    
+    @Test
+    public void validateNullThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            SubscriptionHelper.validate(null, null);
+            
+            TestHelper.assertError(errors, 0, NullPointerException.class, "next is null");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void cancelNoOp() {
+        SubscriptionHelper.CANCELLED.cancel();
+    }
+    
+    @Test
+    public void set() {
+        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        
+        assertTrue(SubscriptionHelper.set(s, bs1));
+        
+        BooleanSubscription bs2 = new BooleanSubscription();
+        
+        assertTrue(SubscriptionHelper.set(s, bs2));
+        
+        assertTrue(bs1.isCancelled());
+        
+        assertFalse(bs2.isCancelled());
+    }
+    
+    @Test
+    public void replace() {
+        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        
+        assertTrue(SubscriptionHelper.replace(s, bs1));
+        
+        BooleanSubscription bs2 = new BooleanSubscription();
+        
+        assertTrue(SubscriptionHelper.replace(s, bs2));
+        
+        assertFalse(bs1.isCancelled());
+        
+        assertFalse(bs2.isCancelled());
+    }
+    
+    @Test
+    public void cancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+            
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.cancel(s);
+                }
+            };
+            
+            TestHelper.race(r, r, Schedulers.single());
+        }
+    }
+    
+    @Test
+    public void setRace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+
+            final BooleanSubscription bs1 = new BooleanSubscription();
+            final BooleanSubscription bs2 = new BooleanSubscription();
+            
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.set(s, bs1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.set(s, bs2);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+            
+            assertTrue(bs1.isCancelled() ^ bs2.isCancelled());
+        }
+    }
+    
+    @Test
+    public void replaceRace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+
+            final BooleanSubscription bs1 = new BooleanSubscription();
+            final BooleanSubscription bs2 = new BooleanSubscription();
+            
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.replace(s, bs1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.replace(s, bs2);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+            
+            assertFalse(bs1.isCancelled());
+            assertFalse(bs2.isCancelled());
+        }
+    }
+
+    @Test
+    public void cancelAndChange() {
+        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        
+        SubscriptionHelper.cancel(s);
+        
+        BooleanSubscription bs1 = new BooleanSubscription();
+        assertFalse(SubscriptionHelper.set(s, bs1));
+        assertTrue(bs1.isCancelled());
+
+        assertFalse(SubscriptionHelper.set(s, null));
+
+        BooleanSubscription bs2 = new BooleanSubscription();
+        assertFalse(SubscriptionHelper.replace(s, bs2));
+        assertTrue(bs2.isCancelled());
+        
+        assertFalse(SubscriptionHelper.replace(s, null));
+    }
+
+    @Test
+    public void invalidDeferredRequest() {
+        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        AtomicLong r = new AtomicLong();
+        
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            SubscriptionHelper.deferredRequest(s, r, -99);
+            
+            TestHelper.assertError(errors, 0, IllegalArgumentException.class, "n > 0 required but it was -99");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void deferredRace() {
+        for (int i = 0; i < 500; i++) {
+            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+            final AtomicLong r = new AtomicLong();
+            
+            final AtomicLong q = new AtomicLong();
+            
+            final Subscription a = new Subscription() {
+                @Override
+                public void request(long n) {
+                    q.addAndGet(n);
+                }
+                
+                @Override
+                public void cancel() {
+                    
+                }
+            };
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.deferredSetOnce(s, r, a);
+                }
+            };
+            
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    SubscriptionHelper.deferredRequest(s, r, 1);
+                }
+            };
+            
+            TestHelper.race(r1, r2, Schedulers.single());
+            
+            assertSame(a, s.get());
+            assertEquals(1, q.get());
+            assertEquals(0, r.get());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -212,7 +212,7 @@ public class SerializedObserverTest {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeSubscriber to handle synchronization plus life-cycle
             Subscriber<String> w = serializedSubscriber(new SafeSubscriber<String>(tw));
-            w.onSubscribe(EmptySubscription.INSTANCE);
+            w.onSubscribe(new BooleanSubscription());
 
             Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
             Future<?> f2 = tp.submit(new OnNextThread(w, 5000));

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -239,4 +239,9 @@ public class SchedulerTest {
             RxJavaPlugins.reset();
         }
     }
+    
+    @Test
+    public void schedulersUtility() {
+        TestHelper.checkUtilityClass(Schedulers.class);
+    }
 }

--- a/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.schedulers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.*;
 
@@ -25,10 +25,12 @@ import org.mockito.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.schedulers.TestScheduler.*;
 
 public class TestSchedulerTest {
 
@@ -225,5 +227,32 @@ public class TestSchedulerTest {
             inner.dispose();
         }
     }
+    
+    @Test
+    public void timedRunnableToString() {
+        TimedRunnable r = new TimedRunnable((TestWorker) new TestScheduler().createWorker(), 5, new Runnable() {
+            @Override
+            public void run() {
+                // TODO Auto-generated method stub
+                
+            }
+            @Override
+            public String toString() {
+                return "Runnable";
+            }
+        }, 1);
+        
+        assertEquals("TimedRunnable(time = 5, run = Runnable)", r.toString());
+    }
+    
+    @Test
+    public void workerDisposed() {
+        TestScheduler scheduler = new TestScheduler();
+        
+        Worker w = scheduler.createWorker();
+        w.dispose();
+        assertTrue(w.isDisposed());
+    }
+    
 
 }

--- a/src/test/java/io/reactivex/schedulers/TimedTest.java
+++ b/src/test/java/io/reactivex/schedulers/TimedTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.schedulers;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class TimedTest {
+
+    @Test
+    public void properties() {
+        Timed<Integer> timed = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        
+        assertEquals(1, timed.value().intValue());
+        assertEquals(5, timed.time());
+        assertEquals(5000, timed.time(TimeUnit.MILLISECONDS));
+        assertSame(TimeUnit.SECONDS, timed.unit());
+    }
+    
+    @Test
+    public void hashCodeOf() {
+        Timed<Integer> t1 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        
+        assertEquals(TimeUnit.SECONDS.hashCode() + 31 * (5 + 31 * 1), t1.hashCode());
+
+        Timed<Integer> t2 = new Timed<Integer>(null, 5, TimeUnit.SECONDS);
+        
+        assertEquals(TimeUnit.SECONDS.hashCode() + 31 * (5 + 31 * 0), t2.hashCode());
+    }
+    
+    @Test
+    public void equalsWith() {
+        Timed<Integer> t1 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> t2 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> t3 = new Timed<Integer>(2, 5, TimeUnit.SECONDS);
+        Timed<Integer> t4 = new Timed<Integer>(1, 4, TimeUnit.SECONDS);
+        Timed<Integer> t5 = new Timed<Integer>(1, 5, TimeUnit.MINUTES);
+        
+        assertEquals(t1, t1);
+        assertEquals(t1, t2);
+        
+        assertNotEquals(t1, t3);
+        assertNotEquals(t1, t4);
+        assertNotEquals(t2, t3);
+        assertNotEquals(t2, t4);
+        assertNotEquals(t2, t5);
+
+        assertNotEquals(t3, t1);
+        assertNotEquals(t3, t2);
+        assertNotEquals(t3, t4);
+        assertNotEquals(t3, t5);
+        
+        assertNotEquals(t4, t1);
+        assertNotEquals(t4, t2);
+        assertNotEquals(t4, t3);
+        assertNotEquals(t4, t5);
+        
+        assertNotEquals(t5, t1);
+        assertNotEquals(t5, t2);
+        assertNotEquals(t5, t3);
+        assertNotEquals(t5, t4);
+        
+        assertNotEquals(new Object(), t1);
+        
+        assertFalse(t1.equals(new Object()));
+    }
+    
+    @Test
+    public void toStringOf() {
+        Timed<Integer> t1 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        
+        assertEquals("Timed[time=5, unit=SECONDS, value=1]", t1.toString());
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -13,14 +13,21 @@
 
 package io.reactivex.subscribers;
 
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-import org.junit.Test;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.*;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class SafeSubscriberTest {
 
@@ -147,5 +154,893 @@ public class SafeSubscriberTest {
             });
         }
 
+    }
+
+    @Test
+    public void onNextFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        try {
+            OBSERVER_ONNEXT_FAIL(onError).onNext("one");
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertNull(onError.get());
+            assertTrue(e instanceof SafeSubscriberTestException);
+            assertEquals("onNextFail", e.getMessage());
+        }
+    }
+
+    @Test
+    public void onNextFailureSafe() {
+        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        try {
+            SafeSubscriber<String> safeObserver = new SafeSubscriber<String>(OBSERVER_ONNEXT_FAIL(onError));
+            safeObserver.onSubscribe(new BooleanSubscription());
+            safeObserver.onNext("one");
+            assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeSubscriberTestException);
+            assertEquals("onNextFail", onError.get().getMessage());
+        } catch (Exception e) {
+            fail("expects exception to be passed to onError");
+        }
+    }
+
+    @Test
+    public void onCompletedFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        try {
+            OBSERVER_ONCOMPLETED_FAIL(onError).onComplete();
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertNull(onError.get());
+            assertTrue(e instanceof SafeSubscriberTestException);
+            assertEquals("onCompletedFail", e.getMessage());
+        }
+    }
+
+    @Test
+    public void onErrorFailure() {
+        try {
+            OBSERVER_ONERROR_FAIL().onError(new SafeSubscriberTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof SafeSubscriberTestException);
+            assertEquals("onErrorFail", e.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Observers can't throw")
+    public void onErrorFailureSafe() {
+        try {
+            new SafeSubscriber<String>(OBSERVER_ONERROR_FAIL()).onError(new SafeSubscriberTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Subscriber.onError", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(2, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeSubscriberTestException);
+            assertEquals("error!", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeSubscriberTestException);
+            assertEquals("onErrorFail", e4.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Observers can't throw")
+    public void onErrorNotImplementedFailureSafe() {
+        try {
+            new SafeSubscriber<String>(OBSERVER_ONERROR_NOTIMPLEMENTED()).onError(new SafeSubscriberTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+//            assertTrue(e instanceof OnErrorNotImplementedException);
+            assertTrue(e.getCause() instanceof SafeSubscriberTestException);
+            assertEquals("error!", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void onNextOnErrorFailure() {
+        try {
+            OBSERVER_ONNEXT_ONERROR_FAIL().onNext("one");
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof SafeSubscriberTestException);
+            assertEquals("onNextFail", e.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Observers can't throw")
+    public void onNextOnErrorFailureSafe() {
+        try {
+            new SafeSubscriber<String>(OBSERVER_ONNEXT_ONERROR_FAIL()).onNext("one");
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Subscriber.onError", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(2, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeSubscriberTestException);
+            assertEquals("onNextFail", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeSubscriberTestException);
+            assertEquals("onErrorFail", e4.getMessage());
+        }
+    }
+
+    static final Subscription THROWING_DISPOSABLE = new Subscription() {
+
+        @Override
+        public void cancel() {
+            // break contract by throwing exception
+            throw new SafeSubscriberTestException("failure from unsubscribe");
+        }
+        
+        @Override
+        public void request(long n) {
+            // ignored
+        }
+    };
+    
+    @Test
+    @Ignore("Observers can't throw")
+    public void onCompleteSuccessWithUnsubscribeFailure() {
+        Subscriber<String> o = OBSERVER_SUCCESS();
+        try {
+            o.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(o).onComplete();
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+//            assertTrue(e instanceof UnsubscribeFailedException);
+            assertTrue(e.getCause() instanceof SafeSubscriberTestException);
+            assertEquals("failure from unsubscribe", e.getMessage());
+            // expected since onError fails so SafeSubscriber can't help
+        }
+    }
+
+    @Test
+    @Ignore("Observers can't throw")
+    public void onErrorSuccessWithUnsubscribeFailure() {
+        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        Subscriber<String> o = OBSERVER_SUCCESS(onError);
+        try {
+            o.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(o).onError(new SafeSubscriberTestException("failed"));
+            fail("we expect the unsubscribe failure to cause an exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+
+            // we still expect onError to have received something before unsubscribe blew up
+            assertNotNull(onError.get());
+            assertTrue(onError.get() instanceof SafeSubscriberTestException);
+            assertEquals("failed", onError.get().getMessage());
+
+            // now assert the exception that was thrown
+            RuntimeException onErrorFailedException = (RuntimeException) e;
+            assertTrue(onErrorFailedException.getCause() instanceof SafeSubscriberTestException);
+            assertEquals("failure from unsubscribe", e.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Observers can't throw")
+    public void onErrorFailureWithUnsubscribeFailure() {
+        Subscriber<String> o = OBSERVER_ONERROR_FAIL();
+        try {
+            o.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(o).onError(new SafeSubscriberTestException("onError failure"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+
+            // assertions for what is expected for the actual failure propagated to onError which then fails
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Error occurred when trying to propagate error to Subscriber.onError and during unsubscription.", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(3, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeSubscriberTestException);
+            assertEquals("onError failure", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeSubscriberTestException);
+            assertEquals("onErrorFail", e4.getMessage());
+
+            Throwable e5 = innerExceptions.get(2);
+            assertTrue(e5 instanceof SafeSubscriberTestException);
+            assertEquals("failure from unsubscribe", e5.getMessage());
+        }
+    }
+
+    @Test
+    @Ignore("Observers can't throw")
+    public void onErrorNotImplementedFailureWithUnsubscribeFailure() {
+        Subscriber<String> o = OBSERVER_ONERROR_NOTIMPLEMENTED();
+        try {
+            o.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(o).onError(new SafeSubscriberTestException("error!"));
+            fail("expects exception to be thrown");
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // FIXME no longer assertable
+//            assertTrue(o.isUnsubscribed());
+
+            // assertions for what is expected for the actual failure propagated to onError which then fails
+            assertTrue(e instanceof RuntimeException);
+            assertEquals("Subscriber.onError not implemented and error while unsubscribing.", e.getMessage());
+
+            Throwable e2 = e.getCause();
+            assertTrue(e2 instanceof CompositeException);
+            List<Throwable> innerExceptions = ((CompositeException) e2).getExceptions();
+            assertEquals(2, innerExceptions.size());
+
+            Throwable e3 = innerExceptions.get(0);
+            assertTrue(e3 instanceof SafeSubscriberTestException);
+            assertEquals("error!", e3.getMessage());
+
+            Throwable e4 = innerExceptions.get(1);
+            assertTrue(e4 instanceof SafeSubscriberTestException);
+            assertEquals("failure from unsubscribe", e4.getMessage());
+        }
+    }
+
+    private static Subscriber<String> OBSERVER_SUCCESS() {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+        };
+
+    }
+
+    private static Subscriber<String> OBSERVER_SUCCESS(final AtomicReference<Throwable> onError) {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+        };
+
+    }
+
+    private static Subscriber<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+                throw new SafeSubscriberTestException("onNextFail");
+            }
+        };
+
+    }
+
+    private static Subscriber<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new SafeSubscriberTestException("onErrorFail");
+            }
+
+            @Override
+            public void onNext(String args) {
+                throw new SafeSubscriberTestException("onNextFail");
+            }
+
+        };
+    }
+
+    private static Subscriber<String> OBSERVER_ONERROR_FAIL() {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new SafeSubscriberTestException("onErrorFail");
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    private static Subscriber<String> OBSERVER_ONERROR_NOTIMPLEMENTED() {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new RuntimeException(e);
+//                throw new OnErrorNotImplementedException(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    private static Subscriber<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
+        return new DefaultSubscriber<String>() {
+
+            @Override
+            public void onComplete() {
+                throw new SafeSubscriberTestException("onCompletedFail");
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                onError.set(e);
+            }
+
+            @Override
+            public void onNext(String args) {
+
+            }
+
+        };
+    }
+
+    @SuppressWarnings("serial")
+    private static class SafeSubscriberTestException extends RuntimeException {
+        public SafeSubscriberTestException(String message) {
+            super(message);
+        }
+    }
+    
+    @Test
+    @Ignore("Observers can't throw")
+    public void testOnCompletedThrows() {
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(new DefaultSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                
+            }
+            @Override
+            public void onError(Throwable e) {
+                error.set(e);
+            }
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
+        
+        try {
+            s.onComplete();
+            Assert.fail();
+        } catch (RuntimeException e) {
+           assertNull(error.get());
+        }
+    }
+    
+    @Test
+    public void testActual() {
+        Subscriber<Integer> actual = new DefaultSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+            }
+            @Override
+            public void onError(Throwable e) {
+            }
+            @Override
+            public void onComplete() {
+            }
+        };
+        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(actual);
+
+        assertSame(actual, s.actual);
+    }
+    
+    @Test
+    public void dispose() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        BooleanSubscription d = new BooleanSubscription();
+        
+        so.onSubscribe(d);
+        
+        ts.dispose();
+        
+        assertTrue(d.isCancelled());
+        
+//        assertTrue(so.isDisposed());
+    }
+
+    @Test
+    public void onNextAfterComplete() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        BooleanSubscription d = new BooleanSubscription();
+        
+        so.onSubscribe(d);
+
+        so.onComplete();
+        
+        so.onNext(1);
+        
+        so.onError(new TestException());
+        
+        so.onComplete();
+        
+        ts.assertResult();
+    }
+
+    @Test
+    public void onNextNull() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        BooleanSubscription d = new BooleanSubscription();
+        
+        so.onSubscribe(d);
+
+        so.onNext(null);
+        
+        ts.assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void onNextWithoutOnSubscribe() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        so.onNext(1);
+        
+        ts.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
+    }
+
+    @Test
+    public void onErrorWithoutOnSubscribe() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        so.onError(new TestException());
+        
+        ts.assertFailure(CompositeException.class);
+        
+        TestHelper.assertError(ts, 0, TestException.class);
+        TestHelper.assertError(ts, 1, NullPointerException.class, "Subscription not set!");
+    }
+
+    @Test
+    public void onCompleteWithoutOnSubscribe() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        so.onComplete();
+        
+        ts.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
+    }
+
+    @Test
+    public void onNextNormal() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        
+        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        
+        BooleanSubscription d = new BooleanSubscription();
+        
+        so.onSubscribe(d);
+
+        so.onNext(1);
+        so.onComplete();
+        
+        ts.assertResult(1);
+    }
+    
+    static final class CrashDummy implements Subscriber<Object>, Subscription {
+        boolean crashOnSubscribe;
+        int crashOnNext;
+        boolean crashOnError;
+        boolean crashOnComplete;
+        
+        boolean crashDispose;
+        
+        Throwable error;
+        
+        public CrashDummy(boolean crashOnSubscribe, int crashOnNext, 
+                boolean crashOnError, boolean crashOnComplete, boolean crashDispose) {
+            this.crashOnSubscribe = crashOnSubscribe;
+            this.crashOnNext = crashOnNext;
+            this.crashOnError = crashOnError;
+            this.crashOnComplete = crashOnComplete;
+            this.crashDispose = crashDispose;
+        }
+
+        @Override
+        public void cancel() {
+            if (crashDispose) {
+                throw new TestException("dispose()");
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            // TODO
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (crashOnSubscribe) {
+                throw new TestException("onSubscribe()");
+            }
+        }
+
+        @Override
+        public void onNext(Object value) {
+            if (--crashOnNext == 0) {
+                throw new TestException("onNext(" + value + ")");
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (crashOnError) {
+                throw new TestException("onError(" + e + ")");
+            }
+            error = e;
+        }
+
+        @Override
+        public void onComplete() {
+            if (crashOnComplete) {
+                throw new TestException("onComplete()");
+            }
+        }
+        
+        public SafeSubscriber<Object> toSafe() {
+            return new SafeSubscriber<Object>(this);
+        }
+        
+        public CrashDummy assertError(Class<? extends Throwable> clazz) {
+            if (!clazz.isInstance(error)) {
+                throw new AssertionError("Different error: " + error);
+            }
+            return this;
+        }
+        
+        public CrashDummy assertInnerError(int index, Class<? extends Throwable> clazz) {
+            List<Throwable> cel = TestHelper.compositeList(error);
+            TestHelper.assertError(cel, index, clazz);
+            return this;
+        }
+
+        public CrashDummy assertInnerError(int index, Class<? extends Throwable> clazz, String message) {
+            List<Throwable> cel = TestHelper.compositeList(error);
+            TestHelper.assertError(cel, index, clazz, message);
+            return this;
+        }
+
+    }
+
+    @Test
+    public void onNextOnErrorCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            
+            so.onNext(1);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
+            TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.exceptions.TestException: onNext(1))");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextDisposeCrash() {
+        CrashDummy cd = new CrashDummy(false, 1, false, false, true);
+        SafeSubscriber<Object> so = cd.toSafe();
+        so.onSubscribe(cd);
+        
+        so.onNext(1);
+
+        cd.assertError(CompositeException.class);
+        cd.assertInnerError(0, TestException.class, "onNext(1)");
+        cd.assertInnerError(1, TestException.class, "dispose()");
+    }
+
+    @Test
+    public void onSubscribeTwice() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, false, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            so.onSubscribe(cd);
+            
+            TestHelper.assertError(list, 0, IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onSubscribeCrashes() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            
+            TestHelper.assertError(list, 0, TestException.class, "onSubscribe()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onSubscribeAndDisposeCrashes() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, true);
+            SafeSubscriber<Object> so = cd.toSafe();
+            so.onSubscribe(cd);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
+            TestHelper.assertError(ce, 1, TestException.class, "dispose()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextOnSubscribeCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+
+            so.onNext(1);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+    
+    @Test
+    public void onNextNullDisposeCrashes() {
+        CrashDummy cd = new CrashDummy(false, 1, false, false, true);
+        SafeSubscriber<Object> so = cd.toSafe();
+        so.onSubscribe(cd);
+        
+        so.onNext(null);
+        
+        cd.assertInnerError(0, NullPointerException.class);
+        cd.assertInnerError(1, TestException.class, "dispose()");
+    }
+
+    @Test
+    public void noSubscribeOnErrorCrashes() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+
+            so.onNext(1);
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorNull() {
+        CrashDummy cd = new CrashDummy(false, 1, false, false, false);
+        SafeSubscriber<Object> so = cd.toSafe();
+        so.onSubscribe(cd);
+        
+        so.onError(null);
+        
+        cd.assertError(NullPointerException.class);
+    }
+
+    @Test
+    public void onErrorNoSubscribeCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            
+            so.onError(new TestException());
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class);
+            TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorNoSubscribeOnErrorCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, false, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            
+            so.onError(new TestException());
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, TestException.class);
+            TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 2, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteteCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, false, true, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            
+            so.onSubscribe(cd);
+            
+            so.onComplete();
+            
+            TestHelper.assertError(list, 0, TestException.class, "onComplete()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteteNoSubscribeCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(true, 1, false, true, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            
+            so.onComplete();
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteteNoSubscribeOnErrorCrash() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+        
+        try {
+            CrashDummy cd = new CrashDummy(false, 1, true, true, false);
+            SafeSubscriber<Object> so = cd.toSafe();
+            
+            so.onComplete();
+            
+            TestHelper.assertError(list, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
+            TestHelper.assertError(ce, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }


### PR DESCRIPTION
- enable fusion with `Observable.map`
- remove impossible branches in some classes
- add more tests to cover tool classes
- fix `Observable.range()` entering regular emission if fusion-drain is interrupted
- fix `FullArbiter` and `ObservableFullArbiter` not cancelling/disposing the incoming Subscription/Disposable in some cases
