### PR TITLE
2.x: add new methods to Maybe, Observable and Single from 4481

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -701,8 +701,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     // ------------------------------------------------------------------
 
     /**
-     * Waits in a blocking fashion until the current Maybe signals a success value (which is returned) or
-     * defaultValue if completed or an exception (which is propagated).
+     * Waits in a blocking fashion until the current Maybe signals a success value (which is returned),
+     * null if completed or an exception (which is propagated).
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code blockingGet} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -714,7 +714,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
     
     /**
-     * Waits in a blocking fashion until the current Maybe signals a success value (which is returned) or
+     * Waits in a blocking fashion until the current Maybe signals a success value (which is returned),
      * defaultValue if completed or an exception (which is propagated).
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -1250,9 +1250,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the new Single instance
      */
     public final Single<T> toSingle(T defaultValue) {
-            ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
-            return RxJavaPlugins.onAssembly(new MaybeToSingle<T>(this, defaultValue));
-        }
+        ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
+        return RxJavaPlugins.onAssembly(new MaybeToSingle<T>(this, defaultValue));
+    }
 
     /**
      * Converts this Maybe into an Single instance composing cancellation

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -11517,9 +11517,34 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
-        return RxJavaPlugins.onAssembly(new SingleFromObservable<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleFromObservable<T>(this, null));
     }
 
+    /**
+     * Returns a Single that emits the single item emitted by the source ObservableSource, if that ObservableSource
+     * emits only a single item. If the source ObservableSource emits more than one item or no items, notify of an
+     * {@code IllegalArgumentException} or {@code NoSuchElementException} respectively.
+     * <p>
+     * <img width="640" height="295" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toSingle.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toSingle} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param defaultIfEmpty the value the Single will signal if this Observable is empty
+     * @return a Single that emits the single item emitted by the source ObservableSource
+     * @throws IllegalArgumentException
+     *             if the source ObservableSource emits more than one item
+     * @throws NoSuchElementException
+     *             if the source ObservableSource emits no items
+     * @see <a href="http://reactivex.io/documentation/single.html">ReactiveX documentation: Single</a>
+     * @since 2.0
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Single<T> toSingle(T defaultIfEmpty) {
+        ObjectHelper.requireNonNull(defaultIfEmpty, "defaultIfEmpty is null");
+        return RxJavaPlugins.onAssembly(new SingleFromObservable<T>(this, defaultIfEmpty));
+    }
+    
     /**
      * Returns an Observable that emits a list that contains the items emitted by the source ObservableSource, in a
      * sorted order. Each item emitted by the ObservableSource must implement {@link Comparable} with respect to all

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -11499,7 +11499,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Returns a Single that emits the single item emitted by the source ObservableSource, if that ObservableSource
      * emits only a single item. If the source ObservableSource emits more than one item or no items, notify of an
-     * {@code IllegalArgumentException} or {@code NoSuchElementException} respectively.
+     * {@code IndexOutOfBoundsException} or {@code NoSuchElementException} respectively.
      * <p>
      * <img width="640" height="295" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toSingle.png" alt="">
      * <dl>
@@ -11508,10 +11508,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @return a Single that emits the single item emitted by the source ObservableSource
-     * @throws IllegalArgumentException
-     *             if the source ObservableSource emits more than one item
-     * @throws NoSuchElementException
-     *             if the source ObservableSource emits no items
      * @see <a href="http://reactivex.io/documentation/single.html">ReactiveX documentation: Single</a>
      * @since 2.0
      */
@@ -11522,8 +11518,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns a Single that emits the single item emitted by the source ObservableSource, if that ObservableSource
-     * emits only a single item. If the source ObservableSource emits more than one item or no items, notify of an
-     * {@code IllegalArgumentException} or {@code NoSuchElementException} respectively.
+     * emits only a single item or emits the given defaultIfEmpty value if the ObservableSource is empty. 
+     * If the source ObservableSource emits more than one item a {@link IndexOutOfBoundsException} is signalled.
      * <p>
      * <img width="640" height="295" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toSingle.png" alt="">
      * <dl>
@@ -11532,10 +11528,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @param defaultIfEmpty the value the Single will signal if this Observable is empty
      * @return a Single that emits the single item emitted by the source ObservableSource
-     * @throws IllegalArgumentException
-     *             if the source ObservableSource emits more than one item
-     * @throws NoSuchElementException
-     *             if the source ObservableSource emits no items
      * @see <a href="http://reactivex.io/documentation/single.html">ReactiveX documentation: Single</a>
      * @since 2.0
      */

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeAwait.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeAwait.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.util.ExceptionHelper;
+
+public enum MaybeAwait {
+    ;
+    
+    public static <T> T get(MaybeSource<T> source, final T defaultValue) {
+        final AtomicReference<T> valueRef = new AtomicReference<T>();
+        final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
+        final CountDownLatch cdl = new CountDownLatch(1);
+        
+        source.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onError(Throwable e) {
+                errorRef.lazySet(e);
+                cdl.countDown();
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                valueRef.lazySet(value);
+                cdl.countDown();
+            }
+            
+            @Override
+            public void onComplete() {
+                if (defaultValue != null) {
+                    valueRef.lazySet(defaultValue);
+                } else {
+                    errorRef.lazySet(new NoSuchElementException());
+                }
+                cdl.countDown();
+            }
+        });
+        
+        if (cdl.getCount() != 0L) {
+            try {
+                cdl.await();
+            } catch (InterruptedException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+        Throwable e = errorRef.get();
+        if (e != null) {
+            throw ExceptionHelper.wrapOrThrow(e);
+        }
+        return valueRef.get();
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletable.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Maps the success value of the source MaybeSource into a Completable. 
+ * @param <T>
+ */
+public final class MaybeFlatMapCompletable<T> extends Completable {
+
+    final MaybeSource<T> source;
+    
+    final Function<? super T, ? extends CompletableSource> mapper;
+
+    public MaybeFlatMapCompletable(MaybeSource<T> source, Function<? super T, ? extends CompletableSource> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+    
+    @Override
+    protected void subscribeActual(CompletableObserver s) {
+        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(s, mapper);
+        s.onSubscribe(parent);
+        source.subscribe(parent);
+    }
+    
+    static final class FlatMapCompletableObserver<T> 
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, CompletableObserver, Disposable {
+        /** */
+        private static final long serialVersionUID = -2177128922851101253L;
+
+        final CompletableObserver actual;
+        
+        final Function<? super T, ? extends CompletableSource> mapper;
+
+        Disposable d;
+        
+        public FlatMapCompletableObserver(CompletableObserver actual,
+                Function<? super T, ? extends CompletableSource> mapper) {
+            this.actual = actual;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.replace(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            CompletableSource cs;
+            
+            try {
+                cs = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null CompletableSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                onError(ex);
+                return;
+            }
+            
+            cs.subscribe(this);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.*;
+import io.reactivex.Observable;
 import io.reactivex.functions.Function;
 
 /**
@@ -94,5 +95,19 @@ public enum SingleInternalHelper {
 
     public static <T> Iterable<? extends Flowable<T>> iterableToFlowable(final Iterable<? extends SingleSource<? extends T>> sources) {
         return new ToFlowableIterable<T>(sources);
+    }
+    
+    @SuppressWarnings("rawtypes")
+    enum ToObservable implements Function<SingleSource, Observable> {
+        INSTANCE;
+        @SuppressWarnings("unchecked")
+        @Override 
+        public Observable apply(SingleSource v){
+            return new SingleToObservable(v);
+        }
+    }
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static <T> Function<SingleSource<? extends T>, Observable<? extends T>> toObservable() {
+        return (Function)ToObservable.INSTANCE;
     }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/single/FutureSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/subscribers/single/FutureSingleObserver.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers.single;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.SingleObserver;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * A Observer + Future that expects exactly one upstream value and provides it
+ * via the (blocking) Future API.
+ *
+ * @param <T> the value type
+ */
+public final class FutureSingleObserver<T> extends CountDownLatch
+implements SingleObserver<T>, Future<T>, Disposable {
+
+    T value;
+    Throwable error;
+    
+    final AtomicReference<Disposable> s;
+    
+    public FutureSingleObserver() {
+        super(1);
+        this.s = new AtomicReference<Disposable>();
+    }
+    
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        for (;;) {
+            Disposable a = s.get();
+            if (a == this || a == DisposableHelper.DISPOSED) {
+                return false;
+            }
+            
+            if (s.compareAndSet(a, DisposableHelper.DISPOSED)) {
+                if (a != null) {
+                    a.dispose();
+                }
+                countDown();
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return DisposableHelper.isDisposed(s.get());
+    }
+
+    @Override
+    public boolean isDone() {
+        return getCount() == 0;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        if (getCount() != 0) {
+            await();
+        }
+        
+        if (isCancelled()) {
+            throw new CancellationException();
+        }
+        Throwable ex = error;
+        if (ex != null) {
+            throw new ExecutionException(ex);
+        }
+        return value;
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (getCount() != 0) {
+            if (!await(timeout, unit)) {
+                throw new TimeoutException();
+            }
+        }
+        
+        if (isCancelled()) {
+            throw new CancellationException();
+        }
+        
+        Throwable ex = error;
+        if (ex != null) {
+            throw new ExecutionException(ex);
+        }
+        return value;
+    }
+
+    @Override
+    public void onSubscribe(Disposable s) {
+        DisposableHelper.setOnce(this.s, s);
+    }
+
+    @Override
+    public void onSuccess(T t) {
+        if (value != null) {
+            s.get().dispose();
+            onError(new IndexOutOfBoundsException("More than one element received"));
+            return;
+        }
+        value = t;
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (error == null) {
+            error = t;
+
+            for (;;) {
+                Disposable a = s.get();
+                if (a == this || a == DisposableHelper.DISPOSED) {
+                    RxJavaPlugins.onError(t);
+                    return;
+                }
+                if (s.compareAndSet(a, this)) {
+                    countDown();
+                    return;
+                }
+            }
+        } else {
+            RxJavaPlugins.onError(t);
+        }
+    }
+    
+    @Override
+    public void dispose() {
+        // ignoring as `this` means a finished Disposable only
+    }
+    
+    @Override
+    public boolean isDisposed() {
+        return isDone();
+    }
+}


### PR DESCRIPTION
This PR adds just the new methods from #4481 to allow a much cleaner change of return types later on.
