### PR TITLE
2.x: rename emitters #isCancelled to #isDisposed

### DIFF
--- a/src/main/java/io/reactivex/CompletableEmitter.java
+++ b/src/main/java/io/reactivex/CompletableEmitter.java
@@ -52,8 +52,8 @@ public interface CompletableEmitter {
     void setCancellable(Cancellable c);
     
     /**
-     * Returns true if the downstream cancelled the sequence.
-     * @return true if the downstream cancelled the sequence
+     * Returns true if the downstream disposed the sequence.
+     * @return true if the downstream disposed the sequence
      */
-    boolean isCancelled();
+    boolean isDisposed();
 }

--- a/src/main/java/io/reactivex/MaybeEmitter.java
+++ b/src/main/java/io/reactivex/MaybeEmitter.java
@@ -63,5 +63,5 @@ public interface MaybeEmitter<T> {
      * Returns true if the downstream cancelled the sequence.
      * @return true if the downstream cancelled the sequence
      */
-    boolean isCancelled();
+    boolean isDisposed();
 }

--- a/src/main/java/io/reactivex/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/ObservableEmitter.java
@@ -42,13 +42,13 @@ public interface ObservableEmitter<T> extends Emitter<T> {
      * @param c the cancellable resource, null is allowed
      */
     void setCancellable(Cancellable c);
-    
+
     /**
-     * Returns true if the downstream cancelled the sequence.
-     * @return true if the downstream cancelled the sequence
+     * Returns true if the downstream disposed the sequence.
+     * @return true if the downstream disposed the sequence
      */
-    boolean isCancelled();
-    
+    boolean isDisposed();
+
     /**
      * Ensures that calls to onNext, onError and onComplete are properly serialized.
      * @return the serialized FlowableEmitter

--- a/src/main/java/io/reactivex/SingleEmitter.java
+++ b/src/main/java/io/reactivex/SingleEmitter.java
@@ -58,5 +58,5 @@ public interface SingleEmitter<T> {
      * Returns true if the downstream cancelled the sequence.
      * @return true if the downstream cancelled the sequence
      */
-    boolean isCancelled();
+    boolean isDisposed();
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
@@ -104,11 +104,6 @@ public final class CompletableCreate extends Completable {
         }
 
         @Override
-        public boolean isCancelled() {
-            return DisposableHelper.isDisposed(get());
-        }
-
-        @Override
         public void dispose() {
             DisposableHelper.dispose(this);
         }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
@@ -130,11 +130,6 @@ public final class MaybeCreate<T> extends Maybe<T> {
         }
 
         @Override
-        public boolean isCancelled() {
-            return DisposableHelper.isDisposed(get());
-        }
-
-        @Override
         public void dispose() {
             DisposableHelper.dispose(this);
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
@@ -105,11 +105,6 @@ public final class ObservableCreate<T> extends Observable<T> {
         }
 
         @Override
-        public boolean isCancelled() {
-            return isDisposed();
-        }
-
-        @Override
         public ObservableEmitter<T> serialize() {
             return new SerializedEmitter<T>(this);
         }
@@ -152,7 +147,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
         @Override
         public void onNext(T t) {
-            if (emitter.isCancelled() || done) {
+            if (emitter.isDisposed() || done) {
                 return;
             }
             if (t == null) {
@@ -178,7 +173,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
         @Override
         public void onError(Throwable t) {
-            if (emitter.isCancelled() || done) {
+            if (emitter.isDisposed() || done) {
                 RxJavaPlugins.onError(t);
                 return;
             }
@@ -195,7 +190,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
         @Override
         public void onComplete() {
-            if (emitter.isCancelled() || done) {
+            if (emitter.isDisposed() || done) {
                 return;
             }
             done = true;
@@ -216,7 +211,7 @@ public final class ObservableCreate<T> extends Observable<T> {
             for (;;) {
                 
                 for (;;) {
-                    if (e.isCancelled()) {
+                    if (e.isDisposed()) {
                         q.clear();
                         return;
                     }
@@ -270,8 +265,8 @@ public final class ObservableCreate<T> extends Observable<T> {
         }
 
         @Override
-        public boolean isCancelled() {
-            return emitter.isCancelled();
+        public boolean isDisposed() {
+            return emitter.isDisposed();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
@@ -108,11 +108,6 @@ public final class SingleCreate<T> extends Single<T> {
         }
 
         @Override
-        public boolean isCancelled() {
-            return DisposableHelper.isDisposed(get());
-        }
-
-        @Override
         public void dispose() {
             DisposableHelper.dispose(this);
         }


### PR DESCRIPTION
Renames Observable/Single/CompletableEmitter#isCancelled to #isDisposed.

This now causes a bit of a weird situation where most (not all) Emitter classes implement `Disposable` as well, so both interfaces expose the same `#isDisposed` method. Before the `#isCancelled` methods were basically just calling `#isDisposed` or had the same implementation. 

Suggestions on how to improve this?
