### PR TITLE
2.x: Replace `finallyDo` references with `doAfterTerminate`

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -7472,7 +7472,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnTerminate.png" alt="">
      * <p>
-     * This differs from {@code finallyDo} in that this happens <em>before</em> the {@code onComplete} or
+     * This differs from {@code doAfterTerminate} in that this happens <em>before</em> the {@code onComplete} or
      * {@code onError} notification.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6476,7 +6476,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnTerminate.png" alt="">
      * <p>
-     * This differs from {@code finallyDo} in that this happens <em>before</em> the {@code onComplete} or
+     * This differs from {@code doAfterTerminate} in that this happens <em>before</em> the {@code onComplete} or
      * {@code onError} notification.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1263,7 +1263,7 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void finallyDoNull() {
+    public void doAfterTerminateNull() {
         just1.doAfterTerminate(null);
     }
 

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1329,7 +1329,7 @@ public class ObservableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void finallyDoNull() {
+    public void doAfterTerminateNull() {
         just1.doAfterTerminate(null);
     }
 


### PR DESCRIPTION
This should be less confusing.
