### PR TITLE
2.x: add system properties to adjust thread priorities of Schedulers

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -31,7 +31,7 @@ public final class ComputationScheduler extends Scheduler {
     static final FixedSchedulerPool NONE = new FixedSchedulerPool(0);
     /** Manages a fixed number of workers. */
     private static final String THREAD_NAME_PREFIX = "RxComputationThreadPool";
-    static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
+    static final RxThreadFactory THREAD_FACTORY;
     /**
      * Key to setting the maximum number of computation scheduler threads.
      * Zero or less is interpreted as use available. Capped by available.
@@ -43,6 +43,8 @@ public final class ComputationScheduler extends Scheduler {
     static final PoolWorker SHUTDOWN_WORKER;
 
     final AtomicReference<FixedSchedulerPool> pool;
+    /** The name of the system property for setting the thread priority for this Scheduler. */
+    private static final String KEY_COMPUTATION_PRIORITY = "rx2.computation-priority";
 
     static {
         int maxThreads = Integer.getInteger(KEY_MAX_THREADS, 0);
@@ -57,6 +59,11 @@ public final class ComputationScheduler extends Scheduler {
 
         SHUTDOWN_WORKER = new PoolWorker(new RxThreadFactory("RxComputationShutdown"));
         SHUTDOWN_WORKER.dispose();
+
+        int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
+                Integer.getInteger(KEY_COMPUTATION_PRIORITY, Thread.NORM_PRIORITY)));
+
+        THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
     }
 
     static final class FixedSchedulerPool {

--- a/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
@@ -24,6 +24,9 @@ import io.reactivex.internal.schedulers.ExecutorScheduler.ExecutorWorker.Boolean
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 
+/**
+ * Wraps an Executor and provides the Scheduler API over it.
+ */
 public final class ExecutorScheduler extends Scheduler {
 
     final Executor executor;

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
@@ -24,8 +24,19 @@ import io.reactivex.Scheduler;
 public final class NewThreadScheduler extends Scheduler {
 
     private static final String THREAD_NAME_PREFIX = "RxNewThreadScheduler";
-    private static final RxThreadFactory THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX);
+    private static final RxThreadFactory THREAD_FACTORY;
+
     private static final NewThreadScheduler INSTANCE = new NewThreadScheduler();
+
+    /** The name of the system property for setting the thread priority for this Scheduler. */
+    private static final String KEY_NEWTHREAD_PRIORITY = "rx2.newthread-priority";
+
+    static {
+        int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
+                Integer.getInteger(KEY_NEWTHREAD_PRIORITY, Thread.NORM_PRIORITY)));
+
+        THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
+    }
 
     public static NewThreadScheduler instance() {
         return INSTANCE;

--- a/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
@@ -16,16 +16,27 @@ package io.reactivex.internal.schedulers;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * A ThreadFactory that counts how many threads have been created and given a prefix,
+ * sets the created Thread's name to {@code prefix-count}.
+ */
 public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     /** */
     private static final long serialVersionUID = -7789753024099756196L;
 
     final String prefix;
 
+    final int priority;
+
     static volatile boolean CREATE_TRACE;
 
     public RxThreadFactory(String prefix) {
+        this(prefix, Thread.NORM_PRIORITY);
+    }
+
+    public RxThreadFactory(String prefix, int priority) {
         this.prefix = prefix;
+        this.priority = priority;
     }
 
     @Override
@@ -52,6 +63,7 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
             }
         }
         Thread t = new Thread(r, nameBuilder.toString());
+        t.setPriority(priority);
         t.setDaemon(true);
         return t;
     }

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -21,6 +21,17 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Static factory methods for returning standard Scheduler instances.
+ * <p>
+ * <strong>Supported system properties ({@code System.getProperty()}):</strong>
+ * <ul>
+ * <li>{@code rx2.io-priority} (int): sets the thread priority of the {@link #io()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx2.computation-threads} (int): sets the number of threads in the {@link #computation()} Scheduler, default is the number of available CPUs</li>
+ * <li>{@code rx2.computation-priority} (int): sets the thread priority of the {@link #computation()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx2.newthread-priority} (int): sets the thread priority of the {@link #newThread()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx2.single-priority} (int): sets the thread priority of the {@link #single()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx2.purge-enabled} (boolean): enables periodic purging of all Scheduler's backing thread pools, default is false</li>
+ * <li>{@code rx2.purge-period-seconds} (int): specifies the periodic purge interval of all Scheduler's backing thread pools, default is 1 second</li>
+ * </ul>
  */
 public final class Schedulers {
     static final Scheduler SINGLE;


### PR DESCRIPTION
This PR adds the ability to specify the default thread priorities of `computation()`, `io()`, `newThread()` and `single()` schedulers via system properties. I've added the property names to the `Schedulers` javadoc.

Related: #4389.
