### PR TITLE
2.x: Add Disposable Observer for Maybe, Completable & Single

### DIFF
--- a/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
@@ -15,16 +15,14 @@ package io.reactivex.observers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Observer;
+import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
- * An abstract {@link Observer} that allows asynchronous cancellation by implementing Disposable.
- *
- * @param <T> the received value type
+ * An abstract {@link CompletableObserver} that allows asynchronous cancellation by implementing Disposable.
  */
-public abstract class DisposableObserver<T> implements Observer<T>, Disposable {
+public abstract class DisposableCompletableObserver implements CompletableObserver, Disposable {
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override

--- a/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
@@ -15,16 +15,16 @@ package io.reactivex.observers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Observer;
+import io.reactivex.MaybeObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
- * An abstract {@link Observer} that allows asynchronous cancellation by implementing Disposable.
+ * An abstract {@link MaybeObserver} that allows asynchronous cancellation by implementing Disposable.
  *
  * @param <T> the received value type
  */
-public abstract class DisposableObserver<T> implements Observer<T>, Disposable {
+public abstract class DisposableMaybeObserver<T> implements MaybeObserver<T>, Disposable {
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override

--- a/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
@@ -15,16 +15,16 @@ package io.reactivex.observers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Observer;
+import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
- * An abstract {@link Observer} that allows asynchronous cancellation by implementing Disposable.
+ * An abstract {@link SingleObserver} that allows asynchronous cancellation by implementing Disposable.
  *
  * @param <T> the received value type
  */
-public abstract class DisposableObserver<T> implements Observer<T>, Disposable {
+public abstract class DisposableSingleObserver<T> implements SingleObserver<T>, Disposable {
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override


### PR DESCRIPTION
Also any reason the Dispoable is called `s`? Is it still from the Subscription time?

Fixes #4501 
