### PR TITLE
2.x: fix operator RefCount, disable FindBugs (due to Travis OOM)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ group = 'io.reactivex.rxjava2'
 description = 'RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.'
 
 apply plugin: 'java'
-// apply plugin: 'pmd'
-apply plugin: 'findbugs'
+// apply plugin: 'pmd'  // disabled because runs out of memory on Travis
+// apply plugin: 'findbugs'  // disabled because runs out of memory on Travis
 apply plugin: 'checkstyle'
 apply plugin: 'jacoco'
 apply plugin: 'ru.vyarus.animalsniffer'
@@ -126,6 +126,7 @@ checkstyle {
     ignoreFailures = true
 }
 
+/*
 findbugs {
     ignoreFailures true
     toolVersion = '3.0.1'
@@ -140,4 +141,4 @@ findbugsMain {
         xml.enabled = true
     }
 }
-
+*/

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -132,7 +132,7 @@ public class ObservableWindowWithSizeTest {
                         if (count.incrementAndGet() == 500000) {
                             // give it a small break halfway through
                             try {
-                                Thread.sleep(1);
+                                Thread.sleep(5);
                             } catch (InterruptedException ex) {
                                 // ignored
                             }


### PR DESCRIPTION
This PR fixes the operators `refCount` (ensure proper call order to onXXX), disables FindBugs due to out-of-memory kills on Travis and increases the half-time sleep of a flaky unit-test.
