### PR TITLE
2.x: add Reactive-Streams TCK infrastructure and couple of tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     perfCompile 'org.openjdk.jmh:jmh-core:1.13'
     perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.13'
+
+    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.0'
+    testCompile group: 'org.testng', name: 'testng', version: '6.9.10'
 }
 
 javadoc {
@@ -71,6 +74,12 @@ test {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }
 }
+
+task testng(type: Test) { 
+     useTestNG() 
+} 
+
+check.dependsOn testng 
 
 jacoco {
     toolVersion = '0.7.7.201606060606' // See http://www.eclemma.org/jacoco/.

--- a/src/main/java/io/reactivex/internal/util/HalfSerializer.java
+++ b/src/main/java/io/reactivex/internal/util/HalfSerializer.java
@@ -30,6 +30,15 @@ public final class HalfSerializer {
         throw new IllegalStateException("No instances!");
     }
 
+    /**
+     * Emits the given value if possible and terminates if there was an onComplete or onError
+     * while emitting, drops the value otherwise.
+     * @param <T> the value type
+     * @param subscriber the target Subscriber to emit to
+     * @param value the value to emit
+     * @param wip the serialization work-in-progress counter/indicator
+     * @param error the holder of Throwables
+     */
     public static <T> void onNext(Subscriber<? super T> subscriber, T value,
             AtomicInteger wip, AtomicThrowable error) {
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
@@ -45,6 +54,15 @@ public final class HalfSerializer {
         }
     }
 
+    /**
+     * Emits the given exception if possible or adds it to the given error container to
+     * be emitted by a concurrent onNext if one is running.
+     * Undeliverable exceptions are sent to the RxJavaPlugins.onError.
+     * @param subscriber the target Subscriber to emit to
+     * @param ex the Throwable to emit
+     * @param wip the serialization work-in-progress counter/indicator
+     * @param error the holder of Throwables
+     */
     public static void onError(Subscriber<?> subscriber, Throwable ex,
             AtomicInteger wip, AtomicThrowable error) {
         if (error.addThrowable(ex)) {
@@ -56,6 +74,14 @@ public final class HalfSerializer {
         }
     }
 
+
+    /**
+     * Emits an onComplete signal or an onError signal with the given error or indicates
+     * the concurrently running onNext should do that.
+     * @param subscriber the target Subscriber to emit to
+     * @param wip the serialization work-in-progress counter/indicator
+     * @param error the holder of Throwables
+     */
     public static void onComplete(Subscriber<?> subscriber, AtomicInteger wip, AtomicThrowable error) {
         if (wip.getAndIncrement() == 0) {
             Throwable ex = error.terminate();
@@ -67,39 +93,64 @@ public final class HalfSerializer {
         }
     }
 
-    public static <T> void onNext(Observer<? super T> subscriber, T value,
+    /**
+     * Emits the given value if possible and terminates if there was an onComplete or onError
+     * while emitting, drops the value otherwise.
+     * @param <T> the value type
+     * @param observer the target Observer to emit to
+     * @param value the value to emit
+     * @param wip the serialization work-in-progress counter/indicator
+     * @param error the holder of Throwables
+     */
+    public static <T> void onNext(Observer<? super T> observer, T value,
             AtomicInteger wip, AtomicThrowable error) {
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
-            subscriber.onNext(value);
+            observer.onNext(value);
             if (wip.decrementAndGet() != 0) {
                 Throwable ex = error.terminate();
                 if (ex != null) {
-                    subscriber.onError(ex);
+                    observer.onError(ex);
                 } else {
-                    subscriber.onComplete();
+                    observer.onComplete();
                 }
             }
         }
     }
 
-    public static void onError(Observer<?> subscriber, Throwable ex,
+    /**
+     * Emits the given exception if possible or adds it to the given error container to
+     * be emitted by a concurrent onNext if one is running.
+     * Undeliverable exceptions are sent to the RxJavaPlugins.onError.
+     * @param observer the target Subscriber to emit to
+     * @param ex the Throwable to emit
+     * @param wip the serialization work-in-progress counter/indicator
+     * @param error the holder of Throwables
+     */
+    public static void onError(Observer<?> observer, Throwable ex,
             AtomicInteger wip, AtomicThrowable error) {
         if (error.addThrowable(ex)) {
             if (wip.getAndIncrement() == 0) {
-                subscriber.onError(error.terminate());
+                observer.onError(error.terminate());
             }
         } else {
             RxJavaPlugins.onError(ex);
         }
     }
 
-    public static void onComplete(Observer<?> subscriber, AtomicInteger wip, AtomicThrowable error) {
+    /**
+     * Emits an onComplete signal or an onError signal with the given error or indicates
+     * the concurrently running onNext should do that.
+     * @param observer the target Subscriber to emit to
+     * @param wip the serialization work-in-progress counter/indicator
+     * @param error the holder of Throwables
+     */
+    public static void onComplete(Observer<?> observer, AtomicInteger wip, AtomicThrowable error) {
         if (wip.getAndIncrement() == 0) {
             Throwable ex = error.terminate();
             if (ex != null) {
-                subscriber.onError(ex);
+                observer.onError(ex);
             } else {
-                subscriber.onComplete();
+                observer.onComplete();
             }
         }
     }

--- a/src/test/java/io/reactivex/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/tck/BaseTck.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import java.util.*;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.*;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
+
+/**
+ * Base abstract class for Flowable verifications, contains support for creating
+ * Iterable range of values
+ */
+@Test
+public abstract class BaseTck extends PublisherVerification<Long> {
+
+    public BaseTck() {
+        super(new TestEnvironment(300L));
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return Flowable.error(new TestException());
+    }
+
+    /**
+     * Creates an Iterable with the specified number of elements or an infinite one if
+     * elements > Integer.MAX_VALUE
+     * @param elements the number of elements to return, Integer.MAX_VALUE means an infinite sequence
+     * @return the Iterable
+     */
+    protected Iterable<Long> iterate(long elements) {
+        return iterate(elements > Integer.MAX_VALUE, elements);
+    }
+
+    protected Iterable<Long> iterate(boolean useInfinite, long elements) {
+        return useInfinite ? new InfiniteRange() : new FiniteRange(elements);
+    }
+
+    /**
+     * Create an array of Long values, ranging from 0L to elements - 1L.
+     * @param elements the number of elements to return
+     * @return the array
+     */
+    protected Long[] array(long elements) {
+        Long[] a = new Long[(int)elements];
+        for (int i = 0; i < elements; i++) {
+            a[i] = (long)i;
+        }
+        return a;
+    }
+
+    static final class FiniteRange implements Iterable<Long> {
+        final long end;
+        public FiniteRange(long end) {
+            this.end = end;
+        }
+
+        @Override
+        public Iterator<Long> iterator() {
+            return new FiniteRangeIterator(end);
+        }
+
+        static final class FiniteRangeIterator implements Iterator<Long> {
+            final long end;
+            long count;
+
+            public FiniteRangeIterator(long end) {
+                this.end = end;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return count != end;
+            }
+
+            @Override
+            public Long next() {
+                long c = count;
+                if (c != end) {
+                    count = c + 1;
+                    return c;
+                }
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    static final class InfiniteRange implements Iterable<Long> {
+        @Override
+        public Iterator<Long> iterator() {
+            return new InfiniteRangeIterator();
+        }
+
+        static final class InfiniteRangeIterator implements Iterator<Long> {
+            long count;
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Long next() {
+                return count++;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/tck/FlowableTck.java
+++ b/src/test/java/io/reactivex/tck/FlowableTck.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+
+/**
+ * Helper Flowable that makes sure invalid requests from downstream are reported
+ * as onErrors (instead of RxJavaPlugins.onError). Since requests can be
+ * async to  the onXXX method calls, we need half-serialization to ensure correct
+ * operations.
+ *
+ * @param <T> the value type
+ */
+public final class FlowableTck<T> extends Flowable<T> {
+
+    /**
+     * Wraps a given Publisher and makes sure invalid requests trigger an onError(IllegalArgumentException).
+     * @param <T> the value type
+     * @param source the source to wrap, not null
+     * @return the new Flowable instance
+     */
+    public static <T> Flowable<T> wrap(Publisher<T> source) {
+        return new FlowableTck<T>(ObjectHelper.requireNonNull(source, "source is null"));
+    }
+
+    final Publisher<T> source;
+
+    FlowableTck(Publisher<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new TckSubscriber<T>(s));
+    }
+
+    static final class TckSubscriber<T>
+    extends AtomicInteger
+    implements Subscriber<T>, Subscription {
+        /** */
+        private static final long serialVersionUID = -4945028590049415624L;
+
+        final Subscriber<? super T> actual;
+
+        final AtomicThrowable error;
+
+        Subscription s;
+
+        public TckSubscriber(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.error = new AtomicThrowable();
+        }
+
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                s.cancel();
+                onError(new IllegalArgumentException("§3.9 violated: positive request amount required but it was " + n));
+            } else {
+                s.request(n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            HalfSerializer.onNext(actual, t, this, error);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            HalfSerializer.onError(actual, t, this, error);
+        }
+
+        @Override
+        public void onComplete() {
+            HalfSerializer.onComplete(actual, this, error);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/tck/FromArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromArrayTckTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+
+@Test
+public class FromArrayTckTest extends BaseTck {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return FlowableTck.wrap(
+                Flowable.fromArray(array(elements))
+        );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024 * 1024;
+    }
+}

--- a/src/test/java/io/reactivex/tck/FromIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromIterableTckTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+
+@Test
+public class FromIterableTckTest extends BaseTck {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return FlowableTck.wrap(
+                Flowable.fromIterable(iterate(elements))
+        );
+    }
+}

--- a/src/test/java/io/reactivex/tck/JustTckTest.java
+++ b/src/test/java/io/reactivex/tck/JustTckTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+
+@Test
+public class JustTckTest extends BaseTck {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return FlowableTck.wrap(
+                Flowable.just(0L)
+        );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1L;
+    }
+}

--- a/src/test/java/io/reactivex/tck/MergeTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeTckTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+
+@Test
+public class MergeTckTest extends BaseTck {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return FlowableTck.wrap(
+            Flowable.merge(
+                Flowable.fromIterable(iterate(elements / 2)),
+                Flowable.fromIterable(iterate(elements - elements / 2))
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR sets up the build to run TestNG tests as well and adds the Reactive-Streams TCK to allow validating our operators.

Included tests are: `just`, `fromArray`, `fromIterable`, `concat`, `merge`.

Note that the TCK tests for invalid `request()` amount which, according to the spec, should be reported to the running `Subscriber` via `onError`. Unfortunately, this is a very expensive requirement (requiring half-serialization all the time) and we are not going to support it in RxJava 2. Negative requests are bugs in operators and should be fixed, we only provide a notification about such situations in the `RxJavaPlugins.onError` for those who want to check for such errors. 

Therefore, the `FlowableTCK` has been added with does the required behavior by the TCK and can be used as `FlowableTCK.wrap(flowable)` when returning from the TCK's `createPublisher(long)`.
