### PR TITLE
2.x: fix switchMap bad cancellation

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -175,6 +175,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
         public void cancel() {
             if (!cancelled) {
                 cancelled = true;
+                s.cancel();
 
                 disposeInner();
             }
@@ -186,7 +187,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
             if (a != CANCELLED) {
                 a = active.getAndSet((SwitchMapInnerSubscriber<T, R>)CANCELLED);
                 if (a != CANCELLED && a != null) {
-                    s.cancel();
+                    a.cancel();
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -160,7 +160,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
         public void dispose() {
             if (!cancelled) {
                 cancelled = true;
-
+                s.dispose();
                 disposeInner();
             }
         }
@@ -176,7 +176,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
             if (a != CANCELLED) {
                 a = active.getAndSet((SwitchMapInnerSubscriber<T, R>)CANCELLED);
                 if (a != CANCELLED && a != null) {
-                    s.dispose();
+                    a.cancel();
                 }
             }
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -797,4 +797,18 @@ public class FlowableSwitchTest {
 
     }
 
+    @Test
+    public void switchMapInnerCancelled() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Flowable.just(1)
+                .switchMap(Functions.justFunction(pp))
+                .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -607,4 +607,20 @@ public class ObservableSwitchTest {
 
     }
 
+
+    @Test
+    public void switchMapInnerCancelled() {
+        PublishSubject<Integer> pp = PublishSubject.create();
+
+        TestObserver<Integer> ts = Observable.just(1)
+                .switchMap(Functions.justFunction(pp))
+                .test();
+
+        assertTrue(pp.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasObservers());
+    }
+
 }


### PR DESCRIPTION
Both `switchMap` implementations didn't properly cancel the current inner consumer (but instead cancelled the outer 'connection' only).

Reported in #4512.
