### PR TITLE
2.x: fix Single.using, add unit tests and coverage

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -14,12 +14,13 @@
 package io.reactivex.internal.operators.single;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -31,15 +32,14 @@ public final class SingleUsing<T, U> extends Single<T> {
     final boolean eager;
 
     public SingleUsing(Callable<U> resourceSupplier,
-                       Function<? super U, ? extends SingleSource<? extends T>> singleFunction, Consumer<? super U> disposer,
+                       Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
+                       Consumer<? super U> disposer,
                        boolean eager) {
         this.resourceSupplier = resourceSupplier;
         this.singleFunction = singleFunction;
         this.disposer = disposer;
         this.eager = eager;
     }
-
-
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
@@ -54,84 +54,142 @@ public final class SingleUsing<T, U> extends Single<T> {
             return;
         }
 
-        SingleSource<? extends T> s1;
+        SingleSource<? extends T> source;
 
         try {
-            s1 = ObjectHelper.requireNonNull(singleFunction.apply(resource), "The singleFunction returned a null SingleSource");
+            source = ObjectHelper.requireNonNull(singleFunction.apply(resource), "The singleFunction returned a null SingleSource");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
+
+            if (eager) {
+                try {
+                    disposer.accept(resource);
+                } catch (Throwable exc) {
+                    Exceptions.throwIfFatal(exc);
+                    ex = new CompositeException(ex, exc);
+                }
+            }
             EmptyDisposable.error(ex, s);
+            if (!eager) {
+                try {
+                    disposer.accept(resource);
+                } catch (Throwable exc) {
+                    Exceptions.throwIfFatal(exc);
+                    RxJavaPlugins.onError(exc);
+                }
+            }
             return;
         }
 
-        s1.subscribe(new SingleObserver<T>() {
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                if (eager) {
-                    CompositeDisposable set = new CompositeDisposable();
-                    set.add(d);
-                    set.add(Disposables.fromRunnable(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                disposer.accept(resource);
-                            } catch (Throwable e) {
-                                Exceptions.throwIfFatal(e);
-                                RxJavaPlugins.onError(e);
-                            }
-                        }
-                    }));
-                    s.onSubscribe(set);
-                } else {
-                    s.onSubscribe(d);
-                }
-            }
-
-            @Override
-            public void onSuccess(T value) {
-                if (eager) {
-                    try {
-                        disposer.accept(resource);
-                    } catch (Throwable e) {
-                        Exceptions.throwIfFatal(e);
-                        s.onError(e);
-                        return;
-                    }
-                }
-                s.onSuccess(value);
-                if (!eager) {
-                    try {
-                        disposer.accept(resource);
-                    } catch (Throwable e) {
-                        Exceptions.throwIfFatal(e);
-                        RxJavaPlugins.onError(e);
-                    }
-                }
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                if (eager) {
-                    try {
-                        disposer.accept(resource);
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        e = new CompositeException(ex, e);
-                    }
-                }
-                s.onError(e);
-                if (!eager) {
-                    try {
-                        disposer.accept(resource);
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        RxJavaPlugins.onError(ex);
-                    }
-                }
-            }
-
-        });
+        source.subscribe(new UsingSingleObserver<T, U>(s, resource, eager, disposer));
     }
 
+    static final class UsingSingleObserver<T, U> extends
+    AtomicReference<Object> implements SingleObserver<T>, Disposable {
+        /** */
+        private static final long serialVersionUID = -5331524057054083935L;
+
+        final SingleObserver<? super T> actual;
+
+        final Consumer<? super U> disposer;
+
+        final boolean eager;
+
+        Disposable d;
+
+        public UsingSingleObserver(SingleObserver<? super T> actual, U resource, boolean eager,
+                Consumer<? super U> disposer) {
+            super(resource);
+            this.actual = actual;
+            this.eager = eager;
+            this.disposer = disposer;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+            disposeAfter();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void onSuccess(T value) {
+            d = DisposableHelper.DISPOSED;
+
+            if (eager) {
+                Object u = getAndSet(this);
+                if (u != this) {
+                    try {
+                        disposer.accept((U)u);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        actual.onError(ex);
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            }
+
+            actual.onSuccess(value);
+
+            if (!eager) {
+                disposeAfter();
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+
+            if (eager) {
+                Object u = getAndSet(this);
+                if (u != this) {
+                    try {
+                        disposer.accept((U)u);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        e = new CompositeException(e, ex);
+                    }
+                } else {
+                    return;
+                }
+            }
+
+            actual.onError(e);
+
+            if (!eager) {
+                disposeAfter();
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        void disposeAfter() {
+            Object u = getAndSet(this);
+            if (u != this) {
+                try {
+                    disposer.accept((U)u);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class SingleCacheTest {
+
+    @Test
+    public void cancelImmediately() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Single<Integer> cached = pp.toSingle().cache();
+
+        TestSubscriber<Integer> ts = cached.test(true);
+
+        pp.onNext(1);
+        pp.onComplete();
+
+        ts.assertEmpty();
+
+        cached.test().assertResult(1);
+    }
+
+    @Test
+    public void addRemoveRace() {
+        for (int i = 0; i < 500; i++) {
+            PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final Single<Integer> cached = pp.toSingle().cache();
+
+            final TestSubscriber<Integer> ts1 = cached.test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ts1.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cached.test();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void doubleDispose() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final Single<Integer> cached = pp.toSingle().cache();
+
+        SingleObserver<Integer> doubleDisposer = new SingleObserver<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                d.dispose();
+                d.dispose();
+            }
+
+            @Override
+            public void onSuccess(Integer value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+        };
+        cached.subscribe(doubleDisposer);
+
+        cached.test();
+
+        cached.subscribe(doubleDisposer);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDeferTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+
+public class SingleDeferTest {
+
+    @Test
+    public void normal() {
+
+        Single<Integer> s = Single.defer(new Callable<Single<Integer>>() {
+            int counter;
+            @Override
+            public Single<Integer> call() throws Exception {
+                return Single.just(++counter);
+            }
+        });
+
+        for (int i = 1; i < 33; i++) {
+            s.test().assertResult(i);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.schedulers.Schedulers;
 
@@ -44,6 +45,14 @@ public class SingleDelayTest {
         Thread.sleep(200);
 
         assertEquals(1, value.get());
+    }
+
+    @Test
+    public void delayError() {
+        Single.error(new TestException()).delay(5, TimeUnit.SECONDS)
+        .test()
+        .awaitDone(1, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/single/SingleLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleLiftTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+
+public class SingleLiftTest {
+
+    @Test
+    public void normal() {
+
+        Single.just(1).lift(new SingleOperator<Integer, Integer>() {
+            @Override
+            public SingleObserver<Integer> apply(final SingleObserver<? super Integer> s) throws Exception {
+                return new SingleObserver<Integer>() {
+
+                    @Override
+                    public void onSubscribe(Disposable d) {
+                        s.onSubscribe(d);
+                    }
+
+                    @Override
+                    public void onSuccess(Integer value) {
+                        s.onSuccess(value + 1);
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        s.onError(e);
+                    }
+                };
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -1,0 +1,330 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class SingleUsingTest {
+
+    Function<Disposable, Single<Integer>> mapper = new Function<Disposable, Single<Integer>>() {
+        @Override
+        public Single<Integer> apply(Disposable d) throws Exception {
+            return Single.just(1);
+        }
+    };
+
+    Function<Disposable, Single<Integer>> mapperThrows = new Function<Disposable, Single<Integer>>() {
+        @Override
+        public Single<Integer> apply(Disposable d) throws Exception {
+            throw new TestException("Mapper");
+        }
+    };
+
+    Consumer<Disposable> disposer = new Consumer<Disposable>() {
+        @Override
+        public void accept(Disposable d) throws Exception {
+            d.dispose();
+        }
+    };
+
+    Consumer<Disposable> disposerThrows = new Consumer<Disposable>() {
+        @Override
+        public void accept(Disposable d) throws Exception {
+            throw new TestException("Disposer");
+        }
+    };
+
+    @Test
+    public void resourceSupplierThrows() {
+        Single.using(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                throw new TestException();
+            }
+        }, Functions.justFunction(Single.just(1)), Functions.emptyConsumer())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void normalEager() {
+        Single.using(Functions.justCallable(1), Functions.justFunction(Single.just(1)), Functions.emptyConsumer())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void normalNonEager() {
+        Single.using(Functions.justCallable(1), Functions.justFunction(Single.just(1)), Functions.emptyConsumer(), false)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void errorEager() {
+        Single.using(Functions.justCallable(1), Functions.justFunction(Single.error(new TestException())), Functions.emptyConsumer())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorNonEager() {
+        Single.using(Functions.justCallable(1), Functions.justFunction(Single.error(new TestException())), Functions.emptyConsumer(), false)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void eagerMapperThrowsDisposerThrows() {
+        TestSubscriber<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows)
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> ce = TestHelper.compositeList(ts.errors().get(0));
+        TestHelper.assertError(ce, 0, TestException.class, "Mapper");
+        TestHelper.assertError(ce, 1, TestException.class, "Disposer");
+    }
+
+    @Test
+    public void noneagerMapperThrowsDisposerThrows() {
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows, false)
+            .test()
+            .assertFailureAndMessage(TestException.class, "Mapper");
+
+            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void resourceDisposedIfMapperCrashes() {
+        Disposable d = Disposables.empty();
+
+        Single.using(Functions.justCallable(d), mapperThrows, disposer)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void resourceDisposedIfMapperCrashesNonEager() {
+        Disposable d = Disposables.empty();
+
+        Single.using(Functions.justCallable(d), mapperThrows, disposer, false)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void dispose() {
+        Disposable d = Disposables.empty();
+
+        Single.using(Functions.justCallable(d), mapper, disposer, false)
+        .test(true);
+
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void disposerThrowsEager() {
+        Single.using(Functions.justCallable(Disposables.empty()), mapper, disposerThrows)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void disposerThrowsNonEager() {
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Single.using(Functions.justCallable(Disposables.empty()), mapper, disposerThrows, false)
+            .test()
+            .assertResult(1);
+            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void errorAndDisposerThrowsEager() {
+        TestSubscriber<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()),
+        new Function<Disposable, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Disposable v) throws Exception {
+                return Single.<Integer>error(new TestException("Mapper-run"));
+            }
+        }, disposerThrows)
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> ce = TestHelper.compositeList(ts.errors().get(0));
+        TestHelper.assertError(ce, 0, TestException.class, "Mapper-run");
+        TestHelper.assertError(ce, 1, TestException.class, "Disposer");
+    }
+
+    @Test
+    public void errorAndDisposerThrowsNonEager() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Single.using(Functions.justCallable(Disposables.empty()),
+            new Function<Disposable, SingleSource<Integer>>() {
+                @Override
+                public SingleSource<Integer> apply(Disposable v) throws Exception {
+                    return Single.<Integer>error(new TestException("Mapper-run"));
+                }
+            }, disposerThrows, false)
+            .test()
+            .assertFailure(TestException.class);
+            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void successDisposeRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            Disposable d = Disposables.empty();
+
+            final TestSubscriber<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+                @Override
+                public SingleSource<Integer> apply(Disposable v) throws Exception {
+                    return pp.toSingle();
+                }
+            }, disposer)
+            .test();
+
+            pp.onNext(1);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onComplete();
+                }
+            };
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            assertTrue(d.isDisposed());
+        }
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Single.using(Functions.justCallable(1), new Function<Integer, SingleSource<Integer>>() {
+                @Override
+                public SingleSource<Integer> apply(Integer v) throws Exception {
+                    return new Single<Integer>() {
+                        @Override
+                        protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposables.empty());
+
+                            assertFalse(((Disposable)observer).isDisposed());
+
+                            Disposable d = Disposables.empty();
+                            observer.onSubscribe(d);
+
+                            assertTrue(d.isDisposed());
+
+                            assertFalse(((Disposable)observer).isDisposed());
+
+                            observer.onSuccess(1);
+
+                            assertTrue(((Disposable)observer).isDisposed());
+                        }
+                    };
+                }
+            }, Functions.emptyConsumer())
+            .test()
+            .assertResult(1)
+            ;
+
+            TestHelper.assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void errorDisposeRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            Disposable d = Disposables.empty();
+
+            final TestSubscriber<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+                @Override
+                public SingleSource<Integer> apply(Disposable v) throws Exception {
+                    return pp.toSingle();
+                }
+            }, disposer)
+            .test();
+
+            final TestException ex = new TestException();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onError(ex);
+                }
+            };
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            assertTrue(d.isDisposed());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -15,7 +15,7 @@ package io.reactivex.single;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -25,6 +25,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.operators.single.SingleInternalHelper;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -505,5 +506,14 @@ public class SingleTest {
         }
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void toFlowableIterableRemove() {
+        @SuppressWarnings("unchecked")
+        Iterable<? extends Flowable<Integer>> f = SingleInternalHelper.iterableToFlowable(Arrays.asList(Single.just(1)));
+
+        Iterator<? extends Flowable<Integer>> iterator = f.iterator();
+        iterator.next();
+        iterator.remove();
+    }
 }
 


### PR DESCRIPTION
I've forgotten to create a branch so the first part of todays coverage work [landed in 2.x direct](https://github.com/ReactiveX/RxJava/commit/1145819b658983807e0cede5ba2c7d5ac1117baa)
- removed unused methods from various classes
- compacted `SpscArrayQueue`
- added null checks to `SpscLinkedArrayQueue.offer()` and `MpscLinkedQueue.offer()`
- fixed `ResourceObserver` not calling `onStart`
- Added direct NotificationLite-emission methods to `AppendOnlyLinkedArrayList`, updated `SerializedObserver` and `SerializedSubscriber` to use it directly instead of the former indirection
- `TestObserver.isDisposed` now reports true if terminal events were received (#4514)
- `ResourceSubscriber` to use `SubscriptionHelper`'s deferred Subscription/requesting management
- added unit tests to cover `DisposableXObserver`s
- `SerializedObserver` and `SerializedSubscriber` now have proper unit tests each

This current PR fixes `Single.using` not properly managing the resource and adds unit tests to verify the behavior along with a few extra coverage improvements.
