### PR TITLE
2.x: add more Maybe operators 9/09-1

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
@@ -15,8 +15,8 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.internal.subscribers.flowable.EmptyComponent;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.EmptyComponent;
 
 public final class FlowableDetach<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCache.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCache.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+
+/**
+ * Consumes the source once and replays its signal to any current or future MaybeObservers.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeCache<T> extends Maybe<T> implements MaybeObserver<T> {
+
+    @SuppressWarnings("rawtypes")
+    static final CacheDisposable[] EMPTY = new CacheDisposable[0];
+
+    @SuppressWarnings("rawtypes")
+    static final CacheDisposable[] TERMINATED = new CacheDisposable[0];
+
+    final AtomicReference<MaybeSource<T>> source;
+
+    final AtomicReference<CacheDisposable<T>[]> observers;
+
+    T value;
+
+    Throwable error;
+
+    @SuppressWarnings("unchecked")
+    public MaybeCache(MaybeSource<T> source) {
+        this.source = new AtomicReference<MaybeSource<T>>(source);
+        this.observers = new AtomicReference<CacheDisposable<T>[]>(EMPTY);
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        CacheDisposable<T> parent = new CacheDisposable<T>(observer, this);
+        observer.onSubscribe(parent);
+
+        if (add(parent)) {
+            if (parent.isDisposed()) {
+                remove(parent);
+                return;
+            }
+        } else {
+            if (!parent.isDisposed()) {
+                Throwable ex = error;
+                if (ex != null) {
+                    observer.onError(ex);
+                } else {
+                    T v = value;
+                    if (v != null) {
+                        observer.onSuccess(v);
+                    } else {
+                        observer.onComplete();
+                    }
+                }
+            }
+            return;
+        }
+
+        MaybeSource<T> src = source.getAndSet(null);
+        if (src != null) {
+            src.subscribe(this);
+        }
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+        // deliberately ignored
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onSuccess(T value) {
+        this.value = value;
+        for (CacheDisposable<T> inner : observers.getAndSet(TERMINATED)) {
+            if (!inner.isDisposed()) {
+                inner.actual.onSuccess(value);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onError(Throwable e) {
+        this.error = e;
+        for (CacheDisposable<T> inner : observers.getAndSet(TERMINATED)) {
+            if (!inner.isDisposed()) {
+                inner.actual.onError(e);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onComplete() {
+        for (CacheDisposable<T> inner : observers.getAndSet(TERMINATED)) {
+            if (!inner.isDisposed()) {
+                inner.actual.onComplete();
+            }
+        }
+    }
+
+    boolean add(CacheDisposable<T> inner) {
+        for (;;) {
+            CacheDisposable<T>[] a = observers.get();
+            if (a == TERMINATED) {
+                return false;
+            }
+            int n = a.length;
+
+            @SuppressWarnings("unchecked")
+            CacheDisposable<T>[] b = new CacheDisposable[n + 1];
+            System.arraycopy(a, 0, b, 0, n);
+            b[n] = inner;
+            if (observers.compareAndSet(a, b)) {
+                return true;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    void remove(CacheDisposable<T> inner) {
+        for (;;) {
+            CacheDisposable<T>[] a = observers.get();
+            int n = a.length;
+            if (n == 0) {
+                return;
+            }
+
+            int j = -1;
+
+            for (int i = 0; i < n; i++) {
+                if (a[i] == inner) {
+                    j = i;
+                    break;
+                }
+            }
+
+            if (j < 0) {
+                return;
+            }
+
+            CacheDisposable<T>[] b;
+            if (n == 1) {
+                b = EMPTY;
+            } else {
+                b = new CacheDisposable[n - 1];
+                System.arraycopy(a, 0, b, 0, j);
+                System.arraycopy(a, j + 1, b, j, n - j - 1);
+            }
+            if (observers.compareAndSet(a, b)) {
+                return;
+            }
+        }
+    }
+
+    static final class CacheDisposable<T>
+    extends AtomicReference<MaybeCache<T>>
+    implements Disposable {
+        /** */
+        private static final long serialVersionUID = -5791853038359966195L;
+
+        final MaybeObserver<? super T> actual;
+
+        public CacheDisposable(MaybeObserver<? super T> actual, MaybeCache<T> parent) {
+            super(parent);
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            MaybeCache<T> mc = getAndSet(null);
+            if (mc != null) {
+                mc.remove(this);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get() == null;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeContains.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeContains.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+/**
+ * Signals true if the source signals a value that is object-equals with the provided
+ * value, false otherwise or for empty sources.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeContains<T> extends Single<Boolean> implements HasUpstreamMaybeSource<T> {
+
+    final MaybeSource<T> source;
+
+    final Object value;
+
+    public MaybeContains(MaybeSource<T> source, Object value) {
+        this.source = source;
+        this.value = value;
+    }
+
+    @Override
+    public MaybeSource<T> source() {
+        return source;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Boolean> observer) {
+        source.subscribe(new ContainsMaybeObserver(observer, value));
+    }
+
+    static final class ContainsMaybeObserver implements MaybeObserver<Object>, Disposable {
+
+        final SingleObserver<? super Boolean> actual;
+
+        final Object value;
+
+        Disposable d;
+
+        public ContainsMaybeObserver(SingleObserver<? super Boolean> actual, Object value) {
+            this.actual = actual;
+            this.value = value;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(Object value) {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(ObjectHelper.equals(value, this.value));
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(false);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCount.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCount.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+/**
+ * Singals 1L if the source signalled an item or 0L if the source is empty.
+ *
+ * @param <T> the source value type
+ */
+public final class MaybeCount<T> extends Single<Long> implements HasUpstreamMaybeSource<T> {
+
+    final MaybeSource<T> source;
+
+    public MaybeCount(MaybeSource<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    public MaybeSource<T> source() {
+        return source;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Long> observer) {
+        source.subscribe(new CountMaybeObserver(observer));
+    }
+
+    static final class CountMaybeObserver implements MaybeObserver<Object>, Disposable {
+        final SingleObserver<? super Long> actual;
+
+        Disposable d;
+
+        public CountMaybeObserver(SingleObserver<? super Long> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(Object value) {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(1L);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(0L);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelay.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Delays all signal types by the given amount and re-emits them on the given scheduler.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeDelay<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final long delay;
+
+    final TimeUnit unit;
+
+    final Scheduler scheduler;
+
+    public MaybeDelay(MaybeSource<T> source, long delay, TimeUnit unit, Scheduler scheduler) {
+        super(source);
+        this.delay = delay;
+        this.unit = unit;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new DelayMaybeObserver<T>(observer, delay, unit, scheduler));
+    }
+
+    static final class DelayMaybeObserver<T>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, Disposable, Runnable {
+        /** */
+        private static final long serialVersionUID = 5566860102500855068L;
+
+        final MaybeObserver<? super T> actual;
+
+        final long delay;
+
+        final TimeUnit unit;
+
+        final Scheduler scheduler;
+
+        T value;
+
+        Throwable error;
+
+        public DelayMaybeObserver(MaybeObserver<? super T> actual, long delay, TimeUnit unit, Scheduler scheduler) {
+            this.actual = actual;
+            this.delay = delay;
+            this.unit = unit;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public void run() {
+            Throwable ex = error;
+            if (ex != null) {
+                actual.onError(ex);
+            } else {
+                T v = value;
+                if (v != null) {
+                    actual.onSuccess(v);
+                } else {
+                    actual.onComplete();
+                }
+            }
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d)) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            this.value = value;
+            schedule();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            this.error = e;
+            schedule();
+        }
+
+        @Override
+        public void onComplete() {
+            schedule();
+        }
+
+        void schedule() {
+            DisposableHelper.replace(this, scheduler.scheduleDirect(this, delay, unit));
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmpty.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Subscribes to the other source if the main source is empty.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeSwitchIfEmpty<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final MaybeSource<? extends T> other;
+
+    public MaybeSwitchIfEmpty(MaybeSource<T> source, MaybeSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new SwitchIfEmptyMaybeObserver<T>(observer, other));
+    }
+
+    static final class SwitchIfEmptyMaybeObserver<T>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, Disposable {
+        /** */
+        private static final long serialVersionUID = -2223459372976438024L;
+
+        final MaybeObserver<? super T> actual;
+
+        final MaybeSource<? extends T> other;
+
+        public SwitchIfEmptyMaybeObserver(MaybeObserver<? super T> actual, MaybeSource<? extends T> other) {
+            this.actual = actual;
+            this.other = other;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d)) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            Disposable d = get();
+            if (d != DisposableHelper.DISPOSED) {
+                if (compareAndSet(d, null)) {
+                    other.subscribe(new OtherMaybeObserver<T>(actual, this));
+                }
+            }
+        }
+
+        static final class OtherMaybeObserver<T> implements MaybeObserver<T> {
+
+            final MaybeObserver<? super T> actual;
+
+            final AtomicReference<Disposable> parent;
+            public OtherMaybeObserver(MaybeObserver<? super T> actual, AtomicReference<Disposable> parent) {
+                this.actual = actual;
+                this.parent = parent;
+            }
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(parent, d);
+            }
+            @Override
+            public void onSuccess(T value) {
+                actual.onSuccess(value);
+            }
+            @Override
+            public void onError(Throwable e) {
+                actual.onError(e);
+            }
+            @Override
+            public void onComplete() {
+                actual.onComplete();
+            }
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.subscribers.flowable.EmptyComponent;
+import io.reactivex.internal.util.EmptyComponent;
 
 /**
  * Breaks the links between the upstream and the downstream (the Disposable and

--- a/src/main/java/io/reactivex/internal/util/EmptyComponent.java
+++ b/src/main/java/io/reactivex/internal/util/EmptyComponent.java
@@ -11,18 +11,19 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.subscribers.flowable;
+package io.reactivex.internal.util;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Observer;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Singleton implementing many interfaces as empty.
  */
-public enum EmptyComponent implements Subscriber<Object>, Observer<Object>, Subscription, Disposable {
+public enum EmptyComponent implements Subscriber<Object>, Observer<Object>, MaybeObserver<Object>,
+SingleObserver<Object>, CompletableObserver, Subscription, Disposable {
     INSTANCE;
 
     @SuppressWarnings("unchecked")
@@ -77,6 +78,11 @@ public enum EmptyComponent implements Subscriber<Object>, Observer<Object>, Subs
 
     @Override
     public void onComplete() {
+        // deliberately no-op
+    }
+
+    @Override
+    public void onSuccess(Object value) {
         // deliberately no-op
     }
 }

--- a/src/test/java/io/reactivex/PublicFinalMethods.java
+++ b/src/test/java/io/reactivex/PublicFinalMethods.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.*;
+
+import org.junit.Test;
+
+/**
+ * Verifies that instance methods of the base reactive classes are all declared final.
+ */
+public class PublicFinalMethods {
+
+    static void scan(Class<?> clazz) {
+        for (Method m : clazz.getMethods()) {
+            if (m.getDeclaringClass() == clazz) {
+                if ((m.getModifiers() & Modifier.STATIC) == 0) {
+                    if ((m.getModifiers() & (Modifier.PUBLIC | Modifier.FINAL)) == Modifier.PUBLIC) {
+                        fail("Not final: " + m);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void flowable() {
+        scan(Flowable.class);
+    }
+
+    @Test
+    public void observable() {
+        scan(Observable.class);
+    }
+
+    @Test
+    public void single() {
+        scan(Single.class);
+    }
+
+    @Test
+    public void completable() {
+        scan(Completable.class);
+    }
+
+    @Test
+    public void maybe() {
+        scan(Maybe.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeCacheTest {
+
+    @Test
+    public void offlineSuccess() {
+        Maybe<Integer> source = Maybe.just(1).cache();
+        assertEquals(1, source.blockingGet().intValue());
+
+        source.test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void offlineError() {
+        Maybe<Integer> source = Maybe.<Integer>error(new TestException()).cache();
+
+        try {
+            source.blockingGet();
+            fail("Should have thrown");
+        } catch (TestException ex) {
+            // expected
+        }
+
+        source.test()
+        .assertFailure(TestException.class);
+    }
+
+
+    @Test
+    public void offlineComplete() {
+        Maybe<Integer> source = Maybe.<Integer>empty().cache();
+
+        assertNull(source.blockingGet());
+
+        source.test()
+        .assertResult();
+    }
+
+    @Test
+    public void onlineSuccess() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Maybe<Integer> source = pp.toMaybe().cache();
+
+        assertFalse(pp.hasSubscribers());
+
+        assertNotNull(((MaybeCache<Integer>)source).source.get());
+
+        TestSubscriber<Integer> ts = source.test();
+
+        assertNull(((MaybeCache<Integer>)source).source.get());
+
+        assertTrue(pp.hasSubscribers());
+
+        source.test(true).assertEmpty();
+
+        ts.assertEmpty();
+
+        pp.onNext(1);
+        pp.onComplete();
+
+        ts.assertResult(1);
+
+        source.test().assertResult(1);
+
+        source.test(true).assertEmpty();
+    }
+
+    @Test
+    public void onlineError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Maybe<Integer> source = pp.toMaybe().cache();
+
+        assertFalse(pp.hasSubscribers());
+
+        assertNotNull(((MaybeCache<Integer>)source).source.get());
+
+        TestSubscriber<Integer> ts = source.test();
+
+        assertNull(((MaybeCache<Integer>)source).source.get());
+
+        assertTrue(pp.hasSubscribers());
+
+        source.test(true).assertEmpty();
+
+        ts.assertEmpty();
+
+        pp.onError(new TestException());
+
+        ts.assertFailure(TestException.class);
+
+        source.test().assertFailure(TestException.class);
+
+        source.test(true).assertEmpty();
+    }
+
+    @Test
+    public void onlineComplete() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Maybe<Integer> source = pp.toMaybe().cache();
+
+        assertFalse(pp.hasSubscribers());
+
+        assertNotNull(((MaybeCache<Integer>)source).source.get());
+
+        TestSubscriber<Integer> ts = source.test();
+
+        assertNull(((MaybeCache<Integer>)source).source.get());
+
+        assertTrue(pp.hasSubscribers());
+
+        source.test(true).assertEmpty();
+
+        ts.assertEmpty();
+
+        pp.onComplete();
+
+        ts.assertResult();
+
+        source.test().assertResult();
+
+        source.test(true).assertEmpty();
+    }
+
+    @Test
+    public void crossCancelOnSuccess() {
+
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Maybe<Integer> source = pp.toMaybe().cache();
+
+        source.subscribe(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                ts.cancel();
+            }
+        });
+
+        source.toFlowable().subscribe(ts);
+
+        pp.onNext(1);
+        pp.onComplete();
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void crossCancelOnError() {
+
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Maybe<Integer> source = pp.toMaybe().cache();
+
+        source.subscribe(Functions.emptyConsumer(), new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                ts.cancel();
+            }
+        });
+
+        source.toFlowable().subscribe(ts);
+
+        pp.onError(new TestException());
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void crossCancelOnComplete() {
+
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Maybe<Integer> source = pp.toMaybe().cache();
+
+        source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.cancel();
+            }
+        });
+
+        source.toFlowable().subscribe(ts);
+
+        pp.onComplete();
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void addAddRace() {
+        for (int i = 0; i < 500; i++) {
+            PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final Maybe<Integer> source = pp.toMaybe().cache();
+
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    source.test();
+                }
+            };
+
+            TestHelper.race(r, r, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void removeRemoveRace() {
+        for (int i = 0; i < 500; i++) {
+            PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final Maybe<Integer> source = pp.toMaybe().cache();
+
+            final TestSubscriber<Integer> ts1 = source.test();
+            final TestSubscriber<Integer> ts2 = source.test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ts1.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts2.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void doubleDispose() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final Maybe<Integer> source = pp.toMaybe().cache();
+
+        final Disposable[] dout = { null };
+
+        source.subscribe(new MaybeObserver<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                dout[0] = d;
+            }
+
+            @Override
+            public void onSuccess(Integer value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+
+        });
+
+        dout[0].dispose();
+        dout[0].dispose();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeContainsTest {
+
+    @Test
+    public void doesContain() {
+        Maybe.just(1).contains(1).test().assertResult(true);
+    }
+
+    @Test
+    public void doesntContain() {
+        Maybe.just(1).contains(2).test().assertResult(false);
+    }
+
+    @Test
+    public void empty() {
+        Maybe.empty().contains(2).test().assertResult(false);
+    }
+
+    @Test
+    public void error() {
+        Maybe.error(new TestException()).contains(2).test().assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Boolean> ts = pp.toMaybe().contains(1).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+
+    @Test
+    public void isDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestHelper.checkDisposed(pp.toMaybe().contains(1));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, SingleSource<Boolean>>() {
+            @Override
+            public SingleSource<Boolean> apply(Maybe<Object> f) throws Exception {
+                return f.contains(1);
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void hasSource() {
+        assertSame(Maybe.empty(), ((HasUpstreamMaybeSource<Object>)(Maybe.empty().contains(0))).source());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeDelayTest {
+
+    @Test
+    public void success() {
+        Maybe.just(1).delay(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void error() {
+        Maybe.error(new TestException()).delay(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void complete() {
+        Maybe.empty().delay(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullUnit() {
+        Maybe.just(1).delay(1, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullScheduler() {
+        Maybe.just(1).delay(1, TimeUnit.MILLISECONDS, null);
+    }
+
+    @Test
+    public void disposeDuringDelay() {
+        TestScheduler scheduler = new TestScheduler();
+
+        TestSubscriber<Integer> ts = Maybe.just(1).delay(100, TimeUnit.MILLISECONDS, scheduler)
+        .test();
+
+        ts.cancel();
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void dispose() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp.toMaybe().delay(100, TimeUnit.MILLISECONDS).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void isDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestHelper.checkDisposed(pp.toMaybe().delay(100, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
+                return f.delay(100, TimeUnit.MILLISECONDS);
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeSwitchIfEmptyTest {
+
+    @Test
+    public void nonEmpty() {
+        Maybe.just(1).switchIfEmpty(Maybe.just(2)).test().assertResult(1);
+    }
+
+    @Test
+    public void empty() {
+        Maybe.<Integer>empty().switchIfEmpty(Maybe.just(2)).test().assertResult(2);
+    }
+
+    @Test
+    public void defaultIfEmptyNonEmpty() {
+        Maybe.just(1).defaultIfEmpty(2).test().assertResult(1);
+    }
+
+    @Test
+    public void defaultIfEmptyEmpty() {
+        Maybe.<Integer>empty().defaultIfEmpty(2).test().assertResult(2);
+    }
+
+    @Test
+    public void error() {
+        Maybe.<Integer>error(new TestException()).switchIfEmpty(Maybe.just(2))
+        .test().assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorOther() {
+        Maybe.empty().switchIfEmpty(Maybe.<Integer>error(new TestException()))
+        .test().assertFailure(TestException.class);
+    }
+
+    @Test
+    public void emptyOtherToo() {
+        Maybe.empty().switchIfEmpty(Maybe.empty())
+        .test().assertResult();
+    }
+
+    @Test
+    public void dispose() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+
+    @Test
+    public void isDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestHelper.checkDisposed(pp.toMaybe().switchIfEmpty(Maybe.just(2)));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, Maybe<Integer>>() {
+            @Override
+            public Maybe<Integer> apply(Maybe<Integer> f) throws Exception {
+                return f.switchIfEmpty(Maybe.just(2));
+            }
+        });
+    }
+
+    @Test
+    public void emptyCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final TestSubscriber<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/flowable/EmptyComponentTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/flowable/EmptyComponentTest.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.subscribers.flowable.EmptyComponent;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.internal.util.EmptyComponent;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public class EmptyComponentTest {

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -2739,6 +2739,14 @@ public class MaybeTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void zipWith() {
+        Maybe.just(1).zipWith(Maybe.just(2), ArgsToString.INSTANCE)
+        .test()
+        .assertResult("12");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void zip3() {
         Maybe.zip(Maybe.just(1), Maybe.just(2), Maybe.just(3),
             ArgsToString.INSTANCE)
@@ -2804,4 +2812,50 @@ public class MaybeTest {
         .test()
         .assertResult("123456789");
     }
+
+
+    @Test
+    public void ambWith1SignalsSuccess() {
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
+        .test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp1.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+
+        pp1.onNext(1);
+        pp1.onComplete();
+
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void ambWith2SignalsSuccess() {
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
+        .test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp1.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onNext(2);
+        pp2.onComplete();
+
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        ts.assertResult(2);
+    }
+
 }


### PR DESCRIPTION
This PR adds some more `Maybe` operators:
- `ambWith`
- `cache`
- `concatWith`
- `contains`
- `count`
- `defaultIfEmpty`
- `delay`
- `switchIfEmpty`
- `zipWith`

Plus a small cleanup and additional `TestHelper` test support (check double onSubscribe calls, dispose() state management).
