### PR TITLE
Observable/Flowable/Completable/Single.delay should always call onError on the provided Scheduler

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
@@ -57,16 +57,12 @@ public final class CompletableDelay extends Completable {
 
             @Override
             public void onError(final Throwable e) {
-                if (delayError) {
-                    set.add(scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            s.onError(e);
-                        }
-                    }, delay, unit));
-                } else {
-                    s.onError(e);
-                }
+                set.add(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onError(e);
+                    }
+                }, delayError ? delay : 0, unit));
             }
 
             @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -88,20 +88,16 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
 
         @Override
         public void onError(final Throwable t) {
-            if (delayError) {
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            actual.onError(t);
-                        } finally {
-                            w.dispose();
-                        }
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        actual.onError(t);
+                    } finally {
+                        w.dispose();
                     }
-                }, delay, unit);
-            } else {
-                actual.onError(t);
-            }
+                }
+            }, delayError ? delay : 0, unit);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
@@ -88,20 +88,16 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
 
         @Override
         public void onError(final Throwable t) {
-            if (delayError) {
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            actual.onError(t);
-                        } finally {
-                            w.dispose();
-                        }
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        actual.onError(t);
+                    } finally {
+                        w.dispose();
                     }
-                }, delay, unit);
-            } else {
-                actual.onError(t);
-            }
+                }
+            }, delayError ? delay : 0, unit);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
@@ -56,8 +56,13 @@ public final class SingleDelay<T> extends Single<T> {
             }
 
             @Override
-            public void onError(Throwable e) {
-                s.onError(e);
+            public void onError(final Throwable e) {
+                sd.replace(scheduler.scheduleDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onError(e);
+                    }
+                }, 0, unit));
             }
 
         });

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -1602,7 +1602,8 @@ public class CompletableTest {
 
     @Test(timeout = 1000)
     public void delayErrorImmediately() throws InterruptedException {
-        Completable c = error.completable.delay(250, TimeUnit.MILLISECONDS);
+        final TestScheduler scheduler = new TestScheduler();
+        final Completable c = error.completable.delay(250, TimeUnit.MILLISECONDS, scheduler);
 
         final AtomicBoolean done = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
@@ -1624,14 +1625,14 @@ public class CompletableTest {
             }
         });
 
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
         Assert.assertTrue(error.get().toString(), error.get() instanceof TestException);
         Assert.assertFalse("Already done", done.get());
 
-        Thread.sleep(100);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
         Assert.assertFalse("Already done", done.get());
-
-        Thread.sleep(200);
     }
 
     @Test(timeout = 1000)

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDelayTest.java
@@ -13,12 +13,17 @@
 
 package io.reactivex.internal.operators.completable;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.functions.Consumer;
 import org.junit.Test;
 
 import io.reactivex.Completable;
 import io.reactivex.schedulers.Schedulers;
+
+import static org.junit.Assert.assertNotEquals;
 
 public class CompletableDelayTest {
 
@@ -30,4 +35,27 @@ public class CompletableDelayTest {
         .test()
         .assertResult();
     }
+
+    @Test
+    public void testOnErrorCalledOnScheduler() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+
+        Completable.<String>error(new Exception())
+                .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())
+                .doOnError(new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable throwable) throws Exception {
+                        thread.set(Thread.currentThread());
+                        latch.countDown();
+                    }
+                })
+                .onErrorComplete()
+                .subscribe();
+
+        latch.await();
+
+        assertNotEquals(Thread.currentThread(), thread.get());
+    }
+
 }


### PR DESCRIPTION
Fixes #4521 
