### PR TITLE
2.x: add Maybe operators, add annotation and source code checker tests

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -16,11 +16,12 @@ import java.util.concurrent.*;
 
 import org.reactivestreams.Publisher;
 
-import io.reactivex.annotations.SchedulerSupport;
+import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.observers.*;
 import io.reactivex.internal.operators.completable.*;
 import io.reactivex.internal.operators.flowable.FlowableDelaySubscriptionOther;
@@ -43,7 +44,7 @@ public abstract class Completable implements CompletableSource {
      * terminates (normally or with an error) and cancels all other Completables.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code ambArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of source Completables
      * @return the new Completable instance
@@ -97,7 +98,7 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable which completes only when all sources complete, one after another.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the sources to concatenate
      * @return the Completable instance which completes only when all sources complete
@@ -143,6 +144,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     public static Completable concat(Publisher<? extends CompletableSource> sources) {
         return concat(sources, 2);
     }
@@ -159,6 +161,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     public static Completable concat(Publisher<? extends CompletableSource> sources, int prefetch) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -359,6 +362,7 @@ public abstract class Completable implements CompletableSource {
      * @return the new Completable instance
      * @throws NullPointerException if publisher is null
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Completable fromPublisher(final Publisher<T> publisher) {
         ObjectHelper.requireNonNull(publisher, "publisher is null");
@@ -388,7 +392,7 @@ public abstract class Completable implements CompletableSource {
      * completes only when all source Completables complete or one of them emits an error.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the iterable sequence of sources.
      * @return the new Completable instance
@@ -435,6 +439,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     public static Completable merge(Publisher<? extends CompletableSource> sources) {
         return merge0(sources, Integer.MAX_VALUE, false);
     }
@@ -453,6 +458,7 @@ public abstract class Completable implements CompletableSource {
      * @throws IllegalArgumentException if maxConcurrency is less than 1
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     public static Completable merge(Publisher<? extends CompletableSource> sources, int maxConcurrency) {
         return merge0(sources, maxConcurrency, false);
     }
@@ -473,6 +479,7 @@ public abstract class Completable implements CompletableSource {
      * @throws IllegalArgumentException if maxConcurrency is less than 1
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     private static Completable merge0(Publisher<? extends CompletableSource> sources, int maxConcurrency, boolean delayErrors) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -485,7 +492,7 @@ public abstract class Completable implements CompletableSource {
      * them terminate in a way or another.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of Completables
      * @return the new Completable instance
@@ -529,6 +536,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     public static Completable mergeDelayError(Publisher<? extends CompletableSource> sources) {
         return merge0(sources, Integer.MAX_VALUE, true);
     }
@@ -548,6 +556,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if sources is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     public static Completable mergeDelayError(Publisher<? extends CompletableSource> sources, int maxConcurrency) {
         return merge0(sources, maxConcurrency, true);
     }
@@ -670,7 +679,7 @@ public abstract class Completable implements CompletableSource {
      * if not already Completable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code wrap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param source the source to wrap
      * @return the source or its wrapper Completable
@@ -736,6 +745,7 @@ public abstract class Completable implements CompletableSource {
      * @return Flowable that composes this Completable and next
      * @throws NullPointerException if next is null
      */
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> andThen(Publisher<T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
@@ -821,7 +831,7 @@ public abstract class Completable implements CompletableSource {
      * the emitted exception if any.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doAfterTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code blockingGet} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the throwable if this terminated with an error, null otherwise
      * @throws RuntimeException that wraps an InterruptedException if the wait is interrupted
@@ -836,6 +846,10 @@ public abstract class Completable implements CompletableSource {
     /**
      * Subscribes to this Completable instance and blocks until it terminates or the specified timeout
      * elapses, then returns null for normal termination or the emitted exception if any.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code blockingGet} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the time unit
      * @return the throwable if this terminated with an error, null otherwise
@@ -1162,7 +1176,7 @@ public abstract class Completable implements CompletableSource {
      * true, it will emit an onComplete and swallow the throwable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param predicate the predicate to call when an Throwable is emitted which should return true
      * if the Throwable should be swallowed and replaced with an onComplete.
@@ -1381,6 +1395,7 @@ public abstract class Completable implements CompletableSource {
      * @return the new Observable instance
      * @throws NullPointerException if other is null
      */
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> startWith(Publisher<T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
@@ -1442,12 +1457,17 @@ public abstract class Completable implements CompletableSource {
      *
      * composite.add(source.subscribeWith(new ResourceCompletableObserver()));
      * </code></pre>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <E> the type of the CompletableObserver to use and return
      * @param observer the CompletableObserver (subclass) to use and return, not null
      * @return the input {@code observer}
      * @throws NullPointerException if {@code observer} is null
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E extends CompletableObserver> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
@@ -1595,6 +1615,10 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable that runs this Completable and optionally switches to the other Completable
      * in case this Completable doesn't complete within the given time while "waiting" on
      * the specified scheduler.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>you specify the {@link Scheduler} this operator runs on.</dd>
+     * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
      * @param scheduler the scheduler to use to wait for completion
@@ -1641,8 +1665,13 @@ public abstract class Completable implements CompletableSource {
      * @param <T> the value type
      * @return the new Observable created
      */
+    @SuppressWarnings("unchecked")
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> toFlowable() {
+        if (this instanceof FuseToFlowable) {
+            return ((FuseToFlowable<T>)this).fuseToFlowable();
+        }
         return RxJavaPlugins.onAssembly(new CompletableToFlowable<T>(this));
     }
 
@@ -1652,13 +1681,18 @@ public abstract class Completable implements CompletableSource {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code toMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the value type
      * @return an {@link Maybe} that emits a single item T or an error.
      */
+    @SuppressWarnings("unchecked")
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Maybe<T> toMaybe() {
+        if (this instanceof FuseToMaybe) {
+            return ((FuseToMaybe<T>)this).fuseToMaybe();
+        }
         return RxJavaPlugins.onAssembly(new MaybeFromCompletable<T>(this));
     }
 
@@ -1672,8 +1706,12 @@ public abstract class Completable implements CompletableSource {
      * @param <T> the value type
      * @return the new Observable created
      */
+    @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> toObservable() {
+        if (this instanceof FuseToObservable) {
+            return ((FuseToObservable<T>)this).fuseToObservable();
+        }
         return RxJavaPlugins.onAssembly(new CompletableToObservable<T>(this));
     }
 
@@ -1736,9 +1774,14 @@ public abstract class Completable implements CompletableSource {
     /**
      * Creates a TestSubscriber and subscribes
      * it to this Completable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<Void> test() {
         TestSubscriber<Void> ts = new TestSubscriber<Void>();
         subscribe(new SubscriberCompletableObserver<Void>(ts));
@@ -1749,9 +1792,14 @@ public abstract class Completable implements CompletableSource {
      * Creates a TestSubscriber optionally in cancelled state, then subscribes it to this Completable.
      * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
      * Completable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<Void> test(boolean cancelled) {
         TestSubscriber<Void> ts = new TestSubscriber<Void>();
 

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -102,7 +102,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by the winning
      *  {@code Publisher}'s backpressure behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code ambArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element type
@@ -346,7 +346,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -384,7 +384,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -417,8 +417,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      *
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Publisher} honors backpressure from downstream. The source {@code Publisher}s
+     *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
+     *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -436,6 +440,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     public static <T, R> Flowable<R> combineLatestDelayError(Function<? super Object[], ? extends R> combiner,
             int bufferSize, Publisher<? extends T>... sources) {
         return combineLatestDelayError(sources, combiner, bufferSize);
@@ -457,7 +462,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -503,7 +508,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -541,7 +546,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -1211,7 +1216,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  If any of the source {@code Publisher}s violate this, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
@@ -1242,7 +1247,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  If any of the source {@code Publisher}s violate this, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
@@ -1528,6 +1533,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * You should call the FlowableEmitter onNext, onError and onComplete methods in a serialized fashion. The
      * rest of its methods are thread-safe.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The backpressure behavior is determined by the {@code mode} parameter.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @param <T> the element type
      * @param source the emitter that is called when a Subscriber subscribes to the returned {@code Flowable}
@@ -1558,7 +1569,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by the {@code Publisher}
-     *  returned by the {@code PublisherFactory}.</dd>
+     *  returned by the {@code supplier}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1667,7 +1678,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and iterates the given {@code array}
      *  on demand (i.e., when requested).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param items
@@ -1738,7 +1749,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -1773,7 +1784,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -1813,7 +1824,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -1853,7 +1864,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param future
@@ -1883,7 +1894,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and iterates the given {@code iterable}
      *  on demand (i.e., when requested).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param source
@@ -1935,7 +1946,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code generator} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code generate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the generated value type
@@ -2109,7 +2120,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  may lead to {@code MissingBackpressureException} at some point in the chain.
      *  Consumers should consider applying one of the {@code onBackpressureXXX} operators as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param initialDelay
@@ -2138,6 +2149,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="195" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/interval.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator signals a {@code MissingBackpressureException} if the downstream
+     *  is not ready to receive the next value.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code interval} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
@@ -2166,7 +2180,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  may lead to {@code MissingBackpressureException} at some point in the chain.
      *  Consumers should consider applying one of the {@code onBackpressureXXX} operators as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param period
@@ -2705,7 +2719,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
      *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -2869,7 +2883,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
      *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -3006,6 +3020,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. All inner {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3039,6 +3056,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. All inner {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3075,8 +3095,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. All source {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -3111,6 +3134,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. All inner {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3219,8 +3245,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -3435,6 +3464,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator honors downstream backpressure and expects both of its sources
+     *  to honor backpressure as well. If violated, the operator will emit a MissingBackpressureException.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3532,6 +3564,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator honors downstream backpressure and expects both of its sources
+     *  to honor backpressure as well. If violated, the operator will emit a MissingBackpressureException.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3650,7 +3685,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but it is not enforced; the operator won't signal a {@code MissingBackpressureException}
      *  but the violation <em>may</em> lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the item type
@@ -3688,7 +3723,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but it is not enforced; the operator won't signal a {@code MissingBackpressureException}
      *  but the violation <em>may</em> lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the item type
@@ -3742,7 +3777,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure as it uses time. If the downstream needs a slower rate
      *      it should slow the timer or use something like {@link #onBackpressureDrop}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -4719,7 +4754,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  (I.e., zipping with {@link #interval(long, TimeUnit)} may result in MissingBackpressureException, use
      *  one of the {@code onBackpressureX} to handle similar, backpressure-ignoring sources.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code zipArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element type
@@ -4779,7 +4814,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  (I.e., zipping with {@link #interval(long, TimeUnit)} may result in MissingBackpressureException, use
      *  one of the {@code onBackpressureX} to handle similar, backpressure-ignoring sources.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code zipIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      *
@@ -4848,7 +4883,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by the winning
      *  {@code Publisher}'s backpressure behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code ambWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -4879,7 +4914,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an unbounded manner
      *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code exists} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code any} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param predicate
@@ -4911,6 +4946,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *             if this {@code Flowable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst() {
         BlockingFirstSubscriber<T> s = new BlockingFirstSubscriber<T>();
         subscribe(s);
@@ -4938,6 +4975,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst(T defaultItem) {
         BlockingFirstSubscriber<T> s = new BlockingFirstSubscriber<T>();
         subscribe(s);
@@ -4975,6 +5014,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX documentation: Subscribe</a>
      * @see #subscribe(Consumer)
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingForEach(Consumer<? super T> onNext) {
         Iterator<T> it = blockingIterable().iterator();
         while (it.hasNext()) {
@@ -4994,8 +5035,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toIterable.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
+     *  <dd>The operator expects the upstream to honor backpressure otherwise the returned
+     *  Iterable's iterator will throw a {@code MissingBackpressureException}.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -5003,6 +5044,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return an {@link Iterable} version of this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingIterable() {
         return blockingIterable(bufferSize());
     }
@@ -5013,8 +5056,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="315" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toIterable.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
+     *  <dd>The operator expects the upstream to honor backpressure otherwise the returned
+     *  Iterable's iterator will throw a {@code MissingBackpressureException}.
+     *  </dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -5023,6 +5067,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return an {@link Iterable} version of this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingIterable(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return new BlockingFlowableIterable<T>(this, bufferSize);
@@ -5046,6 +5092,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *             if this {@code Flowable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast() {
         BlockingLastSubscriber<T> s = new BlockingLastSubscriber<T>();
         subscribe(s);
@@ -5075,6 +5123,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast(T defaultItem) {
         BlockingLastSubscriber<T> s = new BlockingLastSubscriber<T>();
         subscribe(s);
@@ -5102,6 +5152,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return an Iterable that always returns the latest item emitted by this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingLatest() {
         return BlockingFlowableLatest.latest(this);
     }
@@ -5126,6 +5178,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         has most recently emitted
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingMostRecent(T initialItem) {
         return BlockingFlowableMostRecent.mostRecent(this, initialItem);
     }
@@ -5147,6 +5201,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         a new item, whereupon the Iterable returns that item
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX documentation: TakeLast</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingNext() {
         return BlockingFlowableNext.next(this);
     }
@@ -5167,6 +5223,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the single item emitted by this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingSingle() {
         return single().blockingFirst();
     }
@@ -5191,6 +5249,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingSingle(T defaultItem) {
         return single(defaultItem).blockingFirst();
     }
@@ -5216,6 +5276,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a {@link Future} that expects a single item to be emitted by this {@code Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Future<T> toFuture() {
         return subscribeWith(new FutureSubscriber<T>());
     }
@@ -5231,6 +5293,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe() {
         FlowableBlockingSubscribe.subscribe(this);
     }
@@ -5247,6 +5311,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onNext the callback action for each source value
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext) {
         FlowableBlockingSubscribe.subscribe(this, onNext, Functions.ERROR_CONSUMER, Functions.EMPTY_ACTION);
     }
@@ -5264,6 +5330,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onError the callback action for an error event
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION);
     }
@@ -5283,6 +5351,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onComplete the callback action for the completion event.
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, onComplete);
     }
@@ -5292,9 +5362,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the source
-     *  {@code Flowable} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
+     *  <dd>The supplied {@code Subscriber} determines how backpressure is applied.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -5302,6 +5370,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Subscriber<? super T> subscriber) {
         FlowableBlockingSubscribe.subscribe(this, subscriber);
     }
@@ -5482,7 +5552,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -5516,7 +5586,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <U> the collection subclass type to buffer into
@@ -5623,7 +5693,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -5660,7 +5730,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <U> the collection subclass type to buffer into
@@ -5710,7 +5780,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -6075,7 +6145,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator consumes this Publisher in an unbounded fashion but respects the backpressure
      *  of each downstream Subscriber individually.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code cacheWithInitialCapacity} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>
      * <em>Note:</em> The capacity hint is not an upper bound on cache size. For that, consider
@@ -6166,7 +6236,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>This operator does not support backpressure because by intent it will receive all values and reduce
      *      them to a single {@code onNext}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code collect} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code collectInto} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <U> the accumulator and output type
@@ -6553,7 +6623,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  are expected to honor backpressure as well. If any of then violates this rule, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -6605,7 +6675,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code countLong} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code count} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return a Flowable that emits a single item: the number of items emitted by the source Publisher as a
@@ -6710,7 +6780,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -6859,7 +6929,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with the backpressure behavior which is determined by the source {@code Publisher}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -6886,7 +6956,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with the backpressure behavior which is determined by the source {@code Publisher}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -6968,6 +7038,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         until the other Publisher emits an element or completes normally.
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Flowable<T> delaySubscription(Publisher<U> subscriptionIndicator) {
         ObjectHelper.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
         return RxJavaPlugins.onAssembly(new FlowableDelaySubscriptionOther<T, U>(this, subscriptionIndicator));
@@ -6981,7 +7053,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with the backpressure behavior which is determined by the source {@code Publisher}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This version of {@code delay} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      *
      * @param delay
@@ -7006,7 +7078,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with the backpressure behavior which is determined by the source {@code Publisher}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -7255,7 +7327,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code doOnUnsubscribe} does not interact with backpressure requests or value delivery; backpressure
      *  behavior is preserved between its upstream and its downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doOnUnsubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code doOnCancel} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onCancel
@@ -7420,7 +7492,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
      *  backpressure behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code doOnLifecycle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onSubscribe
@@ -7591,7 +7663,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an unbounded manner
      *  (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code elementAtOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code elementAt} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param index
@@ -7673,7 +7745,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code firstOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code first} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultItem
@@ -7961,6 +8033,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed
      *  in unbounded mode (i.e., no backpressure is applied to it). The inner {@code Publisher}s are expected to honor
      *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
@@ -7994,6 +8067,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.png" alt="">
      * <dl>
+     * <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed
      *  in unbounded mode (i.e., no backpressure is applied to it). The inner {@code Publisher}s are expected to honor
      *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
@@ -8320,7 +8394,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code forEach} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code forEachWhile} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onNext
@@ -8347,7 +8421,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code forEach} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code forEachWhile} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onNext
@@ -8375,7 +8449,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code forEach} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code forEachWhile} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onNext
@@ -8823,7 +8897,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code lastOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code last} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultItem
@@ -8968,7 +9042,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  such as {@code interval}, {@code timer}, {code PublishSubject} or {@code BehaviorSubject} and apply any
      *  of the {@code onBackpressureXXX} operators <strong>before</strong> applying {@code observeOn} itself.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -9000,7 +9074,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  such as {@code interval}, {@code timer}, {code PublishSubject} or {@code BehaviorSubject} and apply any
      *  of the {@code onBackpressureXXX} operators <strong>before</strong> applying {@code observeOn} itself.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -9036,7 +9110,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  such as {@code interval}, {@code timer}, {code PublishSubject} or {@code BehaviorSubject} and apply any
      *  of the {@code onBackpressureXXX} operators <strong>before</strong> applying {@code observeOn} itself.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -9318,6 +9392,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Publisher<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
         ObjectHelper.requireNonNull(overflowStrategy, "strategy is null");
         ObjectHelper.verifyPositive(capacity, "capacity");
@@ -9553,7 +9629,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
      *  {@code MissingBackpressureException} is signalled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param item
@@ -9894,7 +9970,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure of its downstream consumer and consumes the
      *  upstream source in unbounded mode.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code reduce} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code reduceWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the accumulator and output value type
@@ -9979,7 +10055,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
      *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param stop
@@ -10166,7 +10242,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -10211,7 +10287,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -10283,7 +10359,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -10322,7 +10398,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -10420,7 +10496,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param bufferSize
@@ -10460,7 +10536,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param bufferSize
@@ -10521,7 +10597,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -10555,7 +10631,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  Subscriber which requests the largest amount: i.e., two child Subscribers with requests of 10 and 100 will
      *  request 100 elements from the underlying Publisher sequence.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -10714,7 +10790,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
      *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code retryUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param stop the function that should return true to stop retrying
      * @return the new Flowable instance
@@ -10795,7 +10871,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>This operator leaves the reactive world and the backpressure behavior depends on the Subscriber's behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code safeSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param s the incoming Subscriber instance
      * @throws NullPointerException if s is null
@@ -10848,7 +10924,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param period
@@ -11014,7 +11090,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
      *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signalled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code scan} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code scanWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the initial, accumulator and result type
@@ -11130,7 +11206,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code singleOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code single} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultItem
@@ -11214,7 +11290,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for the timed skipping</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for the timed skipping</dd>
      * </dl>
      *
      * @param time
@@ -11345,7 +11421,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for tracking the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
      * </dl>
      *
      * @param time
@@ -11376,7 +11452,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use to track the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use to track the current time</dd>
      * </dl>
      *
      * @param time
@@ -11410,7 +11486,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -11513,6 +11589,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *             all other items emitted by the Publisher
      * @return a Flowable that emits the items emitted by the source Publisher in sorted order
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> sorted(){
         return toSortedList().flatMapIterable(Functions.<List<T>>identity());
     }
@@ -11537,6 +11615,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            that indicates their sort order
      * @return a Flowable that emits the items emitted by the source Publisher in sorted order
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> sorted(Comparator<? super T> sortFunction) {
         return toSortedList(sortFunction).flatMapIterable(Functions.<List<T>>identity());
     }
@@ -11635,7 +11715,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  is expected to honor backpressure as well. If it violates this rule, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code startWithArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param items
@@ -11861,12 +11941,21 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * composite.add(source.subscribeWith(rs));
      * </code></pre>
+     * 
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The backpressure behavior/expectation is determined by the supplied {@code Subscriber}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <E> the type of the Subscriber to use and return
      * @param subscriber the Subscriber (subclass) to use and return, not null
      * @return the input {@code subscriber}
      * @throws NullPointerException if {@code subscriber} is null
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E extends Subscriber<? super T>> E subscribeWith(E subscriber) {
         subscribe(subscriber);
         return subscriber;
@@ -11881,7 +11970,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -12010,7 +12099,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but it is not enforced; the operator won't signal a {@code MissingBackpressureException}
      *  but the violation <em>may</em> lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the element type of the inner Publishers and the output
@@ -12021,6 +12110,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> switchMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return switchMapDelayError(mapper, bufferSize());
     }
@@ -12042,7 +12133,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but it is not enforced; the operator won't signal a {@code MissingBackpressureException}
      *  but the violation <em>may</em> lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the element type of the inner Publishers and the output
@@ -12055,6 +12146,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> switchMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize) {
         return switchMap0(mapper, bufferSize, true);
     }
@@ -12142,7 +12235,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -12264,7 +12357,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., no backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for tracking the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
      * </dl>
      *
      * @param count
@@ -12299,7 +12392,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., no backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for tracking the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
      * </dl>
      *
      * @param count
@@ -12410,7 +12503,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  lead to {@code OutOfMemoryError} due to internal buffer bloat.
      *  Consider using {@link #takeLast(long, long, TimeUnit, Scheduler)} in this case.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -12443,7 +12536,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  lead to {@code OutOfMemoryError} due to internal buffer bloat.
      *  Consider using {@link #takeLast(long, long, TimeUnit, Scheduler)} in this case.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -12479,7 +12572,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  lead to {@code OutOfMemoryError} due to internal buffer bloat.
      *  Consider using {@link #takeLast(long, long, TimeUnit, Scheduler)} in this case.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -12632,7 +12725,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param skipDuration
@@ -12697,7 +12790,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param intervalDuration
@@ -12780,7 +12873,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -13049,7 +13142,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  If any of the source {@code Publisher}s violate this, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -13083,7 +13176,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -13114,7 +13207,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  are expected to honor backpressure as well. If any of then violates this rule, it <em>may</em> throw an
      *  {@code IllegalStateException} when the {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This version of {@code timeout} operates by default on the {@code immediate} {@link Scheduler}.</dd>
+     *  <dd>{@code timeout} does not operates by default on any {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <U>
@@ -13133,6 +13226,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         the time windows specified by the timeout selectors
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Flowable<T> timeout(Callable<? extends Publisher<U>> firstTimeoutSelector,
             Function<? super T, ? extends Publisher<V>> timeoutSelector) {
         ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
@@ -13152,7 +13247,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  If any of the source {@code Publisher}s violate this, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This version of {@code timeout} operates by default on the {@code immediate} {@link Scheduler}.</dd>
+     *  <dd>{@code timeout} does not operates by default on any {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <U>
@@ -13234,7 +13329,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>The operator does not operate on any particular scheduler but uses the current time
+     *  <dd>This operator does not operate on any particular scheduler but uses the current time
      *  from the specified {@link Scheduler}.</dd>
      * </dl>
      *
@@ -13284,7 +13379,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>The operator does not operate on any particular scheduler but uses the current time
+     *  <dd>This operator does not operate on any particular scheduler but uses the current time
      *  from the specified {@link Scheduler}.</dd>
      * </dl>
      *
@@ -13307,6 +13402,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Calls the specified converter function during assembly time and returns its resulting value.
      * <p>
      * This allows fluent conversion to any other type.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The backpressure behavior depends on what happens in the {@code converter} function.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <R> the resulting object type
      * @param converter the function that receives the current Flowable instance and returns a value
      * @return the value returned by the function
@@ -13560,7 +13661,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as by intent it is requesting and buffering everything.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -13590,7 +13691,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -13622,7 +13723,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -13664,7 +13765,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
      *  unbounded manner (i.e., without applying backpressure to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -13696,7 +13797,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>Publishers don't support backpressure thus the current Flowable is consumed in an unbounded
      *  manner (by requesting Long.MAX_VALUE).</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new Publisher instance
      * @since 2.0
@@ -13751,7 +13852,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> toMaybe() {
-        return new MaybeFromPublisher<T>(this);
+        return RxJavaPlugins.onAssembly(new MaybeFromPublisher<T>(this));
     }
 
     /**
@@ -13876,7 +13977,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
      *  behavior.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -14037,7 +14138,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but have an unbounded inner buffer that <em>may</em> lead to {@code OutOfMemoryError}
      *  if left unconsumed.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -14073,7 +14174,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but have an unbounded inner buffer that <em>may</em> lead to {@code OutOfMemoryError}
      *  if left unconsumed.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -14223,7 +14324,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  backpressure but have an unbounded inner buffer that <em>may</em> lead to {@code OutOfMemoryError}
      *  if left unconsumed.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -14259,7 +14360,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  time to control the creation of windows. The returned inner {@code Publisher}s honor
      *  backpressure and may hold up to {@code count} elements at most.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -14298,7 +14399,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  time to control the creation of windows. The returned inner {@code Publisher}s honor
      *  backpressure and may hold up to {@code count} elements at most.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -14339,7 +14440,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  time to control the creation of windows. The returned inner {@code Publisher}s honor
      *  backpressure and may hold up to {@code count} elements at most.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -14640,6 +14741,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the new Publisher instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T1, T2, R> Flowable<R> withLatestFrom(Publisher<T1> source1, Publisher<T2> source2,
             Function3<? super T, ? super T1, ? super T2, R> combiner) {
         Function<Object[], R> f = Functions.toFunction(combiner);
@@ -14674,6 +14777,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the new Publisher instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T1, T2, T3, R> Flowable<R> withLatestFrom(
             Publisher<T1> source1, Publisher<T2> source2,
             Publisher<T3> source3,
@@ -14712,6 +14817,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the new Publisher instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T1, T2, T3, T4, R> Flowable<R> withLatestFrom(
             Publisher<T1> source1, Publisher<T2> source2,
             Publisher<T3> source3, Publisher<T4> source4,
@@ -14743,6 +14850,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the new Publisher instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> withLatestFrom(Publisher<?>[] others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
@@ -14772,6 +14881,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the new Publisher instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> withLatestFrom(Iterable<? extends Publisher<?>> others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
@@ -14971,9 +15082,17 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Creates a TestSubscriber that requests Long.MAX_VALUE and subscribes
      * it to this Flowable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned TestSubscriber consumes this Flowable in an unbounded fashion.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test() { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>();
         subscribe(ts);
@@ -14983,10 +15102,18 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Creates a TestSubscriber with the given initial request amount and subscribes
      * it to this Flowable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned TestSubscriber requests the given {@code initialRequest} amount upfront.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param initialRequest the initial request amount, positive
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test(long initialRequest) { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
         subscribe(ts);
@@ -14997,11 +15124,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Creates a TestSubscriber with the given initial request amount,
      * optionally cancels it before the subscription and subscribes
      * it to this Flowable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned TestSubscriber requests the given {@code initialRequest} amount upfront.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param initialRequest the initial request amount, positive
      * @param cancel should the TestSubscriber be cancelled before the subscription?
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test(long initialRequest, boolean cancel) { // NoPMD
         TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
         if (cancel) {

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -53,6 +53,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param sources the Iterable sequence of sources
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> amb(final Iterable<? extends MaybeSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new MaybeAmbIterable<T>(sources));
@@ -63,12 +64,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * the rest).
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code ambArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param sources the array of sources
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Maybe<T> ambArray(final MaybeSource<? extends T>... sources) {
         if (sources.length == 0) {
@@ -91,6 +93,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param sources the Iterable sequence of MaybeSource instances
      * @return the new Flowable instance
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concat(Iterable<? extends MaybeSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new MaybeConcatIterable<T>(sources));
@@ -113,6 +117,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits items emitted by the two source MaybeSources, one after the other.
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
@@ -139,6 +145,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits items emitted by the three source MaybeSources, one after the other.
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             MaybeSource<? extends T> source1, MaybeSource<? extends T> source2, MaybeSource<? extends T> source3) {
@@ -169,6 +177,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits items emitted by the four source MaybeSources, one after the other.
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             MaybeSource<? extends T> source1, MaybeSource<? extends T> source2, MaybeSource<? extends T> source3, MaybeSource<? extends T> source4) {
@@ -190,6 +200,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param sources the Publisher of MaybeSource instances
      * @return the new Flowable instance
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concat(Publisher<? extends MaybeSource<? extends T>> sources) {
         return concat(sources, 2);
     }
@@ -206,6 +218,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param prefetch the number of MaybeSources to prefetch from the Publisher
      * @return the new Flowable instance
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> concat(Publisher<? extends MaybeSource<? extends T>> sources, int prefetch) {
         ObjectHelper.requireNonNull(sources, "sources is null");
@@ -217,12 +231,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources in the array.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param sources the Publisher of MaybeSource instances
      * @return the new Flowable instance
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concatArray(MaybeSource<? extends T>... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
@@ -246,7 +262,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  If the {@code Publisher} violate this, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
@@ -379,7 +395,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the value type
      * @param sources a sequence of Publishers that need to be eagerly concatenated
      * @return the new Publisher instance with the specified concatenation behavior
-     * @since 2.0
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -427,6 +442,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @see MaybeOnSubscribe
      * @see Cancellable
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> create(MaybeOnSubscribe<T> onSubscribe) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         return RxJavaPlugins.onAssembly(new MaybeCreate<T>(onSubscribe));
@@ -444,6 +460,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * returns a MaybeSource instance to subscribe to
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> defer(final Callable<? extends MaybeSource<? extends T>> maybeSupplier) {
         ObjectHelper.requireNonNull(maybeSupplier, "maybeSupplier is null");
         return RxJavaPlugins.onAssembly(new MaybeDefer<T>(maybeSupplier));
@@ -461,6 +478,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the value type
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Maybe<T> empty() {
         return RxJavaPlugins.onAssembly((Maybe<T>)MaybeEmpty.INSTANCE);
@@ -484,6 +502,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         the subscriber subscribes to it
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> error(Throwable exception) {
         ObjectHelper.requireNonNull(exception, "exception is null");
         return RxJavaPlugins.onAssembly(new MaybeError<T>(exception));
@@ -507,6 +526,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         the MaybeObserver subscribes to it
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> error(Callable<? extends Throwable> supplier) {
         ObjectHelper.requireNonNull(supplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new MaybeErrorCallable<T>(supplier));
@@ -548,6 +568,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         the type of the item emitted by the {@link Maybe}.
      * @return a {@link Maybe} whose {@link MaybeObserver}s' subscriptions trigger an invocation of the given function.
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> fromCallable(final Callable<? extends T> callable) {
         ObjectHelper.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new MaybeFromCallable<T>(callable));
@@ -568,7 +589,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * cancellation effect: {@code futureMaybe.doOnDispose(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -579,7 +600,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> fromFuture(Future<? extends T> future) {
         ObjectHelper.requireNonNull(future, "future is null");
@@ -603,7 +623,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -618,7 +638,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
         ObjectHelper.requireNonNull(future, "future is null");
@@ -664,6 +683,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a {@code Maybe} that emits {@code item}
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> just(T item) {
         ObjectHelper.requireNonNull(item, "item is null");
         return RxJavaPlugins.onAssembly(new MaybeJust<T>(item));
@@ -681,8 +701,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the common and resulting value type
      * @param sources the Iterable sequence of MaybeSource sources
      * @return the new Flowable instance
-     * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> merge(Iterable<? extends MaybeSource<? extends T>> sources) {
         return merge(Flowable.fromIterable(sources));
     }
@@ -699,8 +720,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the common and resulting value type
      * @param sources the Flowable sequence of MaybeSource sources
      * @return the new Flowable instance
-     * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> merge(Publisher<? extends MaybeSource<? extends T>> sources) {
         return merge(sources, Integer.MAX_VALUE);
     }
@@ -718,8 +740,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param sources the Flowable sequence of MaybeSource sources
      * @param maxConcurrency the maximum number of concurrently running MaybeSources
      * @return the new Flowable instance
-     * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> merge(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
         return RxJavaPlugins.onAssembly(new FlowableFlatMap(sources, MaybeToPublisher.instance(), false, maxConcurrency, Flowable.bufferSize()));
@@ -743,9 +766,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         by {@code source}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Maybe<T> merge(MaybeSource<? extends MaybeSource<? extends T>> source) {
-        return new MaybeFlatten(source, Functions.identity());
+        return RxJavaPlugins.onAssembly(new MaybeFlatten(source, Functions.identity()));
     }
 
     /**
@@ -770,6 +794,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             MaybeSource<? extends T> source1, MaybeSource<? extends T> source2
@@ -803,6 +829,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
@@ -840,6 +868,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
@@ -859,13 +889,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the common and resulting value type
      * @param sources the array sequence of MaybeSource sources
      * @return the new Flowable instance
-     * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> mergeArray(MaybeSource<? extends T>... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
@@ -895,7 +926,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -1125,6 +1156,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that never emits any items or sends any notifications to an {@link MaybeObserver}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Never</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Maybe<T> never() {
         return RxJavaPlugins.onAssembly((Maybe<T>)MaybeNever.INSTANCE);
@@ -1150,7 +1182,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Single that emits a Boolean value that indicates whether the two sequences are the same
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<Boolean> sequenceEqual(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate());
@@ -1179,7 +1210,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         are the same according to the specified function
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<Boolean> sequenceEqual(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
             BiPredicate<? super T, ? super T> isEqual) {
@@ -1202,7 +1232,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits one item after a specified delay
      * @see <a href="http://reactivex.io/documentation/operators/timer.html">ReactiveX operators documentation: Timer</a>
      */
-    @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public static Maybe<Long> timer(long delay, TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
@@ -1214,7 +1243,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -1226,7 +1255,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits one item after a specified delay, on a specified Scheduler
      * @see <a href="http://reactivex.io/documentation/operators/timer.html">ReactiveX operators documentation: Timer</a>
      */
-    @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static Maybe<Long> timer(long delay, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
@@ -1246,6 +1274,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param onSubscribe the function that is called with the subscribing MaybeObserver
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> unsafeCreate(MaybeSource<T> onSubscribe) {
         if (onSubscribe instanceof Maybe) {
             throw new IllegalArgumentException("unsafeCreate(Maybe) should be upgraded");
@@ -1253,7 +1282,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<T>(onSubscribe));
     }
-
 
     /**
      * Constructs a Maybe that creates a dependent resource object which is disposed of on unsubscription.
@@ -1330,6 +1358,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param source the source to wrap
      * @return the Maybe wrapper or the source cast to Maybe (if possible)
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> wrap(MaybeSource<T> source) {
         if (source instanceof Maybe) {
             return RxJavaPlugins.onAssembly((Maybe<T>)source);
@@ -1337,7 +1366,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         ObjectHelper.requireNonNull(source, "onSubscribe is null");
         return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<T>(source));
     }
-
 
     /**
      * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
@@ -1789,7 +1817,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code zipArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element type
@@ -1802,7 +1830,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Maybe<R> zipArray(Function<? super Object[], ? extends R> zipper,
             MaybeSource<? extends T>... sources) {
@@ -1824,7 +1851,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/amb.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code ambWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -1849,6 +1876,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * @return the success value
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingGet() {
         BlockingObserver<T> observer = new BlockingObserver<T>();
         subscribe(observer);
@@ -1865,6 +1893,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param defaultValue the default item to return if this Maybe is empty
      * @return the success value
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingGet(T defaultValue) {
         ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         BlockingObserver<T> observer = new BlockingObserver<T>();
@@ -1891,10 +1920,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         benefit of subsequent subscribers
      * @see <a href="http://reactivex.io/documentation/operators/replay.html">ReactiveX operators documentation: Replay</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> cache() {
-        return new MaybeCache<T>(this);
+        return RxJavaPlugins.onAssembly(new MaybeCache<T>(this));
     }
 
     /**
@@ -1907,8 +1935,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <U> the target type
      * @param clazz the type token to use for casting the success result from the current Maybe
      * @return the new Maybe instance
-     * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Maybe<U> cast(final Class<? extends U> clazz) {
         ObjectHelper.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
@@ -1933,6 +1961,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> compose(Function<? super Maybe<T>, ? extends MaybeSource<R>> transformer) {
         return wrap(to(transformer));
     }
@@ -1944,7 +1973,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>Note that flatMap and concatMap for Maybe is the same operation.
      * @param <R> the result value type
@@ -1953,6 +1982,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the Maybe returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> concatMap(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new MaybeFlatten<T, R>(this, mapper));
@@ -1968,7 +1998,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -2013,7 +2043,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/longCount.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code countLong} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code count} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return a Single that emits a single item: the number of items emitted by the source Publisher as a
@@ -2042,7 +2072,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         items, or the items emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/defaultifempty.html">ReactiveX operators documentation: DefaultIfEmpty</a>
      */
-    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> defaultIfEmpty(T defaultItem) {
         ObjectHelper.requireNonNull(defaultItem, "item is null");
@@ -2099,6 +2128,105 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Delays the emission of this Maybe until the given Publisher signals an item or completes.
+     * <p>
+     * <img width="640" height="450" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delay.oo.png" alt="">
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code delayIndicator} is consumed in an unbounded manner but is cancelled after
+     *  the first item it produces.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This version of {@code delay} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <U>
+     *            the subscription delay value type (ignored)
+     * @param <V>
+     *            the item delay value type (ignored)
+     * @param delayIndicator
+     *            the Publisher that gets subscribed to when this Maybe signals an event and that
+     *            signal is emitted when the Publisher signals an item or completes
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    public final <U, V> Maybe<T> delay(Publisher<U> delayIndicator) {
+        return RxJavaPlugins.onAssembly(new MaybeDelayOtherPublisher<T, U>(this, delayIndicator));
+    }
+
+    /**
+     * Returns a Maybe that delays the subscription to this Maybe
+     * until the other Publisher emits an element or completes normally.
+     * <p>
+     * <dl>
+     *  <dt><b></b><dt>
+     *  <dd>The {@code Publisher} source is consumed in an unbounded fashion (without applying backpressure).
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <U> the value type of the other Publisher, irrelevant
+     * @param subscriptionIndicator the other Publisher that should trigger the subscription
+     *        to this Publisher.
+     * @return a Maybe that delays the subscription to this Maybe
+     *         until the other Publisher emits an element or completes normally.
+     */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <U> Maybe<T> delaySubscription(Publisher<U> subscriptionIndicator) {
+        ObjectHelper.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
+        return RxJavaPlugins.onAssembly(new MaybeDelaySubscriptionOtherPublisher<T, U>(this, subscriptionIndicator));
+    }
+
+    /**
+     * Returns a Maybe that delays the subscription to the source Maybe by a given amount of time.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delaySubscription.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param delay
+     *            the time to delay the subscription
+     * @param unit
+     *            the time unit of {@code delay}
+     * @return a Maybe that delays the subscription to the source Maybe by the given amount
+     * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
+     */
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Maybe<T> delaySubscription(long delay, TimeUnit unit) {
+        return delaySubscription(delay, unit, Schedulers.computation());
+    }
+
+    /**
+     * Returns a Maybe that delays the subscription to the source Maybe by a given amount of time,
+     * both waiting and subscribing on a given Scheduler.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delaySubscription.s.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
+     * </dl>
+     *
+     * @param delay
+     *            the time to delay the subscription
+     * @param unit
+     *            the time unit of {@code delay}
+     * @param scheduler
+     *            the Scheduler on which the waiting and subscription will happen
+     * @return a Maybe that delays the subscription to the source Maybe by a given
+     *         amount, waiting and subscribing on the given Scheduler
+     * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
+     */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final Maybe<T> delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
+        return delaySubscription(Flowable.timer(delay, unit, scheduler));
+    }
+
+    /**
      * Registers an {@link Action} to be called when this Maybe invokes either
      * {@link MaybeObserver#onComplete onSuccess},
      * {@link MaybeObserver#onComplete onComplete} or {@link MaybeObserver#onError onError}.
@@ -2132,11 +2260,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * disposes the common Disposable it received via onSubscribe.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onDispose the runnable called when the subscription is cancelled (disposed)
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> doOnDispose(Action onDispose) {
         return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
                 Functions.emptyConsumer(), // onSubscribe
@@ -2179,11 +2308,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * MaybeObserver that subscribes to the current Single.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onError the consumer called with the success value of onError
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> doOnError(Consumer<? super Throwable> onError) {
         return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
                 Functions.emptyConsumer(), // onSubscribe
@@ -2209,6 +2339,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param onEvent the callback to call with the terminal event tuple
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> doOnEvent(BiConsumer<? super T, ? super Throwable> onEvent) {
         ObjectHelper.requireNonNull(onEvent, "onEvent is null");
         return RxJavaPlugins.onAssembly(new MaybeDoOnEvent<T>(this, onEvent));
@@ -2224,6 +2355,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param onSubscribe the consumer called with the Disposable sent via onSubscribe
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> doOnSubscribe(Consumer<? super Disposable> onSubscribe) {
         return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
                 ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null"),
@@ -2240,11 +2372,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * MaybeObserver that subscribes to the current Single.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onSuccess the consumer called with the success value of onSuccess
      * @return the new Maybe instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> doOnSuccess(Consumer<? super T> onSuccess) {
         return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
                 Functions.emptyConsumer(), // onSubscribe
@@ -2296,6 +2429,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the Maybe returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> flatMap(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new MaybeFlatten<T, R>(this, mapper));
@@ -2330,7 +2464,35 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         ObjectHelper.requireNonNull(onSuccessMapper, "onSuccessMapper is null");
         ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
         ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return new MaybeFlatMapNotification<T, R>(this, onSuccessMapper, onErrorMapper, onCompleteSupplier);
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapNotification<T, R>(this, onSuccessMapper, onErrorMapper, onCompleteSupplier));
+    }
+
+    /**
+     * Returns a Maybe that emits the results of a specified function to the pair of values emitted by the
+     * source Maybe and a specified mapped MaybeSource.
+     * <p>
+     * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <U>
+     *            the type of items emitted by the collection Publisher
+     * @param <R>
+     *            the type of items emitted by the resulting Publisher
+     * @param mapper
+     *            a function that returns a Publisher for each item emitted by the source Publisher
+     * @param resultSelector
+     *            a function that combines one item emitted by each of the source and collection Publishers and
+     *            returns an item to be emitted by the resulting Publisher
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <U, R> Maybe<R> flatMap(Function<? super T, ? extends MaybeSource<? extends U>> mapper,
+            BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapBiSelector<T, U, R>(this, mapper, resultSelector));
     }
 
     /**
@@ -2340,7 +2502,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code flatMapObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the result value type
@@ -2349,6 +2511,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the Observable returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMapObservable(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return toObservable().flatMap(mapper);
     }
@@ -2359,8 +2522,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapObservable.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned Flowable honors the downstream backpressure.</dd>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code flatMapObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code flatMapPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the result value type
@@ -2370,6 +2535,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the Flowable returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return toFlowable().flatMap(mapper);
     }
@@ -2389,11 +2556,26 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            Completable
      * @return the Completable returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable flatMapCompletable(final Function<? super T, ? extends Completable> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new MaybeFlatMapCompletable<T>(this, mapper));
+    }
+
+    /**
+     * Hides the identity of this Maybe and its Disposable.
+     * <p>Allows preventing certain identity-based
+     * optimizations (fusion).
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code hide} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new Maybe instance
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> hide() {
+        return RxJavaPlugins.onAssembly(new MaybeHide<T>(this));
     }
 
     /**
@@ -2414,6 +2596,22 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         return RxJavaPlugins.onAssembly(new MaybeIgnoreElement<T>(this));
     }
 
+    /**
+     * Returns a Single that emits {@code true} if the source Maybe is empty, otherwise {@code false}.
+     * <p>
+     * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/isEmpty.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code isEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return a Single that emits a Boolean
+     * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Single<Boolean> isEmpty() {
+        return RxJavaPlugins.onAssembly(new MaybeIsEmptySingle<T>(this));
+    }
 
     /**
      * Lifts a function to the current Maybe and returns a new Maybe that when subscribed to will pass the
@@ -2438,6 +2636,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that is the result of applying the lifted Operator to the source Maybe
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> lift(final MaybeOperator<? extends R, ? super T> lift) {
         ObjectHelper.requireNonNull(lift, "onLift is null");
         return RxJavaPlugins.onAssembly(new MaybeLift<T, R>(this, lift));
@@ -2459,11 +2658,38 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the item from the source Maybe, transformed by the specified function
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> map(Function<? super T, ? extends R> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new MaybeMap<T, R>(this, mapper));
     }
 
+    /**
+     * Flattens this and another Maybe into a single Flowable, without any transformation.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Maybes so that they appear as a single Flowable, by
+     * using the {@code mergeWith} method.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. This and the other {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            a MaybeSource to be merged
+     * @return a new Flowable instance
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> mergeWith(MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return merge(this, other);
+    }
 
     /**
      * Wraps a Maybe to emit its item (or notify of its error) on a specified {@link Scheduler},
@@ -2483,10 +2709,34 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Maybe<T> observeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new MaybeObserveOn<T>(this, scheduler));
     }
+
+    /**
+     * Filters the items emitted by a Maybe, only emitting its success value if that
+     * is an instance of the supplied Class.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ofClass.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code ofType} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <U> the output type
+     * @param clazz
+     *            the class type to filter the items emitted by the source Maybe
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/filter.html">ReactiveX operators documentation: Filter</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <U> Maybe<U> ofType(final Class<U> clazz) {
+        ObjectHelper.requireNonNull(clazz, "clazz is null");
+        return filter(Functions.isInstanceOf(clazz)).cast(clazz);
+    }
+
     /**
      * Calls the specified converter function with the current Maybe instance
      * during assembly time and returns its result.
@@ -2500,6 +2750,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @return the value returned by the convert function
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R to(Function<? super Maybe<T>, R> convert) {
         try {
             return convert.apply(this);
@@ -2514,10 +2765,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * through and dropping a success value if emitted.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new Completable instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable toCompletable() {
         return RxJavaPlugins.onAssembly(new MaybeToCompletable<T>(this));
     }
@@ -2526,11 +2778,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Converts this Maybe into a backpressure-aware Flowable instance composing cancellation
      * through.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned Flowable honors the backpressure of the downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new Flowable instance
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> toFlowable() {
         return RxJavaPlugins.onAssembly(new MaybeToFlowable<T>(this));
     }
@@ -2540,10 +2796,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * through.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new Observable instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> toObservable() {
         return RxJavaPlugins.onAssembly(new MaybeToObservable<T>(this));
     }
@@ -2553,11 +2810,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * through and turing an empty Maybe into a signal of NoSuchElementException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param defaultValue the default item to signal in Single if this Maybe is empty
      * @return the new Single instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle(T defaultValue) {
         ObjectHelper.requireNonNull(defaultValue, "defaultValue is null");
         return RxJavaPlugins.onAssembly(new MaybeToSingle<T>(this, defaultValue));
@@ -2568,12 +2826,172 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * through and turing an empty Maybe into a signal of NoSuchElementException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new Single instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> toSingle() {
         return RxJavaPlugins.onAssembly(new MaybeToSingle<T>(this, null));
+    }
+
+    /**
+     * Returns a Maybe instance that if this Maybe emits an error, it will emit an onComplete
+     * and swallow the throwable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new Completable instance
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorComplete() {
+        return onErrorComplete(Functions.alwaysTrue());
+    }
+
+    /**
+     * Returns a Maybe instance that if this Maybe emits an error and the predicate returns
+     * true, it will emit an onComplete and swallow the throwable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param predicate the predicate to call when an Throwable is emitted which should return true
+     * if the Throwable should be swallowed and replaced with an onComplete.
+     * @return the new Completable instance
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorComplete(final Predicate<? super Throwable> predicate) {
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
+
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorComplete<T>(this, predicate));
+    }
+
+    /**
+     * Instructs a Maybe to pass control to another MaybeSource rather than invoking
+     * {@link MaybeObserver#onError onError} if it encounters an error.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param next
+     *            the next Maybe source that will take over if the source Maybe encounters
+     *            an error
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorResumeNext(final MaybeSource<? extends T> next) {
+        ObjectHelper.requireNonNull(next, "next is null");
+        return onErrorResumeNext(Functions.justFunction(next));
+    }
+
+    /**
+     * Instructs a Maybe to pass control to another Maybe rather than invoking
+     * {@link MaybeObserver#onError onError} if it encounters an error.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param resumeFunction
+     *            a function that returns a MaybeSource that will take over if the source Maybe encounters
+     *            an error
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorResumeNext(Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
+        ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<T>(this, resumeFunction, true));
+    }
+
+    /**
+     * Instructs a Maybe to emit an item (returned by a specified function) rather than invoking
+     * {@link MaybeObserver#onError onError} if it encounters an error.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorReturn.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param valueSupplier
+     *            a function that returns a single value that will be emitted as success value
+     *            the current Maybe signals an onError event
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
+        ObjectHelper.requireNonNull(valueSupplier, "valueSupplier is null");
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorReturn<T>(this, valueSupplier));
+    }
+
+    /**
+     * Instructs a Maybe to emit an item (returned by a specified function) rather than invoking
+     * {@link MaybeObserver#onError onError} if it encounters an error.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorReturn.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param item
+     *            the value that is emitted as onSuccess in case this Maybe signals an onError
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorReturnItem(final T item) {
+        ObjectHelper.requireNonNull(item, "item is null");
+        return onErrorReturn(Functions.justFunction(item));
+    }
+
+    /**
+     * Instructs a Maybe to pass control to another MaybeSource rather than invoking
+     * {@link MaybeObserver#onError onError} if it encounters an {@link java.lang.Exception}.
+     * <p>
+     * This differs from {@link #onErrorResumeNext} in that this one does not handle {@link java.lang.Throwable}
+     * or {@link java.lang.Error} but lets those continue through.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onExceptionResumeNextViaPublisher.png" alt="">
+     * <p>
+     * You can use this to prevent exceptions from propagating or to supply fallback data should exceptions be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onExceptionResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param next
+     *            the next MaybeSource that will take over if the source Maybe encounters
+     *            an exception
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onExceptionResumeNext(final MaybeSource<? extends T> next) {
+        ObjectHelper.requireNonNull(next, "next is null");
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<T>(this, Functions.justFunction(next), false));
     }
 
     /**
@@ -2673,6 +3091,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
 
 
+    @SchedulerSupport(SchedulerSupport.NONE)
     @Override
     public final void subscribe(MaybeObserver<? super T> observer) {
         ObjectHelper.requireNonNull(observer, "observer is null");
@@ -2715,6 +3134,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #observeOn
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Maybe<T> subscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new MaybeSubscribeOn<T>(this, scheduler));
@@ -2734,11 +3154,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * composite.add(source.subscribeWith(ms));
      * </code></pre>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <E> the type of the MaybeObserver to use and return
      * @param observer the MaybeObserver (subclass) to use and return, not null
      * @return the input {@code subscriber}
      * @throws NullPointerException if {@code subscriber} is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E extends MaybeObserver<? super T>> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
@@ -2804,8 +3229,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Creates a TestSubscriber and subscribes
      * it to this Maybe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new TestSubscriber instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test() {
         TestSubscriber<T> ts = new TestSubscriber<T>();
         toFlowable().subscribe(ts);
@@ -2814,10 +3244,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Creates a TestSubscriber optionally in cancelled state, then subscribes it to this Maybe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
      * Maybe.
      * @return the new TestSubscriber instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test(boolean cancelled) {
         TestSubscriber<T> ts = new TestSubscriber<T>();
 

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -77,6 +77,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         emitted an item or sent a termination notification
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> amb(Iterable<? extends ObservableSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableAmb<T>(null, sources));
@@ -89,7 +90,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/amb.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code ambArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element type
@@ -672,7 +673,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -705,7 +706,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -740,7 +741,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -782,7 +783,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -815,7 +816,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -1001,6 +1002,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Concatenates a variable number of ObservableSource sources.
      * <p>
      * Note: named this way because of overload conflict with concat(ObservableSource&lt;ObservableSource&gt;)
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
      * @return the new Observable instance
@@ -1025,7 +1030,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
@@ -1265,6 +1270,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * You should call the ObservableEmitter's onNext, onError and onComplete methods in a serialized fashion. The
      * rest of its methods are thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @param <T> the element type
      * @param source the emitter that is called when an Observer subscribes to the returned {@code Observable}
@@ -1385,7 +1394,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param items
@@ -1450,7 +1459,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * cancellation effect: {@code futureObservableSource.doOnCancel(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -1482,7 +1491,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <em>Important note:</em> This ObservableSource is blocking; you cannot unsubscribe from it.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -1519,7 +1528,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <em>Important note:</em> This ObservableSource is blocking; you cannot unsubscribe from it.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param future
@@ -1557,7 +1566,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * cancellation effect: {@code futureObservableSource.doOnCancel(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param future
@@ -1584,7 +1593,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code from} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param source
@@ -1595,6 +1604,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item in the source {@link Iterable} sequence
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromIterable(Iterable<? extends T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new ObservableFromIterable<T>(source));
@@ -1603,6 +1613,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Converts an arbitrary Reactive-Streams Publisher into an Observable.
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The source {@code publisher} is consumed in an unbounded fashion without applying any
+     *  backpressure to it.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1611,6 +1624,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      * @throws NullPointerException if publisher is null
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromPublisher(Publisher<? extends T> publisher) {
         ObjectHelper.requireNonNull(publisher, "publisher is null");
         return RxJavaPlugins.onAssembly(new ObservableFromPublisher<T>(publisher));
@@ -1621,7 +1636,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code generator} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code generate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the generated value type
@@ -1774,7 +1789,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.ps.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param initialDelay
@@ -1826,7 +1841,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/interval.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param period
@@ -2322,7 +2337,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * using the {@code merge} method.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -2419,6 +2434,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         {@code source} ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, Integer.MAX_VALUE, bufferSize()));
@@ -2560,7 +2576,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * using the {@code merge} method.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -2656,7 +2672,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * invoke the {@code onError} method of its Observers once.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -2734,6 +2750,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         {@code source} ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, Integer.MAX_VALUE, bufferSize()));
@@ -2904,7 +2921,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * invoke the {@code onError} method of its Observers once.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
@@ -3173,7 +3190,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * or wrapped into a CompositeException along with the other possible errors the former inner ObservableSources signalled.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the item type
@@ -3205,7 +3222,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * or wrapped into a CompositeException along with the other possible errors the former inner ObservableSources signalled.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the item type
@@ -3254,7 +3271,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -3363,7 +3380,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code wrap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the value type
@@ -4138,7 +4155,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code zipArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element type
@@ -4198,7 +4215,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code zipIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      *
@@ -4259,7 +4276,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/amb.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code ambWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -4286,7 +4303,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * idioms.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code exists} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code any} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param predicate
@@ -4314,6 +4331,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             if this {@code Observable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst() {
         BlockingFirstObserver<T> s = new BlockingFirstObserver<T>();
         subscribe(s);
@@ -4338,6 +4356,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst(T defaultItem) {
         BlockingFirstObserver<T> s = new BlockingFirstObserver<T>();
         subscribe(s);
@@ -4372,6 +4391,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX documentation: Subscribe</a>
      * @see #subscribe(Consumer)
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingForEach(Consumer<? super T> onNext) {
         Iterator<T> it = blockingIterable().iterator();
         while (it.hasNext()) {
@@ -4397,6 +4417,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an {@link Iterable} version of this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingIterable() {
         return blockingIterable(bufferSize());
     }
@@ -4414,6 +4435,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an {@link Iterable} version of this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingIterable(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return new BlockingObservableIterable<T>(this, bufferSize);
@@ -4434,6 +4456,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             if this {@code Observable} emits no items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast() {
         BlockingLastObserver<T> s = new BlockingLastObserver<T>();
         subscribe(s);
@@ -4460,6 +4483,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX documentation: Last</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast(T defaultItem) {
         BlockingLastObserver<T> s = new BlockingLastObserver<T>();
         subscribe(s);
@@ -4484,6 +4508,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Iterable that always returns the latest item emitted by this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingLatest() {
         return BlockingObservableLatest.latest(this);
     }
@@ -4505,6 +4530,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         has most recently emitted
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingMostRecent(T initialValue) {
         return BlockingObservableMostRecent.mostRecent(this, initialValue);
     }
@@ -4523,6 +4549,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         a new item, whereupon the Iterable returns that item
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX documentation: TakeLast</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingNext() {
         return BlockingObservableNext.next(this);
     }
@@ -4540,6 +4567,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the single item emitted by this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingSingle() {
         return single().blockingFirst();
     }
@@ -4561,6 +4589,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         items
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX documentation: First</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingSingle(T defaultItem) {
         return single(defaultItem).blockingFirst();
     }
@@ -4583,6 +4612,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a {@link Future} that expects a single item to be emitted by this {@code Observable}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Future<T> toFuture() {
         return subscribeWith(new FutureObserver<T>());
     }
@@ -4595,6 +4625,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe() {
         ObservableBlockingSubscribe.subscribe(this);
     }
@@ -4608,6 +4639,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onNext the callback action for each source value
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext) {
         ObservableBlockingSubscribe.subscribe(this, onNext, Functions.ERROR_CONSUMER, Functions.EMPTY_ACTION);
     }
@@ -4622,6 +4654,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onError the callback action for an error event
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
         ObservableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION);
     }
@@ -4638,6 +4671,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onComplete the callback action for the completion event.
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
         ObservableBlockingSubscribe.subscribe(this, onNext, onError, onComplete);
     }
@@ -4653,6 +4687,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Observer<? super T> subscriber) {
         ObservableBlockingSubscribe.subscribe(this, subscriber);
     }
@@ -4806,7 +4841,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer7.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -4836,7 +4871,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer7.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <U> the collection subclass type to buffer into
@@ -4930,7 +4965,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer6.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -4963,7 +4998,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer6.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <U> the collection subclass type to buffer into
@@ -5009,7 +5044,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer5.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -5334,7 +5369,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </code></pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code cacheWithInitialCapacity} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>
      * <em>Note:</em> The capacity hint is not an upper bound on cache size. For that, consider
@@ -5412,7 +5447,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * This is a simplified version of {@code reduce} that does not need to return the state on each pass.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code collect} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code collectInto} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <U> the accumulator and output type
@@ -5450,6 +5485,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the source ObservableSource, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> compose(Function<? super Observable<T>, ? extends ObservableSource<R>> composer) {
         return wrap(to(composer));
     }
@@ -5734,7 +5770,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -5778,7 +5814,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/longCount.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code countLong} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code count} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return an Observable that emits a single item: the number of items emitted by the source ObservableSource as a
@@ -5871,7 +5907,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </ul>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -5999,7 +6035,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delay.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -6023,7 +6059,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delay.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -6096,6 +6132,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         until the other Observable emits an element or completes normally.
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> delaySubscription(ObservableSource<U> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<T, U>(this, other));
@@ -6107,7 +6144,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delaySubscription.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This version of {@code delay} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      *
      * @param delay
@@ -6129,7 +6166,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delaySubscription.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param delay
@@ -6478,7 +6515,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnNext.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code doOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code doOnLifecycle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onSubscribe
@@ -6598,7 +6635,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/elementAtOrDefault.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code elementAtOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code elementAt} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param index
@@ -6668,7 +6705,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstOrDefault.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code firstOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code first} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultItem
@@ -6730,6 +6767,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         transformation
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors) {
         return flatMap(mapper, delayErrors, Integer.MAX_VALUE);
     }
@@ -7196,7 +7234,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * onNext Predicate returns false.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code forEach} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code forEachWhile} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onNext
@@ -7219,7 +7257,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * onNext Predicate returns false.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code forEach} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code forEachWhile} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onNext
@@ -7243,7 +7281,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * onNext Predicate returns false.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code forEach} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code forEachWhile} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onNext
@@ -7631,7 +7669,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastOrDefault.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code lastOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code last} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultItem
@@ -7671,6 +7709,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that is the result of applying the lifted Operator to the source ObservableSource
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> lift(ObservableOperator<? extends R, ? super T> lifter) {
         ObjectHelper.requireNonNull(lifter, "onLift is null");
         return RxJavaPlugins.onAssembly(new ObservableLift<R, T>(this, lifter));
@@ -7693,6 +7732,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         function
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> map(Function<? super T, ? extends R> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableMap<T, R>(this, mapper));
@@ -7750,7 +7790,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -7775,7 +7815,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -7804,7 +7844,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -7969,7 +8009,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * encountered.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param item
@@ -8237,7 +8277,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </code></pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code reduce} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code reduceWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the accumulator and output value type
@@ -8310,7 +8350,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param stop
@@ -8468,7 +8508,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="445" height="440" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.fnts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -8508,7 +8548,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="440" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.fns.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -8569,7 +8609,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="440" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.fts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -8603,7 +8643,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="445" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.fs.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param <R>
@@ -8686,7 +8726,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.nts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param bufferSize
@@ -8721,7 +8761,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.ns.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param bufferSize
@@ -8771,7 +8811,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -8800,7 +8840,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -8935,7 +8975,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Retries until the given stop function returns true.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code retryUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param stop the function that should return true to stop retrying
      * @return the new Observable instance
@@ -9008,7 +9048,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Reactive-Streams specification).
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code safeSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param s the incoming Subscriber instance
      * @throws NullPointerException if s is null
@@ -9054,7 +9094,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param period
@@ -9203,7 +9243,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </code></pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code scan} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code scanWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the initial, accumulator and result type
@@ -9302,7 +9342,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleOrDefault.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code singleOrDefault} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code single} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param defaultItem
@@ -9349,6 +9389,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/skip.t.png" alt="">
      * <dl>
+     *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code skip} does not operate on any particular scheduler but uses the current time
      *  from the {@code computation} {@link Scheduler}.</dd>
      * </dl>
@@ -9361,7 +9402,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         by {@code time} elapses and the emits the remainder
      * @see <a href="http://reactivex.io/documentation/operators/skip.html">ReactiveX operators documentation: Skip</a>
      */
-    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<T> skip(long time, TimeUnit unit) {
         return skipUntil(timer(time, unit));
     }
@@ -9373,7 +9414,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/skip.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for the timed skipping</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for the timed skipping</dd>
      * </dl>
      *
      * @param time
@@ -9488,7 +9529,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for tracking the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
      * </dl>
      *
      * @param time
@@ -9515,7 +9556,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use to track the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use to track the current time</dd>
      * </dl>
      *
      * @param time
@@ -9545,7 +9586,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -9637,6 +9678,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             all other items emitted by the ObservableSource
      * @return an Observable that emits the items emitted by the source ObservableSource in sorted order
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> sorted(){
         return toSortedList().flatMapIterable(Functions.<List<T>>identity());
     }
@@ -9658,6 +9700,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            that indicates their sort order
      * @return an Observable that emits the items emitted by the source ObservableSource in sorted order
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> sorted(Comparator<? super T> sortFunction) {
         return toSortedList(sortFunction).flatMapIterable(Functions.<List<T>>identity());
     }
@@ -9737,7 +9780,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/startWith.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code startWithArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param items
@@ -9892,6 +9935,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         return ls;
     }
 
+    @SchedulerSupport(SchedulerSupport.NONE)
     @Override
     public final void subscribe(Observer<? super T> observer) {
         ObjectHelper.requireNonNull(observer, "s is null");
@@ -9938,12 +9982,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * composite.add(source.subscribeWith(rs));
      * </code></pre>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <E> the type of the Observer to use and return
      * @param observer the Observer (subclass) to use and return, not null
      * @return the input {@code observer}
      * @throws NullPointerException if {@code observer} is null
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E extends Observer<? super T>> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
@@ -9955,7 +10004,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/subscribeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -10069,7 +10118,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the element type of the inner ObservableSources and the output
@@ -10080,6 +10129,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return switchMapDelayError(mapper, bufferSize());
     }
@@ -10096,7 +10146,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the element type of the inner ObservableSources and the output
@@ -10109,6 +10159,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -10180,7 +10231,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/take.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -10193,7 +10244,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         according to the specified Scheduler
      * @see <a href="http://reactivex.io/documentation/operators/take.html">ReactiveX operators documentation: Take</a>
      */
-    @SchedulerSupport(SchedulerSupport.NONE)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> take(long time, TimeUnit unit, Scheduler scheduler) {
         return takeUntil(timer(time, unit, scheduler));
     }
@@ -10286,7 +10337,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeLast.tns.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for tracking the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
      * </dl>
      *
      * @param count
@@ -10317,7 +10368,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeLast.tns.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use for tracking the current time</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
      * </dl>
      *
      * @param count
@@ -10408,7 +10459,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeLast.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -10435,7 +10486,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeLast.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -10465,7 +10516,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeLast.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param time
@@ -10599,7 +10650,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleFirst.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param skipDuration
@@ -10656,7 +10707,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLast.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param intervalDuration
@@ -10731,7 +10782,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </ul>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -10956,7 +11007,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -10986,7 +11037,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.1s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timeout
@@ -11031,6 +11082,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         the time windows specified by the timeout selectors
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Observable<T> timeout(Callable<? extends ObservableSource<U>> firstTimeoutSelector,
             Function<? super T, ? extends ObservableSource<V>> timeoutSelector) {
         ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
@@ -11119,7 +11171,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timestamp.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>The operator does not operate on any particular scheduler but uses the current time
+     *  <dd>This operator does not operate on any particular scheduler but uses the current time
      *  from the specified {@link Scheduler}.</dd>
      * </dl>
      *
@@ -11161,7 +11213,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timestamp.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>The operator does not operate on any particular scheduler but uses the current time
+     *  <dd>This operator does not operate on any particular scheduler but uses the current time
      *  from the specified {@link Scheduler}.</dd>
      * </dl>
      *
@@ -11183,10 +11235,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Calls the specified converter function during assembly time and returns its resulting value.
      * <p>
      * This allows fluent conversion to any other type.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <R> the resulting object type
      * @param converter the function that receives the current Observable instance and returns a value
      * @return the value returned by the function
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R to(Function<? super Observable<T>, R> converter) {
         try {
             return converter.apply(this);
@@ -11404,7 +11461,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMultiMap.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -11431,7 +11488,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMultiMap.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -11459,7 +11516,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMultiMap.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -11497,7 +11554,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMultiMap.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toMultiMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toMultimap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <K> the key type of the Map
@@ -11527,12 +11584,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator applies the chosen backpressure strategy of {@link BackpressureStrategy} enum.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param strategy the backpressure strategy to apply
      * @return the new Observable instance
      */
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> toFlowable(BackpressureStrategy strategy) {
         Flowable<T> o = new FlowableFromObservable<T>(this);
 
@@ -11556,7 +11615,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Maybe instance
      * @since 2.0
      */
-    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> toMaybe() {
         return new MaybeFromObservable<T>(this);
@@ -11706,7 +11764,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@link Scheduler}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -11841,7 +11899,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window7.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -11870,7 +11928,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window7.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -11995,7 +12053,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="375" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window5.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -12025,7 +12083,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -12058,7 +12116,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -12093,7 +12151,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use</dd>
+     *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param timespan
@@ -12351,6 +12409,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T1, T2, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2,
             Function3<? super T, ? super T1, ? super T2, R> combiner) {
@@ -12386,6 +12445,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T1, T2, T3, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2,
             ObservableSource<T3> o3,
@@ -12425,6 +12485,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <T1, T2, T3, T4, R> Observable<R> withLatestFrom(
             ObservableSource<T1> o1, ObservableSource<T2> o2,
             ObservableSource<T3> o3, ObservableSource<T4> o4,
@@ -12458,6 +12519,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
@@ -12484,6 +12546,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> withLatestFrom(Iterable<? extends ObservableSource<?>> others, Function<? super Object[], R> combiner) {
         ObjectHelper.requireNonNull(others, "others is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
@@ -12526,7 +12589,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Returns an Observable that emits items that are the result of applying a specified function to pairs of
      * values, one each from the source ObservableSource and another specified ObservableSource.
-     * <p>
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
      * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
@@ -12664,9 +12726,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Creates a TestObserver and subscribes
      * it to this Observable.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new TestObserver instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test() { // NoPMD
         TestObserver<T> ts = new TestObserver<T>();
         subscribe(ts);
@@ -12676,10 +12743,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Creates a TestObserver, optionally disposes it and then subscribes
      * it to this Observable.
+     * 
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param dispose dispose the TestObserver before it is subscribed to this Observable?
      * @return the new TestObserver instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test(boolean dispose) { // NoPMD
         TestObserver<T> ts = new TestObserver<T>();
         if (dispose) {

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -17,12 +17,12 @@ import java.util.concurrent.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.annotations.SchedulerSupport;
+import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
-import io.reactivex.internal.fuseable.FuseToFlowable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.observers.*;
 import io.reactivex.internal.operators.completable.*;
 import io.reactivex.internal.operators.flowable.*;
@@ -70,6 +70,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> amb(final Iterable<? extends SingleSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new SingleAmbIterable<T>(sources));
@@ -80,13 +81,14 @@ public abstract class Single<T> implements SingleSource<T> {
      * the rest).
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code ambArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param sources the array of sources
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Single<T> ambArray(final SingleSource<? extends T>... sources) {
         if (sources.length == 0) {
@@ -110,6 +112,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     public static <T> Flowable<T> concat(Iterable<? extends SingleSource<? extends T>> sources) {
         return concat(Flowable.fromIterable(sources));
     }
@@ -126,6 +130,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> concat(Observable<? extends SingleSource<? extends T>> sources) {
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, SingleInternalHelper.toObservable(), 2, ErrorMode.IMMEDIATE));
@@ -143,6 +148,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources) {
         return concat(sources, 2);
     }
@@ -160,6 +167,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources, int prefetch) {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -183,6 +192,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits items emitted by the two source Singles, one after the other.
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2
@@ -211,6 +222,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits items emitted by the three source Singles, one after the other.
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2,
@@ -243,6 +256,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits items emitted by the four source Singles, one after the other.
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2,
@@ -260,13 +275,15 @@ public abstract class Single<T> implements SingleSource<T> {
      * an array.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param sources the array of SingleSource instances
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> concatArray(SingleSource<? extends T>... sources) {
         return RxJavaPlugins.onAssembly(new FlowableConcatMap(Flowable.fromArray(sources), SingleInternalHelper.toFlowable(), 2, ErrorMode.BOUNDARY));
@@ -307,6 +324,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see SingleOnSubscribe
      * @see Cancellable
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> create(SingleOnSubscribe<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new SingleCreate<T>(source));
@@ -324,6 +342,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * returns a SingleSource instance to subscribe to
      * @return the new Single instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> defer(final Callable<? extends SingleSource<? extends T>> singleSupplier) {
         ObjectHelper.requireNonNull(singleSupplier, "singleSupplier is null");
         return RxJavaPlugins.onAssembly(new SingleDefer<T>(singleSupplier));
@@ -333,13 +352,14 @@ public abstract class Single<T> implements SingleSource<T> {
      * Signals a Throwable returned by the callback function for each individual SingleObserver.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param errorSupplier the callable that is called for each individual SingleObserver and
      * returns a Throwable instance to be emitted.
      * @return the new Single instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> error(final Callable<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new SingleError<T>(errorSupplier));
@@ -363,6 +383,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *         the subscriber subscribes to it
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> error(final Throwable exception) {
         ObjectHelper.requireNonNull(exception, "error is null");
         return error(Functions.justCallable(exception));
@@ -385,6 +406,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *         the type of the item emitted by the {@link Single}.
      * @return a {@link Single} whose {@link Observer}s' subscriptions trigger an invocation of the given function.
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromCallable(final Callable<? extends T> callable) {
         ObjectHelper.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new SingleFromCallable<T>(callable));
@@ -413,6 +435,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromFuture(Future<? extends T> future) {
         return Flowable.<T>fromFuture(future).toSingle();
     }
@@ -444,6 +467,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
         return Flowable.<T>fromFuture(future, timeout, unit).toSingle();
     }
@@ -477,6 +501,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
         return Flowable.<T>fromFuture(future, timeout, unit, scheduler).toSingle();
     }
@@ -491,7 +516,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * {@code from} method.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param future
@@ -505,6 +530,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@code Single} that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Single<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
         return Flowable.<T>fromFuture(future, scheduler).toSingle();
     }
@@ -514,13 +540,18 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>If the source Publisher is empty, a NoSuchElementException is signalled. If
      * the source has more than one element, an IndexOutOfBoundsException is signalled.
      * <dl>
+     * <dt><b>Backpressure:</b></dt>
+     * <dd>The {@code publisher} is consumed in an unbounded fashion but will be cancelled
+     * if it produced more than one item.</dd>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code fromPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param publisher the source Publisher instance, not null
      * @return the new Single instance
      */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromPublisher(final Publisher<? extends T> publisher) {
         ObjectHelper.requireNonNull(publisher, "publisher is null");
         return RxJavaPlugins.onAssembly(new SingleFromPublisher<T>(publisher));
@@ -545,6 +576,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@code Single} that emits {@code item}
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> just(final T item) {
         ObjectHelper.requireNonNull(item, "value is null");
         return RxJavaPlugins.onAssembly(new SingleJust<T>(item));
@@ -562,6 +594,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> merge(Iterable<? extends SingleSource<? extends T>> sources) {
         return merge(Flowable.fromIterable(sources));
     }
@@ -578,6 +612,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> merge(Publisher<? extends SingleSource<? extends T>> sources) {
         return RxJavaPlugins.onAssembly(new FlowableFlatMap(sources, SingleInternalHelper.toFlowable(), false, Integer.MAX_VALUE, Flowable.bufferSize()));
@@ -601,6 +637,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *         by {@code source}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Single<T> merge(SingleSource<? extends SingleSource<? extends T>> source) {
         ObjectHelper.requireNonNull(source, "source is null");
@@ -627,6 +664,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2
@@ -658,6 +697,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2,
@@ -693,6 +734,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2,
@@ -715,6 +758,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the singleton never instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T> Single<T> never() {
         return RxJavaPlugins.onAssembly((Single<T>) SingleNever.INSTANCE);
@@ -724,13 +768,14 @@ public abstract class Single<T> implements SingleSource<T> {
      * Signals success with 0L value after the given delay for each SingleObserver.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code never} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * <dd>{@code timer} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      * @param delay the delay amount
      * @param unit the time unit of the delay
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public static Single<Long> timer(long delay, TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
@@ -747,6 +792,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static Single<Long> timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
@@ -765,6 +811,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<Boolean> equals(final SingleSource<? extends T> first, final SingleSource<? extends T> second) { // NOPMD
         ObjectHelper.requireNonNull(first, "first is null");
         ObjectHelper.requireNonNull(second, "second is null");
@@ -786,6 +833,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * instead.
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> unsafeCreate(SingleSource<T> onSubscribe) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         if (onSubscribe instanceof Single) {
@@ -813,6 +861,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, U> Single<T> using(Callable<U> resourceSupplier,
                                          Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
                                          Consumer<? super U> disposer) {
@@ -841,6 +890,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, U> Single<T> using(
             final Callable<U> resourceSupplier,
             final Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
@@ -864,6 +914,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param source the source to wrap
      * @return the Single wrapper or the source cast to Single (if possible)
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> wrap(SingleSource<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Single) {
@@ -898,6 +949,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Single<R> zip(final Iterable<? extends SingleSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return Flowable.zipIterable(SingleInternalHelper.iterableToFlowable(sources), zipper, false, 1).toSingle();
@@ -926,6 +978,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -962,6 +1015,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1003,6 +1057,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1048,6 +1103,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1098,6 +1154,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1152,6 +1209,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1211,6 +1269,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1274,6 +1333,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(
             SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
@@ -1321,6 +1381,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T, R> Single<R> zipArray(Function<? super Object[], ? extends R> zipper, SingleSource<? extends T>... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
@@ -1344,6 +1405,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public final Single<T> ambWith(SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
@@ -1360,6 +1422,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> hide() {
         return RxJavaPlugins.onAssembly(new SingleHide<T>(this));
     }
@@ -1383,6 +1446,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the source Single, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> compose(Function<? super Single<T>, ? extends SingleSource<R>> transformer) {
         return wrap(to(transformer));
     }
@@ -1393,12 +1457,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * The returned Single subscribes to the current Single when the first SingleObserver subscribes.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code compose} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> cache() {
         return RxJavaPlugins.onAssembly(new SingleCache<T>(this));
     }
@@ -1415,6 +1480,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Single<U> cast(final Class<? extends U> clazz) {
         ObjectHelper.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
@@ -1427,7 +1493,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concatWith.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
@@ -1436,6 +1502,8 @@ public abstract class Single<T> implements SingleSource<T> {
      *         {@code t1}
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> concatWith(SingleSource<? extends T> other) {
         return concat(this, other);
     }
@@ -1453,6 +1521,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Single<T> delay(long time, TimeUnit unit) {
         return delay(time, unit, Schedulers.computation());
     }
@@ -1471,6 +1540,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
@@ -1491,6 +1561,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> delaySubscription(CompletableSource other) {
         return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<T>(this, other));
     }
@@ -1510,6 +1581,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Single<T> delaySubscription(SingleSource<U> other) {
         return RxJavaPlugins.onAssembly(new SingleDelayWithSingle<T, U>(this, other));
     }
@@ -1529,6 +1601,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Single<T> delaySubscription(ObservableSource<U> other) {
         return RxJavaPlugins.onAssembly(new SingleDelayWithObservable<T, U>(this, other));
     }
@@ -1540,6 +1613,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * to the current Single happens.
      * <p>The other source is consumed in an unbounded manner (requesting Long.MAX_VALUE from it).
      * <dl>
+     * <dt><b>Backpressure:</b></dt>
+     * <dd>The {@code other} publisher is consumed in an unbounded fashion but will be
+     * cancelled after the first item it produced.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1549,6 +1625,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Single<T> delaySubscription(Publisher<U> other) {
         return RxJavaPlugins.onAssembly(new SingleDelayWithPublisher<T, U>(this, other));
     }
@@ -1566,6 +1644,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final <U> Single<T> delaySubscription(long time, TimeUnit unit) {
         return delaySubscription(time, unit, Schedulers.computation());
     }
@@ -1584,6 +1663,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <U> Single<T> delaySubscription(long time, TimeUnit unit, Scheduler scheduler) {
         return delaySubscription(Observable.timer(time, unit, scheduler));
     }
@@ -1599,6 +1679,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> doOnSubscribe(final Consumer<? super Disposable> onSubscribe) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         return RxJavaPlugins.onAssembly(new SingleDoOnSubscribe<T>(this, onSubscribe));
@@ -1609,12 +1690,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * SingleObserver that subscribes to the current Single.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onSuccess the consumer called with the success value of onSuccess
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> doOnSuccess(final Consumer<? super T> onSuccess) {
         ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
         return RxJavaPlugins.onAssembly(new SingleDoOnSuccess<T>(this, onSuccess));
@@ -1625,12 +1707,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * via onSuccess for each SingleObserver that subscribes to the current Single.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnEvent} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onEvent the consumer called with the success value of onEvent
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> doOnEvent(final BiConsumer<? super T, ? super Throwable> onEvent) {
         ObjectHelper.requireNonNull(onEvent, "onEvent is null");
         return RxJavaPlugins.onAssembly(new SingleDoOnEvent<T>(this, onEvent));
@@ -1641,12 +1724,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * SingleObserver that subscribes to the current Single.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onError the consumer called with the success value of onError
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> doOnError(final Consumer<? super Throwable> onError) {
         ObjectHelper.requireNonNull(onError, "onError is null");
         return RxJavaPlugins.onAssembly(new SingleDoOnError<T>(this, onError));
@@ -1657,12 +1741,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * disposes the common Disposable it received via onSubscribe.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onDispose the runnable called when the subscription is disposed
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> doOnDispose(final Action onDispose) {
         ObjectHelper.requireNonNull(onDispose, "onDispose is null");
         return RxJavaPlugins.onAssembly(new SingleDoOnDispose<T>(this, onDispose));
@@ -1707,6 +1792,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the Single returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> flatMap(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new SingleFlatMap<T, R>(this, mapper));
@@ -1719,7 +1805,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapObservable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code flatMapObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code flatMapPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the result value type
@@ -1729,6 +1815,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the Flowable returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return toFlowable().flatMap(mapper);
     }
@@ -1740,7 +1828,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code flatMapObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the result value type
@@ -1749,6 +1837,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the Single returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMapObservable(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return toObservable().flatMap(mapper);
     }
@@ -1770,6 +1859,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable flatMapCompletable(final Function<? super T, ? extends Completable> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new SingleFlatMapCompletable<T>(this, mapper));
@@ -1784,6 +1874,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * </dl>
      * @return the success value
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingGet() {
         BlockingObserver<T> observer = new BlockingObserver<T>();
         subscribe(observer);
@@ -1813,6 +1904,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that is the result of applying the lifted Operator to the source Single
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> lift(final SingleOperator<? extends R, ? super T> lift) {
         ObjectHelper.requireNonNull(lift, "onLift is null");
         return RxJavaPlugins.onAssembly(new SingleLift<T, R>(this, lift));
@@ -1834,6 +1926,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the item from the source Single, transformed by the specified function
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> map(Function<? super T, ? extends R> mapper) {
         return RxJavaPlugins.onAssembly(new SingleMap<T, R>(this, mapper));
     }
@@ -1849,6 +1942,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Boolean> contains(Object value) {
         return contains(value, ObjectHelper.equalsPredicate());
     }
@@ -1866,6 +1960,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Boolean> contains(final Object value, final BiPredicate<Object, Object> comparer) {
         ObjectHelper.requireNonNull(value, "value is null");
         ObjectHelper.requireNonNull(comparer, "comparer is null");
@@ -1889,6 +1984,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return  that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> mergeWith(SingleSource<? extends T> other) {
         return merge(this, other);
     }
@@ -1911,6 +2008,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Single<T> observeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new SingleObserveOn<T>(this, scheduler));
@@ -1942,6 +2040,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the original Single with appropriately modified behavior
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onErrorReturn(final Function<Throwable, ? extends T> resumeFunction) {
         ObjectHelper.requireNonNull(resumeFunction, "resumeFunction is null");
         return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, resumeFunction, null));
@@ -1951,12 +2050,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * Signals the specified value as success in case the current Single signals an error.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param value the value to signal if the current Single fails
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onErrorReturnItem(final T value) {
         ObjectHelper.requireNonNull(value, "value is null");
         return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, null, value));
@@ -1989,6 +2089,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the original Single, with appropriately modified behavior.
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onErrorResumeNext(final Single<? extends T> resumeSingleInCaseOfError) {
         ObjectHelper.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
         return onErrorResumeNext(Functions.justFunction(resumeSingleInCaseOfError));
@@ -2022,6 +2123,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      * @since .20
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onErrorResumeNext(
             final Function<? super Throwable, ? extends SingleSource<? extends T>> resumeFunctionInCaseOfError) {
         ObjectHelper.requireNonNull(resumeFunctionInCaseOfError, "resumeFunctionInCaseOfError is null");
@@ -2037,6 +2139,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeat() {
         return toFlowable().repeat();
     }
@@ -2051,6 +2155,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeat(long times) {
         return toFlowable().repeat(times);
     }
@@ -2070,6 +2176,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
         return toFlowable().repeatWhen(handler);
     }
@@ -2078,13 +2186,15 @@ public abstract class Single<T> implements SingleSource<T> {
      * Re-subscribes to the current Single until the given BooleanSupplier returns true.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param stop the BooleanSupplier called after the current Single succeeds and if returns false,
      *             the Single is re-subscribed; otherwise the sequence completes.
      * @return the new Flowable instance
      * @since 2.0
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> repeatUntil(BooleanSupplier stop) {
         return toFlowable().repeatUntil(stop);
     }
@@ -2098,6 +2208,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry() {
         return toFlowable().retry().toSingle();
     }
@@ -2113,6 +2224,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(long times) {
         return toFlowable().retry(times).toSingle();
     }
@@ -2129,6 +2241,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
         return toFlowable().retry(predicate).toSingle();
     }
@@ -2145,6 +2258,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(Predicate<? super Throwable> predicate) {
         return toFlowable().retry(predicate).toSingle();
     }
@@ -2156,7 +2270,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * If the Publisher signals an onComplete, the resulting Single will signal a NoSuchElementException.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param handler the function that receives a Flowable of the error the Single emits and should
@@ -2165,6 +2279,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *                be the output of the resulting Single
      * @return the new Single instance
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
         return toFlowable().retryWhen(handler).toSingle();
     }
@@ -2179,6 +2294,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@link Disposable} reference can request the {@link Single} stop work.
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe() {
         return subscribe(Functions.emptyConsumer(), Functions.ERROR_CONSUMER);
     }
@@ -2199,6 +2315,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @throws IllegalArgumentException
      *             if {@code onCallback} is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(final BiConsumer<? super T, ? super Throwable> onCallback) {
         ObjectHelper.requireNonNull(onCallback, "onCallback is null");
 
@@ -2221,6 +2338,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *             if {@code onSuccess} is null
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(Consumer<? super T> onSuccess) {
         return subscribe(onSuccess, Functions.ERROR_CONSUMER);
     }
@@ -2244,6 +2362,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *             if {@code onNext} is null, or
      *             if {@code onError} is null
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(final Consumer<? super T> onSuccess, final Consumer<? super Throwable> onError) {
         ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
         ObjectHelper.requireNonNull(onError, "onError is null");
@@ -2253,6 +2372,7 @@ public abstract class Single<T> implements SingleSource<T> {
         return s;
     }
 
+    @SchedulerSupport(SchedulerSupport.NONE)
     @Override
     public final void subscribe(SingleObserver<? super T> subscriber) {
         ObjectHelper.requireNonNull(subscriber, "subscriber is null");
@@ -2293,12 +2413,17 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * composite.add(source.subscribeWith(new ResourceSingleObserver()));
      * </code></pre>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param <E> the type of the SingleObserver to use and return
      * @param observer the SingleObserver (subclass) to use and return, not null
      * @return the input {@code observer}
      * @throws NullPointerException if {@code observer} is null
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E extends SingleObserver<? super T>> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
@@ -2310,7 +2435,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribeOn.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>you specify which {@link Scheduler} this operator will use</dd>
+     * <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
      *
      * @param scheduler
@@ -2320,6 +2445,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #observeOn
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Single<T> subscribeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new SingleSubscribeOn<T>(this, scheduler));
@@ -2342,6 +2468,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the item emitted by the source Single until such time as {@code other} terminates.
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> takeUntil(final CompletableSource other) {
         return takeUntil(new CompletableToFlowable<T>(other));
     }
@@ -2353,6 +2480,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code other} publisher is consumed in an unbounded fashion but will be
+     *  cancelled after the first item it produced.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2366,6 +2496,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * its first item
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E> Single<T> takeUntil(final Publisher<E> other) {
         return RxJavaPlugins.onAssembly(new SingleTakeUntil<T, E>(this, other));
     }
@@ -2388,6 +2520,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Single that emits the item emitted by the source Single until such time as {@code other} emits its item
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <E> Single<T> takeUntil(final SingleSource<? extends E> other) {
         return takeUntil(new SingleToFlowable<E>(other));
     }
@@ -2404,6 +2537,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Single<T> timeout(long timeout, TimeUnit unit) {
         return timeout0(timeout, unit, Schedulers.computation(), null);
     }
@@ -2422,6 +2556,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler) {
         return timeout0(timeout, unit, scheduler, null);
     }
@@ -2440,6 +2575,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler, SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, scheduler, other);
@@ -2459,6 +2595,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Single<T> timeout(long timeout, TimeUnit unit, SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, Schedulers.computation(), other);
@@ -2483,6 +2620,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @return the value returned by the convert function
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R to(Function<? super Single<T>, R> convert) {
         try {
             return convert.apply(this);
@@ -2510,6 +2648,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation: Completable</a>
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable toCompletable() {
         return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(this));
     }
@@ -2520,11 +2659,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return an {@link Flowable} that emits a single item T or an error.
      */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
     public final Flowable<T> toFlowable() {
         if (this instanceof FuseToFlowable) {
@@ -2545,6 +2686,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@link Future} that expects a single item to be emitted by this {@code Single}
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Future<T> toFuture() {
         return subscribeWith(new FutureSingleObserver<T>());
     }
@@ -2555,12 +2697,17 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code toMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return an {@link Maybe} that emits a single item T or an error.
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @SuppressWarnings("unchecked")
     public final Maybe<T> toMaybe() {
+        if (this instanceof FuseToMaybe) {
+            return ((FuseToMaybe<T>)this).fuseToMaybe();
+        }
         return RxJavaPlugins.onAssembly(new MaybeFromSingle<T>(this));
     }
     /**
@@ -2569,12 +2716,17 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return an {@link Observable} that emits a single item T or an error.
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @SuppressWarnings("unchecked")
     public final Observable<T> toObservable() {
+        if (this instanceof FuseToObservable) {
+            return ((FuseToObservable<T>)this).fuseToObservable();
+        }
         return RxJavaPlugins.onAssembly(new SingleToObservable<T>(this));
     }
 
@@ -2601,6 +2753,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Single<R> zipWith(SingleSource<U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
         return zip(this, other, zipper);
     }
@@ -2611,9 +2764,14 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Creates a TestSubscriber and subscribes
      * it to this Single.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test() {
         TestSubscriber<T> ts = new TestSubscriber<T>();
         toFlowable().subscribe(ts);
@@ -2622,11 +2780,16 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Creates a TestSubscriber optionally in cancelled state, then subscribes it to this Single.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
      * Single.
      * @return the new TestSubscriber instance
      * @since 2.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final TestSubscriber<T> test(boolean cancelled) {
         TestSubscriber<T> ts = new TestSubscriber<T>();
 

--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -52,6 +52,17 @@ public enum DisposableHelper implements Disposable {
         }
     }
 
+    /**
+     * Atomically sets the field to the given non-null Disposable and returns true
+     * or returns false if the field is non-null.
+     * If the target field contains the common DISPOSED instance, the supplied disposable
+     * is disposed. If the field contains other non-null Disposable, an IllegalStateException
+     * is signalled to the RxJavaPlugins.onError hook.
+     * 
+     * @param field the target field
+     * @param d the disposable to set, not null
+     * @return true if the operation succeeded, false
+     */
     public static boolean setOnce(AtomicReference<Disposable> field, Disposable d) {
         ObjectHelper.requireNonNull(d, "d is null");
         if (!field.compareAndSet(null, d)) {
@@ -64,6 +75,14 @@ public enum DisposableHelper implements Disposable {
         return true;
     }
 
+    /**
+     * Atomically replaces the Disposable in the field with the given new Disposable
+     * but does not dispose the old one.
+     * @param field the target field to change
+     * @param d the new disposable, null allowed
+     * @return true if the operation succeeded, false if the target field contained
+     * the common DISPOSED instance and the given disposable (if not null) is disposed.
+     */
     public static boolean replace(AtomicReference<Disposable> field, Disposable d) {
         for (;;) {
             Disposable current = field.get();

--- a/src/main/java/io/reactivex/internal/fuseable/FuseToMaybe.java
+++ b/src/main/java/io/reactivex/internal/fuseable/FuseToMaybe.java
@@ -13,31 +13,31 @@
 
 package io.reactivex.internal.fuseable;
 
-import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 
 /**
- * Interface indicating a operator implementation can be macro-fused back to Flowable in case
- * the operator goes from Flowable to some other reactive type and then the sequence calls
- * for toFlowable again:
+ * Interface indicating a operator implementation can be macro-fused back to Maybe in case
+ * the operator goes from Maybe to some other reactive type and then the sequence calls
+ * for toMaybe again:
  * <pre>
- * Single&lt;Integer> single = Flowable.range(1, 10).reduce((a, b) -> a + b);
- * Flowable&lt;Integer> flowable = single.toFlowable();
+ * Single&lt;Integer> single = Maybe.just(1).isEmpty();
+ * Maybe&lt;Integer> maybe = single.toMaybe();
  * </pre>
  *
- * The {@code Single.toFlowable()} will check for this interface and call the {@link #fuseToFlowable()}
- * to return a Flowable which could be the Flowable-specific implementation of reduce(BiFunction).
+ * The {@code Single.toMaybe()} will check for this interface and call the {@link #fuseToMaybe()}
+ * to return a Maybe which could be the Maybe-specific implementation of isEmpty().
  * <p>
  * This causes a slight overhead in assembly time (1 instanceof check, 1 operator allocation and 1 dropped
  * operator) but does not incur the conversion overhead at runtime.
  *
  * @param <T> the value type
  */
-public interface FuseToFlowable<T> {
+public interface FuseToMaybe<T> {
 
     /**
-     * Returns a (direct) Flowable for the operator.
+     * Returns a (direct) Maybe for the operator.
      * <p>The implementation should handle the necessary RxJavaPlugins wrapping.
-     * @return the Flowable instance
+     * @return the Maybe instance
      */
-    Flowable<T> fuseToFlowable();
+    Maybe<T> fuseToMaybe();
 }

--- a/src/main/java/io/reactivex/internal/fuseable/FuseToObservable.java
+++ b/src/main/java/io/reactivex/internal/fuseable/FuseToObservable.java
@@ -36,6 +36,7 @@ public interface FuseToObservable<T> {
 
     /**
      * Returns a (direct) Observable for the operator.
+     * <p>The implementation should handle the necessary RxJavaPlugins wrapping.
      * @return the Observable instance
      */
     Observable<T> fuseToObservable();

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherPublisher.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Delay the emission of the main signal until the other signals an item or completes.
+ * 
+ * @param <T> the main value type
+ * @param <U> the other value type
+ */
+public final class MaybeDelayOtherPublisher<T, U> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Publisher<U> other;
+
+    public MaybeDelayOtherPublisher(MaybeSource<T> source, Publisher<U> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new DelayMaybeObserver<T, U>(observer, other));
+    }
+
+    static final class DelayMaybeObserver<T, U>
+    implements MaybeObserver<T>, Disposable {
+        final OtherSubscriber<T> other;
+
+        Publisher<U> otherSource;
+
+        Disposable d;
+
+        public DelayMaybeObserver(MaybeObserver<? super T> actual, Publisher<U> otherSource) {
+            this.other = new OtherSubscriber<T>(actual);
+            this.otherSource = otherSource;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+            SubscriptionHelper.cancel(other);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return SubscriptionHelper.isCancelled(other.get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                other.actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            d = DisposableHelper.DISPOSED;
+            other.value = value;
+            subscribeNext();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            other.error = e;
+            subscribeNext();
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            subscribeNext();
+        }
+
+        void subscribeNext() {
+            otherSource.subscribe(other);
+        }
+    }
+
+    static final class OtherSubscriber<T> extends
+    AtomicReference<Subscription>
+    implements Subscriber<Object> {
+        /** */
+        private static final long serialVersionUID = -1215060610805418006L;
+
+        final MaybeObserver<? super T> actual;
+
+        T value;
+
+        Throwable error;
+
+        public OtherSubscriber(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object t) {
+            Subscription s = get();
+            if (s != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                s.cancel();
+                onComplete();
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            Throwable e = error;
+            if (e == null) {
+                actual.onError(t);
+            } else {
+                actual.onError(new CompositeException(e, t));
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            Throwable e = error;
+            if (e != null) {
+                actual.onError(e);
+            } else {
+                T v = value;
+                if (v != null) {
+                    actual.onSuccess(v);
+                } else {
+                    actual.onComplete();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Delay the subscription to the main Maybe until the other signals an item or completes.
+ * 
+ * @param <T> the main value type
+ * @param <U> the other value type
+ */
+public final class MaybeDelaySubscriptionOtherPublisher<T, U> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Publisher<U> other;
+
+    public MaybeDelaySubscriptionOtherPublisher(MaybeSource<T> source, Publisher<U> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        other.subscribe(new OtherSubscriber<T>(observer, source));
+    }
+
+    static final class OtherSubscriber<T> implements Subscriber<Object>, Disposable {
+        final DelayMaybeObserver<T> main;
+
+        MaybeSource<T> source;
+
+        Subscription s;
+
+        public OtherSubscriber(MaybeObserver<? super T> actual, MaybeSource<T> source) {
+            this.main = new DelayMaybeObserver<T>(actual);
+            this.source = source;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                main.actual.onSubscribe(this);
+
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object t) {
+            if (s != SubscriptionHelper.CANCELLED) {
+                s.cancel();
+                s = SubscriptionHelper.CANCELLED;
+
+                subscribeNext();
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (s != SubscriptionHelper.CANCELLED) {
+                s = SubscriptionHelper.CANCELLED;
+
+                main.actual.onError(t);
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (s != SubscriptionHelper.CANCELLED) {
+                s = SubscriptionHelper.CANCELLED;
+
+                subscribeNext();
+            }
+        }
+
+        void subscribeNext() {
+            MaybeSource<T> src = source;
+            source = null;
+
+            src.subscribe(main);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(main.get());
+        }
+
+        @Override
+        public void dispose() {
+            s.cancel();
+            s = SubscriptionHelper.CANCELLED;
+            DisposableHelper.dispose(main);
+        }
+    }
+
+    static final class DelayMaybeObserver<T> extends AtomicReference<Disposable>
+    implements MaybeObserver<T> {
+        /** */
+        private static final long serialVersionUID = 706635022205076709L;
+
+        final MaybeObserver<? super T> actual;
+
+        public DelayMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeEmpty.java
@@ -15,16 +15,22 @@ package io.reactivex.internal.operators.maybe;
 
 import io.reactivex.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.fuseable.ScalarCallable;
 
 /**
  * Signals an onComplete.
  */
-public final class MaybeEmpty extends Maybe<Object> {
+public final class MaybeEmpty extends Maybe<Object> implements ScalarCallable<Object> {
 
     public static final MaybeEmpty INSTANCE = new MaybeEmpty();
 
     @Override
     protected void subscribeActual(MaybeObserver<? super Object> observer) {
         EmptyDisposable.complete(observer);
+    }
+
+    @Override
+    public Object call() {
+        return null; // nulls of ScalarCallable are considered empty sources
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapBiSelector.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapBiSelector.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Maps a source item to another MaybeSource then calls a BiFunction with the
+ * original item and the secondary item to generate the final result.
+ * 
+ * @param <T> the main value type
+ * @param <U> the second value type
+ * @param <R> the result value type
+ */
+public final class MaybeFlatMapBiSelector<T, U, R> extends AbstractMaybeWithUpstream<T, R> {
+
+    final Function<? super T, ? extends MaybeSource<? extends U>> mapper;
+
+    final BiFunction<? super T, ? super U, ? extends R> resultSelector;
+
+    public MaybeFlatMapBiSelector(MaybeSource<T> source,
+            Function<? super T, ? extends MaybeSource<? extends U>> mapper,
+            BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+        super(source);
+        this.mapper = mapper;
+        this.resultSelector = resultSelector;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super R> observer) {
+        source.subscribe(new FlatMapBiMainObserver<T, U, R>(observer, mapper, resultSelector));
+    }
+
+    static final class FlatMapBiMainObserver<T, U, R>
+    implements MaybeObserver<T>, Disposable {
+
+        final Function<? super T, ? extends MaybeSource<? extends U>> mapper;
+
+        final InnerObserver<T, U, R> inner;
+
+        public FlatMapBiMainObserver(MaybeObserver<? super R> actual,
+                Function<? super T, ? extends MaybeSource<? extends U>> mapper,
+                BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+            this.inner = new InnerObserver<T, U, R>(actual, resultSelector);
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(inner);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(inner.get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(inner, d)) {
+                inner.actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            MaybeSource<? extends U> next;
+
+            try {
+                next = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null MaybeSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                inner.actual.onError(ex);
+                return;
+            }
+
+            if (DisposableHelper.replace(inner, null)) {
+                inner.value = value;
+                next.subscribe(inner);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            inner.actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            inner.actual.onComplete();
+        }
+
+        static final class InnerObserver<T, U, R>
+        extends AtomicReference<Disposable>
+        implements MaybeObserver<U> {
+            /** */
+            private static final long serialVersionUID = -2897979525538174559L;
+
+            final MaybeObserver<? super R> actual;
+
+            final BiFunction<? super T, ? super U, ? extends R> resultSelector;
+
+            T value;
+
+            public InnerObserver(MaybeObserver<? super R> actual,
+                    BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+                this.actual = actual;
+                this.resultSelector = resultSelector;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onSuccess(U value) {
+                T t = this.value;
+                this.value = null;
+
+                R r;
+
+                try {
+                    r = ObjectHelper.requireNonNull(resultSelector.apply(t, value), "The resultSelector returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    actual.onError(ex);
+                    return;
+                }
+
+                actual.onSuccess(r);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                actual.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                actual.onComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromAction.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromAction.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import java.util.concurrent.Callable;
+
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
@@ -24,7 +26,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class MaybeFromAction<T> extends Maybe<T> {
+public final class MaybeFromAction<T> extends Maybe<T> implements Callable<T> {
 
     final Action action;
 
@@ -55,5 +57,11 @@ public final class MaybeFromAction<T> extends Maybe<T> {
                 observer.onComplete();
             }
         }
+    }
+
+    @Override
+    public T call() throws Exception {
+        action.run();
+        return null; // considered as onComplete()
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromCallable.java
@@ -25,7 +25,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class MaybeFromCallable<T> extends Maybe<T> {
+public final class MaybeFromCallable<T> extends Maybe<T> implements Callable<T> {
 
     final Callable<? extends T> callable;
 
@@ -62,5 +62,10 @@ public final class MaybeFromCallable<T> extends Maybe<T> {
                 }
             }
         }
+    }
+
+    @Override
+    public T call() throws Exception {
+        return callable.call();
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeHide.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeHide.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Hides the identity of the upstream Maybe and its Disposable sent through onSubscribe.
+ * 
+ * @param <T> the value type
+ */
+public final class MaybeHide<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    public MaybeHide(MaybeSource<T> source) {
+        super(source);
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new HideMaybeObserver<T>(observer));
+    }
+
+    static final class HideMaybeObserver<T> implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super T> actual;
+
+        Disposable d;
+
+        public HideMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeIsEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeIsEmpty.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Signals true if the source Maybe signals onComplete, signals false if the source Maybe
+ * signals onNext.
+ * 
+ * @param <T> the value type
+ */
+public final class MaybeIsEmpty<T> extends AbstractMaybeWithUpstream<T, Boolean> {
+
+    public MaybeIsEmpty(MaybeSource<T> source) {
+        super(source);
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super Boolean> observer) {
+        source.subscribe(new IsEmptyMaybeObserver<T>(observer));
+    }
+
+    static final class IsEmptyMaybeObserver<T>
+    implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super Boolean> actual;
+
+        Disposable d;
+
+        public IsEmptyMaybeObserver(MaybeObserver<? super Boolean> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(false);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onSuccess(true);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingle.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Signals true if the source Maybe signals onComplete, signals false if the source Maybe
+ * signals onNext.
+ * 
+ * @param <T> the value type
+ */
+public final class MaybeIsEmptySingle<T> extends Single<Boolean>
+implements HasUpstreamMaybeSource<T>, FuseToMaybe<Boolean> {
+
+    final MaybeSource<T> source;
+
+    public MaybeIsEmptySingle(MaybeSource<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    public MaybeSource<T> source() {
+        return source;
+    }
+
+    @Override
+    public Maybe<Boolean> fuseToMaybe() {
+        return RxJavaPlugins.onAssembly(new MaybeIsEmpty<T>(source));
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Boolean> observer) {
+        source.subscribe(new IsEmptyMaybeObserver<T>(observer));
+    }
+
+    static final class IsEmptyMaybeObserver<T>
+    implements MaybeObserver<T>, Disposable {
+
+        final SingleObserver<? super Boolean> actual;
+
+        Disposable d;
+
+        public IsEmptyMaybeObserver(SingleObserver<? super Boolean> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(false);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(true);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorComplete.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Emits an onComplete if the source emits an onError and the predicate returns true for
+ * that Throwable.
+ * 
+ * @param <T> the value type
+ */
+public final class MaybeOnErrorComplete<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Predicate<? super Throwable> predicate;
+
+    public MaybeOnErrorComplete(MaybeSource<T> source,
+            Predicate<? super Throwable> predicate) {
+        super(source);
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new OnErrorCompleteMaybeObserver<T>(observer, predicate));
+    }
+
+    static final class OnErrorCompleteMaybeObserver<T> implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super T> actual;
+
+        final Predicate<? super Throwable> predicate;
+
+        Disposable d;
+
+        public OnErrorCompleteMaybeObserver(MaybeObserver<? super T> actual, Predicate<? super Throwable> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            boolean b;
+
+            try {
+                b = predicate.test(e);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                actual.onError(new CompositeException(e, ex));
+                return;
+            }
+
+            if (b) {
+                actual.onComplete();
+            } else {
+                actual.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorNext.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Subscribes to the MaybeSource returned by a function if the main source signals an onError.
+ * 
+ * @param <T> the value type
+ */
+public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction;
+
+    final boolean allowFatal;
+
+    public MaybeOnErrorNext(MaybeSource<T> source,
+            Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction,
+                    boolean allowFatal) {
+        super(source);
+        this.resumeFunction = resumeFunction;
+        this.allowFatal = allowFatal;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new OnErrorNextMaybeObserver<T>(observer, resumeFunction, allowFatal));
+    }
+
+    static final class OnErrorNextMaybeObserver<T>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, Disposable {
+
+        /** */
+        private static final long serialVersionUID = 2026620218879969836L;
+
+        final MaybeObserver<? super T> actual;
+
+        final Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction;
+
+        final boolean allowFatal;
+
+        public OnErrorNextMaybeObserver(MaybeObserver<? super T> actual,
+                Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction,
+                        boolean allowFatal) {
+            this.actual = actual;
+            this.resumeFunction = resumeFunction;
+            this.allowFatal = allowFatal;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d)) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (!allowFatal && !(e instanceof Exception)) {
+                actual.onError(e);
+                return;
+            }
+            MaybeSource<? extends T> m;
+
+            try {
+                m = ObjectHelper.requireNonNull(resumeFunction.apply(e), "The resumeFunction returned a null MaybeSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                actual.onError(new CompositeException(e, ex));
+                return;
+            }
+
+            DisposableHelper.replace(this, null);
+
+            m.subscribe(new NextMaybeObserver<T>(actual, this));
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        static final class NextMaybeObserver<T> implements MaybeObserver<T> {
+            final MaybeObserver<? super T> actual;
+
+            final AtomicReference<Disposable> d;
+
+            public NextMaybeObserver(MaybeObserver<? super T> actual, AtomicReference<Disposable> d) {
+                this.actual = actual;
+                this.d = d;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this.d, d);
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                actual.onSuccess(value);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                actual.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                actual.onComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeOnErrorReturn.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Returns a value generated via a function if the main source signals an onError.
+ * @param <T> the value type
+ */
+public final class MaybeOnErrorReturn<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Function<? super Throwable, ? extends T> valueSupplier;
+
+    public MaybeOnErrorReturn(MaybeSource<T> source,
+            Function<? super Throwable, ? extends T> valueSupplier) {
+        super(source);
+        this.valueSupplier = valueSupplier;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new OnErrorReturnMaybeObserver<T>(observer, valueSupplier));
+    }
+
+    static final class OnErrorReturnMaybeObserver<T> implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super T> actual;
+
+        final Function<? super Throwable, ? extends T> valueSupplier;
+
+        Disposable d;
+
+        public OnErrorReturnMaybeObserver(MaybeObserver<? super T> actual,
+                Function<? super Throwable, ? extends T> valueSupplier) {
+            this.actual = actual;
+            this.valueSupplier = valueSupplier;
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            T v;
+
+            try {
+                v = ObjectHelper.requireNonNull(valueSupplier.apply(e), "The valueSupplier returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                actual.onError(new CompositeException(e, ex));
+                return;
+            }
+
+            actual.onSuccess(v);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/BaseTypeAnnotations.java
+++ b/src/test/java/io/reactivex/BaseTypeAnnotations.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.annotations.*;
+
+/**
+ * Verifies that
+ * <ul>
+ * <li>All public base type methods have the {@link SchedulerSupport} present</li>
+ * <li>All public base type methods which return Flowable have the {@link BackpressureSupport} present</li>
+ * <li>All public base types that don't return Flowable don't have the {@link BackpressureSupport} present (these are copy-paste errors)</li>
+ */
+public class BaseTypeAnnotations {
+
+    static void checkSchedulerSupport(Class<?> clazz) {
+        StringBuilder b = new StringBuilder();
+
+        for (Method m : clazz.getMethods()) {
+            if (m.getName().equals("bufferSize")) {
+                continue;
+            }
+            if (m.getDeclaringClass() == clazz) {
+                if (!m.isAnnotationPresent(SchedulerSupport.class)) {
+                    b.append("Missing @SchedulerSupport: ").append(m).append("\r\n");
+                } else {
+                    SchedulerSupport ann = m.getAnnotation(SchedulerSupport.class);
+
+                    if (ann.value().equals(SchedulerSupport.CUSTOM)) {
+                        boolean found = false;
+                        for (Class<?> paramclazz : m.getParameterTypes()) {
+                            if (Scheduler.class.isAssignableFrom(paramclazz)) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            b.append("Marked with CUSTOM scheduler but no Scheduler parameter: ").append(m).append("\r\n");
+                        }
+                    } else {
+                        for (Class<?> paramclazz : m.getParameterTypes()) {
+                            if (Scheduler.class.isAssignableFrom(paramclazz)) {
+                                if (!m.getName().equals("timestamp") && !m.getName().equals("timeInterval")) {
+                                    b.append("Marked with specific scheduler but Scheduler parameter found: ").append(m).append("\r\n");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (b.length() != 0) {
+            System.out.println(clazz);
+            System.out.println("------------------------");
+            System.out.println(b);
+
+            fail(b.toString());
+        }
+    }
+
+    static void checkBackpressureSupport(Class<?> clazz) {
+        StringBuilder b = new StringBuilder();
+
+        for (Method m : clazz.getMethods()) {
+            if (m.getName().equals("bufferSize")) {
+                continue;
+            }
+            if (m.getDeclaringClass() == clazz) {
+                if (clazz == Flowable.class) {
+                    if (!m.isAnnotationPresent(BackpressureSupport.class)) {
+                        b.append("No @BackpressureSupport annotation (being Flowable): ").append(m).append("\r\n");
+                    }
+                } else {
+                    if (m.getReturnType() == Flowable.class) {
+                        if (!m.isAnnotationPresent(BackpressureSupport.class)) {
+                            b.append("No @BackpressureSupport annotation (having Flowable return): ").append(m).append("\r\n");
+                        }
+                    } else {
+                        boolean found = false;
+                        for (Class<?> paramclazz : m.getParameterTypes()) {
+                            if (Publisher.class.isAssignableFrom(paramclazz)) {
+                                found = true;
+                                break;
+                            }
+                        }
+
+                        if (found) {
+                            if (!m.isAnnotationPresent(BackpressureSupport.class)) {
+                                b.append("No @BackpressureSupport annotation (has Publisher param): ").append(m).append("\r\n");
+                            }
+                        } else {
+                            if (m.isAnnotationPresent(BackpressureSupport.class)) {
+                                b.append("Unnecessary @BackpressureSupport annotation: ").append(m).append("\r\n");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (b.length() != 0) {
+            System.out.println(clazz);
+            System.out.println("------------------------");
+            System.out.println(b);
+
+            fail(b.toString());
+        }
+    }
+
+    @Test
+    public void schedulerSupportFlowable() {
+        checkSchedulerSupport(Flowable.class);
+    }
+
+    @Test
+    public void schedulerSupportObservable() {
+        checkSchedulerSupport(Observable.class);
+    }
+
+    @Test
+    public void schedulerSupportSingle() {
+        checkSchedulerSupport(Single.class);
+    }
+
+    @Test
+    public void schedulerSupportCompletable() {
+        checkSchedulerSupport(Completable.class);
+    }
+
+    @Test
+    public void schedulerSupportMaybe() {
+        checkSchedulerSupport(Maybe.class);
+    }
+
+    @Test
+    public void backpressureSupportFlowable() {
+        checkBackpressureSupport(Flowable.class);
+    }
+
+    @Test
+    public void backpressureSupportObservable() {
+        checkBackpressureSupport(Observable.class);
+    }
+
+    @Test
+    public void backpressureSupportSingle() {
+        checkBackpressureSupport(Single.class);
+    }
+
+    @Test
+    public void backpressureSupportCompletable() {
+        checkBackpressureSupport(Completable.class);
+    }
+
+    @Test
+    public void backpressureSupportMaybe() {
+        checkBackpressureSupport(Maybe.class);
+    }
+}

--- a/src/test/java/io/reactivex/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/JavadocForAnnotations.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import static org.junit.Assert.fail;
+
+import java.io.*;
+
+import org.junit.*;
+
+/**
+ * Checks the source code of the base reactive types and locates missing
+ * mention of {@code Backpressure:} and {@code Scheduler:} of methods
+ */
+public class JavadocForAnnotations {
+
+    static void checkSource(String baseClassName, boolean scheduler) throws Exception {
+        File f = MaybeNo2Dot0Since.findSource(baseClassName);
+        if (f == null) {
+            return;
+        }
+
+        StringBuilder b = readFile(f);
+
+        StringBuilder e = new StringBuilder();
+
+        if (scheduler) {
+            scanFor(b, "@SchedulerSupport", "Scheduler:", e, baseClassName);
+        } else {
+            scanFor(b, "@BackpressureSupport", "Backpressure:", e, baseClassName);
+        }
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    public static StringBuilder readFile(File f) throws Exception {
+        StringBuilder b = new StringBuilder();
+
+        BufferedReader in = new BufferedReader(new FileReader(f));
+        try {
+            for (;;) {
+                String line = in.readLine();
+
+                if (line == null) {
+                    break;
+                }
+
+                b.append(line).append('\n');
+            }
+        } finally {
+            in.close();
+        }
+
+        return b;
+    }
+
+    static final void scanFor(StringBuilder sourceCode, String annotation, String inDoc,
+            StringBuilder e, String baseClassName) {
+        int index = 0;
+        for (;;) {
+            int idx = sourceCode.indexOf(annotation, index);
+
+            if (idx < 0) {
+                break;
+            }
+
+            int j = sourceCode.lastIndexOf("/**", idx);
+
+            // see if the last /** is not before the index (last time the annotation was found
+            // indicating an uncommented method like subscribe()
+            if (j > index) {
+                int k = sourceCode.indexOf(inDoc, j);
+
+                if (k < 0 || k > idx) {
+                    // when printed on the console, IDEs will create a clickable link to help navigate to the offending point
+                    e.append("java.lang.RuntimeException: missing ").append(inDoc).append("\r\n")
+                    ;
+                    int lc = lineNumber(sourceCode, idx);
+
+                    e.append(" at io.reactivex.").append(baseClassName)
+                    .append(" (").append(baseClassName).append(".java:")
+                    .append(lc).append(")").append("\r\n\r\n");
+                }
+            }
+
+            index = idx + annotation.length();
+        }
+    }
+
+
+    static final void scanForBadMethod(StringBuilder sourceCode, String annotation, String inDoc,
+            StringBuilder e, String baseClassName) {
+        int index = 0;
+        for (;;) {
+            int idx = sourceCode.indexOf(annotation, index);
+
+            if (idx < 0) {
+                break;
+            }
+
+            int j = sourceCode.lastIndexOf("/**", idx);
+
+            // see if the last /** is not before the index (last time the annotation was found
+            // indicating an uncommented method like subscribe()
+            if (j > index) {
+                int k = sourceCode.indexOf(inDoc, j);
+
+                if (k >= 0 && k <= idx) {
+
+                    int ll = sourceCode.indexOf("You specify", k);
+                    int lm = sourceCode.indexOf("This operator", k);
+                    if ((ll < 0 || ll > idx) && (lm < 0 || lm > idx)) {
+
+                        int n = sourceCode.indexOf("{@code ", k);
+
+                        if (n < idx) {
+                            int m = sourceCode.indexOf("}", n);
+
+                            if (m < idx) {
+                                String mname = sourceCode.substring(n + 7, m);
+
+                                int q = sourceCode.indexOf("@SuppressWarnings({", idx);
+
+                                int o = sourceCode.indexOf("{", idx);
+
+                                if (q + 18 == o) {
+                                    o = sourceCode.indexOf("{", q + 20);
+                                }
+
+                                if (o >= 0) {
+
+                                    int p = sourceCode.indexOf(" " + mname + "(", idx);
+
+                                    if (p < 0 || p > o) {
+                                        // when printed on the console, IDEs will create a clickable link to help navigate to the offending point
+                                        e.append("java.lang.RuntimeException: wrong method name in description of ").append(inDoc).append(" '").append(mname).append("'\r\n")
+                                        ;
+                                        int lc = lineNumber(sourceCode, idx);
+
+                                        e.append(" at io.reactivex.").append(baseClassName)
+                                        .append(" (").append(baseClassName).append(".java:")
+                                        .append(lc).append(")").append("\r\n\r\n");
+                                    }
+                                }
+                            }
+
+                        }
+
+                    }
+                }
+            }
+
+            index = idx + annotation.length();
+        }
+    }
+
+    static void checkSchedulerBadMethod(String baseClassName) throws Exception {
+        File f = MaybeNo2Dot0Since.findSource(baseClassName);
+        if (f == null) {
+            return;
+        }
+
+        StringBuilder b = readFile(f);
+
+        StringBuilder e = new StringBuilder();
+
+        scanForBadMethod(b, "@SchedulerSupport", "Scheduler:", e, baseClassName);
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    public static int lineNumber(StringBuilder s, int index) {
+        int cnt = 1;
+        for (int i = 0; i < index; i++) {
+            if (s.charAt(i) == '\n') {
+                cnt++;
+            }
+        }
+        return cnt;
+    }
+
+    @Test
+    public void checkFlowableBackpressure() throws Exception {
+        checkSource(Flowable.class.getSimpleName(), false);
+    }
+
+    @Test
+    public void checkFlowableScheduler() throws Exception {
+        checkSource(Flowable.class.getSimpleName(), true);
+    }
+
+    @Test
+    public void checkObservableBackpressure() throws Exception {
+        checkSource(Observable.class.getSimpleName(), false);
+    }
+
+    @Test
+    public void checkObservableScheduler() throws Exception {
+        checkSource(Observable.class.getSimpleName(), true);
+    }
+
+    @Test
+    @Ignore("In the next PR these will be fixed")
+    public void checkSingleBackpressure() throws Exception {
+        checkSource(Single.class.getSimpleName(), false);
+    }
+
+    @Test
+    public void checkSingleScheduler() throws Exception {
+        checkSource(Single.class.getSimpleName(), true);
+    }
+
+    @Test
+    @Ignore("In the next PR these will be fixed")
+    public void checkCompletableBackpressure() throws Exception {
+        checkSource(Completable.class.getSimpleName(), false);
+    }
+
+    @Test
+    public void checkCompletableScheduler() throws Exception {
+        checkSource(Completable.class.getSimpleName(), true);
+    }
+
+    @Test
+    @Ignore("In the next PR these will be fixed")
+    public void checkMaybeBackpressure() throws Exception {
+        checkSource(Maybe.class.getSimpleName(), false);
+    }
+
+    @Test
+    public void checkMaybeScheduler() throws Exception {
+        checkSource(Maybe.class.getSimpleName(), true);
+    }
+
+    @Test
+    public void checkFlowableSchedulerDoc() throws Exception {
+        checkSchedulerBadMethod(Flowable.class.getSimpleName());
+    }
+
+    @Test
+    public void checkObservableSchedulerDoc() throws Exception {
+        checkSchedulerBadMethod(Observable.class.getSimpleName());
+    }
+
+    @Test
+    public void checkSingleSchedulerDoc() throws Exception {
+        checkSchedulerBadMethod(Single.class.getSimpleName());
+    }
+
+    @Test
+    public void checkCompletableSchedulerDoc() throws Exception {
+        checkSchedulerBadMethod(Completable.class.getSimpleName());
+    }
+
+    @Test
+    public void checkMaybeSchedulerDoc() throws Exception {
+        checkSchedulerBadMethod(Maybe.class.getSimpleName());
+    }
+}

--- a/src/test/java/io/reactivex/MaybeNo2Dot0Since.java
+++ b/src/test/java/io/reactivex/MaybeNo2Dot0Since.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import static org.junit.Assert.fail;
+
+import java.io.*;
+import java.net.URL;
+
+import org.junit.Test;
+
+/**
+ * Checks the source code of Maybe and finds unnecessary since 2.0 annotations in the
+ * method's javadocs.
+ */
+public class MaybeNo2Dot0Since {
+
+    /**
+     * Given a base reactive type name, try to find its source in the current runtime
+     * path and return a file to it or null if not found
+     * @param baseClassName the class name such as {@code Maybe}
+     * @return the File pointing to the source
+     * @throws Exception on error
+     */
+    public static File findSource(String baseClassName) throws Exception {
+        URL u = MaybeNo2Dot0Since.class.getResource(MaybeNo2Dot0Since.class.getSimpleName()+ ".class");
+
+        String path = new File(u.toURI()).toString().replace('\\', '/');
+
+//        System.out.println(path);
+
+        int i = path.indexOf("/RxJava/");
+        if (i < 0) {
+            System.out.println("Can't find the base RxJava directory");
+            return null;
+        }
+
+        String p = path.substring(0, i + 8) + "src/main/java/io/reactivex/" + baseClassName + ".java";
+
+        File f = new File(p);
+
+        if (!f.canRead()) {
+            System.out.println("Can't read " + p);
+            return null;
+        }
+
+        return f;
+    }
+
+    @Test
+    public void noSince20InMaybe() throws Exception {
+
+        File f = findSource(Maybe.class.getSimpleName());
+
+        String line;
+
+        StringBuilder b = new StringBuilder();
+
+        boolean classDefPassed = false;
+
+        BufferedReader in = new BufferedReader(new FileReader(f));
+        try {
+            int ln = 1;
+            while (true) {
+                line = in.readLine();
+
+                if (line == null) {
+                    break;
+                }
+
+                if (line.startsWith("public abstract class Maybe<")) {
+                    classDefPassed = true;
+                }
+
+                if (classDefPassed) {
+                    if (line.contains("@since") && line.contains("2.0")) {
+                        b.append("java.lang.RuntimeException: @since 2.0 found").append("\r\n")
+                        .append(" at io.reactivex.Maybe (Maybe.java:").append(ln).append(")\r\n\r\n");
+                        ;
+                    }
+                }
+
+                ln++;
+            }
+        } finally {
+            in.close();
+        }
+
+        if (b.length() != 0) {
+            System.out.println(b);
+
+            fail(b.toString());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeDelayOtherTest {
+
+    @Test
+    public void justWithOnNext() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.just(1)
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void justWithOnComplete() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.just(1)
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onComplete();
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertResult(1);
+    }
+
+
+    @Test
+    public void justWithOnError() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.just(1)
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onError(new TestException("Other"));
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailureAndMessage(TestException.class, "Other");
+    }
+
+    @Test
+    public void emptyWithOnNext() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.<Integer>empty()
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertResult();
+    }
+
+
+    @Test
+    public void emptyWithOnComplete() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.<Integer>empty()
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onComplete();
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void emptyWithOnError() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.<Integer>empty()
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onError(new TestException("Other"));
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailureAndMessage(TestException.class, "Other");
+    }
+
+    @Test
+    public void errorWithOnNext() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailureAndMessage(TestException.class, "Main");
+    }
+
+    @Test
+    public void errorWithOnComplete() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onComplete();
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailureAndMessage(TestException.class, "Main");
+    }
+
+    @Test
+    public void errorWithOnError() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        .delay(pp).test();
+
+        ts.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onError(new TestException("Other"));
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailure(CompositeException.class);
+
+        List<Throwable> list = TestHelper.compositeList(ts.errors().get(0));
+        assertEquals(2, list.size());
+
+        TestHelper.assertError(list, 0, TestException.class, "Main");
+        TestHelper.assertError(list, 1, TestException.class, "Other");
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeDelaySubscriptionTest {
+
+    @Test
+    public void normal() {
+        PublishProcessor<Object> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.just(1).delaySubscription(pp)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        pp.onNext("one");
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void timed() {
+        Maybe.just(1).delaySubscription(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void timedEmpty() {
+        Maybe.<Integer>empty().delaySubscription(100, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void timedTestScheduler() {
+        TestScheduler scheduler = new TestScheduler();
+
+        TestSubscriber<Integer> ts = Maybe.just(1)
+        .delaySubscription(100, TimeUnit.MILLISECONDS, scheduler)
+        .test();
+
+        ts.assertEmpty();
+
+        scheduler.advanceTimeBy(99, TimeUnit.MILLISECONDS);
+
+        ts.assertEmpty();
+
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void otherError() {
+        Maybe.just(1).delaySubscription(Flowable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainError() {
+        Maybe.error(new TestException())
+        .delaySubscription(Flowable.empty())
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+
+public class MaybeFlatMapBiSelectorTest {
+
+    BiFunction<Integer, Integer, String> stringCombine() {
+        return new BiFunction<Integer, Integer, String>() {
+            @Override
+            public String apply(Integer a, Integer b) throws Exception {
+                return a + ":" + b;
+            }
+        };
+    }
+
+    @Test
+    public void normal() {
+        Maybe.just(1)
+        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                return Maybe.just(2);
+            }
+        }, stringCombine())
+        .test()
+        .assertResult("1:2");
+    }
+
+    @Test
+    public void normalWithEmpty() {
+        Maybe.just(1)
+        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                return Maybe.empty();
+            }
+        }, stringCombine())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void emptyWithJust() {
+        final int[] call = { 0 };
+
+        Maybe.<Integer>empty()
+        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                call[0]++;
+                return Maybe.just(1);
+            }
+        }, stringCombine())
+        .test()
+        .assertResult();
+
+        assertEquals(0, call[0]);
+    }
+
+    @Test
+    public void errorWithJust() {
+        final int[] call = { 0 };
+
+        Maybe.<Integer>error(new TestException())
+        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                call[0]++;
+                return Maybe.just(1);
+            }
+        }, stringCombine())
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(0, call[0]);
+    }
+
+    @Test
+    public void justWithError() {
+        final int[] call = { 0 };
+
+        Maybe.just(1)
+        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                call[0]++;
+                return Maybe.<Integer>error(new TestException());
+            }
+        }, stringCombine())
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, call[0]);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.processors.PublishProcessor;
+
+public class MaybeHideTest {
+
+    @Test
+    public void normal() {
+        Maybe.just(1)
+        .hide()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void empty() {
+        Maybe.empty()
+        .hide()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void error() {
+        Maybe.error(new TestException())
+        .hide()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void hidden() {
+        assertTrue(Maybe.just(1) instanceof ScalarCallable);
+
+        assertFalse(Maybe.just(1).hide() instanceof ScalarCallable);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposedMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
+            @Override
+            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
+                return m.hide();
+            }
+        });
+    }
+
+    @Test
+    public void isDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestHelper.checkDisposed(pp.toMaybe().hide());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
+                return f.hide();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+
+public class MaybeIsEmptyTest {
+
+    @Test
+    public void normal() {
+        Maybe.just(1)
+        .isEmpty()
+        .test()
+        .assertResult(false);
+    }
+
+    @Test
+    public void empty() {
+        Maybe.empty()
+        .isEmpty()
+        .test()
+        .assertResult(true);
+    }
+
+    @Test
+    public void error() {
+        Maybe.error(new TestException())
+        .isEmpty()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedBackToMaybe() {
+        assertTrue(Maybe.just(1)
+        .isEmpty()
+        .toMaybe() instanceof MaybeIsEmpty);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposedMaybeToSingle(new Function<Maybe<Object>, SingleSource<Boolean>>() {
+            @Override
+            public SingleSource<Boolean> apply(Maybe<Object> m) throws Exception {
+                return m.isEmpty();
+            }
+        });
+    }
+
+    @Test
+    public void isDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestHelper.checkDisposed(pp.toMaybe().isEmpty());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, Single<Boolean>>() {
+            @Override
+            public Single<Boolean> apply(Maybe<Object> f) throws Exception {
+                return f.isEmpty();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeWithTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeWithTest.java
@@ -13,31 +13,16 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import io.reactivex.*;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import org.junit.Test;
 
-/**
- * Signals a constant value.
- *
- * @param <T> the value type
- */
-public final class MaybeJust<T> extends Maybe<T> implements ScalarCallable<T> {
+import io.reactivex.Maybe;
 
-    final T value;
+public class MaybeMergeWithTest {
 
-    public MaybeJust(T value) {
-        this.value = value;
-    }
-
-    @Override
-    protected void subscribeActual(MaybeObserver<? super T> observer) {
-        observer.onSubscribe(Disposables.disposed());
-        observer.onSuccess(value);
-    }
-
-    @Override
-    public T call() {
-        return value;
+    @Test
+    public void normal() {
+        Maybe.just(1).mergeWith(Maybe.just(2))
+        .test()
+        .assertResult(1, 2);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeOfTypeTest {
+
+    @Test
+    public void normal() {
+        Maybe.just(1).ofType(Integer.class)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void normalDowncast() {
+        TestSubscriber<Number> ts = Maybe.just(1)
+        .ofType(Number.class)
+        .test();
+        // don't make this fluent, target type required!
+        ts.assertResult((Number)1);
+    }
+
+    @Test
+    public void notInstance() {
+        TestSubscriber<String> ts = Maybe.just(1)
+        .ofType(String.class)
+        .test();
+        // don't make this fluent, target type required!
+        ts.assertResult();
+    }
+
+    @Test
+    public void error() {
+        TestSubscriber<Number> ts = Maybe.<Integer>error(new TestException())
+        .ofType(Number.class)
+        .test();
+        // don't make this fluent, target type required!
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorNotInstance() {
+        TestSubscriber<String> ts = Maybe.<Integer>error(new TestException())
+        .ofType(String.class)
+        .test();
+        // don't make this fluent, target type required!
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposedMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Maybe<Object> m) throws Exception {
+                return m.ofType(Object.class);
+            }
+        });
+    }
+
+    @Test
+    public void isDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestHelper.checkDisposed(pp.toMaybe().ofType(Object.class));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
+                return f.ofType(Object.class);
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOnErrorXTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+
+public class MaybeOnErrorXTest {
+
+    @Test
+    public void onErrorReturnConst() {
+        Maybe.error(new TestException())
+        .onErrorReturnItem(1)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void onErrorReturn() {
+        Maybe.error(new TestException())
+        .onErrorReturn(Functions.justFunction(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void onErrorComplete() {
+        Maybe.error(new TestException())
+        .onErrorComplete()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void onErrorCompleteTrue() {
+        Maybe.error(new TestException())
+        .onErrorComplete(Functions.alwaysTrue())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void onErrorCompleteFalse() {
+        Maybe.error(new TestException())
+        .onErrorComplete(Functions.alwaysFalse())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void onErrorReturnFunctionThrows() {
+        TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
+        .onErrorReturn(new Function<Throwable, Object>() {
+            @Override
+            public Object apply(Throwable v) throws Exception {
+                throw new IOException();
+            }
+        })
+        .test(), TestException.class, IOException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void onErrorCompletePredicateThrows() {
+        TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
+        .onErrorComplete(new Predicate<Throwable>() {
+            @Override
+            public boolean test(Throwable v) throws Exception {
+                throw new IOException();
+            }
+        })
+        .test(), TestException.class, IOException.class);
+    }
+
+    @Test
+    public void onErrorResumeNext() {
+        Maybe.error(new TestException())
+        .onErrorResumeNext(Functions.justFunction(Maybe.just(1)))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void onExceptionResumeNext() {
+        Maybe.error(new TestException())
+        .onExceptionResumeNext(Maybe.just(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void onExceptionResumeNextPassthrough() {
+        Maybe.error(new AssertionError())
+        .onExceptionResumeNext(Maybe.just(1))
+        .test()
+        .assertFailure(AssertionError.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void onErrorResumeNextFunctionThrows() {
+        TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
+        .onErrorResumeNext(new Function<Throwable, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Throwable v) throws Exception {
+                throw new IOException();
+            }
+        })
+        .test(), TestException.class, IOException.class);
+    }
+}


### PR DESCRIPTION
- add `Maybe` operators: `delay`, `hide`, `isEmpty`, `onErrorComplete`, `onErrorResumeNext`, `onExceptionResumeNext`
- add more fusion interfaces and mark `Maybe.just` and `Maybe.empty` as `ScalarCallable`.
- added unit test to verify base reactive classes have proper scheduler and backpressure annotations (wherever appropriate)
- added unit test to verify the javadoc of the main reactive types have the **Backpressure:** and **Scheduler:** sections in them (via scanning the source files if it can find it possible, works for me)
- added unit test to verify that when **Scheduler:** section mentions a method name, it actually matches the method the javadoc is there for (lots of copy-paste errors were found this way)
- fix the annotations and documentation errors detected above
- the backpressure javadoc section checker for 3 types are currently disabled as I'm out of time for tonight.
