### PR TITLE
2.x: Fix MaybeTimber by using scheduler and unit

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1238,7 +1238,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits one item after a specified delay on a specified Scheduler.
+     * Returns a Maybe that emits one item after a specified delay on a specified Scheduler.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.s.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1238,7 +1238,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits one item after a specified delay on a specified Scheduler.
+     * Returns a Flowable that emits one item after a specified delay on a specified Scheduler.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.s.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimer.java
@@ -16,9 +16,7 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Completable;
-import io.reactivex.CompletableObserver;
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimer.java
@@ -16,9 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Maybe;
-import io.reactivex.MaybeObserver;
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
@@ -14,10 +14,17 @@
 package io.reactivex.internal.operators.single;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.*;
-import io.reactivex.internal.disposables.SequentialDisposable;
+import io.reactivex.Scheduler;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
 
+/**
+ * Signals a {@code 0L} after the specified delay
+ */
 public final class SingleTimer extends Single<Long> {
 
     final long delay;
@@ -32,16 +39,37 @@ public final class SingleTimer extends Single<Long> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super Long> s) {
-        SequentialDisposable sd = new SequentialDisposable();
-
-        s.onSubscribe(sd);
-
-        sd.replace(scheduler.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                s.onSuccess(0L);
-            }
-        }, delay, unit));
+        TimerDisposable parent = new TimerDisposable(s);
+        s.onSubscribe(parent);
+        parent.setFuture(scheduler.scheduleDirect(parent, delay, unit));
     }
 
+    static final class TimerDisposable extends AtomicReference<Disposable> implements Disposable, Runnable {
+        /** */
+        private static final long serialVersionUID = 8465401857522493082L;
+        final SingleObserver<? super Long> actual;
+
+        TimerDisposable(final SingleObserver<? super Long> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void run() {
+            actual.onSuccess(0L);
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        void setFuture(Disposable d) {
+            DisposableHelper.replace(this, d);
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
@@ -16,9 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Scheduler;
-import io.reactivex.Single;
-import io.reactivex.SingleObserver;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 

--- a/src/test/java/io/reactivex/completable/CompletableTimerTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTimerTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.completable;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.reactivex.Completable;
+import io.reactivex.functions.Action;
+import io.reactivex.schedulers.TestScheduler;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompletableTimerTest {
+    @Test
+    public void timer() {
+        final TestScheduler testScheduler = new TestScheduler();
+
+        final AtomicLong atomicLong = new AtomicLong();
+        Completable.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicLong.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicLong.get());
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertEquals(0, atomicLong.get());
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertEquals(1, atomicLong.get());
+    }
+}

--- a/src/test/java/io/reactivex/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTimerTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.maybe;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.reactivex.Maybe;
+import io.reactivex.functions.Consumer;
+import io.reactivex.schedulers.TestScheduler;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaybeTimerTest {
+    @Test
+    public void timer() {
+        final TestScheduler testScheduler = new TestScheduler();
+
+        final AtomicLong atomicLong = new AtomicLong();
+        Maybe.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(new Consumer<Long>() {
+            @Override
+            public void accept(final Long value) throws Exception {
+                atomicLong.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicLong.get());
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertEquals(0, atomicLong.get());
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertEquals(1, atomicLong.get());
+    }
+}

--- a/src/test/java/io/reactivex/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/single/SingleTimerTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.single;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.reactivex.Single;
+import io.reactivex.functions.Consumer;
+import io.reactivex.schedulers.TestScheduler;
+
+import static org.junit.Assert.assertEquals;
+
+public class SingleTimerTest {
+    @Test
+    public void timer() {
+        final TestScheduler testScheduler = new TestScheduler();
+
+        final AtomicLong atomicLong = new AtomicLong();
+        Single.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(new Consumer<Long>() {
+            @Override
+            public void accept(final Long value) throws Exception {
+                atomicLong.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicLong.get());
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertEquals(0, atomicLong.get());
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertEquals(1, atomicLong.get());
+    }
+}


### PR DESCRIPTION
Also one question why does `CompletableTimer` check `if (!sd.isDisposed()) {` before replacing but SingleTimer does not? I adjusted MaybeTimber to SingleTimer so I didn't add the check there either.

However I feel like this should be consistent, can you elaborate which one is wanted?
