### PR TITLE
2.x: cleanup 9/12-1, more Maybe operators, more source code checking

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -136,6 +136,9 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which completes only when all sources complete, one after another.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -152,6 +155,9 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which completes only when all sources complete, one after another.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -197,9 +203,9 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param source the emitter that is called when a Subscriber subscribes to the returned {@code Flowable}
+     * @param source the emitter that is called when a CompletableObserver subscribes to the returned {@code Completable}
      * @return the new Completable instance
-     * @see FlowableOnSubscribe
+     * @see CompletableOnSubscribe
      * @see Cancellable
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -249,7 +255,7 @@ public abstract class Completable implements CompletableSource {
      * Creates a Completable which calls the given error supplier for each subscriber
      * and emits its returned Throwable.
      * <p>
-     * If the errorSupplier returns null, the child CompletableSubscribers will receive a
+     * If the errorSupplier returns null, the child CompletableObservers will receive a
      * NullPointerException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -354,6 +360,9 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable instance that subscribes to the given publisher, ignores all values and
      * emits only the terminal event.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -431,6 +440,9 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable instance that subscribes to all sources at once and
      * completes only when all source Completables complete or one of them emits an error.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -448,6 +460,9 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable instance that keeps subscriptions to a limited number of sources at once and
      * completes only when all source Completables complete or one of them emits an error.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -468,6 +483,9 @@ public abstract class Completable implements CompletableSource {
      * completes only when all source Completables terminate in one way or another, combining any exceptions
      * thrown by either the sources Observable or the inner Completable instances.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code merge0} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -528,6 +546,9 @@ public abstract class Completable implements CompletableSource {
      * any error emitted by either the sources observable or any of the inner Completables until all of
      * them terminate in a way or another.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -547,6 +568,9 @@ public abstract class Completable implements CompletableSource {
      * observable or any of the inner Completables until all of
      * them terminate in a way or another.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -732,11 +756,14 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns an Flowable which will subscribe to this Completable and once that is completed then
+     * Returns a Flowable which will subscribe to this Completable and once that is completed then
      * will subscribe to the {@code next} Flowable. An error event from this Completable will be
      * propagated to the downstream subscriber and will result in skipping the subscription of the
      * Observable.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1387,6 +1414,9 @@ public abstract class Completable implements CompletableSource {
      * Returns an Observable which first delivers the events
      * of the other Observable then runs this Completable.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1659,6 +1689,8 @@ public abstract class Completable implements CompletableSource {
      * Returns an Observable which when subscribed to subscribes to this Completable and
      * relays the terminal events to the subscriber.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -408,7 +408,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Combines a collection of source Publishers by emitting an item that aggregates the latest values of each of
-     * the source ObservableSources each time an item is received from any of the source Publisher, where this
+     * the source Publishers each time an item is received from any of the source Publisher, where this
      * aggregation is defined by a specified function and delays any error from the sources until
      * all source Publishers terminate.
      * <p>
@@ -1274,7 +1274,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * in order, each one after the previous one completes.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd><dd>The operator honors backpressure from downstream. The {@code Publisher}
+     *  <dd>The operator honors backpressure from downstream. The {@code Publisher}
      *  sources are expected to honor backpressure as well.
      *  If any of the source {@code Publisher}s violate this, the operator will signal a
      *  {@code MissingBackpressureException}.</dd>
@@ -1300,7 +1300,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * in order, each one after the previous one completes.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd><dd>The operator honors backpressure from downstream. The {@code Publisher}
+     *  <dd>The operator honors backpressure from downstream. The {@code Publisher}
      *  sources are expected to honor backpressure as well.
      *  If any of the source {@code Publisher}s violate this, the operator will signal a
      *  {@code MissingBackpressureException}.</dd>
@@ -1564,7 +1564,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="340" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/defer.png" alt="">
      * <p>
      * The defer Subscriber allows you to defer or delay emitting items from a Publisher until such time as an
-     * Subscriber subscribes to the Publisher. This allows an {@link Subscriber} to easily obtain updates or a
+     * Subscriber subscribes to the Publisher. This allows a {@link Subscriber} to easily obtain updates or a
      * refreshed version of the sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1616,7 +1616,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that invokes an {@link Subscriber}'s {@link Subscriber#onError onError} method when the
+     * Returns a Flowable that invokes a {@link Subscriber}'s {@link Subscriber#onError onError} method when the
      * Subscriber subscribes to it.
      * <p>
      * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/error.png" alt="">
@@ -1643,7 +1643,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that invokes an {@link Subscriber}'s {@link Subscriber#onError onError} method when the
+     * Returns a Flowable that invokes a {@link Subscriber}'s {@link Subscriber#onError onError} method when the
      * Subscriber subscribes to it.
      * <p>
      * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/error.png" alt="">
@@ -1702,12 +1702,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that, when an Subscriber subscribes to it, invokes a function you specify and then
+     * Returns a Flowable that, when a Subscriber subscribes to it, invokes a function you specify and then
      * emits the value returned from that function.
      * <p>
      * <img width="640" height="195" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCallable.png" alt="">
      * <p>
-     * This allows you to defer the execution of the function you specify until an Subscriber subscribes to the
+     * This allows you to defer the execution of the function you specify until a Subscriber subscribes to the
      * Publisher. That is to say, it makes the function "lazy."
      * <dl>
      *   <dt><b>Backpressure:</b></dt>
@@ -1718,7 +1718,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param supplier
      *         a function, the execution of which should be deferred; {@code fromCallable} will invoke this
-     *         function only when an Subscriber subscribes to the Publisher that {@code fromCallable} returns
+     *         function only when a Subscriber subscribes to the Publisher that {@code fromCallable} returns
      * @param <T>
      *         the type of the item emitted by the Publisher
      * @return a Flowable whose {@link Subscriber}s' subscriptions trigger an invocation of the given function
@@ -2151,7 +2151,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator signals a {@code MissingBackpressureException} if the downstream
-     *  is not ready to receive the next value.
+     *  is not ready to receive the next value.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code interval} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
@@ -3007,7 +3007,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens an Iterable of Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens an Iterable of Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source Publishers without being interrupted by an error
      * notification from one of them.
      * <p>
@@ -3043,7 +3043,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
 
     /**
-     * Flattens an Iterable of Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens an Iterable of Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source Publishers without being interrupted by an error
      * notification from one of them, while limiting the number of concurrent subscriptions to these Publishers.
      * <p>
@@ -3082,7 +3082,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens an array of Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens an array of Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source Publishers without being interrupted by an error
      * notification from one of them, while limiting the number of concurrent subscriptions to these Publishers.
      * <p>
@@ -3121,7 +3121,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens an Iterable of Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens an Iterable of Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source Publishers without being interrupted by an error
      * notification from one of them, while limiting the number of concurrent subscriptions to these Publishers.
      * <p>
@@ -3158,7 +3158,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens a Publisher that emits Publishers into one Publisher, in a way that allows an Subscriber to
+     * Flattens a Publisher that emits Publishers into one Publisher, in a way that allows a Subscriber to
      * receive all successfully emitted items from all of the source Publishers without being interrupted by
      * an error notification from one of them.
      * <p>
@@ -3193,7 +3193,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens a Publisher that emits Publishers into one Publisher, in a way that allows an Subscriber to
+     * Flattens a Publisher that emits Publishers into one Publisher, in a way that allows a Subscriber to
      * receive all successfully emitted items from all of the source Publishers without being interrupted by
      * an error notification from one of them, while limiting the
      * number of concurrent subscriptions to these Publishers.
@@ -3232,7 +3232,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens an array of Publishers into one Flowable, in a way that allows an Subscriber to receive all
+     * Flattens an array of Publishers into one Flowable, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source Publishers without being interrupted by an error
      * notification from one of them.
      * <p>
@@ -3267,7 +3267,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens two Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens two Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source Publishers without being interrupted by an error
      * notification from one of them.
      * <p>
@@ -3305,7 +3305,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Flattens three Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens three Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from all of the source Publishers without being interrupted by an error
      * notification from one of them.
      * <p>
@@ -3348,7 +3348,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
 
     /**
-     * Flattens four Publishers into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens four Publishers into one Publisher, in a way that allows a Subscriber to receive all
      * successfully emitted items from all of the source Publishers without being interrupted by an error
      * notification from one of them.
      * <p>
@@ -3395,7 +3395,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that never sends any items or notifications to an {@link Subscriber}.
+     * Returns a Flowable that never sends any items or notifications to a {@link Subscriber}.
      * <p>
      * <img width="640" height="185" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/never.png" alt="">
      * <p>
@@ -3409,7 +3409,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <T>
      *            the type of items (not) emitted by the Publisher
-     * @return a Flowable that never emits any items or sends any notifications to an {@link Subscriber}
+     * @return a Flowable that never emits any items or sends any notifications to a {@link Subscriber}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Never</a>
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -86,6 +86,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources provided by
      * an Iterable sequence.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -103,8 +105,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a Flowable that emits the items emitted by two MaybeSources, one after the other.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -129,8 +133,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a Flowable that emits the items emitted by three MaybeSources, one after the other.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -159,8 +165,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a Flowable that emits the items emitted by four MaybeSources, one after the other.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -193,8 +201,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources provided by
      * a Publisher sequence.
      * <dl>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer and
+     *  expects the {@code Publisher} to honor backpressure as well. If the sources {@code Publisher}
+     *  violates this, a {@code MissingBackpressurException} is signalled.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
      * @param sources the Publisher of MaybeSource instances
@@ -210,6 +222,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources provided by
      * a Publisher sequence.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer and
+     *  expects the {@code Publisher} to honor backpressure as well. If the sources {@code Publisher}
+     *  violates this, a {@code MissingBackpressurException} is signalled.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -230,11 +246,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources in the array.
      * <dl>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the Publisher of MaybeSource instances
+     * @param sources the array of MaybeSource instances
      * @return the new Flowable instance
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -258,9 +276,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.
-     *  If the {@code Publisher} violate this, it <em>may</em> throw an
-     *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -290,7 +306,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * in order, each one after the previous one completes.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd><dd>The operator honors backpressure from downstream.</dd>
+     *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -306,22 +322,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates the Iterable sequence of Publishers into a single sequence by subscribing to each Publisher,
-     * one after the other, one at a time and delays any errors till the all inner Publishers terminate.
+     * Concatenates the Iterable sequence of MaybeSources into a single sequence by subscribing to each MaybeSource,
+     * one after the other, one at a time and delays any errors till the all inner MaybeSources terminate.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. The inner {@code Publisher}
-     *  sources are expected to honor backpressure. If any of the inner {@code Publisher}s violates
-     *  this, it <em>may</em> throw an {@code IllegalStateException} when an
-     *  inner {@code Publisher} completes.</dd>
+     *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources the Iterable sequence of MaybeSources
-     * @return the new Publisher with the concatenating behavior
+     * @return the new Flowable with the concatenating behavior
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -361,9 +374,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * in order, each one after the previous one completes.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Backpressure is honored towards the downstream and outer Publisher is expected
-     *  to honor backpressure. Violating this assumption, the operator will
-     *  signal {@code MissingBackpressureException}.</dd>
+     *  <dd>Backpressure is honored towards the downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -437,7 +448,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param onSubscribe the emitter that is called when a MaybeObserver subscribes to the returned {@code Flowable}
+     * @param onSubscribe the emitter that is called when a MaybeObserver subscribes to the returned {@code Maybe}
      * @return the new Maybe instance
      * @see MaybeOnSubscribe
      * @see Cancellable
@@ -488,7 +499,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Returns a Maybe that invokes a subscriber's {@link MaybeObserver#onError onError} method when the
      * subscriber subscribes to it.
      * <p>
-     * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.error.png" alt="">
+     * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.error.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -509,8 +520,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that invokes an {@link Observer}'s {@link MaybeObserver#onError onError} method when the
-     * Observer subscribes to it.
+     * Returns a Maybe that invokes a {@link MaybeObserver}'s {@link MaybeObserver#onError onError} method when the
+     * MaybeObserver subscribes to it.
      * <p>
      * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/error.png" alt="">
      * <dl>
@@ -519,7 +530,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param supplier
-     *            a Callable factory to return a Throwable for each individual Subscriber
+     *            a Callable factory to return a Throwable for each individual MaybeObserver
      * @param <T>
      *            the type of the items (ostensibly) emitted by the Maybe
      * @return a Maybe that invokes the {@link MaybeObserver}'s {@link MaybeObserver#onError onError} method when
@@ -596,7 +607,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the source {@link Future}
      * @param <T>
      *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
-     *            the resulting Publisher
+     *            the resulting Maybe
      * @return a Maybe that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
@@ -615,13 +626,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * return value of the {@link Future#get} method of that object, by passing the object into the {@code fromFuture}
      * method.
      * <p>
-     * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, cancelling the Maybe won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnCancel(() -> future.cancel(true));}.
      * <p>
      * <em>Important note:</em> This Maybe is blocking on the thread it gets subscribed on; you cannot unsubscribe from it.
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -634,7 +643,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the {@link TimeUnit} of the {@code timeout} argument
      * @param <T>
      *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
-     *            the resulting Publisher
+     *            the resulting Maybe
      * @return a Maybe that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
@@ -667,9 +676,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a {@code Maybe} that emits a specified item.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.just.png" alt="">
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.just.png" alt="">
      * <p>
-     * To convert any object into a {@code Single} that emits that object, pass that object into the
+     * To convert any object into a {@code Maybe} that emits that object, pass that object into the
      * {@code just} method.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -749,10 +758,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens a {@code Single} that emits a {@code Single} into a single {@code Single} that emits the item
-     * emitted by the nested {@code Single}, without any transformation.
+     * Flattens a {@code MaybeSource} that emits a {@code MaybeSource} into a single {@code MaybeSource} that emits the item
+     * emitted by the nested {@code MaybeSource}, without any transformation.
      * <p>
-     * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.oo.png" alt="">
+     * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.oo.png" alt="">
      * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -761,8 +770,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the value type of the sources and the output
      * @param source
-     *            a {@code Single} that emits a {@code Single}
-     * @return a {@code Single} that emits the item that is the result of flattening the {@code Single} emitted
+     *            a {@code MaybeSource} that emits a {@code MaybeSource}
+     * @return a {@code Maybe} that emits the item that is the result of flattening the {@code MaybeSource} emitted
      *         by {@code source}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
@@ -773,11 +782,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens two Singles into a single Observable, without any transformation.
+     * Flattens two MaybeSources into a single Flowable, without any transformation.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by
+     * You can combine items emitted by multiple MaybeSources so that they appear as a single Flowable, by
      * using the {@code merge} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -788,10 +797,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a MaybeSource to be merged
      * @param source2
-     *            a Single to be merged
-     * @return a Flowable that emits all of the items emitted by the source Singles
+     *            a MaybeSource to be merged
+     * @return a Flowable that emits all of the items emitted by the source MaybeSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -806,11 +815,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens three Singles into a single Observable, without any transformation.
+     * Flattens three MaybeSources into a single Flowable, without any transformation.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * You can combine items emitted by multiple MaybeSources so that they appear as a single Flowable, by using
      * the {@code merge} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -821,12 +830,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a MaybeSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a MaybeSource to be merged
      * @param source3
-     *            a Single to be merged
-     * @return a Flowable that emits all of the items emitted by the source Singles
+     *            a MaybeSource to be merged
+     * @return a Flowable that emits all of the items emitted by the source MaybeSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -843,11 +852,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens four Singles into a single Observable, without any transformation.
+     * Flattens four MaybeSources into a single Flowable, without any transformation.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * You can combine items emitted by multiple MaybeSources so that they appear as a single Flowable, by using
      * the {@code merge} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -858,14 +867,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a MaybeSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a MaybeSource to be merged
      * @param source3
-     *            a Single to be merged
+     *            a MaybeSource to be merged
      * @param source4
-     *            a Single to be merged
-     * @return a Flowable that emits all of the items emitted by the source Singles
+     *            a MaybeSource to be merged
+     * @return a Flowable that emits all of the items emitted by the source MaybeSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -910,17 +919,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens an array of MaybeSources into one Publisher, in a way that allows an Subscriber to receive all
+     * Flattens an array of MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source MaybeSources without being interrupted by an error
      * notification from one of them.
      * <p>
      * This behaves like {@link #merge(Publisher)} except that if any of the merged MaybeSources notify of an
      * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged Publishers have finished emitting items.
+     * error notification until all of the merged MaybeSources have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -933,7 +942,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param sources
      *            the Iterable of MaybeSources
      * @return a Flowable that emits items that are the result of flattening the items emitted by the
-     *         Publishers in the Iterable
+     *         MaybeSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -945,17 +954,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
 
     /**
-     * Flattens an Iterable of MaybeSources into one Publisher, in a way that allows an Subscriber to receive all
-     * successfully emitted items from each of the source Publishers without being interrupted by an error
+     * Flattens an Iterable of MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
+     * successfully emitted items from each of the source MaybeSources without being interrupted by an error
      * notification from one of them.
      * <p>
-     * This behaves like {@link #merge(Publisher)} except that if any of the merged Publishers notify of an
+     * This behaves like {@link #merge(Publisher)} except that if any of the merged MaybeSources notify of an
      * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged Publishers have finished emitting items.
+     * error notification until all of the merged MaybeSources have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -966,9 +975,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param sources
-     *            the Iterable of Publishers
+     *            the Iterable of MaybeSources
      * @return a Flowable that emits items that are the result of flattening the items emitted by the
-     *         Publishers in the Iterable
+     *         MaybeSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -980,7 +989,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
 
     /**
-     * Flattens a Publisher that emits MaybeSources into one Publisher, in a way that allows an Subscriber to
+     * Flattens a Publisher that emits MaybeSources into one Publisher, in a way that allows a Subscriber to
      * receive all successfully emitted items from all of the source Publishers without being interrupted by
      * an error notification from one of them.
      * <p>
@@ -1015,7 +1024,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens two MaybeSources into one Flowable, in a way that allows an Subscriber to receive all
+     * Flattens two MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
      * successfully emitted items from each of the source MaybeSources without being interrupted by an error
      * notification from one of them.
      * <p>
@@ -1025,7 +1034,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if both merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * Even if both merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1052,18 +1061,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens three MaybeSource into one Flowable, in a way that allows an Subscriber to receive all
+     * Flattens three MaybeSource into one Flowable, in a way that allows a Subscriber to receive all
      * successfully emitted items from all of the source MaybeSources without being interrupted by an error
      * notification from one of them.
      * <p>
      * This behaves like {@link #merge(MaybeSource, MaybeSource, MaybeSource)} except that if any of the merged
-     * Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain
-     * from propagating that error notification until all of the merged Publishers have finished emitting
+     * MaybeSources notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain
+     * from propagating that error notification until all of the merged MaybeSources have finished emitting
      * items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1074,7 +1083,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param source1
-     *            a PublMaybeSourceisher to be merged
+     *            a MaybeSource to be merged
      * @param source2
      *            a MaybeSource to be merged
      * @param source3
@@ -1095,18 +1104,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
 
     /**
-     * Flattens four MaybeSources into one Flowable, in a way that allows an Subscriber to receive all
-     * successfully emitted items from all of the source Publishers without being interrupted by an error
+     * Flattens four MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
+     * successfully emitted items from all of the source MaybeSources without being interrupted by an error
      * notification from one of them.
      * <p>
      * This behaves like {@link #merge(MaybeSource, MaybeSource, MaybeSource, MaybeSource)} except that if any of
-     * the merged Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * the merged MaybeSources notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
      * will refrain from propagating that error notification until all of the merged MaybeSources have finished
      * emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
      * invoke the {@code onError} method of its Subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1141,7 +1150,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that never sends any items or notifications to an {@link MaybeObserver}.
+     * Returns a Maybe that never sends any items or notifications to a {@link MaybeObserver}.
      * <p>
      * <img width="640" height="185" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/never.png" alt="">
      * <p>
@@ -1153,7 +1162,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T>
      *            the type of items (not) emitted by the Maybe
-     * @return a Maybe that never emits any items or sends any notifications to an {@link MaybeObserver}
+     * @return a Maybe that never emits any items or sends any notifications to a {@link MaybeObserver}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Never</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1165,7 +1174,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Returns a Single that emits a Boolean value that indicates whether two MaybeSource sequences are the
-     * same by comparing the items emitted by each Publisher pairwise.
+     * same by comparing the items emitted by each MaybeSource pairwise.
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
      * <dl>
@@ -1238,7 +1247,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits one item after a specified delay on a specified Scheduler.
+     * Returns a Maybe that emits one item after a specified delay on a specified Scheduler.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.s.png" alt="">
      * <dl>
@@ -1292,7 +1301,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <T> the element type of the generated Publisher
+     * @param <T> the element type of the generated MaybeSource
      * @param <D> the type of the resource associated with the output sequence
      * @param resourceSupplier
      *            the factory function to create a resource object that depends on the Maybe
@@ -1323,7 +1332,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <T> the element type of the generated Publisher
+     * @param <T> the element type of the generated MaybeSource
      * @param <D> the type of the resource associated with the output sequence
      * @param resourceSupplier
      *            the factory function to create a resource object that depends on the Maybe
@@ -2161,7 +2170,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * until the other Publisher emits an element or completes normally.
      * <p>
      * <dl>
-     *  <dt><b></b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The {@code Publisher} source is consumed in an unbounded fashion (without applying backpressure).
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2496,8 +2505,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Observable that is based on applying a specified function to the item emitted by the source Maybe,
-     * where that function returns a ObservableSource.
+     * Returns an Observable that is based on applying a specified function to the item emitted by the source Maybe,
+     * where that function returns an ObservableSource.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
@@ -2507,7 +2516,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a ObservableSource
+     *            a function that, when applied to the item emitted by the source Maybe, returns an ObservableSource
      * @return the Observable returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
@@ -2992,6 +3001,302 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public final Maybe<T> onExceptionResumeNext(final MaybeSource<? extends T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
         return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<T>(this, Functions.justFunction(next), false));
+    }
+    /**
+     * Nulls out references to the upstream producer and downstream MaybeObserver if
+     * the sequence is terminated or downstream unsubscribes.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return a Maybe which out references to the upstream producer and downstream MaybeObserver if
+     * the sequence is terminated or downstream unsubscribes
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onTerminateDetach() {
+        return RxJavaPlugins.onAssembly(new MaybeDetach<T>(this));
+    }
+
+    /**
+     * Returns a Flowable that repeats the sequence of items emitted by the source Publisher indefinitely.
+     * <p>
+     * <img width="640" height="309" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.o.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
+     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return a Flowable that emits the items emitted by the source Publisher repeatedly and in sequence
+     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> repeat() {
+        return repeat(Long.MAX_VALUE);
+    }
+
+    /**
+     * Returns a Flowable that repeats the sequence of items emitted by the source Publisher at most
+     * {@code count} times.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
+     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param times
+     *            the number of times the source Publisher items are repeated, a count of 0 will yield an empty
+     *            sequence
+     * @return a Flowable that repeats the sequence of items emitted by the source Publisher at most
+     *         {@code count} times
+     * @throws IllegalArgumentException
+     *             if {@code count} is less than zero
+     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> repeat(long times) {
+        return toFlowable().repeat(times);
+    }
+
+    /**
+     * Returns a Flowable that repeats the sequence of items emitted by the source Publisher until
+     * the provided stop function returns true.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
+     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param stop
+     *                a boolean supplier that is called when the current Flowable completes and unless it returns
+     *                false, the current Flowable is resubscribed
+     * @return the new Flowable instance
+     * @throws NullPointerException
+     *             if {@code stop} is null
+     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> repeatUntil(BooleanSupplier stop) {
+        return toFlowable().repeatUntil(stop);
+    }
+
+    /**
+     * Returns a Flowable that emits the same values as the source Publisher with the exception of an
+     * {@code onComplete}. An {@code onComplete} notification from the source will result in the emission of
+     * a {@code void} item to the Publisher provided as an argument to the {@code notificationHandler}
+     * function. If that Publisher calls {@code onComplete} or {@code onError} then {@code repeatWhen} will
+     * call {@code onComplete} or {@code onError} on the child subscription. Otherwise, this Publisher will
+     * resubscribe to the source Publisher.
+     * <p>
+     * <img width="640" height="430" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeatWhen.f.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
+     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code repeatWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param handler
+     *            receives a Publisher of notifications with which a user can complete or error, aborting the repeat.
+     * @return the source Publisher modified with repeat logic
+     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> repeatWhen(final Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+        return toFlowable().repeatWhen(handler);
+    }
+
+
+    /**
+     * Returns a Maybe that mirrors the source Maybe, resubscribing to it if it calls {@code onError}
+     * (infinite retry count).
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <p>
+     * If the source Publisher calls {@link Subscriber#onError}, this method will resubscribe to the source
+     * Publisher rather than propagating the {@code onError} call.
+     * <p>
+     * Any and all items emitted by the source Publisher will be emitted by the resulting Publisher, even
+     * those emitted during failed subscriptions. For example, if a Publisher fails at first but emits
+     * {@code [1, 2]} then succeeds the second time and emits {@code [1, 2, 3, 4, 5]} then the complete sequence
+     * of emissions and notifications would be {@code [1, 2, 1, 2, 3, 4, 5, onComplete]}.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return the nww Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retry() {
+        return retry(Long.MAX_VALUE, Functions.alwaysTrue());
+    }
+
+    /**
+     * Returns a Maybe that mirrors the source Publisher, resubscribing to it if it calls {@code onError}
+     * and the predicate returns true for that specific exception and retry count.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param predicate
+     *            the predicate that determines if a resubscription may happen in case of a specific exception
+     *            and retry count
+     * @return the nww Maybe instance
+     * @see #retry()
+     * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+        return toFlowable().retry(predicate).toMaybe();
+    }
+
+    /**
+     * Returns a Maybe that mirrors the source Publisher, resubscribing to it if it calls {@code onError}
+     * up to a specified number of retries.
+     * <p>
+     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <p>
+     * If the source Publisher calls {@link Subscriber#onError}, this method will resubscribe to the source
+     * Publisher for a maximum of {@code count} resubscriptions rather than propagating the
+     * {@code onError} call.
+     * <p>
+     * Any and all items emitted by the source Publisher will be emitted by the resulting Publisher, even
+     * those emitted during failed subscriptions. For example, if a Publisher fails at first but emits
+     * {@code [1, 2]} then succeeds the second time and emits {@code [1, 2, 3, 4, 5]} then the complete sequence
+     * of emissions and notifications would be {@code [1, 2, 1, 2, 3, 4, 5, onComplete]}.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param count
+     *            number of retry attempts before failing
+     * @return the source Publisher modified with retry logic
+     * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retry(long count) {
+        return retry(count, Functions.alwaysTrue());
+    }
+
+    /**
+     * Retries at most times or until the predicate returns false, whichever happens first.
+     *
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param times the number of times to repeat
+     * @param predicate the predicate called with the failure Throwable and should return true to trigger a retry.
+     * @return the new Maybe instance
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retry(long times, Predicate<? super Throwable> predicate) {
+        return toFlowable().retry(times, predicate).toMaybe();
+    }
+
+    /**
+     * Retries the current Flowable if the predicate returns true.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param predicate the predicate that receives the failure Throwable and should return true to trigger a retry.
+     * @return the new Maybe instance
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retry(Predicate<? super Throwable> predicate) {
+        return retry(Long.MAX_VALUE, predicate);
+    }
+
+    /**
+     * Retries until the given stop function returns true.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retryUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param stop the function that should return true to stop retrying
+     * @return the new Maybe instance
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retryUntil(final BooleanSupplier stop) {
+        ObjectHelper.requireNonNull(stop, "stop is null");
+        return retry(Long.MAX_VALUE, Functions.predicateReverseFor(stop));
+    }
+
+    /**
+     * Returns a Maybe that emits the same values as the source Maybe with the exception of an
+     * {@code onError}. An {@code onError} notification from the source will result in the emission of a
+     * {@link Throwable} item to the Publisher provided as an argument to the {@code notificationHandler}
+     * function. If that Publisher calls {@code onComplete} or {@code onError} then {@code retry} will call
+     * {@code onComplete} or {@code onError} on the child subscription. Otherwise, this Publisher will
+     * resubscribe to the source Publisher.
+     * <p>
+     * <img width="640" height="430" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retryWhen.f.png" alt="">
+     *
+     * Example:
+     *
+     * This retries 3 times, each time incrementing the number of seconds it waits.
+     *
+     * <pre><code>
+     *  Publisher.create((Subscriber<? super String> s) -> {
+     *      System.out.println("subscribing");
+     *      s.onError(new RuntimeException("always fails"));
+     *  }).retryWhen(attempts -> {
+     *      return attempts.zipWith(Publisher.range(1, 3), (n, i) -> i).flatMap(i -> {
+     *          System.out.println("delay retry by " + i + " second(s)");
+     *          return Publisher.timer(i, TimeUnit.SECONDS);
+     *      });
+     *  }).blockingForEach(System.out::println);
+     * </code></pre>
+     *
+     * Output is:
+     *
+     * <pre> {@code
+     * subscribing
+     * delay retry by 1 second(s)
+     * subscribing
+     * delay retry by 2 second(s)
+     * subscribing
+     * delay retry by 3 second(s)
+     * subscribing
+     * } </pre>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param handler
+     *            receives a Publisher of notifications with which a user can complete or error, aborting the
+     *            retry
+     * @return the new Maybe instance
+     * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> retryWhen(
+            final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
+        return toFlowable().retryWhen(handler).toMaybe();
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -118,7 +118,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Returns the default 'island' size or capacity-increment hint for unbounded buffers.
      * <p>Delegates to {@link Flowable#bufferSize} but is public for convenience.
      * <p>The value can be overridden via system parameter {@code rx2.buffer-size}
-     * <em>before</em> the Flowable class is loaded.
+     * <em>before</em> the {@link Flowable} class is loaded.
      * @return the default 'island' size or capacity-increment hint
      */
     public static int bufferSize() {
@@ -1320,7 +1320,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits no items to the {@link Observer} and immediately invokes its
-     * {@link Subscriber#onComplete onComplete} method.
+     * {@link Observer#onComplete onComplete} method.
      * <p>
      * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/empty.png" alt="">
      * <dl>
@@ -1331,7 +1331,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T>
      *            the type of the items (ostensibly) emitted by the ObservableSource
      * @return an Observable that emits no items to the {@link Observer} but immediately invokes the
-     *         {@link Subscriber}'s {@link Subscriber#onComplete() onComplete} method
+     *         {@link Observer}'s {@link Observer#onComplete() onComplete} method
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Empty</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1351,7 +1351,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param errorSupplier
-     *            a Callable factory to return a Throwable for each individual Subscriber
+     *            a Callable factory to return a Throwable for each individual Observer
      * @param <T>
      *            the type of the items (ostensibly) emitted by the ObservableSource
      * @return an Observable that invokes the {@link Observer}'s {@link Observer#onError onError} method when
@@ -1640,7 +1640,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param <T> the generated value type
-     * @param generator the Consumer called whenever a particular downstream Subscriber has
+     * @param generator the Consumer called whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
@@ -1661,10 +1661,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code generate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <S> the type of the per-Subscriber state
+     * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
-     * @param generator the Consumer called with the current state whenever a particular downstream Subscriber has
+     * @param initialState the Callable to generate the initial state for each Observer
+     * @param generator the Consumer called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
@@ -1684,10 +1684,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code generate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <S> the type of the per-Subscriber state
+     * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
-     * @param generator the Consumer called with the current state whenever a particular downstream Subscriber has
+     * @param initialState the Callable to generate the initial state for each Observer
+     * @param generator the Consumer called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
@@ -1712,10 +1712,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code generate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <S> the type of the per-Subscriber state
+     * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
-     * @param generator the Function called with the current state whenever a particular downstream Subscriber has
+     * @param initialState the Callable to generate the initial state for each Observer
+     * @param generator the Function called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
      * the next invocation. Signalling multiple {@code onNext}
@@ -1735,10 +1735,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code generate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <S> the type of the per-Subscriber state
+     * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
-     * @param generator the Function called with the current state whenever a particular downstream Subscriber has
+     * @param initialState the Callable to generate the initial state for each Observer
+     * @param generator the Function called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
      * the next invocation. Signalling multiple {@code onNext}

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -104,6 +104,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the Single sources provided by
      * an Iterable sequence.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -120,19 +122,19 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Concatenate the single values, in a non-overlapping fashion, of the Single sources provided by
-     * a Publisher sequence.
+     * an Observable sequence.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the Publisher of SingleSource instances
-     * @return the new Flowable instance
+     * @param sources the ObservableSource of SingleSource instances
+     * @return the new Observable instance
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> concat(Observable<? extends SingleSource<? extends T>> sources) {
+    public static <T> Observable<T> concat(ObservableSource<? extends SingleSource<? extends T>> sources) {
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, SingleInternalHelper.toObservable(), 2, ErrorMode.IMMEDIATE));
     }
 
@@ -140,6 +142,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the Single sources provided by
      * a Publisher sequence.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and the sources {@code Publisher} is expected to honor it as well.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -158,6 +163,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the Single sources provided by
      * a Publisher sequence and prefetched by the specified amount.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and the sources {@code Publisher} is expected to honor it as well.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -180,6 +188,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -208,6 +218,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -240,6 +252,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -274,6 +288,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * Concatenate the single values, in a non-overlapping fashion, of the Single sources provided in
      * an array.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -319,7 +335,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param source the emitter that is called when a SingleObserver subscribes to the returned {@code Flowable}
+     * @param source the emitter that is called when a SingleObserver subscribes to the returned {@code Single}
      * @return the new Single instance
      * @see SingleOnSubscribe
      * @see Cancellable
@@ -390,9 +406,9 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Returns a {@link Single} that invokes passed function and emits its result for each new Observer that subscribes.
+     * Returns a {@link Single} that invokes passed function and emits its result for each new SingleObserver that subscribes.
      * <p>
-     * Allows you to defer execution of passed function until Observer subscribes to the {@link Single}.
+     * Allows you to defer execution of passed function until SingleObserver subscribes to the {@link Single}.
      * It makes passed function "lazy".
      * Result of the function invocation will be emitted by the {@link Single}.
      * <dl>
@@ -404,7 +420,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *         function which execution should be deferred, it will be invoked when SingleObserver will subscribe to the {@link Single}.
      * @param <T>
      *         the type of the item emitted by the {@link Single}.
-     * @return a {@link Single} whose {@link Observer}s' subscriptions trigger an invocation of the given function.
+     * @return a {@link Single} whose {@link SingleObserver}s' subscriptions trigger an invocation of the given function.
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromCallable(final Callable<? extends T> callable) {
@@ -586,6 +602,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * Merges an Iterable sequence of SingleSource instances into a single Flowable sequence,
      * running all SingleSources at once.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -604,6 +622,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * Merges a Flowable sequence of SingleSource instances into a single Flowable sequence,
      * running all SingleSources at once.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -645,13 +665,15 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Flattens two Singles into a single Observable, without any transformation.
+     * Flattens two Singles into a single Flowable, without any transformation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by
      * using the {@code merge} method.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -676,13 +698,15 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Flattens three Singles into a single Observable, without any transformation.
+     * Flattens three Singles into a single Flowable, without any transformation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
      * the {@code merge} method.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -711,13 +735,15 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Flattens four Singles into a single Observable, without any transformation.
+     * Flattens four Singles into a single Flowable, without any transformation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
      * the {@code merge} method.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1492,6 +1518,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concatWith.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1804,6 +1832,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapObservable.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and the {@code Publisher} returned by the mapper function is expected to honor it as well.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code flatMapPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1975,6 +2006,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
      * the {@code mergeWith} method.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2133,6 +2166,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Repeatedly re-subscribes to the current Single and emits each success value.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2148,6 +2183,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribes to the current Single at most the given number of times and emits each success value.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2166,6 +2203,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * the Publisher returned by the handler function signals a value in response to a
      * value signalled through the Flowable the handle receives.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  The {@code Publisher} returned by the handler function is expected to honor backpressure as well.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeatWhen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2185,6 +2225,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribes to the current Single until the given BooleanSupplier returns true.
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2658,6 +2700,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>

--- a/src/main/java/io/reactivex/internal/fuseable/FuseToMaybe.java
+++ b/src/main/java/io/reactivex/internal/fuseable/FuseToMaybe.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.fuseable;
 import io.reactivex.Maybe;
 
 /**
- * Interface indicating a operator implementation can be macro-fused back to Maybe in case
+ * Interface indicating an operator implementation can be macro-fused back to Maybe in case
  * the operator goes from Maybe to some other reactive type and then the sequence calls
  * for toMaybe again:
  * <pre>

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingle.java
@@ -21,7 +21,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Signals true if the source Maybe signals onComplete, signals false if the source Maybe
- * signals onNext.
+ * signals onSuccess.
  * 
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -54,7 +54,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @param <U> the value type of the ConnectableObservable
      * @param <R> the result value type
      * @param connectableFactory the factory that returns a ConnectableObservable for each individual subscriber
-     * @param selector the function that receives a Observable and should return another Observable that will be subscribed to
+     * @param selector the function that receives an Observable and should return another Observable that will be subscribed to
      * @return the new Observable instance
      */
     public static <U, R> Observable<R> multicastSelector(

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -110,7 +110,7 @@ public enum ObservableScalarXMap {
     }
 
     /**
-     * Maps a scalar value to a ObservableSource and subscribes to it.
+     * Maps a scalar value to an ObservableSource and subscribes to it.
      *
      * @param <T> the scalar value type
      * @param <R> the mapped Publisher's element type.

--- a/src/main/java/io/reactivex/processors/FlowableProcessor.java
+++ b/src/main/java/io/reactivex/processors/FlowableProcessor.java
@@ -18,7 +18,7 @@ import org.reactivestreams.Processor;
 import io.reactivex.Flowable;
 
 /**
- * Represents a Subscriber and an Flowable (Publisher) at the same time, allowing
+ * Represents a Subscriber and a Flowable (Publisher) at the same time, allowing
  * multicasting events from a single source to multiple child Subscribers.
  * <p>All methods except the onSubscribe, onNext, onError and onComplete are thread-safe.
  * Use {@link #toSerialized()} to make these methods thread-safe as well.

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -16,7 +16,7 @@ package io.reactivex.subjects;
 import io.reactivex.*;
 
 /**
- * Represents an Observer and a Observable at the same time, allowing
+ * Represents an Observer and an Observable at the same time, allowing
  * multicasting events from a single source to multiple child Subscribers.
  * <p>All methods except the onSubscribe, onNext, onError and onComplete are thread-safe.
  * Use {@link #toSerialized()} to make these methods thread-safe as well.

--- a/src/test/java/io/reactivex/BaseTypeParser.java
+++ b/src/test/java/io/reactivex/BaseTypeParser.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Parses the java file of a reactive base type to allow discovering Javadoc mistakes algorithmically.
+ */
+public class BaseTypeParser {
+
+    public static class RxMethod {
+        public String signature;
+
+        public String backpressureKind;
+
+        public String schedulerKind;
+
+        public String javadoc;
+
+        public String backpressureDocumentation;
+
+        public String schedulerDocumentation;
+
+        public int javadocLine;
+
+        public int methodLine;
+
+        public int backpressureDocLine;
+
+        public int schedulerDocLine;
+    }
+
+    public static List<RxMethod> parse(File f, String baseClassName) throws Exception {
+        List<RxMethod> list = new ArrayList<RxMethod>();
+
+        StringBuilder b = JavadocForAnnotations.readFile(f);
+
+        int baseIndex = b.indexOf("public abstract class " + baseClassName);
+
+        if (baseIndex < 0) {
+            throw new AssertionError("Wrong base class file: " + baseClassName);
+        }
+
+        for (;;) {
+            RxMethod m = new RxMethod();
+
+            int javadocStart = b.indexOf("/**", baseIndex);
+
+            if (javadocStart < 0) {
+                break;
+            }
+
+            int javadocEnd = b.indexOf("*/", javadocStart + 2);
+
+            m.javadoc = b.substring(javadocStart, javadocEnd + 2);
+            m.javadocLine = JavadocForAnnotations.lineNumber(b, javadocStart);
+
+            int backpressureDoc = b.indexOf("<dt><b>Backpressure:</b></dt>", javadocStart);
+            if (backpressureDoc > 0 && backpressureDoc < javadocEnd) {
+                m.backpressureDocLine = JavadocForAnnotations.lineNumber(b, backpressureDoc);
+                int nextDD = b.indexOf("</dd>", backpressureDoc);
+                if (nextDD > 0 && nextDD < javadocEnd) {
+                    m.backpressureDocumentation = b.substring(backpressureDoc, nextDD + 5);
+                }
+            }
+
+            int schedulerDoc = b.indexOf("<dt><b>Scheduler:</b></dt>", javadocStart);
+            if (schedulerDoc > 0 && schedulerDoc < javadocEnd) {
+                m.schedulerDocLine = JavadocForAnnotations.lineNumber(b, schedulerDoc);
+                int nextDD = b.indexOf("</dd>", schedulerDoc);
+                if (nextDD > 0 && nextDD < javadocEnd) {
+                    m.schedulerDocumentation = b.substring(schedulerDoc, nextDD + 5);
+                }
+            }
+
+            int staticMethodDef = b.indexOf("public static ", javadocEnd + 2);
+            int instanceMethodDef = b.indexOf("public final ", javadocEnd + 2);
+
+            int javadocStartNext = b.indexOf("/**", javadocEnd + 2);
+            if (javadocStartNext < 0) {
+                javadocStartNext = Integer.MAX_VALUE;
+            }
+
+            int definitionStart = -1;
+
+            if (staticMethodDef > 0 && staticMethodDef < javadocStartNext && staticMethodDef < instanceMethodDef) {
+                definitionStart = staticMethodDef;
+            }
+            if (instanceMethodDef > 0 && staticMethodDef < javadocStartNext && instanceMethodDef < staticMethodDef) {
+                definitionStart = instanceMethodDef;
+            }
+
+            if (definitionStart > 0) {
+                int methodDefEnd = b.indexOf("{", definitionStart);
+
+                m.signature = b.substring(definitionStart, methodDefEnd + 1);
+
+                m.methodLine = JavadocForAnnotations.lineNumber(b, definitionStart);
+
+                int backpressureSpec = b.indexOf("@BackpressureSupport(", javadocEnd);
+                if (backpressureSpec > 0 && backpressureSpec < definitionStart) {
+                    int backpressureSpecEnd = b.indexOf(")", backpressureSpec + 21);
+                    m.backpressureKind = b.substring(backpressureSpec + 21, backpressureSpecEnd);
+                }
+
+                int schhedulerSpec = b.indexOf("@SchedulerSupport(", javadocEnd);
+                if (schhedulerSpec > 0 && schhedulerSpec < definitionStart) {
+                    int schedulerSpecEnd = b.indexOf(")", schhedulerSpec + 18);
+                    m.schedulerKind = b.substring(schhedulerSpec + 18, schedulerSpecEnd);
+                }
+
+                list.add(m);
+                baseIndex = methodDefEnd;
+            } else {
+                baseIndex = javadocEnd + 2;
+            }
+
+        }
+
+        return list;
+    }
+}

--- a/src/test/java/io/reactivex/FixLicenseHeaders.java
+++ b/src/test/java/io/reactivex/FixLicenseHeaders.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.io.*;
+import java.util.*;
+
+import org.junit.Test;
+
+/**
+ * Adds license header to java files.
+ */
+public class FixLicenseHeaders {
+
+    String[] header = {
+    "/**",
+    " * Copyright 2016 Netflix, Inc.",
+    " *",
+    " * Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in",
+    " * compliance with the License. You may obtain a copy of the License at",
+    " *",
+    " * http://www.apache.org/licenses/LICENSE-2.0",
+    " *",
+    " * Unless required by applicable law or agreed to in writing, software distributed under the License is",
+    " * distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See",
+    " * the License for the specific language governing permissions and limitations under the License.",
+    " */",
+    ""
+    };
+
+    @Test
+    public void checkAndUpdateLicenses() throws Exception {
+        if (System.getenv("CI") != null) {
+            // no point in changing the files in CI
+            return;
+        }
+        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        if (f == null) {
+            return;
+        }
+
+        Queue<File> dirs = new ArrayDeque<File>();
+
+        File parent = f.getParentFile();
+        dirs.offer(parent);
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/perf/java")));
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/test/java")));
+
+        StringBuilder fail = new StringBuilder();
+
+        while (!dirs.isEmpty()) {
+            f = dirs.poll();
+
+            File[] list = f.listFiles();
+            if (list != null && list.length != 0) {
+
+                for (File u : list) {
+                    if (u.isDirectory()) {
+                        dirs.offer(u);
+                    } else {
+                        if (u.getName().endsWith(".java")) {
+
+                            List<String> lines = new ArrayList<String>();
+                            BufferedReader in = new BufferedReader(new FileReader(u));
+                            try {
+                                for (;;) {
+                                    String line = in.readLine();
+                                    if (line == null) {
+                                        break;
+                                    }
+
+                                    lines.add(line);
+                                }
+                            } finally {
+                                in.close();
+                            }
+
+                            if (!lines.get(0).equals(header[0]) && !lines.get(1).equals(header[1])) {
+                                fail.append("java.lang.RuntimeException: missing header added, refresh and re-run tests!\r\n")
+                                .append(" at ")
+                                ;
+
+                                String fn = u.toString().replace('\\', '/');
+
+                                int idx = fn.indexOf("io/reactivex/");
+
+                                fn = fn.substring(idx).replace('/', '.').replace(".java", "");
+
+                                fail.append(fn).append(" (")
+                                ;
+
+                                int jdx = fn.lastIndexOf('.');
+
+                                fail.append(fn.substring(jdx + 1));
+
+                                fail.append(".java:1)\r\n\r\n");
+
+                                lines.addAll(0, Arrays.asList(header));
+
+                                PrintWriter w = new PrintWriter(new FileWriter(u));
+
+                                try {
+                                    for (String s : lines) {
+                                        w.println(s);
+                                    }
+                                } finally {
+                                    w.close();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (fail.length() != 0) {
+            System.out.println(fail);
+            throw new AssertionError(fail.toString());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/JavadocForAnnotations.java
@@ -88,7 +88,7 @@ public class JavadocForAnnotations {
 
                 if (k < 0 || k > idx) {
                     // when printed on the console, IDEs will create a clickable link to help navigate to the offending point
-                    e.append("java.lang.RuntimeException: missing ").append(inDoc).append("\r\n")
+                    e.append("java.lang.RuntimeException: missing ").append(inDoc).append(" section\r\n")
                     ;
                     int lc = lineNumber(sourceCode, idx);
 
@@ -219,7 +219,6 @@ public class JavadocForAnnotations {
     }
 
     @Test
-    @Ignore("In the next PR these will be fixed")
     public void checkSingleBackpressure() throws Exception {
         checkSource(Single.class.getSimpleName(), false);
     }
@@ -230,7 +229,6 @@ public class JavadocForAnnotations {
     }
 
     @Test
-    @Ignore("In the next PR these will be fixed")
     public void checkCompletableBackpressure() throws Exception {
         checkSource(Completable.class.getSimpleName(), false);
     }
@@ -241,7 +239,6 @@ public class JavadocForAnnotations {
     }
 
     @Test
-    @Ignore("In the next PR these will be fixed")
     public void checkMaybeBackpressure() throws Exception {
         checkSource(Maybe.class.getSimpleName(), false);
     }

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -1,0 +1,790 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.BaseTypeParser.RxMethod;
+
+/**
+ * Check if the method wording is consistent with the target base type.
+ */
+public class JavadocWording {
+
+    public static int lineNumber(CharSequence s, int index) {
+        int cnt = 1;
+        for (int i = 0; i < index; i++) {
+            if (s.charAt(i) == '\n') {
+                cnt++;
+            }
+        }
+        return cnt;
+    }
+
+    @Test
+    public void maybeDocRefersToMaybeTypes() throws Exception {
+        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Maybe"), "Maybe");
+
+        assertFalse(list.isEmpty());
+
+        StringBuilder e = new StringBuilder();
+
+        for (RxMethod m : list) {
+            int jdx;
+            if (m.javadoc != null) {
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("onNext", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")
+                                && !m.signature.contains("Observable")
+                                && !m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Subscriber", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observer", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")
+                                && !m.signature.contains("Observable")) {
+
+                            if (idx < 5 || !m.javadoc.substring(idx - 5, idx + 8).equals("MaybeObserver")) {
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Observer but not using Observable\r\n at io.reactivex.")
+                                .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Publisher", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")) {
+                            if (idx == 0 || !m.javadoc.substring(idx - 1, idx + 9).equals("(Publisher")) {
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Publisher but not in the signature\r\n at io.reactivex.")
+                                .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Flowable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Flowable but not in the signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Single", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Single")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Single but not in the signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("SingleSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("SingleSource")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Observable")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Observable but not in the signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("ObservableSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                aOrAn(e, m, "Maybe");
+                missingClosingDD(e, m, "Maybe");
+                backpressureMentionedWithoutAnnotation(e, m, "Maybe");
+            }
+        }
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    @Test
+    public void flowableDocRefersToFlowableTypes() throws Exception {
+        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Flowable"), "Flowable");
+
+        assertFalse(list.isEmpty());
+
+        StringBuilder e = new StringBuilder();
+
+        for (RxMethod m : list) {
+            int jdx;
+            if (m.javadoc != null) {
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("onSuccess", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Maybe")
+                                && !m.signature.contains("MaybeSource")
+                                && !m.signature.contains("Single")
+                                && !m.signature.contains("SingleSource")) {
+                            e.append("java.lang.RuntimeException: Flowable doc mentions onSuccess\r\n at io.reactivex.")
+                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observer", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")
+                                && !m.signature.contains("Observable")) {
+                            e.append("java.lang.RuntimeException: Flowable doc mentions Observer but not using Flowable\r\n at io.reactivex.")
+                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Observable")) {
+                            e.append("java.lang.RuntimeException: Flowable doc mentions Observable but not in the signature\r\n at io.reactivex.")
+                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("ObservableSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Flowable doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
+                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                aOrAn(e, m, "Flowable");
+                missingClosingDD(e, m, "Flowable");
+                backpressureMentionedWithoutAnnotation(e, m, "Flowable");
+            }
+        }
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    @Test
+    public void observableDocRefersToObservableTypes() throws Exception {
+        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Observable"), "Observable");
+
+        assertFalse(list.isEmpty());
+
+        StringBuilder e = new StringBuilder();
+
+        for (RxMethod m : list) {
+            int jdx;
+            if (m.javadoc != null) {
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("onSuccess", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Maybe")
+                                && !m.signature.contains("MaybeSource")
+                                && !m.signature.contains("Single")
+                                && !m.signature.contains("SingleSource")) {
+                            e.append("java.lang.RuntimeException: Observable doc mentions onSuccess\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Flowable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")) {
+                            if (idx < 6 || !m.javadoc.substring(idx - 6, idx + 8).equals("@link Flowable")) {
+                                e.append("java.lang.RuntimeException: Observable doc mentions Flowable but not in the signature\r\n at io.reactivex.")
+                                .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Publisher", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")) {
+                            e.append("java.lang.RuntimeException: Observable doc mentions Publisher but not in the signature\r\n at io.reactivex.")
+                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Subscriber", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Observable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                aOrAn(e, m, "Observable");
+                missingClosingDD(e, m, "Observable");
+                backpressureMentionedWithoutAnnotation(e, m, "Observable");
+            }
+        }
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    @Test
+    public void singleDocRefersToSingleTypes() throws Exception {
+        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Single"), "Single");
+
+        assertFalse(list.isEmpty());
+
+        StringBuilder e = new StringBuilder();
+
+        for (RxMethod m : list) {
+            int jdx;
+            if (m.javadoc != null) {
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("onNext", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")
+                                && !m.signature.contains("Observable")
+                                && !m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Subscriber", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observer", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")
+                                && !m.signature.contains("Observable")) {
+
+                            if (idx < 6 || !m.javadoc.substring(idx - 6, idx + 8).equals("SingleObserver")) {
+                                e.append("java.lang.RuntimeException: Single doc mentions Observer but not using Observable\r\n at io.reactivex.")
+                                .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Publisher", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")) {
+                            if (idx == 0 || !m.javadoc.substring(idx - 1, idx + 9).equals("(Publisher")) {
+                                e.append("java.lang.RuntimeException: Single doc mentions Publisher but not in the signature\r\n at io.reactivex.")
+                                .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Flowable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions Flowable but not in the signature\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Maybe", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Maybe")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions Maybe but not in the signature\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("MaybeSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("MaybeSource")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Observable")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions Observable but not in the signature\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("ObservableSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Single doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+
+                aOrAn(e, m, "Single");
+                missingClosingDD(e, m, "Single");
+                backpressureMentionedWithoutAnnotation(e, m, "Single");
+            }
+        }
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    @Test
+    public void completableDocRefersToCompletableTypes() throws Exception {
+        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Completable"), "Completable");
+
+        assertFalse(list.isEmpty());
+
+        StringBuilder e = new StringBuilder();
+
+        for (RxMethod m : list) {
+            int jdx;
+            if (m.javadoc != null) {
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("onNext", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")
+                                && !m.signature.contains("Observable")
+                                && !m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Subscriber", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observer", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")
+                                && !m.signature.contains("Observable")) {
+
+                            if (idx < 11 || !m.javadoc.substring(idx - 11, idx + 8).equals("CompletableObserver")) {
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Observer but not using Observable\r\n at io.reactivex.")
+                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Publisher", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")) {
+                            if (idx == 0 || !m.javadoc.substring(idx - 1, idx + 9).equals("(Publisher")) {
+                                e.append("java.lang.RuntimeException: Completable doc mentions Publisher but not in the signature\r\n at io.reactivex.")
+                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Flowable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions Flowable but not in the signature\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Single", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Single")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions Single but not in the signature\r\n at io.reactivex.")
+                            .append("Completable (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("SingleSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("SingleSource")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("Observable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Observable")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions Observable but not in the signature\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf("ObservableSource", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("ObservableSource")) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                aOrAn(e, m, "Completable");
+                missingClosingDD(e, m, "Completable");
+                backpressureMentionedWithoutAnnotation(e, m, "Completable");
+            }
+        }
+
+        if (e.length() != 0) {
+            System.out.println(e);
+
+            fail(e.toString());
+        }
+    }
+
+    static void aOrAn(StringBuilder e, RxMethod m, String baseTypeName) {
+        aOrAn(e, m, " an", "Single", baseTypeName);
+        aOrAn(e, m, " an", "Maybe", baseTypeName);
+        aOrAn(e, m, " a", "Observer", baseTypeName);
+        aOrAn(e, m, " a", "Observable", baseTypeName);
+        aOrAn(e, m, " an", "Publisher", baseTypeName);
+        aOrAn(e, m, " an", "Subscriber", baseTypeName);
+        aOrAn(e, m, " an", "Flowable", baseTypeName);
+
+        aOrAn(e, m, " a", "Observable", baseTypeName);
+
+    }
+
+    static void aOrAn(StringBuilder e, RxMethod m, String wrongPre, String word, String baseTypeName) {
+        int jdx = 0;
+        int idx;
+        for (;;) {
+            idx = m.javadoc.indexOf(wrongPre + " " + word, jdx);
+            if (idx >= 0) {
+                e.append("java.lang.RuntimeException: a/an typo ")
+                .append(word)
+                .append("\r\n at io.reactivex.")
+                .append(baseTypeName)
+                .append(" (")
+                .append(baseTypeName)
+                .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                jdx = idx + 6;
+            } else {
+                break;
+            }
+        }
+
+        for (;;) {
+            idx = m.javadoc.indexOf(wrongPre + " {@link " + word, jdx);
+            if (idx >= 0) {
+                e.append("java.lang.RuntimeException: a/an typo ")
+                .append(word)
+                .append("\r\n at io.reactivex.")
+                .append(baseTypeName)
+                .append(" (")
+                .append(baseTypeName)
+                .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                jdx = idx + 6;
+            } else {
+                break;
+            }
+        }
+
+        for (;;) {
+            idx = m.javadoc.indexOf(wrongPre + " {@linkplain " + word, jdx);
+            if (idx >= 0) {
+                e.append("java.lang.RuntimeException: a/an typo ")
+                .append(word)
+                .append("\r\n at io.reactivex.")
+                .append(baseTypeName)
+                .append(" (")
+                .append(baseTypeName)
+                .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                jdx = idx + 6;
+            } else {
+                break;
+            }
+        }
+
+        for (;;) {
+            idx = m.javadoc.indexOf(wrongPre + " {@code " + word, jdx);
+            if (idx >= 0) {
+                e.append("java.lang.RuntimeException: a/an typo ")
+                .append(word)
+                .append("\r\n at io.reactivex.")
+                .append(baseTypeName)
+                .append(" (")
+                .append(baseTypeName)
+                .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                jdx = idx + 6;
+            } else {
+                break;
+            }
+        }
+
+    }
+
+    static void missingClosingDD(StringBuilder e, RxMethod m, String baseTypeName) {
+        int jdx = 0;
+        for (;;) {
+            int idx1 = m.javadoc.indexOf("<dd>", jdx);
+            int idx2 = m.javadoc.indexOf("</dd>", jdx);
+
+            if (idx1 < 0 && idx2 < 0) {
+                break;
+            }
+
+            int idx3 = m.javadoc.indexOf("<dd>", idx1 + 4);
+
+            if (idx1 > 0 && idx2 > 0 && (idx3 < 0 || (idx2 < idx3 && idx3 > 0))) {
+                jdx = idx2 + 5;
+            } else {
+                e.append("java.lang.RuntimeException: unbalanced <dd></dd> ")
+                .append("\r\n at io.reactivex.")
+                .append(baseTypeName)
+                .append(" (")
+                .append(baseTypeName)
+                .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx1) - 1).append(")\r\n\r\n");
+                break;
+            }
+        }
+    }
+
+    static void backpressureMentionedWithoutAnnotation(StringBuilder e, RxMethod m, String baseTypeName) {
+        if (m.backpressureDocLine > 0 && m.backpressureKind == null) {
+            e.append("java.lang.RuntimeException: backpressure documented but not annotated ")
+            .append("\r\n at io.reactivex.")
+            .append(baseTypeName)
+            .append(" (")
+            .append(baseTypeName)
+            .append(".java:").append(m.backpressureDocLine).append(")\r\n\r\n");
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -227,7 +227,7 @@ public class FlowableMergeDelayErrorTest {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                // simulate what would happen in an Flowable
+                // simulate what would happen in a Flowable
                 observer.onNext(o1);
                 observer.onNext(o2);
                 observer.onComplete();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -82,7 +82,7 @@ public class FlowableMergeTest {
             @Override
             public void subscribe(Subscriber<? super Flowable<String>> observer) {
                 observer.onSubscribe(new BooleanSubscription());
-                // simulate what would happen in an Flowable
+                // simulate what would happen in a Flowable
                 observer.onNext(o1);
                 observer.onNext(o2);
                 observer.onComplete();

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -114,7 +114,7 @@ public class SafeSubscriberTest {
     }
 
     /**
-     * A Observable that doesn't do the right thing on UnSubscribe/Error/etc in that it will keep sending events down the pipe regardless of what happens.
+     * An Observable that doesn't do the right thing on UnSubscribe/Error/etc in that it will keep sending events down the pipe regardless of what happens.
      */
     private static class TestObservable implements Publisher<String> {
 


### PR DESCRIPTION
- more `Maybe` operators: `onTerminateDetach`, `repeat`, `retry`
- fixed missing `Backpressure:` entries of the javadoc where the base type uses Flowable/Publisher
- new base type source parser and check for javadoc mistakes: wrong type mentions, a/an use
- fixes of those javadoc mistakes
