### PR TITLE
2.x: more cleanup and fixed checker, Maybe.takeUntil

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -759,16 +759,16 @@ public abstract class Completable implements CompletableSource {
      * Returns a Flowable which will subscribe to this Completable and once that is completed then
      * will subscribe to the {@code next} Flowable. An error event from this Completable will be
      * propagated to the downstream subscriber and will result in skipping the subscription of the
-     * Observable.
+     * Publisher.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
-     *  and expects the other {@code Publisher} to honor it as well.
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code andThen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type of the next Publisher
-     * @param next the Observable to subscribe after this Completable is completed, not null
+     * @param next the Publisher to subscribe after this Completable is completed, not null
      * @return Flowable that composes this Completable and next
      * @throws NullPointerException if next is null
      */
@@ -1135,7 +1135,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * <strong>Advanced use without safeguards:</strong> lifts a CompletableSubscriber
+     * <strong>Advanced use without safeguards:</strong> lifts a CompletableOperator
      * transformation into the chain of Completables.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1360,13 +1360,13 @@ public abstract class Completable implements CompletableSource {
 
     /**
      * Returns a Completable which given a Publisher and when this Completable emits an error, delivers
-     * that error through an Observable and the Publisher should return a value indicating a retry in response
+     * that error through a Flowable and the Publisher should return a value indicating a retry in response
      * or a terminal event indicating a termination.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param handler the handler that receives an Observable delivering Throwables and should return a Publisher that
+     * @param handler the handler that receives a Flowable delivering Throwables and should return a Publisher that
      * emits items to indicate retries or emits terminal events to indicate termination.
      * @return the new Completable instance
      * @throws NullPointerException if handler is null
@@ -1411,18 +1411,18 @@ public abstract class Completable implements CompletableSource {
         return other.concatWith(this.<T>toObservable());
     }
     /**
-     * Returns an Observable which first delivers the events
-     * of the other Observable then runs this Completable.
+     * Returns a Flowable which first delivers the events
+     * of the other Publisher then runs this Completable.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
-     *  and expects the other {@code Publisher} to honor it as well.
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param other the other Observable to run first
-     * @return the new Observable instance
+     * @param other the other Publisher to run first
+     * @return the new Flowable instance
      * @throws NullPointerException if other is null
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1647,7 +1647,7 @@ public abstract class Completable implements CompletableSource {
      * the specified scheduler.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify the {@link Scheduler} this operator runs on.</dd>
+     *  <dd>You specify the {@link Scheduler} this operator runs on.</dd>
      * </dl>
      * @param timeout the timeout value
      * @param unit the timeout unit
@@ -1686,16 +1686,16 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns an Observable which when subscribed to subscribes to this Completable and
+     * Returns a Flowable which when subscribed to subscribes to this Completable and
      * relays the terminal events to the subscriber.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @return the new Observable created
+     * @return the new Flowable instance
      */
     @SuppressWarnings("unchecked")
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1708,16 +1708,16 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Converts this Single into a {@link Maybe}.
+     * Converts this Completable into a {@link Maybe}.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.toObservable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code toMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the value type
-     * @return an {@link Maybe} that emits a single item T or an error.
+     * @return a {@link Maybe} that emits a single item T or an error.
      */
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -4985,16 +4985,16 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Invokes a method on each item emitted by this {@code Flowable} and blocks until the Observable
+     * Invokes a method on each item emitted by this {@code Flowable} and blocks until the Flowable
      * completes.
      * <p>
-     * <em>Note:</em> This will block even if the underlying Observable is asynchronous.
+     * <em>Note:</em> This will block even if the underlying Flowable is asynchronous.
      * <p>
      * <img width="640" height="330" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.forEach.png" alt="">
      * <p>
      * This is similar to {@link Flowable#subscribe(Subscriber)}, but it blocks. Because it blocks it does not
      * need the {@link Subscriber#onComplete()} or {@link Subscriber#onError(Throwable)} methods. If the
-     * underlying Observable terminates with an error, rather than calling {@code onError}, this method will
+     * underlying Flowable terminates with an error, rather than calling {@code onError}, this method will
      * throw an exception.
      *
      * <p>The difference between this method and {@link #subscribe(Consumer)} is that the {@code onNext} action
@@ -5036,7 +5036,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator expects the upstream to honor backpressure otherwise the returned
-     *  Iterable's iterator will throw a {@code MissingBackpressureException}.
+     *  Iterable's iterator will throw a {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingIterable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -5262,7 +5262,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link java.lang.IllegalArgumentException}. If the {@link Flowable} is empty, {@link java.util.concurrent.Future}
      * will receive an {@link java.util.NoSuchElementException}.
      * <p>
-     * If the {@code Flowable} may emit more than one item, use {@code Observable.toList().toBlocking().toFuture()}.
+     * If the {@code Flowable} may emit more than one item, use {@code Flowable.toList().toBlocking().toFuture()}.
      * <p>
      * <img width="640" height="395" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toFuture.png" alt="">
      * <dl>
@@ -7422,7 +7422,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Modifies the source Publisher so that it notifies an Subscriber for each item and terminal event it emits.
+     * Modifies the source Publisher so that it notifies a Subscriber for each item and terminal event it emits.
      * <p>
      * In case the {@code onError} of the supplied Subscriber throws, the downstream will receive a composite
      * exception containing the original exception and the exception thrown by {@code onError}. If either the
@@ -7553,7 +7553,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param onRequest
-     *            the action that gets called when an Subscriber requests items from this
+     *            the action that gets called when a Subscriber requests items from this
      *            {@code Publisher}
      * @return the source {@code Publisher} modified so as to call this Action when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators
@@ -8363,7 +8363,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * Alias to {@link #subscribe(Consumer)}
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -8390,7 +8390,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes to the {@link Publisher} and receives notifications for each element until the
      * onNext Predicate returns false.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -8400,7 +8400,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onNext
      *            {@link Predicate} to execute for each item.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a {@link Disposable} that allows cancelling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null
      * @throws RuntimeException
@@ -8417,7 +8417,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes to the {@link Publisher} and receives notifications for each element and error events until the
      * onNext Predicate returns false.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -8429,7 +8429,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onError
      *            {@link Consumer} to execute when an error is emitted.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a {@link Disposable} that allows cancelling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null
@@ -8445,7 +8445,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes to the {@link Publisher} and receives notifications for each element and the terminal events until the
      * onNext Predicate returns false.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -8459,7 +8459,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onComplete
      *            {@link Action} to execute when completion is signalled.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a {@link Disposable} that allows cancelling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or
@@ -8480,7 +8480,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Groups the items emitted by an {@code Publisher} according to a specified criterion, and emits these
+     * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
      * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
@@ -8507,7 +8507,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            a function that extracts the key for each item
      * @param <K>
      *            the key type
-     * @return an {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
+     * @return a {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
@@ -8519,7 +8519,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Groups the items emitted by an {@code Publisher} according to a specified criterion, and emits these
+     * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
      * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
@@ -8549,7 +8549,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param delayError
      *            if true, the exception from the current Flowable is delayed in each group until that specific group emitted
      *            the normal values; if false, the exception bypasses values in the groups and is reported immediately.
-     * @return an {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
+     * @return a {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
@@ -8561,7 +8561,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Groups the items emitted by an {@code Publisher} according to a specified criterion, and emits these
+     * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
      * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
@@ -8592,7 +8592,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the key type
      * @param <V>
      *            the element type
-     * @return an {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
+     * @return a {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
@@ -8605,7 +8605,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Groups the items emitted by an {@code Publisher} according to a specified criterion, and emits these
+     * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
      * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
@@ -8639,7 +8639,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param delayError
      *            if true, the exception from the current Flowable is delayed in each group until that specific group emitted
      *            the normal values; if false, the exception bypasses values in the groups and is reported immediately.
-     * @return an {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
+     * @return a {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
@@ -8652,7 +8652,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Groups the items emitted by an {@code Publisher} according to a specified criterion, and emits these
+     * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
      * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
@@ -8688,7 +8688,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the key type
      * @param <V>
      *            the element type
-     * @return an {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
+     * @return a {@code Publisher} that emits {@link GroupedFlowable}s, each of which corresponds to a
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
@@ -11131,7 +11131,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code serialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Publisher} that is guaranteed to be well-behaved and to make only serialized calls to
+     * @return a {@link Publisher} that is guaranteed to be well-behaved and to make only serialized calls to
      *         its Subscribers
      * @see <a href="http://reactivex.io/documentation/operators/serialize.html">ReactiveX operators documentation: Serialize</a>
      */
@@ -11158,7 +11158,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code share} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@code Publisher} that upon connection causes the source {@code Publisher} to emit items
+     * @return a {@code Publisher} that upon connection causes the source {@code Publisher} to emit items
      *         to its {@link Subscriber}s
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX operators documentation: RefCount</a>
      */
@@ -11740,7 +11740,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * If the Flowable emits an error, it is routed to the RxJavaPlugins.onError handler.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -11763,7 +11763,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * If the Flowable emits an error, it is routed to the RxJavaPlugins.onError handler.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -11789,7 +11789,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes to a Publisher and provides callbacks to handle the items it emits and any error
      * notification it issues.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -11818,7 +11818,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes to a Publisher and provides callbacks to handle the items it emits and any error or
      * completion notification it issues.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -11852,7 +11852,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes to a Publisher and provides callbacks to handle the items it emits and any error or
      * completion notification it issues.
      * <dl>
-     *  <dd><b>Backpressure:</b><dt>
+     *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner (i.e., no
      *  backpressure is applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -14629,7 +14629,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <B> the element type of the boundary Publisher
      * @param boundaryIndicatorSupplier
-     *            a {@link Callable} that returns an {@code Publisher} that governs the boundary between windows.
+     *            a {@link Callable} that returns a {@code Publisher} that governs the boundary between windows.
      *            When the source {@code Publisher} emits an item, {@code window} emits the current window and begins
      *            a new one.
      * @return a Flowable that emits connected, non-overlapping windows of items from the source Publisher
@@ -14661,7 +14661,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <B> the element type of the boundary Publisher
      * @param boundaryIndicatorSupplier
-     *            a {@link Callable} that returns an {@code Publisher} that governs the boundary between windows.
+     *            a {@link Callable} that returns a {@code Publisher} that governs the boundary between windows.
      *            When the source {@code Publisher} emits an item, {@code window} emits the current window and begins
      *            a new one.
      * @param bufferSize

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1925,7 +1925,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Flowable that, when first subscribed to, caches all of its items and notifications for the
+     * @return a Maybe that, when first subscribed to, caches all of its items and notifications for the
      *         benefit of subsequent subscribers
      * @see <a href="http://reactivex.io/documentation/operators/replay.html">ReactiveX operators documentation: Replay</a>
      */
@@ -1979,7 +1979,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Returns a Maybe that is based on applying a specified function to the item emitted by the source Maybe,
      * where that function returns a MaybeSource.
      * <p>
-     * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMap.png" alt="">
+     * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2024,7 +2024,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits a Boolean that indicates whether the source Publisher emitted a
+     * Returns a Single that emits a Boolean that indicates whether the source Maybe emitted a
      * specified item.
      * <p>
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/contains.png" alt="">
@@ -2055,7 +2055,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code count} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Single that emits a single item: the number of items emitted by the source Publisher as a
+     * @return a Single that emits a single item: the number of items emitted by the source Maybe as a
      *         64-bit Long item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
      * @see #count()
@@ -2171,7 +2171,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The {@code Publisher} source is consumed in an unbounded fashion (without applying backpressure).
+     *  <dd>The {@code Publisher} source is consumed in an unbounded fashion (without applying backpressure).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2265,7 +2265,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the shared runnable if a MaybeObserver subscribed to the current Single
+     * Calls the shared runnable if a MaybeObserver subscribed to the current Maybe
      * disposes the common Disposable it received via onSubscribe.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2314,7 +2314,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Calls the shared consumer with the error sent via onError for each
-     * MaybeObserver that subscribes to the current Single.
+     * MaybeObserver that subscribes to the current Maybe.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnError} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2356,7 +2356,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Calls the shared consumer with the Disposable sent through the onSubscribe for each
-     * MaybeObserver that subscribes to the current Single.
+     * MaybeObserver that subscribes to the current Maybe.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2378,7 +2378,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Calls the shared consumer with the success value sent via onSuccess for each
-     * MaybeObserver that subscribes to the current Single.
+     * MaybeObserver that subscribes to the current Maybe.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2425,7 +2425,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Returns a Maybe that is based on applying a specified function to the item emitted by the source Maybe,
      * where that function returns a MaybeSource.
      * <p>
-     * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMap.png" alt="">
+     * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2487,14 +2487,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <U>
-     *            the type of items emitted by the collection Publisher
+     *            the type of items emitted by the MaybeSource returned by the {@code mapper} function
      * @param <R>
-     *            the type of items emitted by the resulting Publisher
+     *            the type of items emitted by the resulting Maybe
      * @param mapper
-     *            a function that returns a Publisher for each item emitted by the source Publisher
+     *            a function that returns a MaybeSource for the item emitted by the source Maybe
      * @param resultSelector
-     *            a function that combines one item emitted by each of the source and collection Publishers and
-     *            returns an item to be emitted by the resulting Publisher
+     *            a function that combines one item emitted by each of the source and collection MaybeSource and
+     *            returns an item to be emitted by the resulting MaybeSource
      * @return the new Maybe instance
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
@@ -2529,7 +2529,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Returns a Flowable that emits items based on applying a specified function to the item emitted by the
      * source Maybe, where that function returns a Publisher.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapObservable.png" alt="">
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMapPublisher.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned Flowable honors the downstream backpressure.</dd>
@@ -2552,18 +2552,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Returns a {@link Completable} that completes based on applying a specified function to the item emitted by the
-     * source {@link Single}, where that function returns a {@link Completable}.
+     * source {@link Maybe}, where that function returns a {@link Completable}.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMapCompletable.png" alt="">
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMapCompletable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Single, returns a
+     *            a function that, when applied to the item emitted by the source Maybe, returns a
      *            Completable
-     * @return the Completable returned from {@code func} when applied to the item emitted by the source Single
+     * @return the Completable returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2655,7 +2655,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Returns a Maybe that applies a specified function to the item emitted by the source Maybe and
      * emits the result of this function application.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.map.png" alt="">
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.map.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code map} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2682,8 +2682,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * using the {@code mergeWith} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. This and the other {@code Publisher}s are expected to honor
-     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2704,7 +2703,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Wraps a Maybe to emit its item (or notify of its error) on a specified {@link Scheduler},
      * asynchronously.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.observeOn.png" alt="">
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.observeOn.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>you specify which {@link Scheduler} this operator will use</dd>
@@ -2815,7 +2814,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into an Single instance composing cancellation
+     * Converts this Maybe into a Single instance composing cancellation
      * through and turing an empty Maybe into a signal of NoSuchElementException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2831,7 +2830,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into an Single instance composing cancellation
+     * Converts this Maybe into a Single instance composing cancellation
      * through and turing an empty Maybe into a signal of NoSuchElementException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2982,7 +2981,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * This differs from {@link #onErrorResumeNext} in that this one does not handle {@link java.lang.Throwable}
      * or {@link java.lang.Error} but lets those continue through.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onExceptionResumeNextViaPublisher.png" alt="">
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onExceptionResumeNextViaMaybe.png" alt="">
      * <p>
      * You can use this to prevent exceptions from propagating or to supply fallback data should exceptions be
      * encountered.
@@ -3018,18 +3017,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that repeats the sequence of items emitted by the source Publisher indefinitely.
+     * Returns a Flowable that repeats the sequence of items emitted by the source Maybe indefinitely.
      * <p>
      * <img width="640" height="309" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.o.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dd>The operator honors downstream backpressure.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Flowable that emits the items emitted by the source Publisher repeatedly and in sequence
+     * @return a Flowable that emits the items emitted by the source Maybe repeatedly and in sequence
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -3039,22 +3037,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that repeats the sequence of items emitted by the source Publisher at most
+     * Returns a Flowable that repeats the sequence of items emitted by the source Maybe at most
      * {@code count} times.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dd>This operator honors downstream backpressure.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param times
-     *            the number of times the source Publisher items are repeated, a count of 0 will yield an empty
+     *            the number of times the source Maybe items are repeated, a count of 0 will yield an empty
      *            sequence
-     * @return a Flowable that repeats the sequence of items emitted by the source Publisher at most
+     * @return a Flowable that repeats the sequence of items emitted by the source Maybe at most
      *         {@code count} times
      * @throws IllegalArgumentException
      *             if {@code count} is less than zero
@@ -3067,14 +3064,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that repeats the sequence of items emitted by the source Publisher until
+     * Returns a Flowable that repeats the sequence of items emitted by the source Maybe until
      * the provided stop function returns true.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  <dd>This operator honors downstream backpressure.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3128,13 +3124,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
      * <p>
-     * If the source Publisher calls {@link Subscriber#onError}, this method will resubscribe to the source
-     * Publisher rather than propagating the {@code onError} call.
-     * <p>
-     * Any and all items emitted by the source Publisher will be emitted by the resulting Publisher, even
-     * those emitted during failed subscriptions. For example, if a Publisher fails at first but emits
-     * {@code [1, 2]} then succeeds the second time and emits {@code [1, 2, 3, 4, 5]} then the complete sequence
-     * of emissions and notifications would be {@code [1, 2, 1, 2, 3, 4, 5, onComplete]}.
+     * If the source Maybe calls {@link MaybeObserver#onError}, this method will resubscribe to the source
+     * Maybe rather than propagating the {@code onError} call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3149,7 +3140,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Publisher, resubscribing to it if it calls {@code onError}
+     * Returns a Maybe that mirrors the source Maybe, resubscribing to it if it calls {@code onError}
      * and the predicate returns true for that specific exception and retry count.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
@@ -3171,19 +3162,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Publisher, resubscribing to it if it calls {@code onError}
+     * Returns a Maybe that mirrors the source Maybe, resubscribing to it if it calls {@code onError}
      * up to a specified number of retries.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
      * <p>
-     * If the source Publisher calls {@link Subscriber#onError}, this method will resubscribe to the source
-     * Publisher for a maximum of {@code count} resubscriptions rather than propagating the
+     * If the source Maybe calls {@link MaybeObserver#onError}, this method will resubscribe to the source
+     * Maybe for a maximum of {@code count} resubscriptions rather than propagating the
      * {@code onError} call.
-     * <p>
-     * Any and all items emitted by the source Publisher will be emitted by the resulting Publisher, even
-     * those emitted during failed subscriptions. For example, if a Publisher fails at first but emits
-     * {@code [1, 2]} then succeeds the second time and emits {@code [1, 2, 3, 4, 5]} then the complete sequence
-     * of emissions and notifications would be {@code [1, 2, 1, 2, 3, 4, 5, onComplete]}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3191,7 +3177,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param count
      *            number of retry attempts before failing
-     * @return the source Publisher modified with retry logic
+     * @return the new Maybe instance
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3216,7 +3202,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Retries the current Flowable if the predicate returns true.
+     * Retries the current Maybe if it fails and the predicate returns true.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3320,7 +3306,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Subscribes to a Maybe and provides a callback to handle the items it emits.
      * <p>
-     * If the Flowable emits an error, it is routed to the RxJavaPlugins.onError handler.
+     * If the Maybe emits an error, it is routed to the RxJavaPlugins.onError handler.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3352,7 +3338,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param onError
      *             the {@code Consumer<Throwable>} you have designed to accept any error notification from the
      *             Maybe
-     * @return a {@link Subscription} reference with which the caller can stop receiving items before
+     * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the Maybe has finished sending them
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      * @throws IllegalArgumentException
@@ -3426,7 +3412,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Asynchronously subscribes subscribers to this Maybe on the specified {@link Scheduler}.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribeOn.png" alt="">
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.subscribeOn.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>you specify which {@link Scheduler} this operator will use</dd>
@@ -3494,6 +3480,57 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         return RxJavaPlugins.onAssembly(new MaybeSwitchIfEmpty<T>(this, other));
     }
 
+    /**
+     * Returns a Maybe that emits the items emitted by the source Maybe until a second MaybeSource
+     * emits an item.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the MaybeSource whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            from the source Maybe
+     * @param <U>
+     *            the type of items emitted by {@code other}
+     * @return a Maybe that emits the items emitted by the source Maybe until such time as {@code other} emits its first item
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <U> Maybe<T> takeUntil(MaybeSource<U> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new MaybeTakeUntilMaybe<T, U>(this, other));
+    }
+
+    /**
+     * Returns a Maybe that emits the item emitted by the source Maybe until a second Publisher
+     * emits an item.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code Publisher} is consumed in an unbounded fashion and is cancelled after the first item
+     *  emitted.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *            the Publisher whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            from the source Publisher
+     * @param <U>
+     *            the type of items emitted by {@code other}
+     * @return a Maybe that emits the items emitted by the source Maybe until such time as {@code other} emits its first item
+     * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+     */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <U> Maybe<T> takeUntil(Publisher<U> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new MaybeTakeUntilPublisher<T, U>(this, other));
+    }
 
     /**
      * Waits until this and the other MaybeSource signal a success value then applies the given BiFunction
@@ -3510,14 +3547,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <U>
-     *            the type of items emitted by the {@code other} Publisher
+     *            the type of items emitted by the {@code other} MaybeSource
      * @param <R>
-     *            the type of items emitted by the resulting Publisher
+     *            the type of items emitted by the resulting Maybe
      * @param other
-     *            the other Publisher
+     *            the other MaybeSource
      * @param zipper
-     *            a function that combines the pairs of items from the two Publishers to generate the items to
-     *            be emitted by the resulting Publisher
+     *            a function that combines the pairs of items from the two MaybeSources to generate the items to
+     *            be emitted by the resulting Maybe
      * @return the new Maybe instance
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6262,7 +6262,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            a function that projects an emitted item to a key value that is used to decide whether an item
      *            is distinct from another one or not
      * @param collectionSupplier
-     *            function called for each individual Subscriber to return a Collection subtype for holding the extracted
+     *            function called for each individual Observer to return a Collection subtype for holding the extracted
      *            keys and whose add() method's return indicates uniqueness.
      * @return an Observable that emits those items emitted by the source ObservableSource that have distinct keys
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
@@ -6342,7 +6342,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Registers an {@link Action} to be called when this ObservableSource invokes either
-     * {@link Subscriber#onComplete onComplete} or {@link Subscriber#onError onError}.
+     * {@link Observer#onComplete onComplete} or {@link Observer#onError onError}.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/finallyDo.png" alt="">
      * <dl>
@@ -6381,7 +6381,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param onDispose
-     *            the action that gets called when the source {@code ObservableSource}'s Subscription is disposed
+     *            the action that gets called when the source {@code ObservableSource}'s Disposable is disposed
      * @return the source {@code ObservableSource} modified so as to call this Action when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
@@ -6472,7 +6472,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param observer
      *            the observer to be notified about onNext, onError and onComplete events on its
-     *            respective methods before the actual downstream Subscriber gets notified.
+     *            respective methods before the actual downstream Observer gets notified.
      * @return the source ObservableSource with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
@@ -6509,7 +6509,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Calls the appropriate onXXX method (shared between all Subscribers) for the lifecycle events of
+     * Calls the appropriate onXXX method (shared between all Observer) for the lifecycle events of
      * the sequence (subscription, cancellation, requesting).
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnNext.png" alt="">
@@ -6519,9 +6519,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param onSubscribe
-     *              a Consumer called with the Subscription sent via Subscriber.onSubscribe()
+     *              a Consumer called with the Disposable sent via Observer.onSubscribe()
      * @param onDispose
-     *              called when the downstream disposes the Subscription via dispose()
+     *              called when the downstream disposes the Disposable via dispose()
      * @return the source ObservableSource with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
@@ -6564,7 +6564,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param onSubscribe
-     *            the Consumer that gets called when a Subscriber subscribes to the current {@code Observable}
+     *            the Consumer that gets called when an Observer subscribes to the current {@code Observable}
      * @return the source {@code ObservableSource} modified so as to call this Consumer when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
@@ -7313,7 +7313,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7346,7 +7346,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7382,7 +7382,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7419,7 +7419,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7459,7 +7459,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7546,9 +7546,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Hides the identity of this Observable and its Subscription.
-     * <p>Allows hiding extra features such as {@link Processor}'s
-     * {@link Subscriber} methods or preventing certain identity-based
+     * Hides the identity of this Observable and its Disposable.
+     * <p>Allows hiding extra features such as {@link io.reactivex.subjects.Subject}'s
+     * {@link Observer} methods or preventing certain identity-based
      * optimizations (fusion).
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -8063,13 +8063,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Nulls out references to the upstream producer and downstream Subscriber if
+     * Nulls out references to the upstream producer and downstream Observer if
      * the sequence is terminated or downstream unsubscribes.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return an Observable which out references to the upstream producer and downstream Subscriber if
+     * @return an Observable which out references to the upstream producer and downstream Observer if
      * the sequence is terminated or downstream unsubscribes
      * @since 2.0
      */
@@ -8112,7 +8112,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the type of items emitted by the resulting ObservableSource
      * @param selector
      *            a function that can use the multicasted source sequence as many times as needed, without
-     *            causing multiple subscriptions to the source sequence. Subscribers to the given source will
+     *            causing multiple subscriptions to the source sequence. Observers to the given source will
      *            receive all notifications of the source from the time of the subscription forward.
      * @return an Observable that emits the results of invoking the selector on the items emitted by a {@link ConnectableObservable} that shares a single subscription to the underlying sequence
      * @see <a href="http://reactivex.io/documentation/operators/publish.html">ReactiveX operators documentation: Publish</a>
@@ -8136,7 +8136,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the type of items emitted by the resulting ObservableSource
      * @param selector
      *            a function that can use the multicasted source sequence as many times as needed, without
-     *            causing multiple subscriptions to the source sequence. Subscribers to the given source will
+     *            causing multiple subscriptions to the source sequence. Observers to the given source will
      *            receive all notifications of the source from the time of the subscription forward.
      * @param bufferSize
      *            the number of elements to prefetch from the current Observable
@@ -8282,7 +8282,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <R> the accumulator and output value type
      * @param seedSupplier
-     *            the Callable that provides the initial (seed) accumulator value for each individual Subscriber
+     *            the Callable that provides the initial (seed) accumulator value for each individual Observer
      * @param reducer
      *            an accumulator function to be invoked on each item emitted by the source ObservableSource, the
      *            result of which will be used in the next accumulator call
@@ -9001,7 +9001,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
      * <pre><code>
-     *  ObservableSource.create((Subscriber<? super String> s) -> {
+     *  ObservableSource.create((Observer<? super String> s) -> {
      *      System.out.println("subscribing");
      *      s.onError(new RuntimeException("always fails"));
      *  }).retryWhen(attempts -> {
@@ -9042,15 +9042,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Subscribes to the current Observable and wraps the given Subscriber into a SafeSubscriber
-     * (if not already a SafeSubscriber) that
-     * deals with exceptions thrown by a misbehaving Subscriber (that doesn't follow the
+     * Subscribes to the current Observable and wraps the given Observer into a SafeObserver
+     * (if not already a SafeObserver) that
+     * deals with exceptions thrown by a misbehaving Observer (that doesn't follow the
      * Reactive-Streams specification).
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code safeSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param s the incoming Subscriber instance
+     * @param s the incoming Observer instance
      * @throws NullPointerException if s is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -9248,7 +9248,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <R> the initial, accumulator and result type
      * @param seedSupplier
-     *            a Callable that returns the initial (seed) accumulator item for each individual Subscriber
+     *            a Callable that returns the initial (seed) accumulator item for each individual Observer
      * @param accumulator
      *            an accumulator function to be invoked on each item emitted by the source ObservableSource, whose
      *            result will be emitted to {@link Observer}s via {@link Observer#onNext onNext} and used in the
@@ -9268,7 +9268,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Forces an ObservableSource's emissions and notifications to be serialized and for it to obey
      * <a href="http://reactivex.io/documentation/contract.html">the ObservableSource contract</a> in other ways.
      * <p>
-     * It is possible for an ObservableSource to invoke its Subscribers' methods asynchronously, perhaps from
+     * It is possible for an ObservableSource to invoke its Observers' methods asynchronously, perhaps from
      * different threads. This could make such an ObservableSource poorly-behaved, in that it might try to invoke
      * {@code onComplete} or {@code onError} before one of its {@code onNext} invocations, or it might call
      * {@code onNext} from two different threads concurrently. You can force such an ObservableSource to be
@@ -9291,7 +9291,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns a new {@link ObservableSource} that multicasts (shares) the original {@link ObservableSource}. As long as
-     * there is at least one {@link Subscriber} this {@link ObservableSource} will be subscribed and emitting data.
+     * there is at least one {@link Observer} this {@link ObservableSource} will be subscribed and emitting data.
      * When all subscribers have unsubscribed it will unsubscribe from the source {@link ObservableSource}.
      * <p>
      * This is an alias for {@link #publish()}.{@link ConnectableObservable#refCount()}.
@@ -9911,7 +9911,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             the {@code Action} you have designed to accept a completion notification from the
      *             ObservableSource
      * @param onSubscribe
-     *             the {@code Consumer} that receives the upstream's Subscription
+     *             the {@code Consumer} that receives the upstream's Disposable
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the ObservableSource has finished sending them
      * @throws IllegalArgumentException
@@ -9976,7 +9976,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Observable<Integer> source = Observable.range(1, 10);
      * CompositeDisposable composite = new CompositeDisposable();
      *
-     * ResourceObserver&lt;Integer> rs = new ResourceSubscriber&lt;>() {
+     * ResourceObserver&lt;Integer> rs = new ResourceObserver&lt;>() {
      *     // ...
      * };
      *
@@ -10181,8 +10181,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/take.png" alt="">
      * <p>
      * This method returns an ObservableSource that will invoke a subscribing {@link Observer}'s
-     * {@link Subscriber#onNext onNext} function a maximum of {@code count} times before invoking
-     * {@link Subscriber#onComplete onComplete}.
+     * {@link Observer#onNext onNext} function a maximum of {@code count} times before invoking
+     * {@link Observer#onComplete onComplete}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code take} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -10541,7 +10541,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns an Observable that emits the items emitted by the source Publisher until a second Publisher
+     * Returns an Observable that emits the items emitted by the source Observable until a second ObservableSource
      * emits an item.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
@@ -10551,11 +10551,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param other
-     *            the Publisher whose first emitted item will cause {@code takeUntil} to stop emitting items
-     *            from the source Publisher
+     *            the ObservableSource whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            from the source Observable
      * @param <U>
      *            the type of items emitted by {@code other}
-     * @return an Observable that emits the items emitted by the source Publisher until such time as {@code other} emits its first item
+     * @return an Observable that emits the items emitted by the source Observable until such time as {@code other} emits its first item
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -10565,7 +10565,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns an Observable that emits items emitted by the source Publisher, checks the specified predicate
+     * Returns an Observable that emits items emitted by the source Observable, checks the specified predicate
      * for each item, and then completes when the condition is satisfied.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.p.png" alt="">
@@ -10579,8 +10579,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param stopPredicate
-     *            a function that evaluates an item emitted by the source Publisher and returns a Boolean
-     * @return an Observable that first emits items emitted by the source Publisher, checks the specified
+     *            a function that evaluates an item emitted by the source Observable and returns a Boolean
+     * @return an Observable that first emits items emitted by the source Observable, checks the specified
      *         condition after each item, and then completes when the condition is satisfied.
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      * @see Observable#takeWhile(Predicate)
@@ -11357,7 +11357,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <U> the subclass of a collection of Ts
      * @param collectionSupplier
-     *               the Callable returning the collection (for each individual Subscriber) to be filled in
+     *               the Callable returning the collection (for each individual Observer) to be filled in
      * @return an Observable that emits a single item: a List containing all of the items emitted by the source
      *         ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
@@ -11606,7 +11606,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Converts this Observable into a Maybe and expects this Flowable to have at most one item
+     * Converts this Observable into a Maybe and expects this Observable to have at most one item
      * or a completion signal; otherwise the resulting Maybe will signal an IndexOutOfBoundsException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1519,7 +1519,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concatWith.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1643,7 +1643,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dl>
      * <dt><b>Backpressure:</b></dt>
      * <dd>The {@code other} publisher is consumed in an unbounded fashion but will be
-     * cancelled after the first item it produced.
+     * cancelled after the first item it produced.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1834,7 +1834,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
-     *  and the {@code Publisher} returned by the mapper function is expected to honor it as well.
+     *  and the {@code Publisher} returned by the mapper function is expected to honor it as well.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code flatMapPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1842,7 +1842,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param <R> the result value type
      * @param mapper
      *            a function that, when applied to the item emitted by the source Single, returns an
-     *            Observable
+     *            Flowable
      * @return the Flowable returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
@@ -1999,15 +1999,15 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Flattens this and another Single into a single Observable, without any transformation.
+     * Flattens this and another Single into a single Flowable, without any transformation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Singles so that they appear as a single Observable, by using
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
      * the {@code mergeWith} method.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2054,11 +2054,11 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorReturn.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to its
-     * subscriber, the Single invokes its subscriber's {@link Subscriber#onError} method, and then quits
+     * subscriber, the Single invokes its subscriber's {@link SingleObserver#onError} method, and then quits
      * without invoking any more of its subscriber's methods. The {@code onErrorReturn} method changes this
      * behavior. If you pass a function ({@code resumeFunction}) to a Single's {@code onErrorReturn} method, if
      * the original Single encounters an error, instead of invoking its subscriber's
-     * {@link Subscriber#onError} method, it will instead emit the return value of {@code resumeFunction}.
+     * {@link SingleObserver#onError} method, it will instead emit the return value of {@code resumeFunction}.
      * <p>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
      * encountered.
@@ -2097,18 +2097,18 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Instructs a Single to pass control to another Single rather than invoking
-     * {@link Observer#onError(Throwable)} if it encounters an error.
+     * {@link SingleObserver#onError(Throwable)} if it encounters an error.
      * <p/>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
      * <p/>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
-     * its {@link Observer}, the Single invokes its Observer's {@code onError} method, and then quits
-     * without invoking any more of its Observer's methods. The {@code onErrorResumeNext} method changes this
+     * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits
+     * without invoking any more of its SingleObserver's methods. The {@code onErrorResumeNext} method changes this
      * behavior. If you pass another Single ({@code resumeSingleInCaseOfError}) to a Single's
      * {@code onErrorResumeNext} method, if the original Single encounters an error, instead of invoking its
-     * Observer's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
-     * will invoke the Observer's {@link Observer#onNext onNext} method if it is able to do so. In such a case,
-     * because no Single necessarily invokes {@code onError}, the Observer may never know that an error
+     * SingleObserver's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
+     * will invoke the SingleObserver's {@link SingleObserver#onSuccess onSuccess} method if it is able to do so. In such a case,
+     * because no Single necessarily invokes {@code onError}, the SingleObserver may never know that an error
      * happened.
      * <p/>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
@@ -2130,18 +2130,18 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Instructs a Single to pass control to another Single rather than invoking
-     * {@link Observer#onError(Throwable)} if it encounters an error.
+     * {@link SingleObserver#onError(Throwable)} if it encounters an error.
      * <p/>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
      * <p/>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
-     * its {@link Observer}, the Single invokes its Observer's {@code onError} method, and then quits
-     * without invoking any more of its Observer's methods. The {@code onErrorResumeNext} method changes this
+     * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits
+     * without invoking any more of its SingleObserver's methods. The {@code onErrorResumeNext} method changes this
      * behavior. If you pass a function that will return another Single ({@code resumeFunctionInCaseOfError}) to a Single's
      * {@code onErrorResumeNext} method, if the original Single encounters an error, instead of invoking its
-     * Observer's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
-     * will invoke the Observer's {@link Observer#onNext onNext} method if it is able to do so. In such a case,
-     * because no Single necessarily invokes {@code onError}, the Observer may never know that an error
+     * SingleObserver's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
+     * will invoke the SingleObserver's {@link SingleObserver#onSuccess onSuccess} method if it is able to do so. In such a case,
+     * because no Single necessarily invokes {@code onError}, the SingleObserver may never know that an error
      * happened.
      * <p/>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
@@ -2167,7 +2167,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Repeatedly re-subscribes to the current Single and emits each success value.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2184,7 +2184,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Re-subscribes to the current Single at most the given number of times and emits each success value.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2205,7 +2205,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
-     *  The {@code Publisher} returned by the handler function is expected to honor backpressure as well.
+     *  The {@code Publisher} returned by the handler function is expected to honor backpressure as well.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeatWhen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2226,7 +2226,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Re-subscribes to the current Single until the given BooleanSupplier returns true.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code repeatUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -2401,7 +2401,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@link Disposable} reference can request the {@link Single} stop work.
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      * @throws IllegalArgumentException
-     *             if {@code onNext} is null, or
+     *             if {@code onSuccess} is null, or
      *             if {@code onError} is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2524,13 +2524,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The {@code other} publisher is consumed in an unbounded fashion but will be
-     *  cancelled after the first item it produced.
+     *  cancelled after the first item it produced.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
-     *            the Flowable whose first emitted item will cause {@code takeUntil} to emit the item from the source
+     *            the Publisher whose first emitted item will cause {@code takeUntil} to emit the item from the source
      *            Single
      * @param <E>
      *            the type of items emitted by {@code other}
@@ -2673,8 +2673,8 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Returns a {@link Completable} that discards result of the {@link Single} (similar to
-     * {@link Observable#ignoreElements()}) and calls {@code onCompleted} when this source {@link Single} calls
+     * Returns a {@link Completable} that discards result of the {@link Single}
+     * and calls {@code onComplete} when this source {@link Single} calls
      * {@code onSuccess}. Error terminal event is propagated.
      * <p>
      * <img width="640" height="295" src=
@@ -2696,17 +2696,17 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Converts this Single into an {@link Flowable}.
+     * Converts this Single into a {@link Flowable}.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Flowable} that emits a single item T or an error.
+     * @return a {@link Flowable} that emits a single item T or an error.
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2744,7 +2744,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code toMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an {@link Maybe} that emits a single item T or an error.
+     * @return a {@link Maybe} that emits a single item T or an error.
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
@@ -2789,11 +2789,11 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param <R>
      *            the type of items emitted by the resulting Single
      * @param other
-     *            the other Observable
+     *            the other SingleSource
      * @param zipper
-     *            a function that combines the pairs of items from the two Observables to generate the items to
+     *            a function that combines the pairs of items from the two SingleSources to generate the items to
      *            be emitted by the resulting Single
-     * @return a Single that pairs up values from the source Observable and the {@code other} Observable
+     * @return a Single that pairs up values from the source Single and the {@code other} SingleSource
      *         and emits the results of {@code zipFunction} applied to these pairs
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatest.java
@@ -25,7 +25,7 @@ import io.reactivex.subscribers.DisposableSubscriber;
 
 /**
  * Wait for and iterate over the latest values of the source observable. If the source works faster than the
- * iterator, values may be skipped, but not the {@code onError} or {@code onCompleted} events.
+ * iterator, values may be skipped, but not the {@code onError} or {@code onComplete} events.
  */
 public enum BlockingFlowableLatest {
     ;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilMaybe.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Relays the main source's event unless the other Maybe signals an item first or just completes
+ * at which point the resulting Maybe is completed.
+ *
+ * @param <T> the value type
+ * @param <U> the other's value type
+ */
+public final class MaybeTakeUntilMaybe<T, U> extends AbstractMaybeWithUpstream<T, T> {
+
+    final MaybeSource<U> other;
+
+    public MaybeTakeUntilMaybe(MaybeSource<T> source, MaybeSource<U> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        TakeUntilMainMaybeObserver<T, U> parent = new TakeUntilMainMaybeObserver<T, U>(observer);
+        observer.onSubscribe(parent);
+
+        other.subscribe(parent.other);
+
+        source.subscribe(parent);
+    }
+
+    static final class TakeUntilMainMaybeObserver<T, U>
+    extends AtomicReference<Disposable> implements MaybeObserver<T>, Disposable {
+        /** */
+        private static final long serialVersionUID = -2187421758664251153L;
+
+        final MaybeObserver<? super T> actual;
+
+        final TakeUntilOtherMaybeObserver<U> other;
+
+        public TakeUntilMainMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+            this.other = new TakeUntilOtherMaybeObserver<U>(this);
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+            DisposableHelper.dispose(other);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            DisposableHelper.dispose(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            DisposableHelper.dispose(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            DisposableHelper.dispose(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onComplete();
+            }
+        }
+
+        void otherError(Throwable e) {
+            if (DisposableHelper.dispose(this)) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        void otherComplete() {
+            if (DisposableHelper.dispose(this)) {
+                actual.onComplete();
+            }
+        }
+
+        static final class TakeUntilOtherMaybeObserver<U>
+        extends AtomicReference<Disposable> implements MaybeObserver<U> {
+
+            /** */
+            private static final long serialVersionUID = -1266041316834525931L;
+
+            final TakeUntilMainMaybeObserver<?, U> parent;
+
+            public TakeUntilOtherMaybeObserver(TakeUntilMainMaybeObserver<?, U> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+                parent.otherComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.otherComplete();
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisher.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Relays the main source's event unless the other Publisher signals an item first or just completes
+ * at which point the resulting Maybe is completed.
+ *
+ * @param <T> the value type
+ * @param <U> the other's value type
+ */
+public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Publisher<U> other;
+
+    public MaybeTakeUntilPublisher(MaybeSource<T> source, Publisher<U> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        TakeUntilMainMaybeObserver<T, U> parent = new TakeUntilMainMaybeObserver<T, U>(observer);
+        observer.onSubscribe(parent);
+
+        other.subscribe(parent.other);
+
+        source.subscribe(parent);
+    }
+
+    static final class TakeUntilMainMaybeObserver<T, U>
+    extends AtomicReference<Disposable> implements MaybeObserver<T>, Disposable {
+        /** */
+        private static final long serialVersionUID = -2187421758664251153L;
+
+        final MaybeObserver<? super T> actual;
+
+        final TakeUntilOtherMaybeObserver<U> other;
+
+        public TakeUntilMainMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+            this.other = new TakeUntilOtherMaybeObserver<U>(this);
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+            SubscriptionHelper.cancel(other);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            SubscriptionHelper.cancel(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            SubscriptionHelper.cancel(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            SubscriptionHelper.cancel(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onComplete();
+            }
+        }
+
+        void otherError(Throwable e) {
+            if (DisposableHelper.dispose(this)) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        void otherComplete() {
+            if (DisposableHelper.dispose(this)) {
+                actual.onComplete();
+            }
+        }
+
+        static final class TakeUntilOtherMaybeObserver<U>
+        extends AtomicReference<Subscription> implements Subscriber<U> {
+
+            /** */
+            private static final long serialVersionUID = -1266041316834525931L;
+
+            final TakeUntilMainMaybeObserver<?, U> parent;
+
+            public TakeUntilOtherMaybeObserver(TakeUntilMainMaybeObserver<?, U> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                if (SubscriptionHelper.setOnce(this, s)) {
+                    s.request(Long.MAX_VALUE);
+                }
+            }
+
+            @Override
+            public void onNext(Object value) {
+                parent.otherComplete();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.otherComplete();
+            }
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/BaseTypeParser.java
+++ b/src/test/java/io/reactivex/BaseTypeParser.java
@@ -87,7 +87,13 @@ public class BaseTypeParser {
             }
 
             int staticMethodDef = b.indexOf("public static ", javadocEnd + 2);
+            if (staticMethodDef < 0) {
+                staticMethodDef = Integer.MAX_VALUE;
+            }
             int instanceMethodDef = b.indexOf("public final ", javadocEnd + 2);
+            if (instanceMethodDef < 0) {
+                instanceMethodDef = Integer.MAX_VALUE;
+            }
 
             int javadocStartNext = b.indexOf("/**", javadocEnd + 2);
             if (javadocStartNext < 0) {
@@ -99,7 +105,7 @@ public class BaseTypeParser {
             if (staticMethodDef > 0 && staticMethodDef < javadocStartNext && staticMethodDef < instanceMethodDef) {
                 definitionStart = staticMethodDef;
             }
-            if (instanceMethodDef > 0 && staticMethodDef < javadocStartNext && instanceMethodDef < staticMethodDef) {
+            if (instanceMethodDef > 0 && instanceMethodDef < javadocStartNext && instanceMethodDef < staticMethodDef) {
                 definitionStart = instanceMethodDef;
             }
 

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -68,8 +68,26 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Subscriber", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")
-                                && !m.signature.contains("Flowable")) {
+                                && !m.signature.contains("Flowable")
+                                && !m.signature.contains("TestSubscriber")
+                        ) {
                             e.append("java.lang.RuntimeException: Maybe doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf(" Subscription", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Publisher")
+                                && !m.signature.contains("Flowable")
+                        ) {
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
                             .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
@@ -235,6 +253,32 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
+                    int idx = m.javadoc.indexOf(" Disposable", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Observable")
+                                && !m.signature.contains("ObservableSource")
+                                && !m.signature.contains("Single")
+                                && !m.signature.contains("SingleSource")
+                                && !m.signature.contains("Completable")
+                                && !m.signature.contains("CompletableSource")
+                                && !m.signature.contains("Maybe")
+                                && !m.signature.contains("MaybeSource")
+                                && !m.signature.contains("Disposable")
+                        ) {
+                            CharSequence subSequence = m.javadoc.subSequence(idx - 6, idx + 11);
+                            if (idx < 6 || !subSequence.equals("{@link Disposable")) {
+                                e.append("java.lang.RuntimeException: Flowable doc mentions Disposable but not using Flowable\r\n at io.reactivex.")
+                                .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
                     int idx = m.javadoc.indexOf("Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
@@ -293,7 +337,23 @@ public class JavadocWording {
                                 && !m.signature.contains("Single")
                                 && !m.signature.contains("SingleSource")) {
                             e.append("java.lang.RuntimeException: Observable doc mentions onSuccess\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf(" Subscription", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")
+                                && !m.signature.contains("Publisher")
+                        ) {
+                            e.append("java.lang.RuntimeException: Observable doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
+                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -391,8 +451,25 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Subscriber", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")
-                                && !m.signature.contains("Flowable")) {
+                                && !m.signature.contains("Flowable")
+                                && !m.signature.contains("TestSubscriber")) {
                             e.append("java.lang.RuntimeException: Single doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf(" Subscription", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")
+                                && !m.signature.contains("Publisher")
+                        ) {
+                            e.append("java.lang.RuntimeException: Single doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
                             .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
@@ -437,7 +514,7 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
-                    int idx = m.javadoc.indexOf("Flowable", jdx);
+                    int idx = m.javadoc.indexOf(" Flowable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Flowable")) {
                             e.append("java.lang.RuntimeException: Single doc mentions Flowable but not in the signature\r\n at io.reactivex.")
@@ -450,7 +527,7 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
-                    int idx = m.javadoc.indexOf("Maybe", jdx);
+                    int idx = m.javadoc.indexOf(" Maybe", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Maybe")) {
                             e.append("java.lang.RuntimeException: Single doc mentions Maybe but not in the signature\r\n at io.reactivex.")
@@ -463,7 +540,7 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
-                    int idx = m.javadoc.indexOf("MaybeSource", jdx);
+                    int idx = m.javadoc.indexOf(" MaybeSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("MaybeSource")) {
                             e.append("java.lang.RuntimeException: Single doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
@@ -476,7 +553,7 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
-                    int idx = m.javadoc.indexOf("Observable", jdx);
+                    int idx = m.javadoc.indexOf(" Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
                             e.append("java.lang.RuntimeException: Single doc mentions Observable but not in the signature\r\n at io.reactivex.")
@@ -489,7 +566,7 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
-                    int idx = m.javadoc.indexOf("ObservableSource", jdx);
+                    int idx = m.javadoc.indexOf(" ObservableSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")) {
                             e.append("java.lang.RuntimeException: Single doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
@@ -547,8 +624,25 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Subscriber", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")
-                                && !m.signature.contains("Flowable")) {
+                                && !m.signature.contains("Flowable")
+                                && !m.signature.contains("TestSubscriber")) {
                             e.append("java.lang.RuntimeException: Completable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                        }
+
+                        jdx = idx + 6;
+                    } else {
+                        break;
+                    }
+                }
+                jdx = 0;
+                for (;;) {
+                    int idx = m.javadoc.indexOf(" Subscription", jdx);
+                    if (idx >= 0) {
+                        if (!m.signature.contains("Flowable")
+                                && !m.signature.contains("Publisher")
+                        ) {
+                            e.append("java.lang.RuntimeException: Completable doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
                             .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
@@ -610,7 +704,7 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("Single")) {
                             e.append("java.lang.RuntimeException: Completable doc mentions Single but not in the signature\r\n at io.reactivex.")
-                            .append("Completable (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -632,7 +726,7 @@ public class JavadocWording {
                 }
                 jdx = 0;
                 for (;;) {
-                    int idx = m.javadoc.indexOf("Observable", jdx);
+                    int idx = m.javadoc.indexOf(" Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
                             e.append("java.lang.RuntimeException: Completable doc mentions Observable but not in the signature\r\n at io.reactivex.")

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+
+public class MaybeTakeUntilTest {
+
+    @Test
+    public void normalPublisher() {
+        Maybe.just(1).takeUntil(Flowable.never())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void normalMaybe() {
+        Maybe.just(1).takeUntil(Maybe.never())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void untilFirstPublisher() {
+        Maybe.just(1).takeUntil(Flowable.just("one"))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void untilFirstMaybe() {
+        Maybe.just(1).takeUntil(Maybe.just("one"))
+        .test()
+        .assertResult();
+    }
+}


### PR DESCRIPTION
- Fix missed javadoc mistakes, fix the checker that hid those mistakes in instance methods' javadoc due to a bug
- add `Maybe.takeUntil`
