### PR TITLE
2.x: last Maybe operators

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeoutMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeoutMaybe.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Switches to the fallback Maybe if the other MaybeSource signals a success or completes, or
+ * signals TimeoutException if fallback is null.
+ * 
+ * @param <T> the main value type
+ * @param <U> the other value type
+ */
+public final class MaybeTimeoutMaybe<T, U> extends AbstractMaybeWithUpstream<T, T> {
+
+    final MaybeSource<U> other;
+
+    final MaybeSource<? extends T> fallback;
+
+    public MaybeTimeoutMaybe(MaybeSource<T> source, MaybeSource<U> other, MaybeSource<? extends T> fallback) {
+        super(source);
+        this.other = other;
+        this.fallback = fallback;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        TimeoutMainMaybeObserver<T, U> parent = new TimeoutMainMaybeObserver<T, U>(observer, fallback);
+        observer.onSubscribe(parent);
+
+        other.subscribe(parent.other);
+
+        source.subscribe(parent);
+    }
+
+    static final class TimeoutMainMaybeObserver<T, U>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, Disposable {
+
+        /** */
+        private static final long serialVersionUID = -5955289211445418871L;
+
+        final MaybeObserver<? super T> actual;
+
+        final TimeoutOtherMaybeObserver<T, U> other;
+
+        final MaybeSource<? extends T> fallback;
+
+        final TimeoutFallbackMaybeObserver<T> otherObserver;
+
+        public TimeoutMainMaybeObserver(MaybeObserver<? super T> actual, MaybeSource<? extends T> fallback) {
+            this.actual = actual;
+            this.other = new TimeoutOtherMaybeObserver<T, U>(this);
+            this.fallback = fallback;
+            this.otherObserver = fallback != null ? new TimeoutFallbackMaybeObserver<T>(actual) : null;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+            DisposableHelper.dispose(other);
+            TimeoutFallbackMaybeObserver<T> oo = otherObserver;
+            if (oo != null) {
+                DisposableHelper.dispose(oo);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            DisposableHelper.dispose(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            DisposableHelper.dispose(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            DisposableHelper.dispose(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onComplete();
+            }
+        }
+
+        public void otherError(Throwable e) {
+            if (DisposableHelper.dispose(this)) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        public void otherComplete() {
+            if (DisposableHelper.dispose(this)) {
+                if (fallback == null) {
+                    actual.onError(new TimeoutException());
+                } else {
+                    fallback.subscribe(otherObserver);
+                }
+            }
+        }
+    }
+
+    static final class TimeoutOtherMaybeObserver<T, U>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<Object> {
+
+        /** */
+        private static final long serialVersionUID = 8663801314800248617L;
+
+        final TimeoutMainMaybeObserver<T, U> parent;
+
+        public TimeoutOtherMaybeObserver(TimeoutMainMaybeObserver<T, U> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(Object value) {
+            parent.otherComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            parent.otherError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.otherComplete();
+        }
+    }
+    static final class TimeoutFallbackMaybeObserver<T>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T> {
+
+        /** */
+        private static final long serialVersionUID = 8663801314800248617L;
+
+        final MaybeObserver<? super T> actual;
+
+        public TimeoutFallbackMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisher.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Switches to the fallback Maybe if the other Publisher signals a success or completes, or
+ * signals TimeoutException if fallback is null.
+ * 
+ * @param <T> the main value type
+ * @param <U> the other value type
+ */
+public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Publisher<U> other;
+
+    final MaybeSource<? extends T> fallback;
+
+    public MaybeTimeoutPublisher(MaybeSource<T> source, Publisher<U> other, MaybeSource<? extends T> fallback) {
+        super(source);
+        this.other = other;
+        this.fallback = fallback;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        TimeoutMainMaybeObserver<T, U> parent = new TimeoutMainMaybeObserver<T, U>(observer, fallback);
+        observer.onSubscribe(parent);
+
+        other.subscribe(parent.other);
+
+        source.subscribe(parent);
+    }
+
+    static final class TimeoutMainMaybeObserver<T, U>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, Disposable {
+
+        /** */
+        private static final long serialVersionUID = -5955289211445418871L;
+
+        final MaybeObserver<? super T> actual;
+
+        final TimeoutOtherMaybeObserver<T, U> other;
+
+        final MaybeSource<? extends T> fallback;
+
+        final TimeoutFallbackMaybeObserver<T> otherObserver;
+
+        public TimeoutMainMaybeObserver(MaybeObserver<? super T> actual, MaybeSource<? extends T> fallback) {
+            this.actual = actual;
+            this.other = new TimeoutOtherMaybeObserver<T, U>(this);
+            this.fallback = fallback;
+            this.otherObserver = fallback != null ? new TimeoutFallbackMaybeObserver<T>(actual) : null;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+            SubscriptionHelper.cancel(other);
+            TimeoutFallbackMaybeObserver<T> oo = otherObserver;
+            if (oo != null) {
+                DisposableHelper.dispose(oo);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            SubscriptionHelper.cancel(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            SubscriptionHelper.cancel(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            SubscriptionHelper.cancel(other);
+            if (getAndSet(DisposableHelper.DISPOSED) != DisposableHelper.DISPOSED) {
+                actual.onComplete();
+            }
+        }
+
+        public void otherError(Throwable e) {
+            if (DisposableHelper.dispose(this)) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        public void otherComplete() {
+            if (DisposableHelper.dispose(this)) {
+                if (fallback == null) {
+                    actual.onError(new TimeoutException());
+                } else {
+                    fallback.subscribe(otherObserver);
+                }
+            }
+        }
+    }
+
+    static final class TimeoutOtherMaybeObserver<T, U>
+    extends AtomicReference<Subscription>
+    implements Subscriber<Object> {
+
+        /** */
+        private static final long serialVersionUID = 8663801314800248617L;
+
+        final TimeoutMainMaybeObserver<T, U> parent;
+
+        public TimeoutOtherMaybeObserver(TimeoutMainMaybeObserver<T, U> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(Object value) {
+            get().cancel();
+            parent.otherComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            parent.otherError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.otherComplete();
+        }
+    }
+
+    static final class TimeoutFallbackMaybeObserver<T>
+    extends AtomicReference<Disposable>
+    implements MaybeObserver<T> {
+
+        /** */
+        private static final long serialVersionUID = 8663801314800248617L;
+
+        final MaybeObserver<? super T> actual;
+
+        public TimeoutFallbackMaybeObserver(MaybeObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+
+
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOn.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Makes sure a dispose() call from downstream happens on the specified scheduler.
+ * 
+ * @param <T> the value type
+ */
+public final class MaybeUnsubscribeOn<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Scheduler scheduler;
+
+    public MaybeUnsubscribeOn(MaybeSource<T> source, Scheduler scheduler) {
+        super(source);
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new UnsubscribeOnMaybeObserver<T>(observer, scheduler));
+    }
+
+    static final class UnsubscribeOnMaybeObserver<T> extends AtomicReference<Disposable>
+    implements MaybeObserver<T>, Disposable, Runnable {
+        /** */
+        private static final long serialVersionUID = 3256698449646456986L;
+
+        final MaybeObserver<? super T> actual;
+
+        final Scheduler scheduler;
+
+        Disposable ds;
+
+        public UnsubscribeOnMaybeObserver(MaybeObserver<? super T> actual, Scheduler scheduler) {
+            this.actual = actual;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public void dispose() {
+            Disposable d = getAndSet(DisposableHelper.DISPOSED);
+            if (d != DisposableHelper.DISPOSED) {
+                this.ds = d;
+                scheduler.scheduleDirect(this);
+            }
+        }
+
+        @Override
+        public void run() {
+            ds.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d)) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class MaybeTimeoutTest {
+
+    @Test
+    public void normal() {
+        Maybe.just(1)
+        .timeout(1, TimeUnit.DAYS)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void normalMaybe() {
+        Maybe.just(1)
+        .timeout(Maybe.timer(1, TimeUnit.DAYS))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void never() {
+        Maybe.never()
+        .timeout(1, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void neverMaybe() {
+        Maybe.never()
+        .timeout(Maybe.timer(1, TimeUnit.MILLISECONDS))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void normalFallback() {
+        Maybe.just(1)
+        .timeout(1, TimeUnit.DAYS, Maybe.just(2))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void normalMaybeFallback() {
+        Maybe.just(1)
+        .timeout(Maybe.timer(1, TimeUnit.DAYS), Maybe.just(2))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void neverFallback() {
+        Maybe.never()
+        .timeout(1, TimeUnit.MILLISECONDS, Maybe.just(2))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(2);
+    }
+
+    @Test
+    public void neverMaybeFallback() {
+        Maybe.never()
+        .timeout(Maybe.timer(1, TimeUnit.MILLISECONDS), Maybe.just(2))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(2);
+    }
+
+    @Test
+    public void neverFallbackScheduler() {
+        Maybe.never()
+        .timeout(1, TimeUnit.MILLISECONDS, Schedulers.single(), Maybe.just(2))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(2);
+    }
+
+    @Test
+    public void neverScheduler() {
+        Maybe.never()
+        .timeout(1, TimeUnit.MILLISECONDS, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void normalFlowableFallback() {
+        Maybe.just(1)
+        .timeout(Flowable.timer(1, TimeUnit.DAYS), Maybe.just(2))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void neverFlowableFallback() {
+        Maybe.never()
+        .timeout(Flowable.timer(1, TimeUnit.MILLISECONDS), Maybe.just(2))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(2);
+    }
+
+    @Test
+    public void normalFlowable() {
+        Maybe.just(1)
+        .timeout(Flowable.timer(1, TimeUnit.DAYS))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void neverFlowable() {
+        Maybe.never()
+        .timeout(Flowable.timer(1, TimeUnit.MILLISECONDS))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.functions.Action;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+public class MaybeUnsubscribeOnTest {
+
+    @Test
+    public void normal() throws Exception {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final String[] name = { null };
+
+        final CountDownLatch cdl = new CountDownLatch(1);
+
+        pp.doOnCancel(new Action() {
+            @Override
+            public void run() throws Exception {
+                name[0] = Thread.currentThread().getName();
+                cdl.countDown();
+            }
+        })
+        .toMaybe()
+        .unsubscribeOn(Schedulers.single())
+        .test(true)
+        ;
+
+        assertTrue(cdl.await(5, TimeUnit.SECONDS));
+
+        assertFalse(pp.hasSubscribers());
+
+        assertNotEquals(Thread.currentThread().getName(), name[0]);
+    }
+}


### PR DESCRIPTION
This PR adds the last couple of `Maybe` operators `timeout` and `unsubscribeOn`.

@abersnaze Let me know if I missed an operator or you want some overload.

In the subsequent PRs, I'll change the return types of some classical operators to better indicate the cardinality they have (`Single`, `Completable`).
