### PR TITLE
2.x: add most relevant ~100 operators' Reactive-Streams TCK tests

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -17,8 +17,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.reactivestreams.*;
 
-import io.reactivex.*;
+import io.reactivex.Scheduler;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream<T, T> {
     final Scheduler scheduler;
@@ -56,17 +57,25 @@ public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            if (!get()) {
+                actual.onNext(t);
+            }
         }
 
         @Override
         public void onError(Throwable t) {
+            if (get()) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
             actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            actual.onComplete();
+            if (!get()) {
+                actual.onComplete();
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOn.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableUnsubscribeOn<T> extends AbstractObservableWithUpstream<T, T> {
     final Scheduler scheduler;
@@ -55,17 +56,25 @@ public final class ObservableUnsubscribeOn<T> extends AbstractObservableWithUpst
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            if (!get()) {
+                actual.onNext(t);
+            }
         }
 
         @Override
         public void onError(Throwable t) {
+            if (get()) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
             actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            actual.onComplete();
+            if (!get()) {
+                actual.onComplete();
+            }
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -182,4 +182,17 @@ public class FlowableUnsubscribeOnTest {
         }
 
     }
+
+    @Test
+    public void takeHalf() {
+        int elements = 1024;
+        Flowable.range(0, elements * 2).unsubscribeOn(Schedulers.single())
+        .take(elements)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(elements)
+        .assertComplete()
+        .assertNoErrors()
+        .assertSubscribed();
+    }
 }

--- a/src/test/java/io/reactivex/tck/AllTckTest.java
+++ b/src/test/java/io/reactivex/tck/AllTckTest.java
@@ -17,14 +17,25 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Predicate;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class AllTckTest extends BaseTck<Boolean> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Boolean> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).all(new Predicate<Integer>() {
+                    @Override
+                    public boolean test(Integer e) throws Exception {
+                        return e < 800;
+                    }
+                })
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/AmbArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/AmbArrayTckTest.java
@@ -19,12 +19,16 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class AmbArrayTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.ambArray(
+                        Flowable.fromIterable(iterate(elements)),
+                        Flowable.<Long>never()
+                )
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/AmbTckTest.java
+++ b/src/test/java/io/reactivex/tck/AmbTckTest.java
@@ -13,18 +13,25 @@
 
 package io.reactivex.tck;
 
+import java.util.Arrays;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class AmbTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.amb(Arrays.asList(
+                    Flowable.fromIterable(iterate(elements)),
+                    Flowable.<Long>never()
+                )
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/AnyTckTest.java
+++ b/src/test/java/io/reactivex/tck/AnyTckTest.java
@@ -17,14 +17,25 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Predicate;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class AnyTckTest extends BaseTck<Boolean> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Boolean> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).any(new Predicate<Integer>() {
+                    @Override
+                    public boolean test(Integer e) throws Exception {
+                        return e == 500;
+                    }
+                })
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/tck/BaseTck.java
@@ -25,17 +25,25 @@ import io.reactivex.exceptions.TestException;
 /**
  * Base abstract class for Flowable verifications, contains support for creating
  * Iterable range of values
+ * 
+ * @param <T> the element type
  */
 @Test
-public abstract class BaseTck extends PublisherVerification<Long> {
+public abstract class BaseTck<T> extends PublisherVerification<T> {
 
     public BaseTck() {
-        super(new TestEnvironment(300L));
+        super(new TestEnvironment(25L));
     }
 
     @Override
-    public Publisher<Long> createFailedPublisher() {
+    public Publisher<T> createFailedPublisher() {
         return Flowable.error(new TestException());
+    }
+
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
     }
 
     /**

--- a/src/test/java/io/reactivex/tck/BufferBoundaryTckTest.java
+++ b/src/test/java/io/reactivex/tck/BufferBoundaryTckTest.java
@@ -13,18 +13,27 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class BufferBoundaryTckTest extends BaseTck<List<Long>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Long>> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.fromIterable(iterate(elements))
+            .buffer(Flowable.just(1).concatWith(Flowable.<Integer>never()))
+            .onBackpressureLatest()
         );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/BufferExactSizeTckTest.java
+++ b/src/test/java/io/reactivex/tck/BufferExactSizeTckTest.java
@@ -13,18 +13,21 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class BufferExactSizeTckTest extends BaseTck<List<Long>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Long>> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.fromIterable(iterate(elements * 2))
+            .buffer(2)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/CacheTckTest.java
+++ b/src/test/java/io/reactivex/tck/CacheTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CacheTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.fromIterable(iterate(elements)).cache()
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/CollectTckTest.java
+++ b/src/test/java/io/reactivex/tck/CollectTckTest.java
@@ -13,18 +13,32 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiConsumer;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CollectTckTest extends BaseTck<List<Integer>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).collect(Functions.<Integer>createArrayList(128), new BiConsumer<List<Integer>, Integer>() {
+                    @Override
+                    public void accept(List<Integer> a, Integer b) throws Exception {
+                        a.add(b);
+                    }
+                })
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestArrayDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestArrayDelayErrorTckTest.java
@@ -17,14 +17,25 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
+            Flowable.combineLatestDelayError(
+                new Function<Object[], Long>() {
+                    @Override
+                    public Long apply(Object[] a) throws Exception {
+                        return (Long)a[0];
+                    }
+                },
+                Flowable.just(1L),
                 Flowable.fromIterable(iterate(elements))
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestArrayTckTest.java
@@ -17,14 +17,25 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CombineLatestArrayTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
+            Flowable.combineLatest(
+                new Function<Object[], Long>() {
+                    @Override
+                    public Long apply(Object[] a) throws Exception {
+                        return (Long)a[0];
+                    }
+                },
+                Flowable.just(1L),
                 Flowable.fromIterable(iterate(elements))
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestIterableDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestIterableDelayErrorTckTest.java
@@ -13,18 +13,32 @@
 
 package io.reactivex.tck;
 
+import java.util.Arrays;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CombineLatestIterableDelayErrorTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.combineLatestDelayError(Arrays.asList(
+                    Flowable.just(1L),
+                    Flowable.fromIterable(iterate(elements))
+                ),
+                new Function<Object[], Long>() {
+                    @Override
+                    public Long apply(Object[] a) throws Exception {
+                        return (Long)a[0];
+                    }
+                }
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestIterableTckTest.java
@@ -13,18 +13,32 @@
 
 package io.reactivex.tck;
 
+import java.util.Arrays;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CombineLatestIterableTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.combineLatest(Arrays.asList(
+                    Flowable.just(1L),
+                    Flowable.fromIterable(iterate(elements))
+                ),
+                new Function<Object[], Long>() {
+                    @Override
+                    public Long apply(Object[] a) throws Exception {
+                        return (Long)a[0];
+                    }
+                }
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatArrayEagerTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatArrayEagerTckTest.java
@@ -13,18 +13,25 @@
 
 package io.reactivex.tck;
 
+import java.util.Arrays;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatArrayEagerTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.concatEager(Arrays.asList(
+                    Flowable.fromIterable(iterate(elements / 2)),
+                    Flowable.fromIterable(iterate(elements - elements / 2))
+                )
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatIterableEagerTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatIterableEagerTckTest.java
@@ -19,12 +19,16 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatIterableEagerTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.concatArrayEager(
+                Flowable.fromIterable(iterate(elements / 2)),
+                Flowable.fromIterable(iterate(elements - elements / 2))
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatMapIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatMapIterableTckTest.java
@@ -13,18 +13,27 @@
 
 package io.reactivex.tck;
 
+import java.util.Collections;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatMapIterableTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(0, (int)elements)
+                .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Integer v) throws Exception {
+                        return Collections.singletonList(v);
+                    }
+                })
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatMapTckTest.java
@@ -17,14 +17,21 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatMapTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(0, (int)elements)
+                .concatMap(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Exception {
+                        return Flowable.just(v);
+                    }
+                })
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatPublisherEagerTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatPublisherEagerTckTest.java
@@ -19,12 +19,16 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatPublisherEagerTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.concatEager(Flowable.just(
+                    Flowable.fromIterable(iterate(elements / 2)),
+                    Flowable.fromIterable(iterate(elements - elements / 2))
+                )
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatPublisherTckTest.java
@@ -19,12 +19,16 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatPublisherTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.concat(Flowable.just(
+                    Flowable.fromIterable(iterate(elements / 2)),
+                    Flowable.fromIterable(iterate(elements - elements / 2))
+                )
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatTckTest.java
@@ -19,12 +19,15 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ConcatTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.concat(
+                    Flowable.fromIterable(iterate(elements / 2)),
+                    Flowable.fromIterable(iterate(elements - elements / 2))
+                )
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/CreateTckTest.java
+++ b/src/test/java/io/reactivex/tck/CreateTckTest.java
@@ -16,15 +16,24 @@ package io.reactivex.tck;
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.FlowableEmitter.BackpressureMode;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class CreateTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.create(new FlowableOnSubscribe<Long>() {
+                @Override
+                public void subscribe(FlowableEmitter<Long> e) throws Exception {
+                    for (long i = 0; i < elements && !e.isCancelled(); i++) {
+                        e.onNext(i);
+                    }
+                    e.onComplete();
+                }
+            }, BackpressureMode.BUFFER)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/DefaultIfEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/DefaultIfEmptyTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class DefaultIfEmptyTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, (int)elements).defaultIfEmpty(0)
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/DeferTckTest.java
+++ b/src/test/java/io/reactivex/tck/DeferTckTest.java
@@ -13,18 +13,26 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.Callable;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class DeferTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.defer(new Callable<Publisher<Long>>() {
+                    @Override
+                    public Publisher<Long> call() throws Exception {
+                        return Flowable.fromIterable(iterate(elements));
+                    }
+                }
+                )
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/DelaySubscriptionTckTest.java
+++ b/src/test/java/io/reactivex/tck/DelaySubscriptionTckTest.java
@@ -13,18 +13,20 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.TimeUnit;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class DelaySubscriptionTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).delaySubscription(1, TimeUnit.MILLISECONDS)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/DelayTckTest.java
+++ b/src/test/java/io/reactivex/tck/DelayTckTest.java
@@ -13,18 +13,20 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.TimeUnit;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class DelayTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).delay(1, TimeUnit.MILLISECONDS)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/DistinctTckTest.java
+++ b/src/test/java/io/reactivex/tck/DistinctTckTest.java
@@ -19,12 +19,14 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class DistinctTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements)
+                .concatWith(Flowable.range(0, (int)elements))
+                .distinct()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/DistinctUntilChangedTckTest.java
+++ b/src/test/java/io/reactivex/tck/DistinctUntilChangedTckTest.java
@@ -19,12 +19,13 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class DistinctUntilChangedTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements)
+                .distinctUntilChanged()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ElementAtTckTest.java
+++ b/src/test/java/io/reactivex/tck/ElementAtTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ElementAtTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 10).elementAt(5)
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/EmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/EmptyTckTest.java
@@ -19,12 +19,16 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class EmptyTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.<Long>empty());
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 0;
     }
 }

--- a/src/test/java/io/reactivex/tck/FilterTckTest.java
+++ b/src/test/java/io/reactivex/tck/FilterTckTest.java
@@ -17,14 +17,20 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Predicate;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class FilterTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements * 2).filter(new Predicate<Integer>() {
+                    @Override
+                    public boolean test(Integer v) throws Exception {
+                        return (v & 1) == 0;
+                    }
+                })
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/FirstTckTest.java
+++ b/src/test/java/io/reactivex/tck/FirstTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class FirstTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 10).first()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/FlatMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/FlatMapTckTest.java
@@ -17,14 +17,21 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class FlatMapTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(0, (int)elements)
+                .flatMap(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Exception {
+                        return Flowable.just(v);
+                    }
+                })
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/FromArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromArrayTckTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromArrayTckTest extends BaseTck {
+public class FromArrayTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {

--- a/src/test/java/io/reactivex/tck/FromCallableTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromCallableTckTest.java
@@ -13,18 +13,31 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.Callable;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class FromCallableTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.fromCallable(new Callable<Long>() {
+                    @Override
+                    public Long call() throws Exception {
+                        return 1L;
+                    }
+                }
+                )
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/FromFutureTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromFutureTckTest.java
@@ -13,18 +13,33 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.*;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class FromFutureTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
+        FutureTask<Long> ft = new FutureTask<Long>(new Callable<Long>() {
+            @Override
+            public Long call() throws Exception {
+                return 1L;
+            }
+        });
+
+        ft.run();
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.fromFuture(ft)
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/GenerateTckTest.java
+++ b/src/test/java/io/reactivex/tck/GenerateTckTest.java
@@ -16,15 +16,27 @@ package io.reactivex.tck;
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class GenerateTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.generate(Functions.justCallable(0L),
+            new BiFunction<Long, Emitter<Long>, Long>() {
+                @Override
+                public Long apply(Long s, Emitter<Long> e) throws Exception {
+                    e.onNext(s);
+                    if (++s == elements) {
+                        e.onComplete();
+                    }
+                    return s;
+                }
+            }, Functions.<Long>emptyConsumer())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/GroupByTckTest.java
+++ b/src/test/java/io/reactivex/tck/GroupByTckTest.java
@@ -17,14 +17,23 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class GroupByTckTest extends BaseTck<Integer> {
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).groupBy(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) throws Exception {
+                        return v & 1;
+                    }
+                })
+                .flatMap((Function)Functions.identity())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/HideTckTest.java
+++ b/src/test/java/io/reactivex/tck/HideTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class HideTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).hide()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/IgnoreElementsTckTest.java
+++ b/src/test/java/io/reactivex/tck/IgnoreElementsTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class IgnoreElementsTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).ignoreElements()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 0;
     }
 }

--- a/src/test/java/io/reactivex/tck/IntervalRangeTckTest.java
+++ b/src/test/java/io/reactivex/tck/IntervalRangeTckTest.java
@@ -13,18 +13,21 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.TimeUnit;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class IntervalRangeTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.intervalRange(0, elements, 0, 1, TimeUnit.MILLISECONDS)
+            .onBackpressureBuffer()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/IntervalTckTest.java
+++ b/src/test/java/io/reactivex/tck/IntervalTckTest.java
@@ -13,18 +13,21 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.TimeUnit;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class IntervalTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.interval(0, 1, TimeUnit.MILLISECONDS).take(elements)
+            .onBackpressureBuffer()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/IsEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/IsEmptyTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class IsEmptyTckTest extends BaseTck<Boolean> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Boolean> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 10).isEmpty()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/JustTckTest.java
+++ b/src/test/java/io/reactivex/tck/JustTckTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class JustTckTest extends BaseTck {
+public class JustTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {

--- a/src/test/java/io/reactivex/tck/LastTckTest.java
+++ b/src/test/java/io/reactivex/tck/LastTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class LastTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 10).last()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/MapTckTest.java
+++ b/src/test/java/io/reactivex/tck/MapTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class MapTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).map(Functions.<Integer>identity())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/MergeIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeIterableTckTest.java
@@ -13,18 +13,25 @@
 
 package io.reactivex.tck;
 
+import java.util.Arrays;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class MergeIterableTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.merge(Arrays.asList(
+                    Flowable.fromIterable(iterate(elements / 2)),
+                    Flowable.fromIterable(iterate(elements - elements / 2))
+                )
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/MergePublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergePublisherTckTest.java
@@ -19,12 +19,16 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class MergePublisherTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.merge(Flowable.just(
+                    Flowable.fromIterable(iterate(elements / 2)),
+                    Flowable.fromIterable(iterate(elements - elements / 2))
+                )
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/MergeTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeTckTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class MergeTckTest extends BaseTck {
+public class MergeTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {

--- a/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ObserveOnTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).observeOn(Schedulers.single())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/OnBackpressureBufferTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnBackpressureBufferTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class OnBackpressureBufferTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).onBackpressureBuffer()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/OnErrorResumeNextTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnErrorResumeNextTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class OnErrorResumeNextTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).onErrorResumeNext(Flowable.<Integer>never())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/OnErrorReturnItemTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnErrorReturnItemTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class OnErrorReturnItemTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).onErrorReturnItem(0)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/PublishSelectorTckTest.java
+++ b/src/test/java/io/reactivex/tck/PublishSelectorTckTest.java
@@ -17,14 +17,17 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class PublishSelectorTckTest extends BaseTck<Integer> {
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).publish((Function)Functions.identity())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/PublishTckTest.java
+++ b/src/test/java/io/reactivex/tck/PublishTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class PublishTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).publish().autoConnect()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/RangeTckTest.java
+++ b/src/test/java/io/reactivex/tck/RangeTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class RangeTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/RebatchRequestsTckTest.java
+++ b/src/test/java/io/reactivex/tck/RebatchRequestsTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class RebatchRequestsTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).rebatchRequests(2)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ReduceTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReduceTckTest.java
@@ -17,14 +17,25 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ReduceTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).reduce(new BiFunction<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer a, Integer b) throws Exception {
+                        return a + b;
+                    }
+                }).toFlowable()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
@@ -17,14 +17,27 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ReduceWithTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).reduceWith(Functions.justCallable(0),
+                new BiFunction<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer a, Integer b) throws Exception {
+                        return a + b;
+                    }
+                })
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/RepeatTckTest.java
+++ b/src/test/java/io/reactivex/tck/RepeatTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class RepeatTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.just(1).repeat(elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ReplaySelectorTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplaySelectorTckTest.java
@@ -17,14 +17,17 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ReplaySelectorTckTest extends BaseTck<Integer> {
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).replay((Function)Functions.identity())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ReplayTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ReplayTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).replay().autoConnect()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/RetryTckTest.java
+++ b/src/test/java/io/reactivex/tck/RetryTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class RetryTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).retry(1)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ScanTckTest.java
+++ b/src/test/java/io/reactivex/tck/ScanTckTest.java
@@ -17,14 +17,20 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ScanTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).scan(new BiFunction<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer a, Integer b) throws Exception {
+                        return a + b;
+                    }
+                })
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SequenceEqualTckTest.java
+++ b/src/test/java/io/reactivex/tck/SequenceEqualTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SequenceEqualTckTest extends BaseTck<Boolean> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Boolean> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.sequenceEqual(Flowable.range(1, 1000), Flowable.range(1, 1001))
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/ShareTckTest.java
+++ b/src/test/java/io/reactivex/tck/ShareTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ShareTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).share()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SingleTckTest.java
+++ b/src/test/java/io/reactivex/tck/SingleTckTest.java
@@ -19,12 +19,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SingleTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.just(1).single()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipLastTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipLastTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SkipLastTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements * 2).skipLast((int)elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SkipTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements * 2).skip(elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipUntilTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipUntilTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SkipUntilTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).skipUntil(Flowable.just(1))
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipWhileTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipWhileTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SkipWhileTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).skipWhile(Functions.alwaysFalse())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SortedTckTest.java
+++ b/src/test/java/io/reactivex/tck/SortedTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SortedTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).sorted()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SubscribeOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/SubscribeOnTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SubscribeOnTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).subscribeOn(Schedulers.single())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchIfEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchIfEmptyTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SwitchIfEmptyTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.<Integer>empty().switchIfEmpty(Flowable.range(1, (int)elements))
+            );
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchMapDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchMapDelayErrorTckTest.java
@@ -17,14 +17,17 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SwitchMapDelayErrorTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.just(1).switchMapDelayError(Functions.justFunction(
+                    Flowable.fromIterable(iterate(elements)))
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchMapTckTest.java
@@ -17,14 +17,17 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SwitchMapTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.just(1).switchMap(Functions.justFunction(
+                    Flowable.fromIterable(iterate(elements)))
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchOnNextTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchOnNextTckTest.java
@@ -19,12 +19,14 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class SwitchOnNextTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.switchOnNext(Flowable.just(
+                    Flowable.fromIterable(iterate(elements)))
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeLastTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeLastTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TakeLastTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements * 2).takeLast((int)elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TakeTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements * 2).take(elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeUntilTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeUntilTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TakeUntilTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).takeUntil(Flowable.never())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeWhileTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeWhileTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TakeWhileTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).takeWhile(Functions.alwaysTrue())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TimeIntervalTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimeIntervalTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Timed;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TimeIntervalTckTest extends BaseTck<Timed<Integer>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Timed<Integer>> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).timeInterval()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TimeoutTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimeoutTckTest.java
@@ -13,18 +13,20 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.TimeUnit;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TimeoutTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).timeout(1, TimeUnit.DAYS)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/TimerTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimerTckTest.java
@@ -13,18 +13,26 @@
 
 package io.reactivex.tck;
 
+import java.util.concurrent.*;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TimerTckTest extends BaseTck<Long> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.timer(1, TimeUnit.MILLISECONDS)
+                .onBackpressureLatest()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/TimestampTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimestampTckTest.java
@@ -17,14 +17,15 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Timed;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class TimestampTckTest extends BaseTck<Timed<Integer>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Timed<Integer>> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements).timestamp()
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ToListTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToListTckTest.java
@@ -13,18 +13,25 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ToListTckTest extends BaseTck<List<Integer>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).toList()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/ToMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToMapTckTest.java
@@ -13,18 +13,26 @@
 
 package io.reactivex.tck;
 
+import java.util.Map;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ToMapTckTest extends BaseTck<Map<Integer, Integer>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Map<Integer, Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).toMap(Functions.<Integer>identity())
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/ToMultimapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToMultimapTckTest.java
@@ -13,18 +13,26 @@
 
 package io.reactivex.tck;
 
+import java.util.*;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ToMultimapTckTest extends BaseTck<Map<Integer, Collection<Integer>>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Map<Integer, Collection<Integer>>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).toMultimap(Functions.<Integer>identity())
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/ToSortedListTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToSortedListTckTest.java
@@ -13,18 +13,25 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ToSortedListTckTest extends BaseTck<List<Integer>> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+                Flowable.range(1, 1000).toSortedList()
+            );
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
     }
 }

--- a/src/test/java/io/reactivex/tck/UnsubscribeOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/UnsubscribeOnTckTest.java
@@ -17,14 +17,17 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class UnsubscribeOnTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements * 2)
+                .unsubscribeOn(Schedulers.single())
+                .take(elements)
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/UsingTckTest.java
+++ b/src/test/java/io/reactivex/tck/UsingTckTest.java
@@ -17,14 +17,18 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class UsingTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.using(Functions.justCallable(1),
+                    Functions.justFunction(Flowable.fromIterable(iterate(elements))),
+                    Functions.emptyConsumer()
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/WindowBoundaryTckTest.java
+++ b/src/test/java/io/reactivex/tck/WindowBoundaryTckTest.java
@@ -13,18 +13,26 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class WindowBoundaryTckTest extends BaseTck<List<Long>> {
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Long>> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.fromIterable(iterate(elements))
+            .window(Flowable.just(1).concatWith(Flowable.<Integer>never()))
+            .onBackpressureBuffer()
+            .flatMap((Function)Functions.identity())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/WindowExactSizeTckTest.java
+++ b/src/test/java/io/reactivex/tck/WindowExactSizeTckTest.java
@@ -13,18 +13,25 @@
 
 package io.reactivex.tck;
 
+import java.util.List;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class WindowExactSizeTckTest extends BaseTck<List<Long>> {
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<List<Long>> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.fromIterable(iterate(elements))
+            .window(2)
+            .flatMap((Function)Functions.identity())
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/WithLatestFromTckTest.java
+++ b/src/test/java/io/reactivex/tck/WithLatestFromTckTest.java
@@ -17,14 +17,21 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class WithLatestFromTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements)
+                .withLatestFrom(Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer a, Integer b) throws Exception {
+                        return a + b;
+                    }
+                })
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipIterableTckTest.java
@@ -13,18 +13,32 @@
 
 package io.reactivex.tck;
 
+import java.util.Arrays;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ZipIterableTckTest extends BaseTck<Long> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.zip(Arrays.asList(
+                    Flowable.fromIterable(iterate(elements)),
+                    Flowable.fromIterable(iterate(elements))
+                ),
+                new Function<Object[], Long>() {
+                    @Override
+                    public Long apply(Object[] a) throws Exception {
+                        return (Long)a[0] + (Long)a[1];
+                    }
+                }
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipTckTest.java
@@ -17,14 +17,24 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ZipTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+            Flowable.zip(
+                    Flowable.fromIterable(iterate(elements)),
+                    Flowable.fromIterable(iterate(elements)),
+                    new BiFunction<Long, Long, Long>() {
+                        @Override
+                        public Long apply(Long a, Long b) throws Exception {
+                            return a + b;
+                        }
+                    }
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipWithIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipWithIterableTckTest.java
@@ -17,14 +17,21 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ZipWithIterableTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements)
+                .zipWith(iterate(elements), new BiFunction<Integer, Long, Integer>() {
+                    @Override
+                    public Integer apply(Integer a, Long b) throws Exception {
+                        return a + b.intValue();
+                    }
+                })
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipWithTckTest.java
@@ -17,14 +17,21 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.BiFunction;
 
 @Test
-public class FromIterableTckTest extends BaseTck<Long> {
+public class ZipWithTckTest extends BaseTck<Integer> {
 
     @Override
-    public Publisher<Long> createPublisher(long elements) {
+    public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
+                Flowable.range(0, (int)elements)
+                .zipWith(Flowable.range((int)elements, (int)elements), new BiFunction<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer a, Integer b) throws Exception {
+                        return a + b;
+                    }
+                })
         );
     }
 }


### PR DESCRIPTION
This PR adds about ~100 Reactive-Streams Test Compatibility Kit (TCK) tests of RxJava's most relevant operators and operation modes.

The PR also contains a behavior fix for `unsubscribeOn` that now stops propagating events if the cancelled because it may take arbitrary time for the scheduled cancellation to reach the upstream which generally keeps emitting in the meantime.
